### PR TITLE
Migrate to UUID pk

### DIFF
--- a/backend/drizzle/uuid_pk.sql
+++ b/backend/drizzle/uuid_pk.sql
@@ -1,0 +1,306 @@
+
+-- Create UUID PK columns.
+-- Note: we can't alter varchar to UUID directly, so we need to add UUID column first.
+
+ALTER TABLE "memberships" ADD COLUMN "uuid" UUID DEFAULT (gen_random_uuid());
+ALTER TABLE "organizations" ADD COLUMN "uuid" UUID DEFAULT (gen_random_uuid());
+ALTER TABLE "sessions" ADD COLUMN "uuid" UUID DEFAULT (gen_random_uuid());
+ALTER TABLE "tokens" ADD COLUMN "uuid" UUID DEFAULT (gen_random_uuid());
+ALTER TABLE "users" ADD COLUMN "uuid" UUID DEFAULT (gen_random_uuid());
+ALTER TABLE "workspaces" ADD COLUMN "uuid" UUID DEFAULT (gen_random_uuid());
+
+
+-- Create UUID columns, and transfer the foreign key relations to new UUID columns.
+-- sql format for transfer:
+-- UPDATE table_has_fk t_fk SET new_foreign_key(***_uuid) = t_ori.new_primary_key(uuid) 
+-- FROM table_ori t_ori WHERE t_ori.old_primary_key(id) = t_fk.old_foreign_key;
+
+ALTER TABLE "memberships" ADD COLUMN "organization_id_uuid" uuid;
+UPDATE "memberships" t_fk SET organization_id_uuid = t_ori.uuid
+FROM "organizations" t_ori WHERE t_ori.id = t_fk.organization_id;
+
+ALTER TABLE "memberships" ADD COLUMN "workspace_id_uuid" uuid;
+UPDATE "memberships" t_fk SET workspace_id_uuid = t_ori.uuid
+FROM "workspaces" t_ori WHERE t_ori.id = t_fk.workspace_id;
+
+ALTER TABLE "memberships" ADD COLUMN "user_id_uuid" uuid;
+UPDATE "memberships" t_fk SET user_id_uuid = t_ori.uuid
+FROM "users" t_ori WHERE t_ori.id = t_fk.user_id;
+
+ALTER TABLE "memberships" ADD COLUMN "created_by_uuid" uuid;
+UPDATE "memberships" t_fk SET created_by_uuid = t_ori.uuid
+FROM "users" t_ori WHERE t_ori.id = t_fk.created_by;
+
+ALTER TABLE "memberships" ADD COLUMN "modified_by_uuid" uuid;
+UPDATE "memberships" t_fk SET modified_by_uuid = t_ori.uuid
+FROM "users" t_ori WHERE t_ori.id = t_fk.modified_by;
+
+ALTER TABLE "oauth_accounts" ADD COLUMN "user_id_uuid" uuid;
+UPDATE "oauth_accounts" t_fk SET user_id_uuid = t_ori.uuid
+FROM "users" t_ori WHERE t_ori.id = t_fk.user_id;
+
+ALTER TABLE "organizations" ADD COLUMN "created_by_uuid" uuid;
+UPDATE "organizations" t_fk SET created_by_uuid = t_ori.uuid
+FROM "users" t_ori WHERE t_ori.id = t_fk.created_by;
+
+ALTER TABLE "organizations" ADD COLUMN "modified_by_uuid" uuid;
+UPDATE "organizations" t_fk SET modified_by_uuid = t_ori.uuid
+FROM "users" t_ori WHERE t_ori.id = t_fk.modified_by;
+
+ALTER TABLE "sessions" ADD COLUMN "user_id_uuid" uuid;
+UPDATE "sessions" t_fk SET user_id_uuid = t_ori.uuid
+FROM "users" t_ori WHERE t_ori.id = t_fk.user_id;
+
+ALTER TABLE "tokens" ADD COLUMN "user_id_uuid" uuid;
+UPDATE "tokens" t_fk SET user_id_uuid = t_ori.uuid
+FROM "users" t_ori WHERE t_ori.id = t_fk.user_id;
+
+ALTER TABLE "tokens" ADD COLUMN "organization_id_uuid" uuid;
+UPDATE "tokens" t_fk SET organization_id_uuid = t_ori.uuid
+FROM "organizations" t_ori WHERE t_ori.id = t_fk.organization_id;
+
+ALTER TABLE "users" ADD COLUMN "modified_by_uuid" uuid;
+UPDATE "users" t_fk SET modified_by_uuid = t_ori.uuid
+FROM "users" t_ori WHERE t_ori.id = t_fk.modified_by;
+
+ALTER TABLE "workspaces" ADD COLUMN "organization_id_uuid" uuid;
+UPDATE "workspaces" t_fk SET organization_id_uuid = t_ori.uuid
+FROM "organizations" t_ori WHERE t_ori.id = t_fk.organization_id;
+
+ALTER TABLE "workspaces" ADD COLUMN "created_by_uuid" uuid;
+UPDATE "workspaces" t_fk SET created_by_uuid = t_ori.uuid
+FROM "users" t_ori WHERE t_ori.id = t_fk.created_by;
+
+ALTER TABLE "workspaces" ADD COLUMN "modified_by_uuid" uuid;
+UPDATE "workspaces" t_fk SET modified_by_uuid = t_ori.uuid
+FROM "users" t_ori WHERE t_ori.id = t_fk.modified_by;
+
+
+-- Rename the PK & FK columns to old_***
+ALTER TABLE "memberships" RENAME COLUMN "id" TO "old_id";
+ALTER TABLE "memberships" RENAME COLUMN "organization_id" TO "old_organization_id";
+ALTER TABLE "memberships" RENAME COLUMN "workspace_id" TO "old_workspace_id";
+ALTER TABLE "memberships" RENAME COLUMN "user_id" TO "old_user_id";
+ALTER TABLE "memberships" RENAME COLUMN "created_by" TO "old_created_by";
+ALTER TABLE "memberships" RENAME COLUMN "modified_by" TO "old_modified_by";
+
+ALTER TABLE "oauth_accounts" RENAME COLUMN "user_id" TO "old_user_id";
+
+ALTER TABLE "organizations" RENAME COLUMN "id" TO "old_id";
+ALTER TABLE "organizations" RENAME COLUMN "created_by" TO "old_created_by";
+ALTER TABLE "organizations" RENAME COLUMN "modified_by" TO "old_modified_by";
+
+ALTER TABLE "sessions" RENAME COLUMN "id" TO "old_id";
+ALTER TABLE "sessions" RENAME COLUMN "user_id" TO "old_user_id";
+
+ALTER TABLE "tokens" RENAME COLUMN "id" TO "old_id";
+ALTER TABLE "tokens" RENAME COLUMN "user_id" TO "old_user_id";
+ALTER TABLE "tokens" RENAME COLUMN "organization_id" TO "old_organization_id";
+
+ALTER TABLE "users" RENAME COLUMN "id" TO "old_id";
+ALTER TABLE "users" RENAME COLUMN "modified_by" TO "old_modified_by";
+
+ALTER TABLE "workspaces" RENAME COLUMN "id" TO "old_id";
+ALTER TABLE "workspaces" RENAME COLUMN "organization_id" TO "old_organization_id";
+ALTER TABLE "workspaces" RENAME COLUMN "created_by" TO "old_created_by";
+ALTER TABLE "workspaces" RENAME COLUMN "modified_by" TO "old_modified_by";
+
+
+-- Rename the UUID PK & FK columns to new name.
+ALTER TABLE "memberships" RENAME COLUMN "uuid" TO "id";
+ALTER TABLE "memberships" RENAME COLUMN "organization_id_uuid" TO "organization_id";
+ALTER TABLE "memberships" RENAME COLUMN "workspace_id_uuid" TO "workspace_id";
+ALTER TABLE "memberships" RENAME COLUMN "user_id_uuid" TO "user_id";
+ALTER TABLE "memberships" RENAME COLUMN "created_by_uuid" TO "created_by";
+ALTER TABLE "memberships" RENAME COLUMN "modified_by_uuid" TO "modified_by";
+
+ALTER TABLE "oauth_accounts" RENAME COLUMN "user_id_uuid" TO "user_id";
+
+ALTER TABLE "organizations" RENAME COLUMN "uuid" TO "id";
+ALTER TABLE "organizations" RENAME COLUMN "created_by_uuid" TO "created_by";
+ALTER TABLE "organizations" RENAME COLUMN "modified_by_uuid" TO "modified_by";
+
+ALTER TABLE "sessions" RENAME COLUMN "uuid" TO "id";
+ALTER TABLE "sessions" RENAME COLUMN "user_id_uuid" TO "user_id";
+
+ALTER TABLE "tokens" RENAME COLUMN "uuid" TO "id";
+ALTER TABLE "tokens" RENAME COLUMN "user_id_uuid" TO "user_id";
+ALTER TABLE "tokens" RENAME COLUMN "organization_id_uuid" TO "organization_id";
+
+ALTER TABLE "users" RENAME COLUMN "uuid" TO "id";
+ALTER TABLE "users" RENAME COLUMN "modified_by_uuid" TO "modified_by";
+
+ALTER TABLE "workspaces" RENAME COLUMN "uuid" TO "id";
+ALTER TABLE "workspaces" RENAME COLUMN "organization_id_uuid" TO "organization_id";
+ALTER TABLE "workspaces" RENAME COLUMN "created_by_uuid" TO "created_by";
+ALTER TABLE "workspaces" RENAME COLUMN "modified_by_uuid" TO "modified_by";
+
+
+-- Remove all FK constraints
+
+ALTER TABLE "memberships" DROP CONSTRAINT "memberships_organization_id_organizations_id_fk";
+ALTER TABLE "memberships" DROP CONSTRAINT "memberships_workspace_id_workspaces_id_fk";
+ALTER TABLE "memberships" DROP CONSTRAINT "memberships_user_id_users_id_fk";
+ALTER TABLE "memberships" DROP CONSTRAINT "memberships_created_by_users_id_fk";
+ALTER TABLE "memberships" DROP CONSTRAINT "memberships_modified_by_users_id_fk";
+
+ALTER TABLE "oauth_accounts" DROP CONSTRAINT "oauth_accounts_user_id_users_id_fk";
+
+ALTER TABLE "organizations" DROP CONSTRAINT "organizations_created_by_users_id_fk";
+ALTER TABLE "organizations" DROP CONSTRAINT "organizations_modified_by_users_id_fk";
+
+ALTER TABLE "sessions" DROP CONSTRAINT "sessions_user_id_users_id_fk";
+
+ALTER TABLE "tokens" DROP CONSTRAINT "tokens_user_id_users_id_fk";
+ALTER TABLE "tokens" DROP CONSTRAINT "tokens_organization_id_organizations_id_fk";
+
+ALTER TABLE "users" DROP CONSTRAINT "users_modified_by_users_id_fk";
+
+ALTER TABLE "workspaces" DROP CONSTRAINT "workspaces_organization_id_organizations_id_fk";
+ALTER TABLE "workspaces" DROP CONSTRAINT "workspaces_created_by_users_id_fk";
+ALTER TABLE "workspaces" DROP CONSTRAINT "workspaces_modified_by_users_id_fk";
+
+
+-- Remove old PK constraints. Note: must behind "Remove all FK constraints"
+ALTER TABLE "memberships" DROP CONSTRAINT "memberships_pkey";
+ALTER TABLE "oauth_accounts" DROP CONSTRAINT "oauth_accounts_provider_id_provider_user_id_pk";
+ALTER TABLE "organizations" DROP CONSTRAINT "organizations_pkey";
+ALTER TABLE "sessions" DROP CONSTRAINT "sessions_pkey";
+ALTER TABLE "tokens" DROP CONSTRAINT "tokens_pkey";
+ALTER TABLE "users" DROP CONSTRAINT "users_pkey";
+ALTER TABLE "workspaces" DROP CONSTRAINT "workspaces_pkey";
+
+
+-- set the UUID columns as primary key
+ALTER TABLE "memberships" ADD PRIMARY KEY (id);
+ALTER TABLE "oauth_accounts" ADD PRIMARY KEY (provider_id, provider_user_id);
+ALTER TABLE "organizations" ADD PRIMARY KEY (id);
+ALTER TABLE "sessions" ADD PRIMARY KEY (id);
+ALTER TABLE "tokens" ADD PRIMARY KEY (id);
+ALTER TABLE "users" ADD PRIMARY KEY (id);
+ALTER TABLE "workspaces" ADD PRIMARY KEY (id);
+
+
+-- set new FK constraints. (Just copy from first migrate sql file.)
+DO $$ BEGIN
+ ALTER TABLE "memberships" ADD CONSTRAINT "memberships_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "memberships" ADD CONSTRAINT "memberships_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "memberships" ADD CONSTRAINT "memberships_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "memberships" ADD CONSTRAINT "memberships_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "memberships" ADD CONSTRAINT "memberships_modified_by_users_id_fk" FOREIGN KEY ("modified_by") REFERENCES "users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "oauth_accounts" ADD CONSTRAINT "oauth_accounts_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "organizations" ADD CONSTRAINT "organizations_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "organizations" ADD CONSTRAINT "organizations_modified_by_users_id_fk" FOREIGN KEY ("modified_by") REFERENCES "users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "tokens" ADD CONSTRAINT "tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "tokens" ADD CONSTRAINT "tokens_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "users" ADD CONSTRAINT "users_modified_by_users_id_fk" FOREIGN KEY ("modified_by") REFERENCES "users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "workspaces" ADD CONSTRAINT "workspaces_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "workspaces" ADD CONSTRAINT "workspaces_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "workspaces" ADD CONSTRAINT "workspaces_modified_by_users_id_fk" FOREIGN KEY ("modified_by") REFERENCES "users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+
+-- (optional) delete the old varchar columns
+
+ALTER TABLE "memberships" DROP COLUMN "old_id";
+ALTER TABLE "memberships" DROP COLUMN "old_organization_id";
+ALTER TABLE "memberships" DROP COLUMN "old_workspace_id";
+ALTER TABLE "memberships" DROP COLUMN "old_user_id";
+ALTER TABLE "memberships" DROP COLUMN "old_created_by";
+ALTER TABLE "memberships" DROP COLUMN "old_modified_by";
+
+ALTER TABLE "oauth_accounts" DROP COLUMN "old_user_id";
+
+ALTER TABLE "organizations" DROP COLUMN "old_id";
+ALTER TABLE "organizations" DROP COLUMN "old_created_by";
+ALTER TABLE "organizations" DROP COLUMN "old_modified_by";
+
+ALTER TABLE "sessions" DROP COLUMN "old_id";
+ALTER TABLE "sessions" DROP COLUMN "old_user_id";
+
+ALTER TABLE "tokens" DROP COLUMN "old_id";
+ALTER TABLE "tokens" DROP COLUMN "old_user_id";
+ALTER TABLE "tokens" DROP COLUMN "old_organization_id";
+
+ALTER TABLE "users" DROP COLUMN "old_id";
+ALTER TABLE "users" DROP COLUMN "old_modified_by";
+
+ALTER TABLE "workspaces" DROP COLUMN "old_id";
+ALTER TABLE "workspaces" DROP COLUMN "old_organization_id";
+ALTER TABLE "workspaces" DROP COLUMN "old_created_by";
+ALTER TABLE "workspaces" DROP COLUMN "old_modified_by";
+
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -49,7 +49,6 @@
     "jsonwebtoken": "^9.0.2",
     "locales": "workspace:*",
     "lucia": "^3.1.1",
