### PR TITLE
fix: When not at least 2 prev tags → Use all commits, Else use second tag as pointer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,22 @@ jobs:
         run: pnpm add -Dw conventional-changelog-cli conventional-changelog-conventionalcommits
 
       - name: Generate draft release notes
-        run: npx conventional-changelog -p conventionalcommits -r 0 -o RELEASE_NOTES.md
+        run: |
+          # Check latest and previous tags
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          PREV_TAG=$(if [ "$(git tag | wc -l)" -ge 2 ]; then git tag --sort=creatordate | tail -2 | head -1; fi)
+
+          echo "Latest tag: $LATEST_TAG"
+          echo "Previous tag: $PREV_TAG"
+
+          if [ -z "$PREV_TAG" ]; then
+            echo "First release — include all commits"
+            npx conventional-changelog -p conventionalcommits -r 0 -o RELEASE_NOTES.md
+          else
+            echo "Generating changelog since previous tag $PREV_TAG"
+            # Use -r 2 and output commits since PREV_TAG
+            npx conventional-changelog -p conventionalcommits -r 2 -o RELEASE_NOTES.md
+          fi
 
       - name: Upload draft release notes
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,22 @@ jobs:
         run: pnpm add -Dw conventional-changelog-cli conventional-changelog-conventionalcommits
 
       - name: Generate release notes
-        run: npx conventional-changelog -p conventionalcommits -r 1 -o RELEASE_NOTES.md
+        run: |
+            # Check latest and previous tags
+            LATEST_TAG=$(git describe --tags --abbrev=0)
+            PREV_TAG=$(if [ "$(git tag | wc -l)" -ge 2 ]; then git tag --sort=creatordate | tail -2 | head -1; fi)
+
+            echo "Latest tag: $LATEST_TAG"
+            echo "Previous tag: $PREV_TAG"
+
+            if [ -z "$PREV_TAG" ]; then
+              echo "First release — include all commits"
+              npx conventional-changelog -p conventionalcommits -r 0 -o RELEASE_NOTES.md
+            else
+              echo "Generating changelog since previous tag $PREV_TAG"
+              # Use -r 2 and output commits since PREV_TAG
+              npx conventional-changelog -p conventionalcommits -r 2 -o RELEASE_NOTES.md
+            fi
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
fix: When not at least 2 prev tags → Use all commits, Else use second tag as pointer