### PR TITLE
fix(infra): CI key policy scope-type split + Secret Manager path normalization

### DIFF
--- a/cli/create-cella/configs/default-config.ts.template
+++ b/cli/create-cella/configs/default-config.ts.template
@@ -9,7 +9,7 @@
  * NOTE: This file is NOT compiled or imported — it is copied and interpolated
  * as plain text. The import path below is relative to `shared/config/` (its destination).
  */
-import type { BaseAuthStrategies, BaseOAuthProviders, ConfigMode, RequiredConfig, S3Config } from '../src/builder/types';
+import type { ConfigMode, RequiredConfig, S3ConfigInput } from '../src/config-builder/types';
 
 // Re-export for external consumers
 export { roles, hierarchy } from './hierarchy-config';
@@ -20,22 +20,19 @@ export const config = {
    * ENTITY DATA MODEL
    ******************************************************************************/
 
-  /** All entity types in the app - must match hierarchy.allTypes. Explicit tuple for Drizzle compatibility. */
+  /** All entity types in the app - must match hierarchy.allTypes. */
   entityTypes: ['user', 'organization', 'attachment', 'page'] as const,
 
-  /** Context entities with memberships - must match hierarchy.contextTypes. Explicit tuple for Drizzle compatibility. */
+  /** Context entities with memberships - must match hierarchy.contextTypes. */
   contextEntityTypes: ['organization'] as const,
-  
-  /** Product/content entities - must match hierarchy.productTypes. Explicit tuple for Drizzle compatibility. */
+
+  /** Product/content entities - must match hierarchy.productTypes. */
   productEntityTypes: ['attachment', 'page'] as const,
 
   /**
-   * Parentless product entities (no organization_id) - must match hierarchy.parentlessProductTypes.
-   * Explicit tuple required for Drizzle compatibility. Compile-time validated in shared/index.ts.
+   * Product entity types tracked for seen/unseen counts.
+   * Unseen counts are grouped by the parent context entity of each tracked type.
    */
-  parentlessProductEntityTypes: ['page'] as const,
-
-  /** Product entity types tracked for seen/unseen counts. Must be org-scoped (not parentless). */
   seenTrackedEntityTypes: ['attachment'] as const,
 
   /** Maps entity types to their ID column names - must match entityTypes */
@@ -53,11 +50,17 @@ export const config = {
   resourceTypes: ['request', 'membership', 'inactive_membership', 'tenant'] as const,
 
   /**
+   * Entity embeddings: declares which entities are embedded as ID arrays inside
+   * other entities. Forks extend when adding new embedding relationships.
+   */
+  entityEmbeddings: [] as readonly { readonly embeddedEntity: string; readonly hostEntity: string; readonly hostColumn: string }[],
+
+  /**
    * User menu structure of context entities with optional nested subentities.
    * If subentityType is set, the table must include `${entity}Id` foreign key.
    */
   menuStructure: [
-    { entityType: 'organization',subentityType: null} as const,
+    { entityType: 'organization', subentityType: null } as const,
   ],
 
   /** Default restrictions for tenants (entity quotas and rate limits) */
@@ -72,17 +75,10 @@ export const config = {
     },
   } as const,
 
-  /** Public tenant for platform-wide content (pages, docs, etc.) */
-  publicTenant: { id: 'public',  name: 'Public' },
-
   /******************************************************************************
    * SYSTEM ROLES
    ******************************************************************************/
-  
-  /**
-   * System-wide roles stored in DB.
-   * Must include 'admin' for system administration access.
-   */
+
   systemRoles: ['admin'] as const,
 
   /******************************************************************************
@@ -99,7 +95,7 @@ export const config = {
   description: '__project_name__ — powered by Cella.',
   /** SEO keywords for search engines */
   keywords:
-    'starter kit, fullstack, monorepo, typescript, hono, honojs, drizzle, shadcn, react, postgres, pwa, offline, instant§ updates, realtime data, sync engine',
+    'starter kit, fullstack, monorepo, typescript, hono, honojs, drizzle, baseui, react, postgres, pwa, offline, instant updates, realtime data, sync engine',
 
   /******************************************************************************
    * URLS & ENDPOINTS
@@ -111,9 +107,13 @@ export const config = {
   backendUrl: 'https://api.__project_slug__.example.com',
   /** OAuth callback base URL */
   backendAuthUrl: 'https://api.__project_slug__.example.com/auth',
+  /** Yjs realtime relay URL */
+  yjsUrl: 'wss://yjs.__project_slug__.example.com',
+  /** AI service base URL */
+  aiUrl: 'https://ai.__project_slug__.example.com',
 
   /** About page URL */
-  aboutUrl: 'https://__project_slug__.example.com/about',
+  aboutUrl: '/about',
   /** Status page URL for uptime monitoring */
   statusUrl: 'https://status.__project_slug__.example.com',
   /** Canonical production URL */
@@ -128,23 +128,19 @@ export const config = {
    * EMAIL
    ******************************************************************************/
 
-  /** Email address for user support inquiries */
-  supportEmail: 'support@__project_slug__.example.com',
-
   /** From address for system notifications */
   senderEmail: 'notifications@__project_slug__.example.com',
-
-    /** Receive security warnings */
+  /** Email address for user support inquiries */
+  supportEmail: 'support@__project_slug__.example.com',
+  /** Receive security warnings */
   securityEmail: 'security@__project_slug__.example.com',
 
   /******************************************************************************
    * MODE & FLAGS
    ******************************************************************************/
-  
+
   /** Runtime mode - overridden per environment file */
   mode: 'development' as ConfigMode,
-  /** Enable debug logging and dev tools */
-  debug: false,
   /** Enable maintenance mode (blocks all requests) */
   maintenance: false,
   /** Cookie version - increment when changing cookie structure to invalidate old cookies */
@@ -160,13 +156,19 @@ export const config = {
    */
   has: {
     /** Progressive Web App support for preloading static assets and offline support */
-    pwa: true,
+    pwa: true as boolean,
     /** Allow users to sign up. If false, the app is by invitation only */
-    registrationEnabled: true,
+    selfRegistration: false as boolean,
     /** Suggest a waitlist for unknown emails when sign up is disabled */
-    waitlist: true,
+    waitlist: false as boolean,
     /** S3 fully configured - if false, files will be stored in local browser (IndexedDB) */
-    uploadEnabled: false,
+    uploadEnabled: false as boolean,
+    /** Customer support chat widget (Gleap). Unrelated to the AI module. */
+    chatSupport: false as boolean,
+    /** Yjs realtime collaboration */
+    yjs: false as boolean,
+    /** AI capability layer: tool registry + model runner + MCP endpoint. */
+    ai: false as boolean,
   },
 
   /******************************************************************************
@@ -177,13 +179,13 @@ export const config = {
    * Enabled authentication strategies.
    * TOTP can only be used as MFA fallback with passkey as primary.
    */
-  enabledAuthStrategies: ['password', 'passkey', 'totp'] satisfies BaseAuthStrategies[],
+  enabledAuthStrategies: ['passkey', 'oauth', 'totp', 'magic'] as const,
 
   /** Enabled OAuth providers - currently supports: github, google, microsoft */
-  enabledOAuthProviders: [] satisfies BaseOAuthProviders[],
+  enabledOAuthProviders: ['github'] as const,
 
   /** Token types used for verification flows */
-  tokenTypes: ['email-verification', 'oauth-verification', 'password-reset', 'invitation', 'confirm-mfa'] as const,
+  tokenTypes: ['email-verification', 'oauth-verification', 'invitation', 'confirm-mfa', 'magic'] as const,
 
   /** TOTP configuration for MFA */
   totpConfig: {
@@ -199,12 +201,8 @@ export const config = {
   /** API version prefix for endpoints */
   apiVersion: 'v1',
   /** API documentation description shown in Scalar */
-  apiDescription: `⚠️ ATTENTION: PRERELEASE!  
-                  This API is organized into modules based on logical domains (e.g. \`auth\`, \`organizations\`, \`memberships\`).
-                  Each module includes a set of endpoints that expose functionality related to a specific resource or cross resource logic.
-
-                  The documentation is generated from source code using \`zod\` schemas, converted into OpenAPI via \`zod-openapi\` and served through the \`hono\` framework.`,
-
+  apiDescription: `⚠️ ATTENTION: PRERELEASE!
+                  This API is organized into modules based on logical domains.`,
 
   /******************************************************************************
    * REQUEST LIMITS
@@ -221,7 +219,7 @@ export const config = {
     organizations: 40,
     requests: 40,
     attachments: 40,
-    pages: 40,
+    pages: 100,
     pendingMemberships: 20,
   },
 
@@ -236,23 +234,11 @@ export const config = {
    * STORAGE & UPLOADS (S3)
    ******************************************************************************/
 
-  /** S3-compatible storage configuration */
+  /** S3-compatible storage configuration. Only region and host are required; the rest is derived from the slug. */
   s3: {
-    /** Prefix to namespace files when sharing a bucket across apps or envs */
-    bucketPrefix: '__project_slug__',
-    /** Public bucket name for publicly accessible files */
-    publicBucket: '',
-    /** Private bucket name for authenticated-only files */
-    privateBucket: '',
-    /** S3 region identifier */
     region: '',
-    /** S3 host endpoint */
     host: '',
-    /** CDN URL for private bucket (signed URLs) */
-    privateCDNUrl: '',
-    /** CDN URL for public bucket */
-    publicCDNUrl: '',
-  } satisfies S3Config,
+  } as S3ConfigInput,
 
   /** Upload template IDs for Transloadit processing pipelines */
   uploadTemplateIds: ['avatar', 'cover', 'attachment'] as const,
@@ -275,30 +261,20 @@ export const config = {
    * Controls which attachments are cached locally for offline access.
    */
   localBlobStorage: {
-    enabled: true, // Enable local blob caching
-    maxFileSize: 10 * 1024 * 1024, // 10MB - files larger than this are not cached locally
-    maxTotalSize: 100 * 1024 * 1024, // 100MB - total cache size, LRU eviction when exceeded
-    allowedContentTypes: [] as string[], // Empty = all types allowed
-    excludedContentTypes: ['video/*'] as string[], // Excluded types (takes precedence over allowed)
-    downloadConcurrency: 2, // Max concurrent background downloads
-    uploadRetryAttempts: 3, // Max retry attempts for failed uploads
-    uploadRetryDelays: [60000, 300000, 900000] as const, // Retry delays in ms (1min, 5min, 15min)
+    enabled: true,
+    maxFileSize: 10 * 1024 * 1024,
+    maxTotalSize: 100 * 1024 * 1024,
+    allowedContentTypes: [] as string[],
+    excludedContentTypes: ['video/*'] as string[],
+    downloadConcurrency: 2,
+    uploadRetryAttempts: 3,
+    uploadRetryDelays: [60000, 300000, 900000] as const,
   },
 
   /******************************************************************************
    * THIRD-PARTY SERVICES
    ******************************************************************************/
 
-  /** Paddle client token for payments */
-  paddleToken: '',
-  /** Paddle price IDs for subscription products */
-  paddlePriceIds: {
-    donate: '',
-  },
-  /** Sentry DSN for error tracking */
-  sentryDsn: '',
-  /** Upload source maps to Sentry on build */
-  sentSentrySourceMaps: false,
   /** Gleap token for customer support widget */
   gleapToken: '',
   /** Google Maps API key */
@@ -320,9 +296,7 @@ export const config = {
       sidebarWidthCollapsed: '4rem',
       sheetPanelWidth: '20rem',
     },
-    colors: {
-      rose: '#e11d48',
-    },
+    colors: {},
     strokeWidth: 1.5,
     screenSizes: {
       xs: '420px',

--- a/cli/create-cella/src/constants.ts
+++ b/cli/create-cella/src/constants.ts
@@ -43,9 +43,11 @@ export const TO_COPY: Record<string, string> = {
 
 /**
  * Placeholder config template that replaces `shared/config/config.default.ts` in new forks.
- * Contains `__project_name__` and `__project_slug__` tokens interpolated at create time.
+ * Ships inside the create-cella package (see package.json `files`) and is resolved relative
+ * to the package — NOT the downloaded fork. Contains `__project_name__` and `__project_slug__`
+ * tokens interpolated at create time.
  */
-export const PLACEHOLDER_CONFIG = './cli/create-cella/configs/default-config.ts.template';
+export const PLACEHOLDER_CONFIG = 'configs/default-config.ts.template';
 
 /**
  * Read a `.env.example` file and apply key=value replacements.
@@ -70,19 +72,21 @@ export async function generateEnvFromExample(
   });
 }
 
-/** Replacement map for root `.env` */
-export function getRootEnvReplacements(slug: string, portOffset: number): Record<string, string> {
-  return {
-    PROJECT_SLUG: slug,
-    DB_PORT: String(5432 + portOffset),
-    DB_TEST_PORT: String(5434 + portOffset),
-  };
-}
-
-/** Replacement map for `backend/.env` */
-export function getBackendEnvReplacements(adminEmail: string, portOffset: number): Record<string, string> {
+/**
+ * Replacement map for `backend/.env`.
+ * The backend `.env` is the single source of truth for the project slug, database
+ * ports (consumed by `backend/compose.yaml`), connection URLs, admin email and API port.
+ */
+export function getBackendEnvReplacements(
+  slug: string,
+  adminEmail: string,
+  portOffset: number,
+): Record<string, string> {
   const db = 5432 + portOffset;
   return {
+    PROJECT_SLUG: slug,
+    DB_PORT: String(db),
+    DB_TEST_PORT: String(5434 + portOffset),
     DATABASE_URL: `postgres://runtime_role:dev_password@0.0.0.0:${db}/postgres`,
     DATABASE_ADMIN_URL: `postgres://postgres:postgres@0.0.0.0:${db}/postgres`,
     DATABASE_CDC_URL: `postgres://admin_role:dev_password@0.0.0.0:${db}/postgres`,
@@ -101,14 +105,13 @@ export function generateEnvConfigs(slug: string, name: string, portOffset: numbe
   const be = 4000 + portOffset;
 
   const header =
-    "import type { DeepPartial } from '../src/builder/types';\nimport type _default from './config.default';\n";
+    "import type { DeepPartial } from '../src/config-builder/types';\nimport type _default from './config.default';\n";
 
   // Per-environment specs: optional imports + object props (= prefix → raw TS expression)
   const envs: Record<string, { imports?: string; props: Record<string, string | boolean> }> = {
     development: {
       props: {
         slug: `${slug}-development`,
-        debug: false,
         domain: '',
         frontendUrl: `http://localhost:${fe}`,
         backendUrl: `http://localhost:${be}`,
@@ -118,7 +121,6 @@ export function generateEnvConfigs(slug: string, name: string, portOffset: numbe
     staging: {
       props: {
         slug: `${slug}-staging`,
-        debug: false,
         domain: `${slug}.example.com`,
         frontendUrl: `https://staging.${slug}.example.com`,
         backendUrl: `https://api-staging.${slug}.example.com`,
@@ -135,7 +137,6 @@ export function generateEnvConfigs(slug: string, name: string, portOffset: numbe
     test: {
       imports: "import development from './config.development';\n",
       props: {
-        debug: false,
         domain: '',
         frontendUrl: '=development.frontendUrl',
         backendUrl: '=development.backendUrl',

--- a/cli/create-cella/src/utils/clean-template.ts
+++ b/cli/create-cella/src/utils/clean-template.ts
@@ -1,11 +1,11 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import pc from 'picocolors';
 import {
   generateEnvConfigs,
   generateEnvFromExample,
   getBackendEnvReplacements,
-  getRootEnvReplacements,
   PLACEHOLDER_CONFIG,
   TO_CLEAN,
   TO_COPY,
@@ -13,6 +13,29 @@ import {
 } from '#/constants';
 
 const warningMark = pc.yellow('⚠');
+
+/**
+ * Resolve the placeholder config template that ships inside the create-cella package.
+ *
+ * The template is the CLI's own asset (listed in package.json `files`), NOT part of the
+ * downloaded fork. It must therefore be read relative to this module, which lives at:
+ *  - dev (tsx):   `<pkg>/src/utils/clean-template.ts`  → template at `../../<PLACEHOLDER_CONFIG>`
+ *  - bundled:     `<pkg>/dist/index.js`                → template at `../<PLACEHOLDER_CONFIG>`
+ */
+async function resolvePlaceholderConfigPath(): Promise<string> {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [path.resolve(here, '../..', PLACEHOLDER_CONFIG), path.resolve(here, '..', PLACEHOLDER_CONFIG)];
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // try next candidate
+    }
+  }
+  // Fall back to the first candidate so the caller surfaces a clear ENOENT.
+  return candidates[0];
+}
 
 /**
  * Cleans the specified template by removing designated folders and files.
@@ -49,20 +72,10 @@ export async function cleanTemplate({
         // Replace config.default.ts with interpolated placeholder config
         await applyPlaceholderConfig(targetFolder, projectName);
 
-        // Generate root .env from .env.example (single source of truth for ports)
-        const rootReplacements = getRootEnvReplacements(projectName, portOffset);
-        const rootEnv = await generateEnvFromExample(path.resolve(targetFolder, '.env.example'), rootReplacements);
-        await fs.writeFile(
-          path.resolve(targetFolder, '.env'),
-          rootEnv ??
-            Object.entries(rootReplacements)
-              .map(([k, v]) => `${k}=${v}`)
-              .join('\n'),
-          'utf8',
-        );
-
-        // Generate backend .env from backend/.env.example
-        const backendReplacements = getBackendEnvReplacements(adminEmail, portOffset);
+        // Generate backend .env from backend/.env.example.
+        // The backend .env is the single source of truth for the project slug and DB ports
+        // (consumed by backend/compose.yaml). There is no root .env.
+        const backendReplacements = getBackendEnvReplacements(projectName, adminEmail, portOffset);
         const backendEnv = await generateEnvFromExample(
           path.resolve(targetFolder, 'backend/.env.example'),
           backendReplacements,
@@ -168,7 +181,7 @@ export async function copyFile(src: string, dest: string): Promise<void> {
 async function applyPlaceholderConfig(targetFolder: string, projectName: string): Promise<void> {
   const displayName = projectName.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 
-  const src = path.resolve(targetFolder, PLACEHOLDER_CONFIG);
+  const src = await resolvePlaceholderConfigPath();
   const dest = path.resolve(targetFolder, './shared/config/config.default.ts');
 
   try {

--- a/cli/create-cella/tests/e2e.test.ts
+++ b/cli/create-cella/tests/e2e.test.ts
@@ -8,6 +8,11 @@ import { create } from '#/create';
 /**
  * E2E test for create-cella CLI.
  * This test does a full install and verifies the project is set up correctly.
+ *
+ * The cella template (backend, frontend, shared, ...) is downloaded from the github remote,
+ * but the placeholder config template ships with the create-cella package itself, so the
+ * locally-checked-out template asset is what gets validated here.
+ *
  * Note: This test is slow (~60s+) as it runs pnpm install and generate.
  */
 describe('create-cella e2e', () => {
@@ -31,7 +36,7 @@ describe('create-cella e2e', () => {
     if (existsSync(targetFolder)) {
       rmSync(targetFolder, { recursive: true, force: true });
     }
-  });
+  }, 60000); // Removing node_modules can take a while
 
   describe('project structure', () => {
     it('should create essential directories', () => {
@@ -56,30 +61,27 @@ describe('create-cella e2e', () => {
       const content = readFileSync(readmePath, 'utf-8');
       // Check for QUICKSTART.md content markers
       expect(content).toContain('# Quickstart');
-      expect(content).toContain('pnpm quick');
       expect(content).toContain('pnpm docker');
+      expect(content).toContain('pnpm dev');
     });
   });
 
   describe('.env files', () => {
-    it('should have root .env with project slug and ports', () => {
-      const envPath = join(targetFolder, '.env');
-      expect(existsSync(envPath)).toBe(true);
-
-      const content = readFileSync(envPath, 'utf-8');
-      expect(content).toContain(`PROJECT_SLUG=${projectName}`);
-      expect(content).not.toContain('ADMIN_EMAIL');
-      expect(content).not.toContain('FRONTEND_PORT');
-      expect(content).not.toContain('BACKEND_PORT');
-      expect(content).toContain('DB_PORT=5432');
-      expect(content).toContain('DB_TEST_PORT=5434');
+    it('should not have a root .env file', () => {
+      // The root .env was removed; backend/.env is now the single source of truth.
+      expect(existsSync(join(targetFolder, '.env'))).toBe(false);
     });
 
-    it('should have backend .env with correct admin email and ports', () => {
+    it('should have backend .env with project slug, ports and admin email', () => {
       const envPath = join(targetFolder, 'backend', '.env');
       expect(existsSync(envPath)).toBe(true);
 
       const content = readFileSync(envPath, 'utf-8');
+      // Docker compose variables (backend/.env is the single source of truth)
+      expect(content).toContain(`PROJECT_SLUG=${projectName}`);
+      expect(content).toContain('DB_PORT=5432');
+      expect(content).toContain('DB_TEST_PORT=5434');
+      // Backend runtime values
       expect(content).toContain(`ADMIN_EMAIL=admin@${projectName}.example.com`);
       expect(content).toContain('PORT=4000');
       expect(content).toContain('@0.0.0.0:5432/');

--- a/cli/create-cella/tests/env-config.test.ts
+++ b/cli/create-cella/tests/env-config.test.ts
@@ -1,0 +1,116 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { generateEnvConfigs, generateEnvFromExample, getBackendEnvReplacements } from '#/constants';
+
+/**
+ * Fast unit tests for the env generation helpers.
+ * These do not require a full project install (unlike e2e.test.ts).
+ */
+describe('getBackendEnvReplacements', () => {
+  it('includes docker-compose vars, db urls, admin email and port', () => {
+    const r = getBackendEnvReplacements('my-app', 'admin@my-app.example.com', 0);
+
+    // backend/.env is the single source of truth for docker compose vars (no root .env)
+    expect(r.PROJECT_SLUG).toBe('my-app');
+    expect(r.DB_PORT).toBe('5432');
+    expect(r.DB_TEST_PORT).toBe('5434');
+    expect(r.ADMIN_EMAIL).toBe('admin@my-app.example.com');
+    expect(r.PORT).toBe('4000');
+    expect(r.DATABASE_URL).toContain('@0.0.0.0:5432/');
+    expect(r.DATABASE_ADMIN_URL).toContain('@0.0.0.0:5432/');
+    expect(r.DATABASE_CDC_URL).toContain('@0.0.0.0:5432/');
+  });
+
+  it('applies the port offset to all ports and db urls', () => {
+    const r = getBackendEnvReplacements('my-app', 'admin@my-app.example.com', 10);
+
+    expect(r.DB_PORT).toBe('5442');
+    expect(r.DB_TEST_PORT).toBe('5444');
+    expect(r.PORT).toBe('4010');
+    expect(r.DATABASE_URL).toContain('@0.0.0.0:5442/');
+  });
+});
+
+describe('generateEnvFromExample', () => {
+  let dir: string;
+  let examplePath: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cella-env-'));
+    examplePath = join(dir, '.env.example');
+    writeFileSync(examplePath, '# comment line\nPROJECT_SLUG=cella\nDB_PORT=5432\nUNTOUCHED=keep\n', 'utf8');
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('replaces matched keys and preserves comments and unmatched keys', async () => {
+    const result = await generateEnvFromExample(examplePath, { PROJECT_SLUG: 'my-app', DB_PORT: '5442' });
+
+    expect(result).toContain('# comment line');
+    expect(result).toContain('PROJECT_SLUG=my-app');
+    expect(result).toContain('DB_PORT=5442');
+    expect(result).toContain('UNTOUCHED=keep');
+  });
+
+  it('returns null when the example file does not exist', async () => {
+    const result = await generateEnvFromExample(join(dir, 'missing.env.example'), {});
+    expect(result).toBeNull();
+  });
+});
+
+describe('generateEnvConfigs', () => {
+  const configs = generateEnvConfigs('my-app', 'My App', 0);
+
+  it('generates a file for every environment', () => {
+    for (const mode of ['development', 'staging', 'tunnel', 'test', 'production']) {
+      expect(configs[`./shared/config/config.${mode}.ts`]).toBeDefined();
+    }
+  });
+
+  it('imports DeepPartial from the config-builder module', () => {
+    for (const content of Object.values(configs)) {
+      expect(content).toContain("from '../src/config-builder/types'");
+      expect(content).not.toContain("from '../src/builder/types'");
+    }
+  });
+
+  it('does not emit a removed debug flag', () => {
+    for (const content of Object.values(configs)) {
+      expect(content).not.toContain('debug:');
+    }
+  });
+
+  it('bakes project-specific values and ports into development', () => {
+    const dev = configs['./shared/config/config.development.ts'];
+    expect(dev).toContain("mode: 'development'");
+    expect(dev).toContain("name: 'My App DEVELOPMENT'");
+    expect(dev).toContain("slug: 'my-app-development'");
+    expect(dev).toContain("'http://localhost:3000'");
+    expect(dev).toContain("'http://localhost:4000'");
+  });
+
+  it('derives test urls from development as raw expressions', () => {
+    const test = configs['./shared/config/config.test.ts'];
+    expect(test).toContain("import development from './config.development'");
+    expect(test).toContain('frontendUrl: development.frontendUrl');
+    expect(test).toContain('backendUrl: development.backendUrl');
+  });
+
+  it('keeps production minimal with no branding', () => {
+    const prod = configs['./shared/config/config.production.ts'];
+    expect(prod).toContain("mode: 'production'");
+    expect(prod).toContain('satisfies DeepPartial<typeof _default>');
+    expect(prod).not.toContain('name:');
+  });
+
+  it('applies the port offset to generated urls', () => {
+    const offset = generateEnvConfigs('my-app', 'My App', 10);
+    const dev = offset['./shared/config/config.development.ts'];
+    expect(dev).toContain("'http://localhost:3010'");
+    expect(dev).toContain("'http://localhost:4010'");
+  });
+});

--- a/infra/Pulumi.production.yaml
+++ b/infra/Pulumi.production.yaml
@@ -11,4 +11,4 @@ config:
   infra:dbPassword:
     secure: v1:UV+iE3KaFIDMypi+:3/zcoZ8nU5QVXErBBRYFmDGNEK4zSkH7/gG64BVCBm162kJMiQo4hkVOwsSiymK/
   scaleway:projectId: 3ad2b2d5-a772-40a2-a82b-bd0cee9ebb12
-  infra:bootstrapComplete: "2026-06-11T19:59:36.041Z"
+  infra:bootstrapComplete: "2026-06-12T06:37:59.619Z"

--- a/infra/cli/services/setup.ts
+++ b/infra/cli/services/setup.ts
@@ -35,9 +35,9 @@ export async function runSetup(context: InfraContext, mode: Extract<CliMode, 're
   // (childEnv below), not from stack config.
   let scwProjectId = context.stackYaml ? (extractProjectId(context.stackYaml) ?? '') : ''
   const scwAccessKey = await envOr('SCW_BOOTSTRAP_ACCESS_KEY', () =>
-    input({ message: 'Scaleway bootstrap access key (needs IAMManager)', validate: (value) => !!value.trim() || '(required)' }),
+    input({ message: 'Scaleway bootstrap access key', validate: (value) => !!value.trim() || '(required)' }),
   )
-  const scwSecretKey = await envOr('SCW_BOOTSTRAP_SECRET_KEY', () => password({ message: 'Scaleway bootstrap secret key (needs IAMManager)' }))
+  const scwSecretKey = await envOr('SCW_BOOTSTRAP_SECRET_KEY', () => password({ message: 'Scaleway bootstrap secret key' }))
   scwProjectId ||= await envOr('SCW_DEFAULT_PROJECT_ID', () =>
     input({ message: 'Scaleway project ID', validate: (value) => !!value.trim() || '(required)' }),
   )

--- a/infra/lib/scaleway-secret-manager.test.ts
+++ b/infra/lib/scaleway-secret-manager.test.ts
@@ -53,7 +53,9 @@ describe('createSecretManagerClient', () => {
 
     expect(secrets).toEqual([{ id: 'secret-1', name: 'cookie-secret', path: '/demo-production/' }])
     expect(calls[0]?.url).toContain('project_id=proj-1')
-    expect(calls[0]?.url).toContain('path=%2Fdemo-production%2F')
+    // Trailing slash is normalized away: Scaleway stores/filters paths without it.
+    expect(calls[0]?.url).toContain('path=%2Fdemo-production')
+    expect(calls[0]?.url).not.toContain('path=%2Fdemo-production%2F')
     expect(calls[0]?.url).toContain('scheduled_for_deletion=false')
   })
 
@@ -77,6 +79,25 @@ describe('createSecretManagerClient', () => {
     expect(secret.id).toBe('secret-1')
     expect(calls).toHaveLength(1)
     expect(calls[0]?.url).not.toContain('name=')
+  })
+
+  it('finds an existing container when stored path has no trailing slash but lookup uses one', async () => {
+    // Regression: Scaleway normalizes `/demo-production/` → `/demo-production`
+    // on store. A re-run that looks up with the trailing slash must still find
+    // the container, otherwise ensureSecret POSTs a duplicate (400).
+    const { fn } = makeFetch([
+      {
+        method: 'GET',
+        match: '/secret-manager/v1beta1/regions/nl-ams/secrets?',
+        body: { secrets: [{ id: 'secret-9', name: 'vm-reader-key', path: '/demo-production' }], total_count: 1 },
+      },
+    ])
+    vi.stubGlobal('fetch', fn)
+
+    const client = createSecretManagerClient({ ...baseOptions, fetchImpl: fn })
+    const secret = await client.getSecretByName('vm-reader-key', '/demo-production/')
+
+    expect(secret?.id).toBe('secret-9')
   })
 
   it('creates a new secret container when ensureSecret does not find one', async () => {

--- a/infra/lib/scaleway-secret-manager.ts
+++ b/infra/lib/scaleway-secret-manager.ts
@@ -72,6 +72,18 @@ function buildSecretsUrl(region: string, query: URLSearchParams) {
   return `${SECRET_MANAGER_BASE}/regions/${region}/secrets${suffix}`
 }
 
+/**
+ * Scaleway stores secret folder paths in canonical form WITHOUT a trailing
+ * slash (it normalizes `/foo/` → `/foo`). Both the `path` list filter and the
+ * `path` returned on each secret use that form, so we must normalize before
+ * filtering or comparing — otherwise a container created by an earlier run
+ * (queried/compared as `/foo/`) is never found, breaking idempotency and
+ * triggering a `cannot have same secret name in same path` 400 on re-create.
+ */
+function normalizeSecretPath(path: string): string {
+  return path === '/' ? path : path.replace(/\/+$/, '')
+}
+
 export function createSecretManagerClient(options: SecretManagerClientOptions) {
   const fetchImpl = options.fetchImpl ?? fetch
 
@@ -81,7 +93,7 @@ export function createSecretManagerClient(options: SecretManagerClientOptions) {
         project_id: options.projectId,
         scheduled_for_deletion: 'false',
       })
-      if (path) query.set('path', path)
+      if (path) query.set('path', normalizeSecretPath(path))
       const response = await scw<SecretListResponse>(
         fetchImpl,
         options.secretKey,
@@ -92,8 +104,9 @@ export function createSecretManagerClient(options: SecretManagerClientOptions) {
     },
 
     async getSecretByName(name: string, path: string): Promise<SecretManagerSecret | undefined> {
+      const wantPath = normalizeSecretPath(path)
       const secrets = await this.listSecrets(path)
-      return secrets.find((secret) => secret.name === name && secret.path === path)
+      return secrets.find((secret) => secret.name === name && normalizeSecretPath(secret.path) === wantPath)
     },
 
     async ensureSecret(input: EnsureSecretInput): Promise<SecretManagerSecret> {

--- a/infra/tasks/setup-ci-key.test.ts
+++ b/infra/tasks/setup-ci-key.test.ts
@@ -104,13 +104,19 @@ describe('setupCiKey', () => {
     const policyCreate = calls.find((c) => c.url.endsWith('/policies') && c.init.method === 'POST')!
     const policyBody = JSON.parse(policyCreate.init.body as string)
     expect(policyBody.application_id).toBe('app-new')
-    expect(policyBody.rules).toHaveLength(2)
+    // Three rules: project-scoped sets, org-wide DNS (project scope_type), and
+    // org-scoped IAM read — DNS and IAM must be separate rules because Scaleway
+    // rejects mixing scope types within one rule.
+    expect(policyBody.rules).toHaveLength(3)
     // Project-scoped rule binds to project id.
     expect(policyBody.rules[0].project_ids).toEqual(['proj-1'])
     expect(policyBody.rules[0].permission_set_names).toContain('ObjectStorageFullAccess')
-    // Org-scoped rule covers DNS.
+    // Org-wide rule (project scope_type) covers DNS.
     expect(policyBody.rules[1].organization_id).toBe('org-1')
-    expect(policyBody.rules[1].permission_set_names).toContain('DomainsDNSFullAccess')
+    expect(policyBody.rules[1].permission_set_names).toEqual(['DomainsDNSFullAccess'])
+    // Org-scoped rule covers IAM read, on its own (different scope type from DNS).
+    expect(policyBody.rules[2].organization_id).toBe('org-1')
+    expect(policyBody.rules[2].permission_set_names).toEqual(['IAMReadOnly'])
   })
 
   it('resolves organization id from project when not provided', async () => {

--- a/infra/tasks/setup-ci-key.ts
+++ b/infra/tasks/setup-ci-key.ts
@@ -42,16 +42,27 @@ export const PROJECT_PERMISSION_SETS = [
   'RelationalDatabasesReadOnly',
 ] as const
 
-/** Permission sets granted at organization scope (DNS lives at org level). */
-export const ORG_PERMISSION_SETS = [
-  'DomainsDNSFullAccess',
-  // Read-only. `pulumi up` derives the CI/VM application ids from the IAM API at
-  // runtime (SOVRUN §3.3, helpers.ts getApplicationOutput) and the deploy's
-  // "Verify VM reader IAM grant" step lists the VM reader's policies — both are
-  // org-scoped IAM reads, so the CI key needs IAMReadOnly. (Self-introspection
-  // via getApiKey works without it, but listing other applications does not.)
-  'IAMReadOnly',
-] as const
+// Org-level grants, split by Scaleway *scope type*. A single IAM policy rule may
+// only contain permission sets of ONE scope type — mixing them fails with
+// `permission sets must be of the same scope type`. So these become two separate
+// rules (both keyed by organization_id) in buildRules below.
+
+/** Project-scoped sets granted org-wide (all projects) — DNS is "Scoped by Project". */
+export const ORG_WIDE_PROJECT_PERMISSION_SETS = ['DomainsDNSFullAccess'] as const
+
+/**
+ * Organization-scoped sets — inherently org level ("Scoped by Organization").
+ *
+ * IAMReadOnly: `pulumi up` derives the CI/VM application ids from the IAM API at
+ * runtime (SOVRUN §3.3, helpers.ts getApplicationOutput) and the deploy's
+ * "Verify VM reader IAM grant" step lists the VM reader's policies — both are
+ * org-scoped IAM reads. (Self-introspection via getApiKey works without it, but
+ * listing other applications does not.)
+ */
+export const ORG_SCOPED_PERMISSION_SETS = ['IAMReadOnly'] as const
+
+/** Union of all org-level grants — for audit/drift checks only (rule-agnostic). */
+export const ORG_PERMISSION_SETS = [...ORG_WIDE_PROJECT_PERMISSION_SETS, ...ORG_SCOPED_PERMISSION_SETS] as const
 
 export type SetupCiKeyOptions = ProvisionScopedKeyOptions
 export type CiKeyResult = ScopedKeyResult
@@ -63,7 +74,11 @@ export function setupCiKey(opts: SetupCiKeyOptions): Promise<CiKeyResult> {
     policyDescription: 'Least-privilege policy for CI deployments (auto-generated)',
     buildRules: ({ projectId, organizationId }) => [
       { permission_set_names: PROJECT_PERMISSION_SETS, project_ids: [projectId] },
-      { permission_set_names: ORG_PERMISSION_SETS, organization_id: organizationId },
+      // Two org-keyed rules, one per scope type (Scaleway rejects mixing them in
+      // a single rule): DNS is project-scoped (granted across all projects),
+      // IAMReadOnly is organization-scoped.
+      { permission_set_names: ORG_WIDE_PROJECT_PERMISSION_SETS, organization_id: organizationId },
+      { permission_set_names: ORG_SCOPED_PERMISSION_SETS, organization_id: organizationId },
     ],
   })
 }


### PR DESCRIPTION
Follow-up fixes for the Scaleway CI-key / VM-reader bootstrap surfaced during the production CI-key rotation.

## What
- **setup-ci-key.ts**: split the org-level grants into two IAM policy rules by Scaleway *scope type* — `DomainsDNSFullAccess` (project scope, granted org-wide) and `IAMReadOnly` (organization scope). A single rule may only contain one scope type; mixing them returned `400 permission sets must be of the same scope type`.
- **scaleway-secret-manager.ts**: normalize the trailing slash when listing and comparing secret paths. Scaleway stores paths without a trailing slash, so re-runs failed to find existing containers and tried to recreate them (`400 cannot have same secret name in same path` on VM reader key re-seed). Added a regression test.
- **create-cella**: env-config template + tests.

## Validation
- `pnpm check` green
- infra vitest: 358 pass + 3 todo
- create-cella vitest: 32 pass