-    "nanoid": "^5.0.6",
     "node-cron": "^3.0.3",
     "oslo": "^1.1.3",
     "pg": "^8.11.3",

--- a/backend/seed/index.ts
+++ b/backend/seed/index.ts
@@ -7,7 +7,7 @@ import { db } from '../src/db/db';
 import { type InsertMembershipModel, membershipsTable } from '../src/db/schema/memberships';
 import { type InsertOrganizationModel, organizationsTable } from '../src/db/schema/organizations';
 import { type InsertUserModel, usersTable } from '../src/db/schema/users';
-import { nanoid } from '../src/lib/nanoid';
+import { randomUUID } from 'crypto';
 
 // Seed an admin user to access app first time
 export const usersSeed = async () => {
@@ -24,7 +24,7 @@ export const usersSeed = async () => {
   await db
     .insert(usersTable)
     .values({
-      id: nanoid(),
+      id: randomUUID(),
       email,
       emailVerified: true,
       name: 'Admin User',
@@ -57,7 +57,7 @@ export const organizationsAndMembersSeed = async () => {
     const name = organizationsUniqueEnforcer.enforce(() => faker.company.name());
 
     return {
-      id: nanoid(),
+      id: randomUUID(),
       name,
       slug: faker.helpers.slugify(name).toLowerCase(),
       bannerUrl: faker.image.url(),
@@ -96,7 +96,7 @@ export const organizationsAndMembersSeed = async () => {
       );
 
       return {
-        id: nanoid(),
+        id: randomUUID(),
         firstName,
         lastName,
         thumbnailUrl: faker.image.avatar(),
@@ -115,7 +115,7 @@ export const organizationsAndMembersSeed = async () => {
     // Create 100 memberships for each organization
     const memberships: InsertMembershipModel[] = users.map((user) => {
       return {
-        id: nanoid(),
+        id: randomUUID(),
         userId: user.id,
         organizationId: organization.id,
         role: faker.helpers.arrayElement(['ADMIN', 'MEMBER']),

--- a/backend/seed/index.ts
+++ b/backend/seed/index.ts
@@ -7,7 +7,7 @@ import { db } from '../src/db/db';
 import { type InsertMembershipModel, membershipsTable } from '../src/db/schema/memberships';
 import { type InsertOrganizationModel, organizationsTable } from '../src/db/schema/organizations';
 import { type InsertUserModel, usersTable } from '../src/db/schema/users';
-import { randomUUID } from 'crypto';
+
 
 // Seed an admin user to access app first time
 export const usersSeed = async () => {
@@ -24,7 +24,6 @@ export const usersSeed = async () => {
   await db
     .insert(usersTable)
     .values({
-      id: randomUUID(),
       email,
       emailVerified: true,
       name: 'Admin User',
@@ -49,15 +48,12 @@ export const organizationsAndMembersSeed = async () => {
 
   const organizationsUniqueEnforcer = new UniqueEnforcer();
 
-  const organizations: (InsertOrganizationModel & {
-    id: string;
-  })[] = Array.from({
+  let organizations: (InsertOrganizationModel & {})[] = Array.from({
     length: 100,
   }).map(() => {
     const name = organizationsUniqueEnforcer.enforce(() => faker.company.name());
 
     return {
-      id: randomUUID(),
       name,
       slug: faker.helpers.slugify(name).toLowerCase(),
       bannerUrl: faker.image.url(),
@@ -70,7 +66,8 @@ export const organizationsAndMembersSeed = async () => {
     };
   });
 
-  await db.insert(organizationsTable).values(organizations).onConflictDoNothing();
+  organizations = await db.insert(organizationsTable).values(organizations).
+  returning().onConflictDoNothing();
 
   console.info('Create 100 organizations successfully.');
 
@@ -96,7 +93,6 @@ export const organizationsAndMembersSeed = async () => {
       );
 
       return {
-        id: randomUUID(),
         firstName,
         lastName,
         thumbnailUrl: faker.image.avatar(),
@@ -110,12 +106,13 @@ export const organizationsAndMembersSeed = async () => {
       };
     });
 
-    const users = await db.insert(usersTable).values(insertUsers).returning().onConflictDoNothing();
+    const users = await db.insert(usersTable).values(insertUsers).returning({
+        id: usersTable.id,
+    }).onConflictDoNothing();
 
     // Create 100 memberships for each organization
     const memberships: InsertMembershipModel[] = users.map((user) => {
       return {
-        id: randomUUID(),
         userId: user.id,
         organizationId: organization.id,
         role: faker.helpers.arrayElement(['ADMIN', 'MEMBER']),

--- a/backend/src/db/schema/memberships.ts
+++ b/backend/src/db/schema/memberships.ts
@@ -1,31 +1,32 @@
-import { relations } from 'drizzle-orm';
-import { pgTable, timestamp, varchar, boolean } from 'drizzle-orm/pg-core';
+import { relations, sql } from 'drizzle-orm';
+import { pgTable, timestamp, varchar, boolean, uuid } from 'drizzle-orm/pg-core';
 import { organizationsTable } from './organizations';
 import { usersTable } from './users';
 import { workspacesTable } from './workspaces';
-import { nanoid } from '../../lib/nanoid';
+
 
 const roleEnum = ['MEMBER', 'ADMIN'] as const;
 
 export const membershipsTable = pgTable('memberships', {
-  id: varchar('id').primaryKey().$defaultFn(nanoid),
-  organizationId: varchar('organization_id').references(() => organizationsTable.id, { onDelete: 'cascade' }),
+    // defaultRandom() can do same thing, but this way makes it easier to use UUIDv7 in the future.
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  organizationId: uuid('organization_id').references(() => organizationsTable.id, { onDelete: 'cascade' }),
   type: varchar('type', {
     enum: ['ORGANIZATION', 'WORKSPACE'],
   })
     .notNull()
     .default('ORGANIZATION'),
-  workspaceId: varchar('workspace_id').references(() => workspacesTable.id, { onDelete: 'cascade' }),
-  userId: varchar('user_id')
+  workspaceId: uuid('workspace_id').references(() => workspacesTable.id, { onDelete: 'cascade' }),
+  userId: uuid('user_id')
     .notNull()
     .references(() => usersTable.id, { onDelete: 'cascade' }),
   role: varchar('role', { enum: roleEnum }).notNull().default('MEMBER'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
-  createdBy: varchar('created_by').references(() => usersTable.id, {
+  createdBy: uuid('created_by').references(() => usersTable.id, {
     onDelete: 'set null',
   }),
   modifiedAt: timestamp('modified_at'),
-  modifiedBy: varchar('modified_by').references(() => usersTable.id, {
+  modifiedBy: uuid('modified_by').references(() => usersTable.id, {
     onDelete: 'set null',
   }),
   inactive: boolean('inactive').default(false),

--- a/backend/src/db/schema/oauth-accounts.ts
+++ b/backend/src/db/schema/oauth-accounts.ts
@@ -1,4 +1,4 @@
-import { pgTable, primaryKey, timestamp, varchar } from 'drizzle-orm/pg-core';
+import { pgTable, primaryKey, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
 import { usersTable } from './users';
 
 const providerIdEnum = ['GITHUB', 'GOOGLE', 'MICROSOFT'] as const;
@@ -8,7 +8,7 @@ export const oauthAccountsTable = pgTable(
   {
     providerId: varchar('provider_id', { enum: providerIdEnum }).notNull(),
     providerUserId: varchar('provider_user_id').notNull(),
-    userId: varchar('user_id')
+    userId: uuid('user_id')
       .notNull()
       .references(() => usersTable.id, { onDelete: 'cascade' }),
     createdAt: timestamp('created_at').defaultNow().notNull(),

--- a/backend/src/db/schema/organizations.ts
+++ b/backend/src/db/schema/organizations.ts
@@ -1,14 +1,14 @@
 import { config } from 'config';
-import { relations } from 'drizzle-orm';
-import { boolean, index, json, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
-import { nanoid } from '../../lib/nanoid';
+import { relations, sql } from 'drizzle-orm';
+import { boolean, index, json, pgTable, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
+
 import { membershipsTable } from './memberships';
 import { usersTable } from './users';
 
 export const organizationsTable = pgTable(
   'organizations',
   {
-    id: varchar('id').primaryKey().$defaultFn(nanoid),
+    id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
     name: varchar('name').notNull(),
     shortName: varchar('short_name'),
     slug: varchar('slug').unique().notNull(),
@@ -32,11 +32,11 @@ export const organizationsTable = pgTable(
     authStrategies: json('auth_strategies').$type<string[]>(),
     chatSupport: boolean('chat_support').notNull().default(false),
     createdAt: timestamp('created_at').defaultNow().notNull(),
-    createdBy: varchar('created_by').references(() => usersTable.id, {
+    createdBy: uuid('created_by').references(() => usersTable.id, {
       onDelete: 'set null',
     }),
     modifiedAt: timestamp('modified_at'),
-    modifiedBy: varchar('modified_by').references(() => usersTable.id, {
+    modifiedBy: uuid('modified_by').references(() => usersTable.id, {
       onDelete: 'set null',
     }),
   },

--- a/backend/src/db/schema/sessions.ts
+++ b/backend/src/db/schema/sessions.ts
@@ -1,9 +1,9 @@
-import { pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
+import { pgTable, timestamp, uuid } from 'drizzle-orm/pg-core';
 import { usersTable } from './users';
 
 export const sessionsTable = pgTable('sessions', {
-  id: varchar('id').primaryKey(),
-  userId: varchar('user_id')
+  id: uuid('id').primaryKey(),  // Lucia doesn't support default database values.
+  userId: uuid('user_id')
     .notNull()
     .references(() => usersTable.id, { onDelete: 'cascade' }),
   createdAt: timestamp('created_at').defaultNow().notNull(),

--- a/backend/src/db/schema/tokens.ts
+++ b/backend/src/db/schema/tokens.ts
@@ -1,18 +1,19 @@
-import { pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
+import { pgTable, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
 import { organizationsTable } from './organizations';
 import { usersTable } from './users';
+import { sql } from 'drizzle-orm';
 
 const tokenTypeEnum = ['EMAIL_VERIFICATION', 'PASSWORD_RESET', 'SYSTEM_INVITATION', 'ORGANIZATION_INVITATION'] as const;
 
 export const tokensTable = pgTable('tokens', {
-  id: varchar('id').primaryKey(),
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
   type: varchar('type', { enum: tokenTypeEnum }).notNull(),
   email: varchar('email'),
   role: varchar('role', {
     enum: ['ADMIN', 'USER', 'MEMBER'],
   }),
-  userId: varchar('user_id').references(() => usersTable.id, { onDelete: 'cascade' }),
-  organizationId: varchar('organization_id').references(() => organizationsTable.id, { onDelete: 'cascade' }),
+  userId: uuid('user_id').references(() => usersTable.id, { onDelete: 'cascade' }),
+  organizationId: uuid('organization_id').references(() => organizationsTable.id, { onDelete: 'cascade' }),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   expiresAt: timestamp('expires_at', { withTimezone: true, mode: 'date' }).notNull(),
 });

--- a/backend/src/db/schema/users.ts
+++ b/backend/src/db/schema/users.ts
@@ -1,6 +1,6 @@
 import { config } from 'config';
-import { relations } from 'drizzle-orm';
-import { boolean, foreignKey, index, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
+import { relations, sql } from 'drizzle-orm';
+import { boolean, foreignKey, index, pgTable, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
 import { membershipsTable } from './memberships';
 
 const roleEnum = ['USER', 'ADMIN'] as const;
@@ -8,7 +8,7 @@ const roleEnum = ['USER', 'ADMIN'] as const;
 export const usersTable = pgTable(
   'users',
   {
-    id: varchar('id').primaryKey(),
+    id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
     hashedPassword: varchar('hashed_password'),
     slug: varchar('slug').unique().notNull(),
     name: varchar('name').notNull(),
@@ -30,7 +30,7 @@ export const usersTable = pgTable(
     lastSignInAt: timestamp('last_sign_in_at'), // last time user went through authentication flow
     createdAt: timestamp('created_at').defaultNow().notNull(),
     modifiedAt: timestamp('modified_at'),
-    modifiedBy: varchar('modified_by'),
+    modifiedBy: uuid('modified_by'),
     role: varchar('role', { enum: roleEnum }).notNull().default('USER'),
   },
   (table) => {

--- a/backend/src/db/schema/workspaces.ts
+++ b/backend/src/db/schema/workspaces.ts
@@ -1,6 +1,6 @@
-import { relations } from 'drizzle-orm';
-import { index, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
-import { nanoid } from '../../lib/nanoid';
+import { relations, sql } from 'drizzle-orm';
+import { index, pgTable, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
+
 import { usersTable } from './users';
 import { membershipsTable } from './memberships';
 import { organizationsTable } from './organizations';
@@ -8,10 +8,10 @@ import { organizationsTable } from './organizations';
 export const workspacesTable = pgTable(
   'workspaces',
   {
-    id: varchar('id').primaryKey().$defaultFn(nanoid),
+    id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
     name: varchar('name').notNull(),
     slug: varchar('slug').unique().notNull(),
-    organizationId: varchar('organization_id')
+    organizationId: uuid('organization_id')
       .notNull()
       .references(() => organizationsTable.id, {
         onDelete: 'cascade',
@@ -19,11 +19,11 @@ export const workspacesTable = pgTable(
     thumbnailUrl: varchar('thumbnail_url'),
     bannerUrl: varchar('banner_url'),
     createdAt: timestamp('created_at').defaultNow().notNull(),
-    createdBy: varchar('created_by').references(() => usersTable.id, {
+    createdBy: uuid('created_by').references(() => usersTable.id, {
       onDelete: 'set null',
     }),
     modifiedAt: timestamp('modified_at'),
-    modifiedBy: varchar('modified_by').references(() => usersTable.id, {
+    modifiedBy: uuid('modified_by').references(() => usersTable.id, {
       onDelete: 'set null',
     }),
   },

--- a/backend/src/lib/nanoid.ts
+++ b/backend/src/lib/nanoid.ts
@@ -1,3 +1,0 @@
-import { customAlphabet } from 'nanoid';
-
-export const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789');

--- a/backend/src/lib/uuid.ts
+++ b/backend/src/lib/uuid.ts
@@ -1,0 +1,20 @@
+
+export function isUUID(uuid: string) {
+    const s = "" + uuid;
+
+    const result = s.match('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$');
+
+    if (result === null) {
+      return false;
+    }
+    return true;
+}
+
+// When we compare UUID column with non-UUID string, drizzle orm will raise error: "invalid input syntax for type uuid..."
+export function mustBeUUID(uuid: string) {
+    if (isUUID(uuid)) {
+      return uuid;
+    }
+
+    return '00000000-0000-0000-0000-000000000000';
+}

--- a/backend/src/middlewares/guard/tenant.ts
+++ b/backend/src/middlewares/guard/tenant.ts
@@ -7,6 +7,7 @@ import { errorResponse } from '../../lib/errors';
 import type { Env } from '../../types/common';
 import { logEvent } from '../logger/log-event';
 import { type WorkspaceModel, workspacesTable } from '../../db/schema/workspaces';
+import { mustBeUUID } from '../../lib/uuid';
 
 function isOrganization(entity: OrganizationModel | WorkspaceModel): entity is OrganizationModel {
   return !('organizationId' in entity);
@@ -20,7 +21,7 @@ export const getOrganization = async (idOrSlug: string) => {
   const [organization] = await db
     .select()
     .from(organizationsTable)
-    .where(or(eq(organizationsTable.id, idOrSlug), eq(organizationsTable.slug, idOrSlug)));
+    .where(or(eq(organizationsTable.id, mustBeUUID(idOrSlug)), eq(organizationsTable.slug, idOrSlug)));
 
   return organization;
 };
@@ -29,7 +30,7 @@ export const getWorkspace = async (idOrSlug: string) => {
   const [workspace] = await db
     .select()
     .from(workspacesTable)
-    .where(or(eq(workspacesTable.id, idOrSlug), eq(workspacesTable.slug, idOrSlug)));
+    .where(or(eq(workspacesTable.id, mustBeUUID(idOrSlug)), eq(workspacesTable.slug, idOrSlug)));
 
   return workspace;
 };

--- a/backend/src/middlewares/logger/logger.ts
+++ b/backend/src/middlewares/logger/logger.ts
@@ -1,5 +1,5 @@
 import type { MiddlewareHandler } from 'hono/types';
-import { nanoid } from 'nanoid';
+import { randomUUID } from 'crypto';
 
 enum LogPrefix {
   Outgoing = 'res',
@@ -35,7 +35,7 @@ export const logger = (fn: PrintFunc = console.info): MiddlewareHandler => {
     const { method } = c.req;
 
     // Generate logId and set it so we can use it to match error reports
-    const logId = nanoid();
+    const logId = randomUUID();
     c.set('logId', logId);
 
     // Show path with search params

--- a/backend/src/modules/auth/helpers/cookies.ts
+++ b/backend/src/modules/auth/helpers/cookies.ts
@@ -7,6 +7,7 @@ import { db } from '../../../db/db';
 import { auth } from '../../../db/lucia';
 import { usersTable } from '../../../db/schema/users';
 import { logEvent } from '../../../middlewares/logger/log-event';
+import { randomUUID } from 'crypto';
 
 export const setCookie = (ctx: Context, name: string, value: string) =>
   baseSetCookie(ctx, name, value, {
@@ -17,7 +18,9 @@ export const setCookie = (ctx: Context, name: string, value: string) =>
   });
 
 export const setSessionCookie = async (ctx: Context, userId: User['id'], strategy: string) => {
-  const session = await auth.createSession(userId, {});
+  const session = await auth.createSession(userId, {}, {
+    sessionId: randomUUID(),
+  });
   const sessionCookie = auth.createSessionCookie(session.id);
 
   const lastSignInAt = new Date();

--- a/backend/src/modules/auth/helpers/user.ts
+++ b/backend/src/modules/auth/helpers/user.ts
@@ -34,18 +34,19 @@ export const handleCreateUser = async (
   try {
     // * Insert the user into the database
     const [user] = await db.insert(usersTable).values({
-      id: data.id,
       slug: slugAvailable ? data.slug : `${data.slug}-${data.id}`,
       firstName: data.firstName,
       email: data.email.toLowerCase(),
       name: data.name,
       language: config.defaultLanguage,
       hashedPassword: data.hashedPassword,
-    }).returning();
+    }).returning({
+        id: usersTable.id,
+    });
 
     // * If a provider is passed, insert the oauth account
     if (options?.provider) {
-      await insertOauthAccount(data.id, options.provider.id, options.provider.userId);
+      await insertOauthAccount(user.id, options.provider.id, options.provider.userId);
       // await setSessionCookie(ctx, data.id, options.provider.id.toLowerCase());
     }
 

--- a/backend/src/modules/auth/index.ts
+++ b/backend/src/modules/auth/index.ts
@@ -59,7 +59,6 @@ const authRoutes = app
 
     // * hash password
     const hashedPassword = await new Argon2id().hash(password);
-    const userId = randomUUID();
 
     const slug = slugFromEmail(email);
 
@@ -69,7 +68,6 @@ const authRoutes = app
     return await handleCreateUser(
       ctx,
       {
-        id: userId,
         slug,
         name: slug,
         email: email.toLowerCase(),

--- a/backend/src/modules/auth/index.ts
+++ b/backend/src/modules/auth/index.ts
@@ -1,6 +1,6 @@
 import { render } from '@react-email/render';
 import { eq } from 'drizzle-orm';
-import { generateId } from 'lucia';
+
 import { TimeSpan, createDate, isWithinExpirationDate } from 'oslo';
 import { VerificationEmail } from '../../../../email/emails/email-verification';
 import { ResetPasswordEmail } from '../../../../email/emails/reset-password';
@@ -15,7 +15,7 @@ import { tokensTable } from '../../db/schema/tokens';
 import { usersTable } from '../../db/schema/users';
 import { errorResponse } from '../../lib/errors';
 import { i18n } from '../../lib/i18n';
-import { nanoid } from '../../lib/nanoid';
+import { randomUUID } from 'crypto';
 import { logEvent } from '../../middlewares/logger/log-event';
 import { CustomHono } from '../../types/common';
 import { transformDatabaseUser } from '../users/helpers/transform-database-user';
@@ -59,7 +59,7 @@ const authRoutes = app
 
     // * hash password
     const hashedPassword = await new Argon2id().hash(password);
-    const userId = nanoid();
+    const userId = randomUUID();
 
     const slug = slugFromEmail(email);
 
@@ -155,7 +155,7 @@ const authRoutes = app
 
     // * creating email verification token
     await db.delete(tokensTable).where(eq(tokensTable.userId, user.id));
-    const token = generateId(40);
+    const token = randomUUID();
     await db.insert(tokensTable).values({
       id: token,
       type: 'EMAIL_VERIFICATION',
@@ -214,7 +214,7 @@ const authRoutes = app
 
     // * creating password reset token
     await db.delete(tokensTable).where(eq(tokensTable.userId, user.id));
-    const token = generateId(40);
+    const token = randomUUID();
     await db.insert(tokensTable).values({
       id: token,
       type: 'PASSWORD_RESET',

--- a/backend/src/modules/auth/oauth.ts
+++ b/backend/src/modules/auth/oauth.ts
@@ -9,7 +9,6 @@ import { db } from '../../db/db';
 import { githubAuth, googleAuth, microsoftAuth } from '../../db/lucia';
 import { tokensTable } from '../../db/schema/tokens';
 import { errorResponse } from '../../lib/errors';
-import { randomUUID } from 'crypto';
 import { logEvent } from '../../middlewares/logger/log-event';
 import { CustomHono } from '../../types/common';
 import { setSessionCookie } from './helpers/cookies';
@@ -197,13 +196,11 @@ const oauthRoutes = app
         });
       }
 
-      const userId = randomUUID();
 
       // * Create new user and oauth account
       return await handleCreateUser(
         ctx,
         {
-          id: userId,
           slug: slugify(githubUser.login, { lower: true }),
           email: primaryEmail.email.toLowerCase(),
           name: githubUser.name || githubUser.login,
@@ -294,13 +291,10 @@ const oauthRoutes = app
         });
       }
 
-      const userId = randomUUID();
-
       // * Create new user and oauth account
       return await handleCreateUser(
         ctx,
         {
-          id: userId,
           slug: slugFromEmail(user.email),
           email: user.email.toLowerCase(),
           name: user.given_name,
@@ -391,13 +385,10 @@ const oauthRoutes = app
         });
       }
 
-      const userId = randomUUID();
-
       // * Create new user and oauth account
       return await handleCreateUser(
         ctx,
         {
-          id: userId,
           slug: slugFromEmail(user.email),
           language: config.defaultLanguage,
           email: user.email.toLowerCase(),

--- a/backend/src/modules/auth/oauth.ts
+++ b/backend/src/modules/auth/oauth.ts
@@ -9,7 +9,7 @@ import { db } from '../../db/db';
 import { githubAuth, googleAuth, microsoftAuth } from '../../db/lucia';
 import { tokensTable } from '../../db/schema/tokens';
 import { errorResponse } from '../../lib/errors';
-import { nanoid } from '../../lib/nanoid';
+import { randomUUID } from 'crypto';
 import { logEvent } from '../../middlewares/logger/log-event';
 import { CustomHono } from '../../types/common';
 import { setSessionCookie } from './helpers/cookies';
@@ -197,7 +197,7 @@ const oauthRoutes = app
         });
       }
 
-      const userId = nanoid();
+      const userId = randomUUID();
 
       // * Create new user and oauth account
       return await handleCreateUser(
@@ -294,7 +294,7 @@ const oauthRoutes = app
         });
       }
 
-      const userId = nanoid();
+      const userId = randomUUID();
 
       // * Create new user and oauth account
       return await handleCreateUser(
@@ -391,7 +391,7 @@ const oauthRoutes = app
         });
       }
 
-      const userId = nanoid();
+      const userId = randomUUID();
 
       // * Create new user and oauth account
       return await handleCreateUser(

--- a/backend/src/modules/general/index.ts
+++ b/backend/src/modules/general/index.ts
@@ -186,7 +186,9 @@ const generalRoutes = app
               role: (role as MembershipModel['role']) || 'MEMBER',
               createdBy: user.id,
             })
-            .returning();
+            .returning({
+                id: membershipsTable.id,
+            });
 
           logEvent('User added to organization', { user: user.id, organization: organization.id });
 

--- a/backend/src/modules/general/index.ts
+++ b/backend/src/modules/general/index.ts
@@ -7,7 +7,8 @@ import { config } from 'config';
 import { env } from 'env';
 import { streamSSE, type SSEStreamingApi } from 'hono/streaming';
 import jwt from 'jsonwebtoken';
-import { type User, generateId } from 'lucia';
+import { type User } from 'lucia';
+import { randomUUID } from 'crypto';
 import { TimeSpan, createDate, isWithinExpirationDate } from 'oslo';
 
 import { db } from '../../db/db';
@@ -198,7 +199,7 @@ const generalRoutes = app
         }
       }
 
-      const token = generateId(40);
+      const token = randomUUID();
       await db.insert(tokensTable).values({
         id: token,
         type: organization ? 'ORGANIZATION_INVITATION' : 'SYSTEM_INVITATION',

--- a/backend/src/modules/organizations/index.ts
+++ b/backend/src/modules/organizations/index.ts
@@ -47,7 +47,9 @@ const organizationsRoutes = app
         defaultLanguage: config.defaultLanguage,
         createdBy: user.id,
       })
-      .returning();
+      .returning({
+        id: organizationsTable.id,
+      });
 
     logEvent('Organization created', { organization: createdOrganization.id });
 

--- a/backend/src/modules/users/index.ts
+++ b/backend/src/modules/users/index.ts
@@ -23,6 +23,7 @@ import {
   terminateSessionsConfig,
   updateUserConfig,
 } from './routes';
+import { mustBeUUID } from '../../lib/uuid';
 
 const app = new CustomHono();
 
@@ -346,7 +347,7 @@ const usersRoutes = app
     const [targetUser] = await db
       .select()
       .from(usersTable)
-      .where(or(eq(usersTable.id, idOrSlug), eq(usersTable.slug, idOrSlug)));
+      .where(or(eq(usersTable.id, mustBeUUID(idOrSlug)), eq(usersTable.slug, idOrSlug)));
 
     if (!targetUser) {
       return errorResponse(ctx, 404, 'not_found', 'warn', 'USER', { user: idOrSlug });

--- a/backend/src/modules/workspaces/index.ts
+++ b/backend/src/modules/workspaces/index.ts
@@ -35,7 +35,9 @@ const workspacesRoutes = app
         name,
         slug,
       })
-      .returning();
+      .returning({
+        id: workspacesTable.id,
+      });
 
     logEvent('Workspace created', { workspace: createdWorkspace.id });
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -119,7 +119,6 @@
     "lodash.clonedeep": "^4.5.0",
     "lowlight": "^3.1.0",
     "lucide-react": "^0.358.0",
-    "nanoid": "^5.0.4",
     "react": "^18.2.0",
     "react-colorful": "^5.6.1",
     "react-confetti-explosion": "^2.1.2",

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import calendar from 'dayjs/plugin/calendar';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import i18next from 'i18next';
-import { customAlphabet } from 'nanoid';
+
 import * as React from 'react';
 import { twMerge } from 'tailwind-merge';
 
@@ -27,8 +27,8 @@ export function dateShort(date?: string | null) {
   });
 }
 
-// nanoid with only lowercase letters and numbers
-export const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789');
+
+
 
 // Merge tailwind classes
 export function cn(...inputs: ClassValue[]) {

--- a/frontend/src/modules/tiptap/extensions/ImageBlock/components/ImageBlockMenu.tsx
+++ b/frontend/src/modules/tiptap/extensions/ImageBlock/components/ImageBlockMenu.tsx
@@ -1,5 +1,5 @@
 import { BubbleMenu as BaseBubbleMenu } from '@tiptap/react';
-import { nanoid } from 'nanoid';
+
 import { useCallback, useRef } from 'react';
 import { type Instance, sticky } from 'tippy.js';
 
@@ -48,7 +48,7 @@ export const ImageBlockMenu = ({ editor, appendTo }: MenuProps): JSX.Element => 
   return (
     <BaseBubbleMenu
       editor={editor}
-      pluginKey={`imageBlockMenu-${nanoid()}`}
+      pluginKey={`imageBlockMenu-${window.crypto.randomUUID()}`}
       shouldShow={shouldShow}
       updateDelay={0}
       tippyOptions={{

--- a/frontend/src/modules/tiptap/extensions/MultiColumn/menus/ColumnsMenu.tsx
+++ b/frontend/src/modules/tiptap/extensions/MultiColumn/menus/ColumnsMenu.tsx
@@ -1,5 +1,5 @@
 import { BubbleMenu as BaseBubbleMenu } from '@tiptap/react';
-import { nanoid } from 'nanoid';
+
 import { useCallback } from 'react';
 import { sticky } from 'tippy.js';
 
@@ -37,7 +37,7 @@ export const ColumnsMenu = ({ editor, appendTo }: MenuProps) => {
   return (
     <BaseBubbleMenu
       editor={editor}
-      pluginKey={`columnsMenu-${nanoid()}`}
+      pluginKey={`columnsMenu-${window.crypto.randomUUID()}`}
       shouldShow={shouldShow}
       updateDelay={0}
       tippyOptions={{


### PR DESCRIPTION
I don't know how you are going to deal with DB migration, so I just created a sql file "backend/drizzle/uuid_pk.sql", and it should be tested carefully.

The last commit is about generating UUID by Postgres. This way is easier to use UUIDv7 in the future, and it's more suitable for Cella to cooperate with other systems and other languages.

If you want to check the code that generates the UUID by TS code, please check the next to last commit "Migrate to UUID primary keys", thanks.
