### PR TITLE
add: query params for shape proxy

### DIFF
--- a/backend/src/modules/attachments/handlers.ts
+++ b/backend/src/modules/attachments/handlers.ts
@@ -1,8 +1,3 @@
-import { OpenAPIHono } from '@hono/zod-openapi';
-import { appConfig } from 'config';
-import { and, count, eq, ilike, inArray, or, type SQL } from 'drizzle-orm';
-import { html, raw } from 'hono/html';
-import { stream } from 'hono/streaming';
 import { db } from '#/db/db';
 import { attachmentsTable } from '#/db/schema/attachments';
 import { organizationsTable } from '#/db/schema/organizations';
@@ -19,6 +14,11 @@ import { logEvent } from '#/utils/logger';
 import { nanoid } from '#/utils/nanoid';
 import { getOrderColumn } from '#/utils/order-column';
 import { prepareStringForILikeFilter } from '#/utils/sql';
+import { OpenAPIHono } from '@hono/zod-openapi';
+import { appConfig } from 'config';
+import { and, count, eq, ilike, inArray, or, type SQL } from 'drizzle-orm';
+import { html, raw } from 'hono/html';
+import { stream } from 'hono/streaming';
 
 const app = new OpenAPIHono<Env>({ defaultHook });
 
@@ -28,27 +28,31 @@ const attachmentsRouteHandlers = app
    * Hono handlers are executed in registration order, so registered first to avoid route collisions.
    */
   .openapi(attachmentRoutes.shapeProxy, async (ctx) => {
-    const url = new URL(ctx.req.url);
+    const { live, handle, offset, cursor, where, table } = ctx.req.valid('query');
+
+    if (table !== 'attachments') {
+      throw new AppError({ status: 403, type: 'forbidden', severity: 'warn', meta: { toastMessage: 'Denied: table name mismatch.' } });
+    }
+
+    if (!where)
+      throw new AppError({ status: 403, type: 'forbidden', severity: 'warn', meta: { toastMessage: 'Denied: no organization ID provided.' } });
+    // Extract organization IDs from `where` clause
+    const [requestedOrganizationId] = [...where.matchAll(/organization_id = '([^']+)'/g)].map((m) => m[1]);
     const organization = getContextOrganization();
 
-    // Extract organization IDs from `where` clause
-    const whereParam = url.searchParams.get('where') ?? '';
-    const [requestedOrganizationId] = [...whereParam.matchAll(/organization_id = '([^']+)'/g)].map((m) => m[1]);
-
-    if (requestedOrganizationId !== organization.id) {
+    if (requestedOrganizationId !== organization.id)
       throw new AppError({ status: 403, type: 'forbidden', severity: 'warn', meta: { toastMessage: 'Denied: organization mismatch.' } });
-    }
 
     // Construct the upstream URL
     const originUrl = new URL(`${appConfig.electricUrl}/v1/shape?table=attachments&api_secret=${env.ELECTRIC_API_SECRET}`);
 
     // Copy over the relevant query params that the Electric client adds
     // so that we return the right part of the Shape log.
-    url.searchParams.forEach((value, key) => {
-      if (['live', 'handle', 'offset', 'cursor', 'where'].includes(key)) {
-        originUrl.searchParams.set(key, value);
-      }
-    });
+    originUrl.searchParams.set('offset', offset);
+    originUrl.searchParams.set('live', live ?? 'false');
+    if (handle) originUrl.searchParams.set('handle', handle);
+    if (cursor) originUrl.searchParams.set('cursor', cursor);
+    if (where) originUrl.searchParams.set('where', where);
 
     try {
       const { body, headers, status, statusText } = await fetch(originUrl.toString());

--- a/backend/src/modules/attachments/routes.ts
+++ b/backend/src/modules/attachments/routes.ts
@@ -1,9 +1,9 @@
-import { z } from '@hono/zod-openapi';
 import { createCustomRoute } from '#/lib/custom-routes';
 import { hasOrgAccess, isAuthenticated, isPublicAccess } from '#/middlewares/guard';
 import { attachmentCreateManySchema, attachmentListQuerySchema, attachmentSchema, attachmentUpdateBodySchema } from '#/modules/attachments/schema';
-import { idInOrgParamSchema, idSchema, idsBodySchema, inOrgParamSchema } from '#/utils/schema/common';
+import { baseElectrycSyncQuery, idInOrgParamSchema, idSchema, idsBodySchema, inOrgParamSchema } from '#/utils/schema/common';
 import { errorResponses, paginationSchema, successWithRejectedItemsSchema } from '#/utils/schema/responses';
+import { z } from '@hono/zod-openapi';
 
 const attachmentRoutes = {
   createAttachments: createCustomRoute({
@@ -154,7 +154,7 @@ const attachmentRoutes = {
     description: `Proxies requests to ElectricSQL\'s shape endpoint for the \`attachments\` table.
       Used by clients to synchronize local data with server state via the shape log system.
       This endpoint ensures required query parameters are forwarded and response headers are adjusted for browser compatibility.`,
-    request: { params: inOrgParamSchema },
+    request: { query: baseElectrycSyncQuery, params: inOrgParamSchema },
     responses: {
       200: {
         description: 'Success',

--- a/backend/src/utils/schema/common.ts
+++ b/backend/src/utils/schema/common.ts
@@ -154,3 +154,17 @@ export const validDomainsSchema = z
       .transform((str) => str.toLowerCase().trim()),
   )
   .optional();
+
+/**
+ * Schema for Electric sync target query parameters.
+ * These are typically passed as query string parameters to define
+ * the shape of a synchronization query used by ElectricSQL.
+ */
+export const baseElectrycSyncQuery = z.object({
+  table: z.string(),
+  offset: z.string(),
+  handle: z.string().optional(),
+  cursor: z.string().optional(),
+  live: z.string().optional(),
+  where: z.string().optional(),
+});

--- a/frontend/src/api.gen/sdk.gen.ts
+++ b/frontend/src/api.gen/sdk.gen.ts
@@ -1719,6 +1719,12 @@ export const getPublicCounts = <ThrowOnError extends boolean = true>(options?: O
  *
  * @param {shapeProxyData} options
  * @param {string | string} options.path.orgidorslug - `string | string`
+ * @param {string} options.query.table - `string`
+ * @param {string} options.query.offset - `string`
+ * @param {string=} options.query.handle - `string` (optional)
+ * @param {string=} options.query.cursor - `string` (optional)
+ * @param {string=} options.query.live - `string` (optional)
+ * @param {string=} options.query.where - `string` (optional)
  * @returns Possible status codes: 200, 400, 401, 403, 404, 429
  */
 export const shapeProxy = <ThrowOnError extends boolean = true>(options: Options<ShapeProxyData, ThrowOnError>) => {

--- a/frontend/src/api.gen/types.gen.ts
+++ b/frontend/src/api.gen/types.gen.ts
@@ -3435,7 +3435,14 @@ export type ShapeProxyData = {
   path: {
     orgIdOrSlug: string;
   };
-  query?: never;
+  query: {
+    table: string;
+    offset: string;
+    handle?: string;
+    cursor?: string;
+    live?: string;
+    where?: string;
+  };
   url: '/{orgIdOrSlug}/attachments/shape-proxy';
 };
 

--- a/frontend/src/api.gen/zod.gen.ts
+++ b/frontend/src/api.gen/zod.gen.ts
@@ -1436,7 +1436,14 @@ export const zShapeProxyData = z.object({
   path: z.object({
     orgIdOrSlug: z.string(),
   }),
-  query: z.optional(z.never()),
+  query: z.object({
+    table: z.string(),
+    offset: z.string(),
+    handle: z.optional(z.string()),
+    cursor: z.optional(z.string()),
+    live: z.optional(z.string()),
+    where: z.optional(z.string()),
+  }),
 });
 
 export const zDeleteAttachmentsData = z.object({


### PR DESCRIPTION
I’m not sure if we need this, but it gives us more control over the request.

The Electric docs specify its usage like this:
```
 // Copy over the relevant query params that the Electric client adds
  // so that we return the right part of the Shape log.
  url.searchParams.forEach((value, key) => {
    if ([`live`, `table`, `handle`, `offset`, `cursor`].includes(key)) {
      originUrl.searchParams.set(key, value)
    }
  })
```