### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
 
   # Will run a quick startup check to ensure the app starts without issues
   quick:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [lint, test]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,8 @@ jobs:
 
   # Generates draft release notes (for testing only)
   draft-release-notes:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Potential fix for [https://github.com/cellajs/cella/security/code-scanning/26](https://github.com/cellajs/cella/security/code-scanning/26)

The best way to fix the problem is to explicitly add a least-privilege `permissions` block to the `quick` job. Since the `quick` job only runs some commands locally and does not interact with GitHub through the GITHUB_TOKEN, it should have `contents: read` as a minimal starting point.  
This is done by adding:
```yaml
permissions:
  contents: read
```
immediately under the job name (i.e., under `quick:` and before `runs-on:`).  
No changes to imports, methods, or other definitions are required, as this is purely a change to the workflow YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
