### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cellajs/cella/security/code-scanning/22](https://github.com/cellajs/cella/security/code-scanning/22)

**How to fix, in general terms:**  
Add a `permissions` block to the workflow, either at the top-level (global to all jobs), or at the job level (for the jobs that require it), specifying the least required permissions for the job(s).

**Detailed description of the single best way to fix the problem without changing existing functionality:**  
Add a `permissions` section at the top-level of the workflow (just after the name or `on` block), so that it applies to all jobs. Since this workflow generates a release using `softprops/action-gh-release`, which requires `contents: write` to create a release and upload assets, you should set `contents: write` (not just `read`). There is no evidence that any further permissions are needed, so this is the minimal required set.

**Where to change:**  
- Edit `.github/workflows/release.yml`
- Insert the following lines after the `name: Release` line (line 1), before the `on:` trigger.

**What is needed:**  
- YAML key `permissions` set to `contents: write`
- No further imports, definitions, or other methods required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
