### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,8 @@ jobs:
 
   # Generates draft release notes (for testing only)
   draft-release-notes:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Potential fix for [https://github.com/cellajs/cella/security/code-scanning/27](https://github.com/cellajs/cella/security/code-scanning/27)

The best fix is to explicitly add a `permissions` block to the `draft-release-notes` job in `.github/workflows/ci.yml`, granting only `contents: read`. This ensures the job cannot use the GITHUB_TOKEN for any write actions, preventing accidental or malicious repository changes by workflow steps. To implement this, add the following lines at the same indentation as `runs-on:` under the `draft-release-notes:` job, i.e., immediately after line 154 (or before `runs-on:` as the first property in the job block for readability). No additional imports or definitions are needed, since this is a declarative change in the workflow YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
