### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 # Controls which events and branches will trigger the workflow
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cellajs/cella/security/code-scanning/23](https://github.com/cellajs/cella/security/code-scanning/23)

To fix this issue, you should add a root-level `permissions` block to `.github/workflows/ci.yml`, specifying the minimum required permissions for the workflow. Since none of the workflow jobs appear to require write access to repository contents, issues, or pull requests, the minimal permission is likely `contents: read`. Place this block following the workflow `name` and before the `on:` block for clarity and convention. No imports or additional YAML definitions are necessary; add only the explicit `permissions` block. If in future some jobs require specific write privileges, a job-specific `permissions:` block can override these settings as needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
