### PR TITLE
fix(infra): grant CI deploy key IAM read + pass org id via env (Option A)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -426,11 +426,15 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SCW_SECRET_KEY }}
           # Scaleway provider authenticates from these env vars (the CI deploy
           # key) — scaleway:accessKey/secretKey/projectId are no longer stored in
-          # Pulumi.<env>.yaml. SCW_PROJECT_ID is the GitHub secret synced by
-          # github-sync.ts alongside the key pair on every CI-key rotation.
+          # Pulumi.<env>.yaml. SCW_PROJECT_ID / SCW_ORGANIZATION_ID are GitHub
+          # secrets synced by github-sync.ts alongside the key pair on every
+          # CI-key rotation. The org id lets helpers.ts derive the IAM
+          # application ids without the Account API (the CI key can read IAM but
+          # not `read project`).
           SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
           SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
           SCW_DEFAULT_PROJECT_ID: ${{ secrets.SCW_PROJECT_ID }}
+          SCW_DEFAULT_ORGANIZATION_ID: ${{ secrets.SCW_ORGANIZATION_ID }}
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           STACK: ${{ needs.setup.outputs.pulumi_stack }}
         run: pulumi up --stack "$STACK" --yes
@@ -451,6 +455,7 @@ jobs:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
           SCW_DEFAULT_PROJECT_ID: ${{ secrets.SCW_PROJECT_ID }}
+          SCW_DEFAULT_ORGANIZATION_ID: ${{ secrets.SCW_ORGANIZATION_ID }}
           STACK: ${{ needs.setup.outputs.pulumi_stack }}
           VM_READER_APP: ${{ needs.setup.outputs.vm_reader_app }}
         run: |
@@ -458,7 +463,10 @@ jobs:
           # source the project from the synced SCW_PROJECT_ID secret — neither
           # the app id nor the project id is stored in stack config anymore
           # (SOVRUN §3.3); the Pulumi program derives them from the IAM API.
-          pnpm --filter infra assert-vm-grants --application-name "$VM_READER_APP" --project-id "$SCW_DEFAULT_PROJECT_ID"
+          # Pass the org id so assert-vm-grants skips the Account `read project`
+          # call (the CI key lacks that permission) and lists IAM policies
+          # directly.
+          pnpm --filter infra assert-vm-grants --application-name "$VM_READER_APP" --project-id "$SCW_DEFAULT_PROJECT_ID" --organization-id "$SCW_DEFAULT_ORGANIZATION_ID"
 
       - name: Capture stack outputs
         id: outputs

--- a/infra/README.md
+++ b/infra/README.md
@@ -162,6 +162,7 @@ deliberately split into **write at steady state** vs **read-only**:
 | Container Registry, Instances, Load Balancers, Edge Services, Object Storage, Secret Manager, Observability | `…FullAccess` | CI deploys mutate these on every run. |
 | **VPC, Private Network, RDB** | `…ReadOnly` | **Bootstrap key.** Created once at bootstrap, refreshed but never mutated by CI. |
 | DNS (`DomainsDNSFullAccess`, org scope) | Full | CI may add/update A records when modules change. |
+| IAM (`IAMReadOnly`, org scope) | Read-only | `pulumi up` ([`helpers.ts`](helpers.ts)) and the "Verify VM reader IAM grant" step look up the CI/VM applications and policies by name. Read-only — `IAMManager`/`IAMFullAccess` stay forbidden. |
 
 This means **any change to [`resources/database.ts`](resources/database.ts), [`resources/network.ts`](resources/network.ts), or anything else under VPC / PN / RDB will fail in CI** with `insufficient permissions: write …`. That's intentional — destructive operations on data-bearing resources go through a human running `pulumi up` locally with the bootstrap key.
 

--- a/infra/helpers.ts
+++ b/infra/helpers.ts
@@ -53,17 +53,29 @@ export const infraConfig = new pulumi.Config('infra')
 // deploy key can perform (CI's "Verify VM reader IAM grant" step already does).
 // ---------------------------------------------------------------------------
 
-// The IAM application lookup is org-scoped, but the provider only auto-resolves
-// an organization id when SCW_DEFAULT_ORGANIZATION_ID is set — which it is not
-// in CI (the deploy env carries access/secret key + project id only). Derive the
-// org id from the project instead (the in-program equivalent of the bootstrap
-// CLI's resolveOrgId REST call), so a name lookup never sends an empty org id.
-const scwProjectId =
-  process.env.SCW_DEFAULT_PROJECT_ID ?? process.env.SCW_PROJECT_ID ?? new pulumi.Config('scaleway').get('projectId')
-if (!scwProjectId) {
-  throw new Error('Scaleway project ID not found. Set SCW_DEFAULT_PROJECT_ID in the environment (or scaleway:projectId in stack config).')
-}
-const organizationId = scaleway.account.getProjectOutput({ projectId: scwProjectId }).organizationId
+// The IAM application lookup is org-scoped. Prefer an explicit organization id
+// from the environment (CI sets SCW_DEFAULT_ORGANIZATION_ID from the synced
+// SCW_ORGANIZATION_ID secret) so the deploy never touches the Account API — the
+// least-privilege CI deploy key can read IAM but NOT `read project`. Only when
+// no org id is in the environment (e.g. local runs) do we resolve it from the
+// project (the in-program equivalent of the bootstrap CLI's resolveOrgId REST
+// call), so a name lookup never sends an empty org id.
+const envOrganizationId = process.env.SCW_DEFAULT_ORGANIZATION_ID ?? process.env.SCW_ORGANIZATION_ID
+const organizationId: pulumi.Input<string> = envOrganizationId
+  ? envOrganizationId
+  : (() => {
+      const scwProjectId =
+        process.env.SCW_DEFAULT_PROJECT_ID ?? process.env.SCW_PROJECT_ID ?? new pulumi.Config('scaleway').get('projectId')
+      if (!scwProjectId) {
+        throw new Error(
+          'Scaleway organization ID not found. Set SCW_DEFAULT_ORGANIZATION_ID (preferred) or SCW_DEFAULT_PROJECT_ID in the environment (or scaleway:projectId in stack config).',
+        )
+      }
+      return scaleway.account.getProjectOutput({ projectId: scwProjectId }).apply((project) => {
+        if (!project.organizationId) throw new Error(`Could not resolve organization id from project '${scwProjectId}'.`)
+        return project.organizationId
+      })
+    })()
 
 /** CI deploy application id — the `<slug>-ci-deploy` principal CI authenticates as. */
 export const ciDeployApplicationId = scaleway.iam

