### PR TITLE
fix(infra): VM reader policy org id; defer compute only on fresh provision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ dist-ssr
 !.env.example
 .envrc
 .pulumi/
-infra/Pulumi.*.yaml.apply-backup
 
 # Cache
 *.tsbuildinfo

--- a/infra/INFRA_ARCHITECTURE.md
+++ b/infra/INFRA_ARCHITECTURE.md
@@ -111,7 +111,7 @@ All sizing has sensible defaults — DB/WAF in `helpers.ts`, per-service VM size
 | `backend` VM size (registry default) | DEV1-S | DEV1-M |
 | `enableWaf` | false | true |
 | `enableEdgeServices` | false | false |
-| `computeEnabled` | true (gated off only while `bootstrap:applyInProgress` is set) | true (same) |
+| `computeEnabled` | true (gated off only while `bootstrap:computeDeferred` is set) | true (same) |
 
 `instanceType` is the fleet-wide VM size. Per-service sizes live in the
 canonical registry (`compose/services.config.ts`, the `instanceType` field) so a

--- a/infra/README.md
+++ b/infra/README.md
@@ -45,7 +45,7 @@ When re-run, `pnpm --filter infra bootstrap` detects existing state from
 |---|---|
 | **Resume** | Re-runs idempotent steps (state bucket, secrets check, edge plan, DNS check, GitHub variable sync) using a freshly-pasted bootstrap key for provider/IAM auth. Does **not** touch the IAM policy. **Cannot apply changes to DB / VPC / private network** via the CI key (it is read-only on those). |
 | **Rotate CI** | Deletes the existing `<slug>-ci-deploy` API key and IAM policy, mints a fresh key, re-attaches the policy with current `PROJECT_PERMISSION_SETS`, pushes new secrets to GitHub. Use after rotating credentials **or after changing permission sets in `tasks/setup-ci-key.ts`**. |
