### PR TITLE
refactor: offset on infinite queries

### DIFF
--- a/frontend/src/hooks/use-data-from-query.tsx
+++ b/frontend/src/hooks/use-data-from-query.tsx
@@ -1,28 +1,20 @@
 import { type InfiniteData, type QueryKey, useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
+import type { QueryData } from '~/modules/common/query-client-provider/types';
 
-interface TQueryFnData<T> {
-  items: T[];
-  total: number;
-}
-
-type OptionsCallback<T, TQueryKey extends QueryKey = QueryKey> = (params: { rowsLength: number }) => Parameters<
+type Options<T, TQueryKey extends QueryKey = QueryKey> = Parameters<
   typeof useSuspenseInfiniteQuery<T, Error, InfiniteData<T, unknown>, TQueryKey, number>
 >[0];
 
 // Custom hook to map query result data to rows
 export const useDataFromSuspenseInfiniteQuery = <T extends { id: string } = { id: string }, TQueryKey extends QueryKey = QueryKey>(
-  optionsCallback: OptionsCallback<TQueryFnData<T>, TQueryKey>,
+  options: Options<QueryData<T>, TQueryKey>,
 ) => {
   const [rows, setRows] = useState<T[]>([]);
   const [selectedRows, setSelectedRows] = useState(new Set<string>());
   const [totalCount, setTotalCount] = useState(0);
 
-  const queryResult = useSuspenseInfiniteQuery(
-    optionsCallback({
-      rowsLength: rows.length,
-    }),
-  );
+  const queryResult = useSuspenseInfiniteQuery(options);
 
   useEffect(() => {
     // Flatten the array of pages to get all items

--- a/frontend/src/modules/organizations/attachments-table/helpers/query-options.ts
+++ b/frontend/src/modules/organizations/attachments-table/helpers/query-options.ts
@@ -2,23 +2,15 @@ import { infiniteQueryOptions } from '@tanstack/react-query';
 import { config } from 'config';
 import { type GetAttachmentsParams, getAttachments } from '~/api/attachments';
 import { attachmentKeys } from '~/modules/common/query-client-provider/attachments';
+import { getPaginatedOffset } from '~/utils/mutate-query';
 
 const LIMIT = config.requestLimits.attachments;
 
 // Build query to get attachments with infinite scroll
-export const attachmentsQueryOptions = ({
-  orgIdOrSlug,
-  q = '',
-  sort: initialSort,
-  order: initialOrder,
-  limit = LIMIT,
-  rowsLength = 0,
-}: GetAttachmentsParams & {
-  rowsLength?: number;
-}) => {
+export const attachmentsQueryOptions = ({ orgIdOrSlug, q = '', sort: initialSort, order: initialOrder, limit = LIMIT }: GetAttachmentsParams) => {
   const sort = initialSort || 'createdAt';
   const order = initialOrder || 'desc';
-  const offset = rowsLength;
+  const offset = getPaginatedOffset(attachmentKeys.list({ orgIdOrSlug, q, sort, order }));
 
   return infiniteQueryOptions({
     queryKey: attachmentKeys.list({ orgIdOrSlug, q, sort, order }),

--- a/frontend/src/modules/organizations/attachments-table/index.tsx
+++ b/frontend/src/modules/organizations/attachments-table/index.tsx
@@ -73,15 +73,13 @@ const AttachmentsTable = ({ organization, isSheet = false }: AttachmentsTablePro
 
   // Query attachments
   const { rows, selectedRows, setRows, setSelectedRows, totalCount, isLoading, isFetching, error, fetchNextPage } = useDataFromSuspenseInfiniteQuery(
-    ({ rowsLength }) =>
-      attachmentsQueryOptions({
-        orgIdOrSlug: organization.id,
-        q,
-        sort,
-        order,
-        limit,
-        rowsLength,
-      }),
+    attachmentsQueryOptions({
+      orgIdOrSlug: organization.id,
+      q,
+      sort,
+      order,
+      limit,
+    }),
   );
 
   const openPreviewDialog = useCallback(
@@ -130,7 +128,6 @@ const AttachmentsTable = ({ organization, isSheet = false }: AttachmentsTablePro
   // Clear selected rows on search
   const onSearch = (searchString: string) => {
     if (selectedRows.size > 0) setSelectedRows(new Set<string>());
-    setRows([]); // to set offset of a new query to 0
     setQuery(searchString);
   };
 
@@ -140,9 +137,7 @@ const AttachmentsTable = ({ organization, isSheet = false }: AttachmentsTablePro
 
     if (column.key === 'name') {
       // If name is changed, update the attachment
-      for (const index of indexes) {
-        updateAttachmentName(changedRows[index]);
-      }
+      for (const index of indexes) updateAttachmentName(changedRows[index]);
     }
 
     setRows(changedRows);

--- a/frontend/src/modules/organizations/members-table/helpers/query-options.ts
+++ b/frontend/src/modules/organizations/members-table/helpers/query-options.ts
@@ -2,6 +2,7 @@ import { infiniteQueryOptions } from '@tanstack/react-query';
 import { config } from 'config';
 import { type GetMembersParams, getMembers } from '~/api/memberships';
 import { membersKeys } from '~/modules/common/query-client-provider/members/keys';
+import { getPaginatedOffset } from '~/utils/mutate-query';
 
 const LIMIT = config.requestLimits.members;
 
@@ -15,13 +16,10 @@ export const membersQueryOptions = ({
   order: initialOrder,
   role,
   limit = LIMIT,
-  rowsLength = 0,
-}: GetMembersParams & {
-  rowsLength?: number;
-}) => {
+}: GetMembersParams) => {
   const sort = initialSort || 'createdAt';
   const order = initialOrder || 'desc';
-  const offset = rowsLength;
+  const offset = getPaginatedOffset(membersKeys.list({ idOrSlug, entityType, orgIdOrSlug, q, sort, order, role }));
 
   return infiniteQueryOptions({
     queryKey: membersKeys.list({ idOrSlug, entityType, orgIdOrSlug, q, sort, order, role }),

--- a/frontend/src/modules/organizations/members-table/index.tsx
+++ b/frontend/src/modules/organizations/members-table/index.tsx
@@ -69,18 +69,16 @@ const MembersTable = ({ entity, isSheet = false }: MembersTableProps) => {
 
   // Query members
   const { rows, selectedRows, setRows, setSelectedRows, totalCount, isLoading, isFetching, error, fetchNextPage } = useDataFromSuspenseInfiniteQuery(
-    ({ rowsLength }) =>
-      membersQueryOptions({
-        idOrSlug: entity.slug,
-        entityType,
-        orgIdOrSlug: organizationId,
-        q,
-        sort,
-        order,
-        role,
-        limit,
-        rowsLength,
-      }),
+    membersQueryOptions({
+      idOrSlug: entity.slug,
+      entityType,
+      orgIdOrSlug: organizationId,
+      q,
+      sort,
+      order,
+      role,
+      limit,
+    }),
   );
 
   // Save filters in search params
@@ -109,13 +107,11 @@ const MembersTable = ({ entity, isSheet = false }: MembersTableProps) => {
   // Drop selected rows on search
   const onSearch = (searchString: string) => {
     if (selectedRows.size > 0) setSelectedRows(new Set<string>());
-    setRows([]); // to set offset of a new query to 0
     setQuery(searchString);
   };
 
   const onRoleChange = (role?: string) => {
     setSelectedRows(new Set<string>());
-    setRows([]); // to set offset of a new query to 0
     setRole(role === 'all' ? undefined : (role as MemberSearch['role']));
   };
 

--- a/frontend/src/modules/organizations/organizations-table/helpers/query-options.ts
+++ b/frontend/src/modules/organizations/organizations-table/helpers/query-options.ts
@@ -1,24 +1,19 @@
 import { infiniteQueryOptions } from '@tanstack/react-query';
 import { config } from 'config';
 import { type GetOrganizationsParams, getOrganizations } from '~/api/organizations';
+import { getPaginatedOffset } from '~/utils/mutate-query';
 
 const LIMIT = config.requestLimits.organizations;
 
-export const organizationsQueryOptions = ({
-  q = '',
-  sort: initialSort,
-  order: initialOrder,
-  limit = LIMIT,
-  rowsLength = 0,
-}: GetOrganizationsParams & {
-  rowsLength?: number;
-}) => {
+export const organizationsQueryOptions = ({ q = '', sort: initialSort, order: initialOrder, limit = LIMIT }: GetOrganizationsParams) => {
   const sort = initialSort || 'createdAt';
   const order = initialOrder || 'desc';
-  const offset = rowsLength;
+
+  const queryKey = ['organizations', 'list', q, sort, order];
+  const offset = getPaginatedOffset(queryKey);
 
   return infiniteQueryOptions({
-    queryKey: ['organizations', 'list', q, sort, order],
+    queryKey,
     initialPageParam: 0,
     retry: 1,
     refetchOnWindowFocus: false,

--- a/frontend/src/modules/organizations/organizations-table/index.tsx
+++ b/frontend/src/modules/organizations/organizations-table/index.tsx
@@ -63,7 +63,7 @@ const OrganizationsTable = () => {
 
   // Query organizations
   const { rows, selectedRows, setRows, setSelectedRows, totalCount, isLoading, isFetching, error, fetchNextPage } = useDataFromSuspenseInfiniteQuery(
-    ({ rowsLength }) => organizationsQueryOptions({ q, sort, order, limit, rowsLength }),
+    organizationsQueryOptions({ q, sort, order, limit }),
   );
 
   const mutateQuery = useMutateQueryData(['organizations', 'list']);
@@ -78,7 +78,6 @@ const OrganizationsTable = () => {
   // Drop selected rows on search
   const onSearch = (searchString: string) => {
     if (selectedRows.size > 0) setSelectedRows(new Set<string>());
-    setRows([]); // to set offset of a new query to 0
     setQuery(searchString);
   };
   // Table selection

--- a/frontend/src/modules/system/requests-table/index.tsx
+++ b/frontend/src/modules/system/requests-table/index.tsx
@@ -28,25 +28,20 @@ import type { Request } from '~/types/common';
 
 import Export from '~/modules/common/data-table/export';
 import { useColumns } from '~/modules/system/requests-table/columns';
+import { getPaginatedOffset } from '~/utils/mutate-query';
 type RequestsSearch = z.infer<typeof getRequestsQuerySchema>;
 
 const LIMIT = config.requestLimits.requests;
 
-export const requestsQueryOptions = ({
-  q = '',
-  sort: initialSort,
-  order: initialOrder,
-  limit = LIMIT,
-  rowsLength = 0,
-}: GetRequestsParams & {
-  rowsLength?: number;
-}) => {
+export const requestsQueryOptions = ({ q = '', sort: initialSort, order: initialOrder, limit = LIMIT }: GetRequestsParams) => {
   const sort = initialSort || 'createdAt';
   const order = initialOrder || 'desc';
-  const offset = rowsLength;
+
+  const queryKey = ['requests', 'list', q, sort, order];
+  const offset = getPaginatedOffset(queryKey);
 
   return infiniteQueryOptions({
-    queryKey: ['requests', 'list', q, sort, order],
+    queryKey,
     initialPageParam: 0,
     retry: 1,
     refetchOnWindowFocus: false,
@@ -72,12 +67,11 @@ const RequestsTable = () => {
 
   // Query requests
   const { rows, selectedRows, setRows, setSelectedRows, totalCount, isLoading, isFetching, error, fetchNextPage } = useDataFromSuspenseInfiniteQuery(
-    ({ rowsLength }) => requestsQueryOptions({ q, sort, order, limit, rowsLength }),
+    requestsQueryOptions({ q, sort, order, limit }),
   );
 
   const onSearch = (searchString: string) => {
     if (selectedRows.size > 0) setSelectedRows(new Set<string>());
-    setRows([]); // to set offset of a new query to 0
     setQuery(searchString);
   };
 

--- a/frontend/src/modules/users/users-table/helpers/query-options.ts
+++ b/frontend/src/modules/users/users-table/helpers/query-options.ts
@@ -1,25 +1,19 @@
 import { infiniteQueryOptions } from '@tanstack/react-query';
 import { config } from 'config';
 import { type GetUsersParams, getUsers } from '~/api/users';
+import { getPaginatedOffset } from '~/utils/mutate-query';
 
 const LIMIT = config.requestLimits.users;
 
-export const usersQueryOptions = ({
-  q = '',
-  sort: initialSort,
-  order: initialOrder,
-  role,
-  limit = LIMIT,
-  rowsLength = 0,
-}: GetUsersParams & {
-  rowsLength?: number;
-}) => {
+export const usersQueryOptions = ({ q = '', sort: initialSort, order: initialOrder, role, limit = LIMIT }: GetUsersParams) => {
   const sort = initialSort || 'createdAt';
   const order = initialOrder || 'desc';
-  const offset = rowsLength;
+
+  const queryKey = ['users', 'list', q, sort, order, role];
+  const offset = getPaginatedOffset(queryKey);
 
   return infiniteQueryOptions({
-    queryKey: ['users', 'list', q, sort, order, role],
+    queryKey,
     initialPageParam: 0,
     refetchOnWindowFocus: false,
     retry: 1,

--- a/frontend/src/modules/users/users-table/index.tsx
+++ b/frontend/src/modules/users/users-table/index.tsx
@@ -61,7 +61,7 @@ const UsersTable = () => {
 
   // Query users
   const { rows, selectedRows, setRows, setSelectedRows, totalCount, isLoading, isFetching, error, fetchNextPage } = useDataFromSuspenseInfiniteQuery(
-    ({ rowsLength }) => usersQueryOptions({ q, sort, order, role, limit, rowsLength }),
+    usersQueryOptions({ q, sort, order, role, limit }),
   );
 
   // Save filters in search params
@@ -98,14 +98,12 @@ const UsersTable = () => {
   // Drop selected Rows on search
   const onSearch = (searchString: string) => {
     if (selectedRows.size > 0) setSelectedRows(new Set<string>());
-    setRows([]); // to set offset of a new query to 0
     setQuery(searchString);
   };
 
   // Change role filter
   const onRoleChange = (role?: string) => {
     setSelectedRows(new Set<string>());
-    setRows([]); // to set offset of a new query to 0
     setRole(role === 'all' ? undefined : (role as SystemRoles));
   };
 

--- a/frontend/src/utils/mutate-query.ts
+++ b/frontend/src/utils/mutate-query.ts
@@ -123,3 +123,11 @@ const getSimilar = <T>(passedQueryKey: QueryKey): [QueryKey, InfiniteQueryData<T
     queryKey: passedQueryKey,
   });
 };
+
+export function getPaginatedOffset<T>(queryKey: QueryKey): number {
+  const queryData = queryClient.getQueryData<InfiniteQueryData<T>>(queryKey);
+
+  if (!queryData?.pages) return 0;
+
+  return queryData.pages.reduce((count, page) => count + (page.items?.length || 0), 0);
+}


### PR DESCRIPTION
Set up the offset to get it from existing queries to avoid issues with dropping the rows' length when query parameters change. And update useDataFromSuspenseInfiniteQuery hook 