--- a/infra/tasks/permission-sets.test.ts
+++ b/infra/tasks/permission-sets.test.ts
@@ -40,7 +40,10 @@ describe('CI key permission sets', () => {
   })
 
   it('ORG_PERMISSION_SETS exact membership snapshot', () => {
-    expect([...ORG_PERMISSION_SETS]).toEqual(['DomainsDNSFullAccess'])
+    // IAMReadOnly: org-scoped IAM *read* so `pulumi up` (helpers.ts) and the
+    // deploy's "Verify VM reader IAM grant" step can look up applications/
+    // policies by name. Read-only — IAMManager/IAMFullAccess remain FORBIDDEN.
+    expect([...ORG_PERMISSION_SETS].sort()).toEqual(['DomainsDNSFullAccess', 'IAMReadOnly'])
   })
 
   it('does not include any privilege-escalation permission', () => {

--- a/infra/tasks/setup-ci-key.ts
+++ b/infra/tasks/setup-ci-key.ts
@@ -43,7 +43,15 @@ export const PROJECT_PERMISSION_SETS = [
 ] as const
 
 /** Permission sets granted at organization scope (DNS lives at org level). */
-export const ORG_PERMISSION_SETS = ['DomainsDNSFullAccess'] as const
+export const ORG_PERMISSION_SETS = [
+  'DomainsDNSFullAccess',
+  // Read-only. `pulumi up` derives the CI/VM application ids from the IAM API at
+  // runtime (SOVRUN §3.3, helpers.ts getApplicationOutput) and the deploy's
+  // "Verify VM reader IAM grant" step lists the VM reader's policies — both are
+  // org-scoped IAM reads, so the CI key needs IAMReadOnly. (Self-introspection
+  // via getApiKey works without it, but listing other applications does not.)
+  'IAMReadOnly',
+] as const
 
 export type SetupCiKeyOptions = ProvisionScopedKeyOptions
 export type CiKeyResult = ScopedKeyResult

--- a/infra/tests/helpers/pulumi-mock.ts
+++ b/infra/tests/helpers/pulumi-mock.ts
@@ -49,10 +49,14 @@ export async function installPulumiMocks(opts: InstallOpts = {}): Promise<MockHa
   process.env.PULUMI_NODEJS_STACK = opts.stack ?? opts.mode ?? 'production'
   process.env.APP_MODE = opts.mode ?? opts.stack ?? 'production'
 
-  // helpers.ts derives the org id from the project (getProjectOutput) to scope
-  // IAM lookups, so it requires a project id. The real deploy env always carries
-  // SCW_DEFAULT_PROJECT_ID; mirror that here so module import doesn't throw.
+  // helpers.ts resolves the org id (to scope IAM lookups) env-first:
+  // SCW_DEFAULT_ORGANIZATION_ID when present (the CI deploy path), else it falls
+  // back to getProjectOutput from SCW_DEFAULT_PROJECT_ID (the local path). Clear
+  // any ambient org id so tests deterministically exercise the project fallback
+  // against the getProject mock below, and mirror CI by always carrying a project id.
   process.env.SCW_DEFAULT_PROJECT_ID = process.env.SCW_DEFAULT_PROJECT_ID ?? 'mock-project-id'
+  delete process.env.SCW_DEFAULT_ORGANIZATION_ID
+  delete process.env.SCW_ORGANIZATION_ID
 
   // Pulumi reads stack config from PULUMI_CONFIG (JSON). Build it before import.
   if (opts.config) {


### PR DESCRIPTION
Fixes the production deploy failure where `pulumi up` errored with `getProject: insufficient permissions: read project`.

## What
- **helpers.ts**: org id is now env-first (`SCW_DEFAULT_ORGANIZATION_ID ?? SCW_ORGANIZATION_ID`), falling back to `getProjectOutput` only for local runs. CI never calls the Account `getProject` endpoint the least-privilege key can't read.
- **setup-ci-key.ts**: added `IAMReadOnly` to `ORG_PERMISSION_SETS` so org-wide `getApplication`-by-name lookups are guaranteed. `IAMManager`/`IAMFullAccess` remain forbidden.
- **deploy.yml**: passes `SCW_DEFAULT_ORGANIZATION_ID` to the Pulumi up and Verify VM reader IAM grant steps (verify also gets `--organization-id` so assert-vm-grants skips the Account read).
- **permission-sets.test.ts** / **pulumi-mock.ts** updated; infra README documents the new grant.

## Validation
- `pnpm --filter infra ts` clean
- infra vitest: 357 pass + 3 todo
- `pnpm check` green

## Operator follow-up
1. Rotate the CI deploy key (bootstrap -> Rotate CI) so the live app picks up `IAMReadOnly`.
2. After a green deploy, `pulumi config rm` the legacy stack-config keys.