-| **Apply infra change** | One-shot `pulumi up` for bootstrap-owned changes (DB, VPC, private network). Prompts for a fresh bootstrap key and supplies it to the provider via `SCW_*` env, runs `pulumi up`, then clears the transient apply marker. See [Applying a bootstrap-owned change](#applying-a-bootstrap-owned-change). |
+| **Apply infra change** | One-shot `pulumi up` for bootstrap-owned changes (DB, VPC, private network). Prompts for a fresh bootstrap key and supplies it to the provider via `SCW_*` env, then runs `pulumi up`. Leaves live compute up. See [Applying a bootstrap-owned change](#applying-a-bootstrap-owned-change). |
 | **Preview** | Read-only `pulumi preview --diff` using a Scaleway key (any key with read access) supplied via `SCW_*` env. Makes no changes; use it to validate provider auth and inspect drift before an Apply or a config cleanup. |
 | **Manage runtime secrets** | List, set, rotate, or delete operator-managed runtime secrets in Scaleway Secret Manager. |
 | **Clean** | Wipes local state and starts over — see [Clean slate](#clean-slate). |
@@ -134,7 +134,7 @@ cd infra && \
 
 (`SCW_*` authenticates the Scaleway provider; `AWS_*` authenticates the S3-compatible Pulumi state backend — same key, two protocols.)
 
-This creates the registry, database, network, load balancer, and other base resources. **Compute VMs are not deployed here** — the bootstrap command sets the transient `bootstrap:applyInProgress` marker around the initial `pulumi up`, which gates VMs off (registry has no images yet, so they would crash-loop). The marker is cleared automatically when the run succeeds.
+This creates the registry, database, network, load balancer, and other base resources. **Compute VMs are not deployed here** — the bootstrap command sets the transient `bootstrap:computeDeferred` marker around the initial `pulumi up`, which gates VMs off (registry has no images yet, so they would crash-loop). The marker is cleared automatically when the run succeeds.
 
 After this completes, commit the updated `infra/Pulumi.production.yaml` and push to `main`. CI will then build and push Docker images and run a second `pulumi up`. The marker is no longer set, so compute VMs come up on their own. **You do not need to run `pulumi up` a second time locally.**
 
@@ -172,12 +172,10 @@ Re-run bootstrap and choose **Apply infra change**. The mode:
 
 1. Prompts for the Pulumi passphrase and a fresh bootstrap key (broad permissions, see [Step 3](#3-generate-a-bootstrap-api-key)).
 2. Supplies that key to the Scaleway provider via `SCW_*` env (it is never written to stack config).
-3. Snapshots the current stack file verbatim to `Pulumi.<stack>.yaml.apply-backup` (gitignored), then sets a transient `bootstrap:applyInProgress` marker.
-4. Runs `pulumi up`.
-5. **Always** restores the snapshot over the stack file — even if `pulumi up` failed or was cancelled (`try/finally`) — which clears the apply marker, then deletes the snapshot.
-6. Reminds you to revoke the bootstrap key.
+3. Runs `pulumi up` against the already-bootstrapped stack. Compute stays up — unlike the fresh-provision flow, Apply infra change does **not** set the `bootstrap:computeDeferred` marker, so the running VMs/LB are left in place.
+4. Reminds you to revoke the bootstrap key.
 
-If the run is interrupted by a hard crash (kill -9, power loss, Ctrl-C) before step 5, the snapshot is left on disk. The next bootstrap run detects it and offers to restore it — clearing the leftover apply marker.
+No stack file is mutated and no credential is written to disk, so an interrupted run needs no cleanup — `pulumi up` is idempotent, so just re-run Apply infra change to converge.
 
 You can also supply `SCW_BOOTSTRAP_ACCESS_KEY` / `SCW_BOOTSTRAP_SECRET_KEY` / `PULUMI_CONFIG_PASSPHRASE` as env vars to skip the prompts.
 

--- a/infra/cli/infra-cli.ts
+++ b/infra/cli/infra-cli.ts
@@ -7,13 +7,13 @@
  * Usage: pnpm --filter infra bootstrap
  */
 import { spawnSync } from 'node:child_process'
-import { copyFileSync, existsSync, readFileSync, unlinkSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { confirm, select } from '@inquirer/prompts'
+import { select } from '@inquirer/prompts'
 import pc from 'shared/cli-utils/colors'
 import { printHeader } from 'shared/cli-utils/display'
-import { checkMark, warningMark } from 'shared/console'
-import { detectInterruptedApply, detectStackState, pickStackShort } from '../lib/bootstrap-stack-state'
+import { warningMark } from 'shared/console'
+import { detectComputeDeferred, detectStackState, pickStackShort } from '../lib/bootstrap-stack-state'
 import { infraDir } from '../lib/paths'
 import { runApply } from './services/apply'
 import { runPreview } from './services/preview'
@@ -40,7 +40,6 @@ async function loadContext(): Promise<InfraContext> {
     stackYaml,
     state,
     hasCiKey: state === 'bootstrapped',
-    applyBackupPath: resolve(infraDir, `Pulumi.${environment}.yaml.apply-backup`),
     appConfig,
   }
 }
@@ -56,26 +55,13 @@ const context = await loadContext()
 
 console.info(`State: ${context.state}${context.state === 'fresh' ? '' : ` (Pulumi.${context.environment}.yaml)`}\n`)
 
-const interrupted = detectInterruptedApply({
-  yamlText: context.stackYaml,
-  backupExists: existsSync(context.applyBackupPath),
-  backupPath: context.applyBackupPath,
-})
-if (interrupted) {
+const deferredSince = detectComputeDeferred(context.stackYaml)
+if (deferredSince) {
   console.warn(
-    `${warningMark} ${pc.bold('Previous Apply infra change run was interrupted.')}\n` +
-      `  Pulumi.${context.environment}.yaml may still carry the transient bootstrap:applyInProgress marker.\n` +
-      `  Trace: ${interrupted.trace}\n`,
+    `${warningMark} ${pc.bold('Compute is currently deferred')} ${pc.dim(`(bootstrap:computeDeferred = ${deferredSince})`)}.\n` +
+      `  A fresh provision sets this so VMs are not declared until images exist;\n` +
+      `  it clears automatically on the next successful provisioning \`pulumi up\`.\n`,
   )
-  if (
-    existsSync(context.applyBackupPath) &&
-    (await confirm({ message: 'Restore the pre-apply stack config from the backup now (clears the apply marker)?', default: true }))
-  ) {
-    copyFileSync(context.applyBackupPath, context.stackPath)
-    unlinkSync(context.applyBackupPath)
-    console.info(`${checkMark} Stack config restored from backup. Re-run bootstrap to continue.`)
-    process.exit(0)
-  }
 }
 
 const mode: CliMode =

--- a/infra/cli/services/apply.ts
+++ b/infra/cli/services/apply.ts
@@ -1,8 +1,7 @@
 import { spawnSync } from 'node:child_process'
-import { copyFileSync, unlinkSync } from 'node:fs'
 import { confirm, input, password } from '@inquirer/prompts'
 import pc from 'shared/cli-utils/colors'
-import { checkMark, warningMark } from 'shared/console'
+import { warningMark } from 'shared/console'
 import { extractProjectId } from '../../lib/bootstrap-stack-state'
 import { scwConfigPathNone } from '../../lib/bootstrap-scw-env'
 import { infraDir } from '../../lib/paths'
@@ -12,13 +11,15 @@ import { type InfraContext, resolveVerifiedPassphrase } from '../shared'
 /** One-shot `pulumi up` using a freshly-supplied bootstrap key passed via
  *  SCW_* env. For applying changes to bootstrap-owned resources (DB / VPC /
  *  private network) that the read-only CI key cannot make, without
- *  permanently widening CI permissions. */
+ *  permanently widening CI permissions. Runs against an already-bootstrapped
+ *  stack with live compute, so it must NOT defer compute (no computeDeferred
+ *  marker) — that is reserved for the fresh-provision flow in setup.ts. */
 export async function runApply(context: InfraContext): Promise<void> {
   if (context.state !== 'bootstrapped') {
     console.error(`${warningMark} "Apply infra change" requires a fully bootstrapped stack (state=${context.state}). Run Resume first.`)
     process.exit(1)
   }
-  console.info(pc.dim('\nApply infra change: run pulumi up with a bootstrap key (supplied via env), then clear the apply marker.\n'))
+  console.info(pc.dim('\nApply infra change: run pulumi up with a bootstrap key (supplied via env).\n'))
 
   const passphrase = await resolveVerifiedPassphrase(context.stackYaml)
 
@@ -33,7 +34,7 @@ export async function runApply(context: InfraContext): Promise<void> {
 
   const bootAccess =
     process.env.SCW_BOOTSTRAP_ACCESS_KEY ||
-    (await input({ message: 'Scaleway bootstrap access key (needs IAMManager + write on the resource you are changing)', validate: (v) => !!v.trim() || '(required)' }))
+    (await input({ message: 'Scaleway bootstrap access key', validate: (v) => !!v.trim() || '(required)' }))
   const bootSecret = process.env.SCW_BOOTSTRAP_SECRET_KEY || (await password({ message: 'Scaleway bootstrap secret key' }))
 
   const targetStack = await input({ message: 'Pulumi stack name', default: `organization/infra/${context.environment}` })
@@ -44,7 +45,7 @@ export async function runApply(context: InfraContext): Promise<void> {
   }
 
   console.warn(
-    `${pc.yellow(pc.bold('\u26A0  Keep this run in the foreground.'))} ${pc.dim('If it is interrupted, re-run bootstrap — it will offer to clear the apply marker from the backup snapshot.')}`,
+    `${pc.yellow(pc.bold('\u26A0  Keep this run in the foreground.'))} ${pc.dim('If it is interrupted, re-run "Apply infra change" to converge — `pulumi up` is idempotent.')}`,
   )
 
   const applyEnv: NodeJS.ProcessEnv = {
@@ -65,36 +66,16 @@ export async function runApply(context: InfraContext): Promise<void> {
   spawnSync('pulumi', ['login', loginUrl], { cwd: infraDir, env: applyEnv, stdio: 'inherit' })
   spawnSync('pulumi', ['stack', 'select', targetStack], { cwd: infraDir, env: applyEnv, stdio: 'ignore' })
 
-  // Back up the stack file before setting the apply marker so an interrupted
-  // run is recoverable (infra-cli.ts offers to restore on the next launch).
-  // The bootstrap key reaches `pulumi up` via SCW_* env (applyEnv above), not
-  // stack config, so there is no credential to swap out or scrub afterwards —
-  // the backup/restore now only brackets the transient applyInProgress marker.
-  copyFileSync(context.stackPath, context.applyBackupPath)
-  let markerSet = false
-  try {
-    const startedAt = new Date().toISOString()
-    const marker = spawnSync('pulumi', ['config', 'set', 'bootstrap:applyInProgress', startedAt, '--stack', targetStack], {
-      cwd: infraDir,
-      env: applyEnv,
-      stdio: 'inherit',
-    })
-    if (marker.status !== 0) throw new Error('Failed to set apply-in-progress marker')
-    markerSet = true
-    while (true) {
-      const code = await runPulumiUpWithHint(targetStack, infraDir, applyEnv)
-      if (code === 0) break
-      if (!(await confirm({ message: 'Retry pulumi up?', default: false }))) break
-    }
-  } finally {
-    if (markerSet) {
-      console.info('\n→ Clearing apply-in-progress marker')
-      copyFileSync(context.applyBackupPath, context.stackPath)
-      console.info(`${checkMark} Marker cleared.`)
-    }
-    try {
-      unlinkSync(context.applyBackupPath)
-    } catch {}
+  // No compute-deferred marker and no stack-file backup here: the stack is
+  // already bootstrapped with live compute, the bootstrap key reaches
+  // `pulumi up` via SCW_* env (applyEnv) rather than stack config, and
+  // `pulumi up` is idempotent — an interrupted run is recovered simply by
+  // re-running it. Deferring compute (as the fresh-provision flow does) would
+  // tear down the running VMs/LB on an established stack.
+  while (true) {
+    const code = await runPulumiUpWithHint(targetStack, infraDir, applyEnv)
+    if (code === 0) break
+    if (!(await confirm({ message: 'Retry pulumi up?', default: false }))) break
   }
 
   console.info(`\n${pc.dim('Reminder:')} revoke the bootstrap key now (Scaleway console → IAM → API keys).`)

--- a/infra/cli/services/setup.ts
+++ b/infra/cli/services/setup.ts
@@ -316,7 +316,7 @@ export async function runSetup(context: InfraContext, mode: Extract<CliMode, 're
       const pulumiUpEnv: NodeJS.ProcessEnv = childEnv
       if (usingBootstrapKey) {
         const startedAt = new Date().toISOString()
-        spawnSync('pulumi', ['config', 'set', 'bootstrap:applyInProgress', startedAt, '--stack', stackName], {
+        spawnSync('pulumi', ['config', 'set', 'bootstrap:computeDeferred', startedAt, '--stack', stackName], {
           cwd: infraDir,
           env: pulumiUpEnv,
           stdio: 'inherit',
@@ -332,7 +332,7 @@ export async function runSetup(context: InfraContext, mode: Extract<CliMode, 're
         if (!(await confirm({ message: 'Retry?', default: true }))) process.exit(code)
       }
       if (usingBootstrapKey && upOk) {
-        spawnSync('pulumi', ['config', 'rm', 'bootstrap:applyInProgress', '--stack', stackName], {
+        spawnSync('pulumi', ['config', 'rm', 'bootstrap:computeDeferred', '--stack', stackName], {
           cwd: infraDir,
           env: pulumiUpEnv,
           stdio: 'ignore',

--- a/infra/cli/shared.ts
+++ b/infra/cli/shared.ts
@@ -17,7 +17,6 @@ export interface InfraContext {
   stackYaml?: string
   state: StackState
   hasCiKey: boolean
-  applyBackupPath: string
   appConfig: typeof AppConfig
 }
 

--- a/infra/helpers.ts
+++ b/infra/helpers.ts
@@ -61,7 +61,7 @@ export const infraConfig = new pulumi.Config('infra')
 // project (the in-program equivalent of the bootstrap CLI's resolveOrgId REST
 // call), so a name lookup never sends an empty org id.
 const envOrganizationId = process.env.SCW_DEFAULT_ORGANIZATION_ID ?? process.env.SCW_ORGANIZATION_ID
-const organizationId: pulumi.Input<string> = envOrganizationId
+export const organizationId: pulumi.Input<string> = envOrganizationId
   ? envOrganizationId
   : (() => {
       const scwProjectId =
@@ -107,13 +107,14 @@ export const operatorPrincipal: pulumi.Output<string> | undefined = callerAccess
 // Mode-aware defaults — forks only need to set secrets + scaleway:projectId
 // ---------------------------------------------------------------------------
 
-// Compute is on by default. It is skipped only while bootstrap tooling is
-// mid-flight: bootstrap sets `bootstrap:applyInProgress` before the initial
-// `pulumi up` (registry has no images yet, VMs would crash-loop) and during
-// "Apply infra change" mode, then clears it via a verbatim stack-file restore.
-// Gating on this marker stops a stray local `pulumi up` from tearing down
-// compute the way a missing `deployCompute=true` would.
-const bootstrapInProgress = new pulumi.Config('bootstrap').get('applyInProgress') !== undefined
+// Compute is on by default. It is deferred only during a FRESH provision: the
+// bootstrap CLI sets `bootstrap:computeDeferred` before the very first
+// `pulumi up` (the registry has no images yet, so VMs would crash-loop) and
+// clears it once base infra exists. An "Apply infra change" run on an already
+// bootstrapped stack must NOT set this — it would tear down live compute.
+// Gating on this marker also stops a stray local `pulumi up` mid-fresh-bootstrap
+// from declaring compute before images are pushed.
+const computeDeferred = new pulumi.Config('bootstrap').get('computeDeferred') !== undefined
 
 // Fleet-wide default VM size. Per-service sizes (incl. per-mode) live in the
 // canonical registry (compose/services.config.ts `instanceType`). Backend runs
@@ -149,7 +150,7 @@ export const infra = {
   /** VM size for a given service — operator override, else registry default, else fleet default. */
   instanceTypeFor: (serviceName: string): string =>
     instanceTypeOverrides[serviceName] ?? registryInstanceType(serviceName) ?? baseInstanceType,
-  computeEnabled: !bootstrapInProgress,
+  computeEnabled: !computeDeferred,
 }
 
 // ---------------------------------------------------------------------------
@@ -168,9 +169,9 @@ export const infra = {
 // by name+path (one infra secret path per stack) and the payload is JSON
 // `{ accessKey, secretKey }`, base64-encoded by the Secret Manager API.
 //
-// Skipped while bootstrap is mid-flight: the marker means compute is gated off
-// (helpers exports empty secrets), so there is nothing to bake and the secret
-// may not exist yet on the very first `pulumi up`.
+// Skipped while compute is deferred during a fresh provision: the marker means
+// compute is gated off (helpers exports empty secrets), so there is nothing to
+// bake and the secret may not exist yet on the very first `pulumi up`.
 // ---------------------------------------------------------------------------
 function readVmReaderKey(): { accessKey: pulumi.Output<string>; secretKey: pulumi.Output<string> } {
   const secretPath = secretManagerPath(naming.slug, mode)
@@ -181,7 +182,7 @@ function readVmReaderKey(): { accessKey: pulumi.Output<string>; secretKey: pulum
   return { accessKey: pulumi.secret(payload.accessKey), secretKey: pulumi.secret(payload.secretKey) }
 }
 
-const vmReaderKey = bootstrapInProgress ? undefined : readVmReaderKey()
+const vmReaderKey = computeDeferred ? undefined : readVmReaderKey()
 export const vmAccessKey = vmReaderKey?.accessKey ?? pulumi.secret('')
 export const vmSecretKey = vmReaderKey?.secretKey ?? pulumi.secret('')
 

--- a/infra/lib/bootstrap-stack-state.test.ts
+++ b/infra/lib/bootstrap-stack-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { detectInterruptedApply, detectStackState, extractApplyMarker, extractProjectId, pickStackShort } from './bootstrap-stack-state'
+import { detectComputeDeferred, detectStackState, extractComputeDeferredMarker, extractProjectId, pickStackShort } from './bootstrap-stack-state'
 
 describe('detectStackState', () => {
   it('fresh: no yaml at all', () => {
@@ -52,51 +52,30 @@ describe('extractProjectId', () => {
   })
 })
 
-describe('extractApplyMarker', () => {
+describe('extractComputeDeferredMarker', () => {
   it('reads the iso timestamp value', () => {
-    expect(extractApplyMarker('config:\n  bootstrap:applyInProgress: 2026-05-27T10:00:00.000Z\n')).toBe('2026-05-27T10:00:00.000Z')
+    expect(extractComputeDeferredMarker('config:\n  bootstrap:computeDeferred: 2026-05-27T10:00:00.000Z\n')).toBe('2026-05-27T10:00:00.000Z')
   })
 
   it('trims surrounding whitespace', () => {
-    expect(extractApplyMarker('config:\n  bootstrap:applyInProgress:   2026-05-27T10:00:00.000Z   \n')).toBe('2026-05-27T10:00:00.000Z')
+    expect(extractComputeDeferredMarker('config:\n  bootstrap:computeDeferred:   2026-05-27T10:00:00.000Z   \n')).toBe('2026-05-27T10:00:00.000Z')
   })
 
   it('returns undefined when absent', () => {
-    expect(extractApplyMarker('config:\n  scaleway:projectId: abc\n')).toBeUndefined()
+    expect(extractComputeDeferredMarker('config:\n  scaleway:projectId: abc\n')).toBeUndefined()
   })
 })
 
-describe('detectInterruptedApply', () => {
-  const backupPath = '/tmp/Pulumi.production.yaml.apply-backup'
-
-  it('clean: no yaml, no backup', () => {
-    expect(detectInterruptedApply({ backupExists: false, backupPath })).toBeUndefined()
+describe('detectComputeDeferred', () => {
+  it('clean: no yaml', () => {
+    expect(detectComputeDeferred()).toBeUndefined()
   })
 
-  it('clean: yaml without marker, no backup', () => {
-    expect(detectInterruptedApply({ yamlText: 'config:\n  scaleway:projectId: abc\n', backupExists: false, backupPath })).toBeUndefined()
+  it('clean: yaml without marker', () => {
+    expect(detectComputeDeferred('config:\n  scaleway:projectId: abc\n')).toBeUndefined()
   })
 
-  it('detects YAML marker when no backup present', () => {
-    const r = detectInterruptedApply({
-      yamlText: 'config:\n  bootstrap:applyInProgress: 2026-05-27T10:00:00.000Z\n',
-      backupExists: false,
-      backupPath,
-    })
-    expect(r?.trace).toBe('YAML marker bootstrap:applyInProgress = 2026-05-27T10:00:00.000Z')
-  })
-
-  it('detects backup-only', () => {
-    const r = detectInterruptedApply({ backupExists: true, backupPath })
-    expect(r?.trace).toBe(`Backup file: ${backupPath}`)
-  })
-
-  it('backup file wins over YAML marker when both present', () => {
-    const r = detectInterruptedApply({
-      yamlText: 'config:\n  bootstrap:applyInProgress: 2026-05-27T10:00:00.000Z\n',
-      backupExists: true,
-      backupPath,
-    })
-    expect(r?.trace).toContain('Backup file')
+  it('returns the marker value when present', () => {
+    expect(detectComputeDeferred('config:\n  bootstrap:computeDeferred: 2026-05-27T10:00:00.000Z\n')).toBe('2026-05-27T10:00:00.000Z')
   })
 })

--- a/infra/lib/bootstrap-stack-state.ts
+++ b/infra/lib/bootstrap-stack-state.ts
@@ -49,33 +49,22 @@ export function extractProjectId(yamlText: string): string | undefined {
 }
 
 /**
- * Extract the plaintext `bootstrap:applyInProgress: <iso-timestamp>` marker
- * written by apply-mode before swapping the CI key out. Returns undefined
- * when not present. Pure.
+ * Extract the plaintext `bootstrap:computeDeferred: <iso-timestamp>` marker.
+ * The bootstrap CLI sets it before the first `pulumi up` of a FRESH provision
+ * (no images exist yet, so compute is intentionally not declared) and clears it
+ * once base infra is up. Returns undefined when not present. Pure.
  */
-export function extractApplyMarker(yamlText: string): string | undefined {
-  return yamlText.match(/^\s*bootstrap:applyInProgress:\s*(.+)$/m)?.[1]?.trim()
-}
-
-export interface ApplyInterruptedTrace {
-  /** Human-readable description of where we detected the trace. */
-  trace: string
+export function extractComputeDeferredMarker(yamlText: string): string | undefined {
+  return yamlText.match(/^\s*bootstrap:computeDeferred:\s*(.+)$/m)?.[1]?.trim()
 }
 
 /**
- * Detect whether a prior "Apply infra change" run was interrupted between
- * swapping the CI key out and restoring it. Either signal is enough:
- *   - A verbatim stack-file backup (`Pulumi.<stack>.yaml.apply-backup`) is
- *     still on disk — apply-mode writes it before the swap and removes it
- *     after restore, so its presence means a run did not finish. This is the
- *     actionable trace: the backup restores the CI key byte-for-byte.
- *   - YAML marker `bootstrap:applyInProgress` is present in the stack file
- *     (secondary trace; normally cleared together with the backup).
- * Returns a trace descriptor when interrupted, or undefined when clean. Pure.
+ * Detect a leftover `bootstrap:computeDeferred` marker — the trace of a fresh
+ * provision whose initial `pulumi up` did not complete. While present, compute
+ * stays gated off (helpers.ts), which is correct until images are pushed; the
+ * next successful provisioning `pulumi up` clears it. Returns the marker value
+ * when present, or undefined when clean. Pure.
  */
-export function detectInterruptedApply(probe: { yamlText?: string; backupExists: boolean; backupPath: string }): ApplyInterruptedTrace | undefined {
-  if (probe.backupExists) return { trace: `Backup file: ${probe.backupPath}` }
-  const marker = probe.yamlText ? extractApplyMarker(probe.yamlText) : undefined
-  if (marker) return { trace: `YAML marker bootstrap:applyInProgress = ${marker}` }
-  return undefined
+export function detectComputeDeferred(yamlText?: string): string | undefined {
+  return yamlText ? extractComputeDeferredMarker(yamlText) : undefined
 }

--- a/infra/lib/pulumi-up.test.ts
+++ b/infra/lib/pulumi-up.test.ts
@@ -34,6 +34,13 @@ describe('classifyPermissionError', () => {
     })
   })
 
+  it('classifies bootstrap-owned resources (iam policy — needs IAM write, never granted to CI)', () => {
+    expect(classifyPermissionError('error: insufficient permissions: write policy: provider=scaleway@1.50.0')).toEqual({
+      kind: 'bootstrap-owned',
+      resource: 'policy',
+    })
+  })
+
   it('classifies CI-grantable resources', () => {
     expect(classifyPermissionError('insufficient permissions: write object_storage_bucket')).toEqual({
       kind: 'ci-grantable',

--- a/infra/lib/pulumi-up.ts
+++ b/infra/lib/pulumi-up.ts
@@ -18,8 +18,15 @@ async function waitForExitCode(child: ReturnType<typeof spawn>): Promise<number>
 
 /** Resources whose permission set is intentionally NOT granted to the CI key
  *  (see PROJECT_PERMISSION_SETS in setup-ci-key.ts). When permission is denied
- *  on one of these, the fix is to use Apply mode, not to widen CI. */
-const BOOTSTRAP_OWNED_RESOURCE = /private_network|^vpc|rdb|instance_db|domain_zone/i
+ *  on one of these, the fix is to use Apply mode, not to widen CI.
+ *
+ *  `policy` covers the VM reader IAM policy (resources/vm-iam.ts): creating or
+ *  updating an IAM policy needs IAM *write*, which the CI key must never hold
+ *  (IAMManager/IAMPolicyManager are forbidden privilege-escalation vectors —
+ *  see tasks/permission-sets.test.ts). So its first creation, like VPC/PN/RDB,
+ *  must run via a local `pulumi up` with the bootstrap key; CI only refreshes
+ *  it afterwards. */
+const BOOTSTRAP_OWNED_RESOURCE = /private_network|^vpc|rdb|instance_db|domain_zone|policy/i
 
 export type PermissionHint =
   | { kind: 'bootstrap-owned'; resource: string }

--- a/infra/lib/yaml-secrets.ts
+++ b/infra/lib/yaml-secrets.ts
@@ -7,24 +7,25 @@
  * runtime — just string parsing so it works on any backend.
  */
 
-/** Explicit list of config keys that MUST be encrypted in stack YAML. */
+import { runtimeSecrets } from './runtime-secrets'
+
+/**
+ * Explicit list of config keys that MUST be encrypted in stack YAML.
+ * Infra-plane keys are listed by hand; every runtime secret from the central
+ * registry is included automatically (any of them may transit stack config as
+ * a migration fallback or bootstrap seed), so a new registry entry needs no
+ * edit here.
+ */
 export const KNOWN_SECRET_KEYS: readonly string[] = [
   'scaleway:accessKey',
   'scaleway:secretKey',
   'infra:dbPassword',
-  'infra:cookieSecret',
-  'infra:unsubscribeSecret',
-  'infra:cdcSecret',
-  'infra:yjsSecret',
-  'infra:piiHashSecret',
-  'infra:adminEmail',
-  'infra:brevoApiKey',
-  'infra:scwAiApiKey',
   'infra:adminPassword',
   'infra:runtimePassword',
   // VM reader key — minimal-privilege identity for service VMs.
   'infra:vmAccessKey',
   'infra:vmSecretKey',
+  ...runtimeSecrets.map((secret) => `infra:${secret.id}`),
 ]
 
 /** Suffix patterns that always imply a secret value, regardless of namespace. */

--- a/infra/resources/database.test.ts
+++ b/infra/resources/database.test.ts
@@ -6,9 +6,9 @@ import { installPulumiMocks } from '../tests/helpers/pulumi-mock'
 let formatPostgresUrl: (user: string, pass: string, host: string, port: number | string, database: string) => string
 
 beforeAll(async () => {
-  // `bootstrap:applyInProgress` disables the compute pin-guard so the module
+  // `bootstrap:computeDeferred` disables the compute pin-guard so the module
   // imports without requiring pinned image tags.
-  await installPulumiMocks({ stack: 'production', config: { 'bootstrap:applyInProgress': 'test' } })
+  await installPulumiMocks({ stack: 'production', config: { 'bootstrap:computeDeferred': 'test' } })
   ;({ formatPostgresUrl } = await import('./database'))
 })
 

--- a/infra/resources/secrets.ts
+++ b/infra/resources/secrets.ts
@@ -10,7 +10,7 @@ import * as pulumi from '@pulumi/pulumi'
 import * as random from '@pulumi/random'
 import * as scaleway from '@pulumiverse/scaleway'
 import { naming, region, tags, mode, infraConfig } from '../helpers'
-import { runtimeSecrets } from '../lib/runtime-secrets'
+import { runtimeSecrets, type RuntimeSecretDefinition } from '../lib/runtime-secrets'
 import { connectionStringAdmin, connectionStringRuntime, connectionStringCdc } from './database'
 
 /** Folder path for secret organization, e.g. '/cella-production/' */
@@ -67,15 +67,27 @@ function pulumiOwnedRuntimeSecret(configKey: string, name: string) {
   }).result
 }
 
-const pulumiRuntimeSecretData: Record<string, pulumi.Input<string>> = {
+/**
+ * Pulumi-derived secret values that cannot be produced generically from the
+ * registry — currently only the database connection strings, which are built
+ * from database resources. Every other `valueSource: 'pulumi'` secret is
+ * resolved from its registry definition (`generation: 'random'` → a stable
+ * RandomPassword named after its `secretName`), so adding a new pulumi-owned
+ * random secret requires no edit here — only a registry entry.
+ */
+const derivedRuntimeSecretData: Record<string, pulumi.Input<string>> = {
   databaseUrlAdmin: connectionStringAdmin,
   databaseUrlRuntime: connectionStringRuntime,
   databaseUrlCdc: connectionStringCdc,
-  cookieSecret: pulumiOwnedRuntimeSecret('cookieSecret', 'cookie-secret'),
-  unsubscribeSecret: pulumiOwnedRuntimeSecret('unsubscribeSecret', 'unsubscribe-token-secret'),
-  cdcSecret: pulumiOwnedRuntimeSecret('cdcSecret', 'cdc-secret'),
-  yjsSecret: pulumiOwnedRuntimeSecret('yjsSecret', 'yjs-secret'),
-  piiHashSecret: pulumiOwnedRuntimeSecret('piiHashSecret', 'pii-hash-secret'),
+}
+
+function pulumiRuntimeSecretData(definition: RuntimeSecretDefinition): pulumi.Input<string> {
+  const derived = derivedRuntimeSecretData[definition.id]
+  if (derived !== undefined) return derived
+  if (definition.generation === 'random') return pulumiOwnedRuntimeSecret(definition.id, definition.secretName)
+  throw new Error(
+    `secrets: pulumi-owned secret '${definition.id}' has generation 'manual' but no derived value — add it to derivedRuntimeSecretData.`,
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -87,7 +99,7 @@ const secretResources = Object.fromEntries(runtimeSecrets.map((definition) => {
     ? createSecretContainer(definition.secretName, definition.description)
     : getExistingSecretContainer(definition.secretName)
   if (definition.valueSource === 'pulumi') {
-    createSecretVersion(definition.secretName, secret.id, pulumiRuntimeSecretData[definition.id]!)
+    createSecretVersion(definition.secretName, secret.id, pulumiRuntimeSecretData(definition))
   }
   return [definition.id, secret]
 }))

--- a/infra/resources/vm-iam.ts
+++ b/infra/resources/vm-iam.ts
@@ -23,7 +23,7 @@
  */
 import * as pulumi from '@pulumi/pulumi'
 import * as scaleway from '@pulumiverse/scaleway'
-import { naming, tags, vmReaderApplicationId } from '../helpers'
+import { naming, organizationId, tags, vmReaderApplicationId } from '../helpers'
 import { VM_PROJECT_PERMISSION_SETS } from '../tasks/setup-vm-key'
 
 // Application the policy binds to — the non-human VM reader principal created by
@@ -73,6 +73,13 @@ export const vmReaderPolicy = new scaleway.iam.Policy('vm-reader-policy', {
   name: naming.resource('vm-reader-policy'),
   description: 'Read-only registry + object storage + secret manager grant for service VMs (managed by Pulumi)',
   applicationId: vmApplicationId,
+  // Set the org explicitly (resolved in helpers from env, else the project) so
+  // the create does not depend on the provider's default org env — the bootstrap
+  // "Apply infra change" flow injects SCW_DEFAULT_PROJECT_ID but no org id, which
+  // left the provider default empty and failed with "organization_id is wrongly
+  // formatted". CI already sets SCW_DEFAULT_ORGANIZATION_ID; this makes both paths
+  // converge on the same resolved org.
+  organizationId,
   rules: buildVmReaderPolicyRules(projectId),
   tags,
 })

--- a/infra/tests/helpers/pulumi-mock.ts
+++ b/infra/tests/helpers/pulumi-mock.ts
@@ -33,7 +33,7 @@ export interface InstallOpts {
   project?: string
   stack?: string
   mode?: 'production' | 'staging' | 'development'
-  /** Stack config overrides, namespaced (e.g. `{ 'bootstrap:applyInProgress': '2026-01-01T00:00:00Z' }`). */
+  /** Stack config overrides, namespaced (e.g. `{ 'bootstrap:computeDeferred': '2026-01-01T00:00:00Z' }`). */
   config?: Record<string, string>
 }
 

--- a/infra/tests/unit/module-invariants.test.ts
+++ b/infra/tests/unit/module-invariants.test.ts
@@ -122,9 +122,10 @@ describe('secrets module', () => {
   it('seeds stable pulumi-owned runtime secrets from stack config only as a migration fallback', () => {
     expect(secrets).toMatch(/new random\.RandomPassword\(/)
     expect(secrets).toContain('const configured = infraConfig.getSecret(configKey)')
-    for (const key of ['cookieSecret', 'unsubscribeSecret', 'cdcSecret', 'yjsSecret', 'piiHashSecret']) {
-      expect(secrets).toContain(`pulumiOwnedRuntimeSecret('${key}'`)
-    }
+    // Random-generated values come generically from the registry definition,
+    // not a hand-maintained per-key list.
+    expect(secrets).toContain("pulumiOwnedRuntimeSecret(definition.id, definition.secretName)")
+    expect(secrets).toMatch(/generation === 'random'/)
   })
 
   it('namespaces every secret under the slug/mode path', () => {

--- a/infra/tests/unit/network.test.ts
+++ b/infra/tests/unit/network.test.ts
@@ -11,10 +11,10 @@ import { flushPulumi, installPulumiMocks, type MockHarness } from '../helpers/pu
 let h: MockHarness
 
 beforeAll(async () => {
-  // bootstrap:applyInProgress gates compute off, which keeps the
+  // bootstrap:computeDeferred gates compute off, which keeps the
   // image-tag pin assertion in helpers.ts from firing in unit tests that
   // don't care about compute.
-  h = await installPulumiMocks({ stack: 'production', config: { 'bootstrap:applyInProgress': 'test' } })
+  h = await installPulumiMocks({ stack: 'production', config: { 'bootstrap:computeDeferred': 'test' } })
   await import('../../resources/network')
   await flushPulumi()
 })

--- a/infra/tests/unit/storage.test.ts
+++ b/infra/tests/unit/storage.test.ts
@@ -19,11 +19,11 @@ let h: MockHarness
 beforeAll(async () => {
   h = await installPulumiMocks({
     stack: 'production',
-    // bootstrap:applyInProgress gates compute off so helpers.ts skips the
+    // bootstrap:computeDeferred gates compute off so helpers.ts skips the
     // image-tag pin assertion (these tests don't render compute). The CI/VM
     // application ids are derived from the IAM API (stubbed in the mock harness),
     // no longer read from stack config.
-    config: { 'bootstrap:applyInProgress': 'test' },
+    config: { 'bootstrap:computeDeferred': 'test' },
   })
   await import('../../resources/storage')
   await flushPulumi()


### PR DESCRIPTION
## Summary

Production deploy fixes for the Scaleway credential refactor (SOVRUN §3.3) plus a registry-driven runtime-secrets cleanup.

## Changes

- **VM reader IAM policy org id** — `vm-reader-policy` now sets `organizationId` explicitly (from `SCW_DEFAULT_ORGANIZATION_ID`, else derived from the project) instead of relying on the provider's default org env. The bootstrap "Apply infra change" flow left that env empty, producing `organization_id is wrongly formatted` on the policy create. `helpers.ts` exports the resolved org id.
- **`applyInProgress` → `computeDeferred`, fresh-flow only** — the compute-gating marker is renamed for clarity and set **only** during a fresh provision (registry has no images yet). "Apply infra change" no longer defers compute or snapshots/restores the stack file, so running it on an established stack no longer tears down live VMs/LB. The obsolete apply-backup machinery and gitignore entry are removed; `infra-cli` shows the marker as an informational notice.
- **Permission hint** — `classifyPermissionError` treats IAM `policy` writes as bootstrap-owned, so the hint points to Apply mode instead of the impossible "Rotate CI".
- **Registry-driven runtime secrets** — `KNOWN_SECRET_KEYS` and pulumi-owned secret values are derived from the central `runtimeSecrets` registry, so a new registry entry needs no hand edits in `yaml-secrets.ts` or `secrets.ts`.

## Validation

- `pnpm check` green (sdk + all typechecks + biome)
- infra typecheck clean; infra vitest passing
