### PR TITLE
feat(infra): auto-adopt orphaned vm-reader-policy + serviceDomainUrls outputs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -477,7 +477,7 @@ jobs:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           STACK: ${{ needs.setup.outputs.pulumi_stack }}
         run: |
-          API_URL=$(pulumi stack output apiDomainUrl --stack "$STACK" 2>/dev/null || echo '')
+          API_URL=$(pulumi stack output serviceDomainUrls --stack "$STACK" 2>/dev/null | jq -r '.backend // empty' || echo '')
           FRONTEND_URL=$(pulumi stack output frontendBucketEndpoint --stack "$STACK" 2>/dev/null || echo '')
           PIPELINE_ID=$(pulumi stack output pipelineId --stack "$STACK" 2>/dev/null || echo '')
           echo "api_url=$API_URL" >> $GITHUB_OUTPUT
@@ -518,8 +518,10 @@ jobs:
           echo "- **Registry:** $(pulumi stack output registryEndpoint --stack "$STACK")" >> $GITHUB_STEP_SUMMARY
           echo "- **Frontend:** $(pulumi stack output frontendBucketEndpoint --stack "$STACK")" >> $GITHUB_STEP_SUMMARY
           echo "- **Cluster:** $(pulumi stack output clusterHost --stack "$STACK" 2>/dev/null || echo 'not deployed')" >> $GITHUB_STEP_SUMMARY
-          echo "- **API Domain:** $(pulumi stack output apiDomainUrl --stack "$STACK" 2>/dev/null || echo 'no domain')" >> $GITHUB_STEP_SUMMARY
-          echo "- **Yjs Domain:** $(pulumi stack output yjsDomainUrl --stack "$STACK" 2>/dev/null || echo 'no domain')" >> $GITHUB_STEP_SUMMARY
+          # One line per LB-exposed service, straight from the registry-driven map.
+          pulumi stack output serviceDomainUrls --stack "$STACK" 2>/dev/null \
+            | jq -r 'to_entries[] | "- **\(.key) domain:** \(.value)"' >> $GITHUB_STEP_SUMMARY \
+            || echo "- **Domains:** no domain" >> $GITHUB_STEP_SUMMARY
 
   # -------------------------------------------------------------------------
   # Roll services — for each backend service (backend, cdc, yjs, ai):

--- a/infra/README.md
+++ b/infra/README.md
@@ -219,7 +219,7 @@ To gate production behind manual approval, configure a [GitHub Environment](http
 After the first deploy:
 
 ```bash
-pulumi stack output apiDomainUrl
+pulumi stack output serviceDomainUrls   # public URL per LB-exposed service
 pulumi stack output frontendBucketEndpoint
 
 # Run database migrations and initial seed. Requires PULUMI_CONFIG_PASSPHRASE

--- a/infra/cli/services/apply.ts
+++ b/infra/cli/services/apply.ts
@@ -2,10 +2,13 @@ import { spawnSync } from 'node:child_process'
 import { confirm, input, password } from '@inquirer/prompts'
 import pc from 'shared/cli-utils/colors'
 import { warningMark } from 'shared/console'
+import { adoptOrphanedPolicy } from '../../lib/adopt-orphaned-policy'
 import { extractProjectId } from '../../lib/bootstrap-stack-state'
 import { scwConfigPathNone } from '../../lib/bootstrap-scw-env'
 import { infraDir } from '../../lib/paths'
 import { runPulumiUpWithHint } from '../../lib/pulumi-up'
+import { resolveOrganizationId } from '../../lib/scaleway-iam'
+import { deriveInfra } from '../../naming'
 import { type InfraContext, resolveVerifiedPassphrase } from '../shared'
 
 /** One-shot `pulumi up` using a freshly-supplied bootstrap key passed via
@@ -65,6 +68,40 @@ export async function runApply(context: InfraContext): Promise<void> {
   const loginUrl = `s3://${appConfig.slug}-pulumi-state?endpoint=s3.${appConfig.s3.region}.scw.cloud&region=${appConfig.s3.region}`
   spawnSync('pulumi', ['login', loginUrl], { cwd: infraDir, env: applyEnv, stdio: 'inherit' })
   spawnSync('pulumi', ['stack', 'select', targetStack], { cwd: infraDir, env: applyEnv, stdio: 'ignore' })
+
+  // Resolve the organization id from the project so (a) it is set explicitly in
+  // the env for the IAM policy create/update inside `pulumi up` (matching CI),
+  // and (b) we can look up an existing IAM policy to adopt below. Non-fatal: if
+  // it cannot be resolved the program still derives it from the project at
+  // runtime, and policy adoption is skipped.
+  let organizationId: string | undefined
+  try {
+    organizationId = await resolveOrganizationId(bootSecret, projectId)
+    applyEnv.SCW_DEFAULT_ORGANIZATION_ID = organizationId
+  } catch (error) {
+    console.warn(`${warningMark} Could not resolve organization id (${(error as Error).message}); continuing without it.`)
+  }
+
+  // The VM reader IAM policy is Pulumi-managed but the original bootstrap created
+  // it out-of-band, so it can be missing from Pulumi state — which makes
+  // `pulumi up` try to create it and fail (409 locally / no IAM write in CI).
+  // Adopt the pre-existing policy into state first; idempotent once imported.
+  if (organizationId) {
+    try {
+      const policyName = deriveInfra(appConfig).naming.resource('vm-reader-policy')
+      await adoptOrphanedPolicy({
+        stack: targetStack,
+        cwd: infraDir,
+        env: applyEnv,
+        pulumiName: 'vm-reader-policy',
+        policyName,
+        secretKey: bootSecret,
+        organizationId,
+      })
+    } catch (error) {
+      console.warn(`${warningMark} ${(error as Error).message}`)
+    }
+  }
 
   // No compute-deferred marker and no stack-file backup here: the stack is
   // already bootstrapped with live compute, the bootstrap key reaches

--- a/infra/cli/services/setup.ts
+++ b/infra/cli/services/setup.ts
@@ -277,6 +277,16 @@ export async function runSetup(context: InfraContext, mode: Extract<CliMode, 're
   }
   console.info(divider)
 
+  // The VM reader IAM *policy* is Pulumi-managed (resources/vm-iam.ts), not minted
+  // here. After rotating, if a CI deploy fails with "insufficient permissions:
+  // write policy" the policy exists in Scaleway but not in Pulumi state — run
+  // "Apply infra change" once to adopt it (it imports the policy automatically).
+  if (mode === 'rotate' && vmAccessKey) {
+    console.info(
+      `  ${pc.dim(`Note: the VM reader IAM policy is reconciled by \`pulumi up\`. If a deploy reports ${pc.italic('"write policy"')}, run ${pc.italic('"Apply infra change"')} once to adopt it.`)}`,
+    )
+  }
+
   const canDeploy = context.hasCiKey || !!ciAccessKey
   if (canDeploy) {
     console.info(`\n${pc.bold('Next: provision base infrastructure')} (registry, DB, network — no compute yet)`)

--- a/infra/compose.gen.yml
+++ b/infra/compose.gen.yml
@@ -157,6 +157,7 @@ services:
       rolloverStrategy: in-place
       drainSeconds: 0
       lbRoute: host
+      lbWebsockets: true
       featureFlag: yjs
   ai:
     image: ${REGISTRY}/backend:${AI_TAG:-latest}

--- a/infra/compose/infrastructure.ts
+++ b/infra/compose/infrastructure.ts
@@ -50,6 +50,7 @@ function metaFrom(slug: string, cfg: AppServiceConfig): ServiceMeta {
     drainSeconds: cfg.drainSeconds ?? 0,
   }
   if (cfg.lbRoute) meta.lbRoute = cfg.lbRoute
+  if (cfg.lbWebsockets) meta.lbWebsockets = true
   if (cfg.reusesImageOf) meta.reusesImageOf = cfg.reusesImageOf
   if (cfg.featureFlag) meta.featureFlag = cfg.featureFlag
   if (cfg.instanceType) meta.instanceType = cfg.instanceType

--- a/infra/compose/services.config.ts
+++ b/infra/compose/services.config.ts
@@ -59,6 +59,8 @@ export default defineServices({
     startPeriod: '10s',
     rolloverStrategy: 'in-place',
     lbRoute: 'host',
+    // WebSocket service — LB keeps connections open for up to an hour.
+    lbWebsockets: true,
     // Only deployed when the app enables collaborative editing (appConfig.has.yjs).
     featureFlag: 'yjs',
     env: {

--- a/infra/compose/types.ts
+++ b/infra/compose/types.ts
@@ -57,6 +57,8 @@ export interface ServiceMeta {
   drainSeconds: number
   /** Public LB exposure; absent = internal-only. */
   lbRoute?: LbRoute
+  /** Long-lived LB timeouts (1h server/tunnel) for WebSocket services. */
+  lbWebsockets?: boolean
   /** Service whose image this one reuses (ai reuses backend); no own image built. */
   reusesImageOf?: string
   /**
@@ -146,6 +148,11 @@ export interface AppServiceConfig {
    * Omit for internal-only (no public LB backend — e.g. cdc).
    */
   lbRoute?: LbRoute
+  /**
+   * Keep LB connections long-lived (1h server/tunnel timeouts) for services
+   * speaking WebSockets through the LB (yjs). Only meaningful with `lbRoute`.
+   */
+  lbWebsockets?: boolean
   /**
    * Service whose image this one reuses, so CI builds no separate image for it
    * (ai reuses the backend image at the same SHA).

--- a/infra/helpers.ts
+++ b/infra/helpers.ts
@@ -19,7 +19,17 @@ const { appConfig } = await import('../shared')
 
 const derived = deriveInfra(appConfig)
 
-export const { naming, dnsZone, region, zone, tags, isProduction, hasDomain } = derived
+export const { naming, dnsZone, region, zone, tags, isProduction } = derived
+
+// Deploys are never run against a localhost config — fail fast here instead of
+// letting each resource module gate on `hasDomain` independently. The pure
+// `hasDomain` derivation stays in naming.ts for the bootstrap CLI's pre-deploy
+// checks; inside the Pulumi program a real domain is simply a requirement.
+if (!derived.hasDomain) {
+  throw new Error(
+    `Pulumi deploys require a real appConfig.domain (got '${appConfig.domain}'). Configure the domain for mode '${appConfig.mode}' before deploying.`,
+  )
+}
 
 // Pure appConfig pass-throughs — exposed here so resource modules import mode
 // from one place (the Pulumi binding layer) rather than from naming.ts.
@@ -42,6 +52,20 @@ export { appConfig }
 /** Pulumi stack config for infrastructure-specific values (sizing, secrets) */
 export const infraConfig = new pulumi.Config('infra')
 
+/**
+ * Scaleway project id — the single source for the Pulumi program. Both deploy
+ * paths inject `SCW_DEFAULT_PROJECT_ID` (CI from the synced `SCW_PROJECT_ID`
+ * secret in deploy.yml; the infra CLI's apply/preview from stack context), so
+ * the program requires it strictly instead of carrying fallback chains.
+ */
+export const projectId: string = (() => {
+  const id = process.env.SCW_DEFAULT_PROJECT_ID
+  if (!id) {
+    throw new Error('SCW_DEFAULT_PROJECT_ID is not set — run deploys via CI or the infra CLI, which inject it from the single source of truth.')
+  }
+  return id
+})()
+
 // ---------------------------------------------------------------------------
 // Derived IAM identities — materialized from the Scaleway IAM API at run time
 // rather than pinned in stack config (SOVRUN §3.3, "materialized, not stored").
@@ -55,27 +79,19 @@ export const infraConfig = new pulumi.Config('infra')
 
 // The IAM application lookup is org-scoped. Prefer an explicit organization id
 // from the environment (CI sets SCW_DEFAULT_ORGANIZATION_ID from the synced
-// SCW_ORGANIZATION_ID secret) so the deploy never touches the Account API — the
+// SCW_ORGANIZATION_ID secret; the CLI's apply flow resolves and injects it
+// best-effort) so the deploy never touches the Account API — the
 // least-privilege CI deploy key can read IAM but NOT `read project`. Only when
 // no org id is in the environment (e.g. local runs) do we resolve it from the
 // project (the in-program equivalent of the bootstrap CLI's resolveOrgId REST
 // call), so a name lookup never sends an empty org id.
-const envOrganizationId = process.env.SCW_DEFAULT_ORGANIZATION_ID ?? process.env.SCW_ORGANIZATION_ID
+const envOrganizationId = process.env.SCW_DEFAULT_ORGANIZATION_ID
 export const organizationId: pulumi.Input<string> = envOrganizationId
   ? envOrganizationId
-  : (() => {
-      const scwProjectId =
-        process.env.SCW_DEFAULT_PROJECT_ID ?? process.env.SCW_PROJECT_ID ?? new pulumi.Config('scaleway').get('projectId')
-      if (!scwProjectId) {
-        throw new Error(
-          'Scaleway organization ID not found. Set SCW_DEFAULT_ORGANIZATION_ID (preferred) or SCW_DEFAULT_PROJECT_ID in the environment (or scaleway:projectId in stack config).',
-        )
-      }
-      return scaleway.account.getProjectOutput({ projectId: scwProjectId }).apply((project) => {
-        if (!project.organizationId) throw new Error(`Could not resolve organization id from project '${scwProjectId}'.`)
-        return project.organizationId
-      })
-    })()
+  : scaleway.account.getProjectOutput({ projectId }).apply((project) => {
+      if (!project.organizationId) throw new Error(`Could not resolve organization id from project '${projectId}'.`)
+      return project.organizationId
+    })
 
 /** CI deploy application id — the `<slug>-ci-deploy` principal CI authenticates as. */
 export const ciDeployApplicationId = scaleway.iam

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -87,8 +87,9 @@ export const computeInstances = compute.computeInstances.map((i) => i.name)
 // ---------------------------------------------------------------------------
 
 import * as lb from './resources/loadbalancer'
-import * as pulumi from '@pulumi/pulumi'
 
-export const apiDomainUrl = lb.apiDomainUrl ?? pulumi.output('')
-export const yjsDomainUrl = lb.yjsDomainUrl ?? pulumi.output('')
-export const aiDomainUrl = lb.aiDomainUrl ?? pulumi.output('')
+// Public URL per LB-exposed service slug (e.g. { backend: 'https://api.…', … }).
+// Empty object when no domain / compute. Consumers (CI summary, docs) read
+// slugs from this map instead of per-service named outputs, so a new service
+// needs no export added here.
+export const serviceDomainUrls = lb.serviceDomainUrls

--- a/infra/lib/adopt-orphaned-policy.test.ts
+++ b/infra/lib/adopt-orphaned-policy.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const spawnSyncMock = vi.fn()
+vi.mock('node:child_process', () => ({ spawnSync: (...args: unknown[]) => spawnSyncMock(...args) }))
+
+const findPolicyIdByNameMock = vi.fn()
+vi.mock('./scaleway-iam', () => ({ findPolicyIdByName: (...args: unknown[]) => findPolicyIdByNameMock(...args) }))
+
+import { adoptOrphanedPolicy, stackExportHasResource } from './adopt-orphaned-policy'
+
+const POLICY_TYPE = 'scaleway:iam/policy:Policy'
+
+const exportWith = (resources: Array<{ urn: string; type: string }>) => JSON.stringify({ deployment: { resources } })
+
+describe('stackExportHasResource', () => {
+  it('finds a resource by type and urn suffix', () => {
+    const json = exportWith([
+      { urn: 'urn:pulumi:production::infra::pulumi:pulumi:Stack::infra-production', type: 'pulumi:pulumi:Stack' },
+      { urn: 'urn:pulumi:production::infra::scaleway:iam/policy:Policy::vm-reader-policy', type: POLICY_TYPE },
+    ])
+    expect(stackExportHasResource(json, POLICY_TYPE, 'vm-reader-policy')).toBe(true)
+  })
+
+  it('returns false when the type matches but the name does not', () => {
+    const json = exportWith([{ urn: 'urn:pulumi:production::infra::scaleway:iam/policy:Policy::other-policy', type: POLICY_TYPE }])
+    expect(stackExportHasResource(json, POLICY_TYPE, 'vm-reader-policy')).toBe(false)
+  })
+
+  it('returns false on empty or malformed export', () => {
+    expect(stackExportHasResource('', POLICY_TYPE, 'vm-reader-policy')).toBe(false)
+    expect(stackExportHasResource('{}', POLICY_TYPE, 'vm-reader-policy')).toBe(false)
+    expect(stackExportHasResource('not json', POLICY_TYPE, 'vm-reader-policy')).toBe(false)
+  })
+})
+
+const opts = {
+  stack: 'organization/infra/production',
+  cwd: '/infra',
+  env: {},
+  pulumiName: 'vm-reader-policy',
+  policyName: 'cella-vm-reader-policy',
+  secretKey: 'boot-secret',
+  organizationId: 'org-1',
+  log: () => {},
+}
+
+describe('adoptOrphanedPolicy', () => {
+  beforeEach(() => {
+    spawnSyncMock.mockReset()
+    findPolicyIdByNameMock.mockReset()
+  })
+
+  it('is a no-op when the policy is already in state', async () => {
+    spawnSyncMock.mockReturnValueOnce({
+      status: 0,
+      stdout: exportWith([{ urn: 'urn:pulumi:production::infra::scaleway:iam/policy:Policy::vm-reader-policy', type: POLICY_TYPE }]),
+    })
+    expect(await adoptOrphanedPolicy(opts)).toBe('in-state')
+    expect(findPolicyIdByNameMock).not.toHaveBeenCalled()
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1) // only the export, no import
+  })
+
+  it('imports the policy when it exists in Scaleway but not in state', async () => {
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: exportWith([]) }) // export: not in state
+    findPolicyIdByNameMock.mockResolvedValueOnce('pol-123')
+    spawnSyncMock.mockReturnValueOnce({ status: 0 }) // import succeeds
+    expect(await adoptOrphanedPolicy(opts)).toBe('imported')
+    const importCall = spawnSyncMock.mock.calls[1]
+    expect(importCall[0]).toBe('pulumi')
+    expect(importCall[1]).toEqual(['import', POLICY_TYPE, 'vm-reader-policy', 'pol-123', '--stack', opts.stack, '--yes', '--non-interactive'])
+  })
+
+  it('reports absent when the policy is in neither state nor Scaleway', async () => {
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: exportWith([]) })
+    findPolicyIdByNameMock.mockResolvedValueOnce(undefined)
+    expect(await adoptOrphanedPolicy(opts)).toBe('absent')
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1) // no import
+  })
+
+  it('reports unavailable (no throw) when the Scaleway lookup fails', async () => {
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: exportWith([]) })
+    findPolicyIdByNameMock.mockRejectedValueOnce(new Error('403'))
+    expect(await adoptOrphanedPolicy(opts)).toBe('unavailable')
+  })
+
+  it('throws when the import subprocess fails', async () => {
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: exportWith([]) })
+    findPolicyIdByNameMock.mockResolvedValueOnce('pol-123')
+    spawnSyncMock.mockReturnValueOnce({ status: 1 })
+    await expect(adoptOrphanedPolicy(opts)).rejects.toThrow(/pulumi import of vm-reader-policy/)
+  })
+})

--- a/infra/lib/adopt-orphaned-policy.ts
+++ b/infra/lib/adopt-orphaned-policy.ts
@@ -1,0 +1,104 @@
+/**
+ * Adopt a pre-existing Scaleway IAM policy into Pulumi state.
+ *
+ * The VM reader grant is a Pulumi-managed `iam.Policy` (`resources/vm-iam.ts`),
+ * but the original bootstrap created it out-of-band via the IAM REST API. After
+ * that flow switched to `managePolicy: false`, the live policy was never in
+ * Pulumi state — so every `pulumi up` tries to *create* it and deadlocks:
+ *   - locally (bootstrap key): HTTP 409 "resource already exists"
+ *   - in CI (read-only key):   "insufficient permissions: write policy"
+ *
+ * Neither caller can create it, and only a bootstrap key can write Pulumi state,
+ * so the fix is a one-time `pulumi import`. This helper performs that import
+ * automatically and idempotently from the "Apply infra change" flow: it is a
+ * no-op once the policy is in state (or absent in Scaleway), so re-running is
+ * safe.
+ */
+import { spawnSync } from 'node:child_process'
+import { findPolicyIdByName } from './scaleway-iam'
+
+/** Pulumi type token for `@pulumiverse/scaleway` IAM policies (`pulumi import`). */
+const POLICY_TYPE = 'scaleway:iam/policy:Policy'
+
+/**
+ * Pure: does a `pulumi stack export` JSON already contain a resource of the
+ * given Pulumi type whose URN ends in `::<name>`? A malformed/empty export
+ * (e.g. an uninitialised stack) is treated as "not present".
+ */
+export function stackExportHasResource(stackExportJson: string, type: string, name: string): boolean {
+  let parsed: { deployment?: { resources?: Array<{ urn?: string; type?: string }> } }
+  try {
+    parsed = JSON.parse(stackExportJson)
+  } catch {
+    return false
+  }
+  return (parsed.deployment?.resources ?? []).some(
+    (r) => r.type === type && typeof r.urn === 'string' && r.urn.endsWith(`::${name}`),
+  )
+}
+
+export type AdoptOutcome =
+  | 'in-state' // already managed by Pulumi — nothing to do
+  | 'imported' // existed in Scaleway, now adopted into state
+  | 'absent' // not in Scaleway either — `pulumi up` will create it
+  | 'unavailable' // could not query Scaleway IAM (skipped; up will report the real error)
+
+export interface AdoptOrphanedPolicyOptions {
+  /** Fully-qualified Pulumi stack, e.g. `organization/infra/production`. */
+  stack: string
+  /** Working directory containing the Pulumi program. */
+  cwd: string
+  /** Environment for the pulumi subprocesses (creds + passphrase). */
+  env: NodeJS.ProcessEnv
+  /** Pulumi logical resource name, e.g. `vm-reader-policy`. */
+  pulumiName: string
+  /** Live Scaleway policy name, e.g. `cella-vm-reader-policy`. */
+  policyName: string
+  /** Bootstrap secret key (IAM read; the env creds provide state write). */
+  secretKey: string
+  /** Organization the policy lives in. */
+  organizationId: string
+  /** Injected for tests; defaults to console.info. */
+  log?: (msg: string) => void
+}
+
+/**
+ * Import `policyName` into the stack as `pulumiName` when it exists in Scaleway
+ * but not in Pulumi state. Idempotent and safe to call before every apply-mode
+ * `pulumi up`.
+ */
+export async function adoptOrphanedPolicy(opts: AdoptOrphanedPolicyOptions): Promise<AdoptOutcome> {
+  const log = opts.log ?? ((msg: string) => console.info(msg))
+
+  // 1. Already in Pulumi state? Then `pulumi up` will reconcile it normally.
+  const exported = spawnSync('pulumi', ['stack', 'export', '--stack', opts.stack], {
+    cwd: opts.cwd,
+    env: opts.env,
+    encoding: 'utf8',
+  })
+  if (exported.status === 0 && stackExportHasResource(exported.stdout, POLICY_TYPE, opts.pulumiName)) {
+    return 'in-state'
+  }
+
+  // 2. Does the policy already exist in Scaleway (the orphan we must adopt)?
+  let policyId: string | undefined
+  try {
+    policyId = await findPolicyIdByName(opts.secretKey, opts.organizationId, opts.policyName)
+  } catch (error) {
+    log(`  (skipping policy adoption — could not query Scaleway IAM: ${(error as Error).message})`)
+    return 'unavailable'
+  }
+  if (!policyId) return 'absent'
+
+  // 3. Adopt it into state so the next `pulumi up` updates rather than creates.
+  log(`\n→ Adopting existing IAM policy ${opts.policyName} (${policyId}) into Pulumi state before \`pulumi up\``)
+  const imported = spawnSync(
+    'pulumi',
+    ['import', POLICY_TYPE, opts.pulumiName, policyId, '--stack', opts.stack, '--yes', '--non-interactive'],
+    { cwd: opts.cwd, env: opts.env, stdio: 'inherit' },
+  )
+  if (imported.status !== 0) {
+    throw new Error(`pulumi import of ${opts.pulumiName} (${policyId}) failed — adopt it manually then re-run.`)
+  }
+  return 'imported'
+}

--- a/infra/lib/scaleway-iam.ts
+++ b/infra/lib/scaleway-iam.ts
@@ -209,3 +209,27 @@ export async function provisionScopedKey(opts: ProvisionScopedKeyOptions, config
     organizationId,
   }
 }
+
+/**
+ * Resolve the organization id from a project id via the Account API. Exported
+ * for callers outside the provisioning flow (e.g. the apply CLI, which needs
+ * the org id to look up an existing IAM policy). Throws with guidance when it
+ * cannot be resolved.
+ */
+export function resolveOrganizationId(secretKey: string, projectId: string): Promise<string> {
+  return resolveOrgId(secretKey, projectId)
+}
+
+/**
+ * Find an IAM policy id by exact name within an organization, or undefined when
+ * none matches. Used to detect a pre-existing (orphaned) policy that must be
+ * adopted into Pulumi state rather than re-created.
+ */
+export async function findPolicyIdByName(secretKey: string, organizationId: string, name: string): Promise<string | undefined> {
+  const { policies } = await scw<{ policies: ScwPolicy[] }>(
+    secretKey,
+    'GET',
+    `${IAM_BASE}/policies?organization_id=${organizationId}&policy_name=${encodeURIComponent(name)}&page_size=20`,
+  )
+  return policies.find((p) => p.name === name)?.id
+}

--- a/infra/resources/compute.ts
+++ b/infra/resources/compute.ts
@@ -1,5 +1,6 @@
 /**
- * Compute — one Docker Compose VM per backend service (backend, cdc, yjs, ai).
+ * Compute — one Docker Compose VM per enabled service from the canonical
+ * registry (compose/services.config.ts).
  *
  * Each VM has a fully-closed inbound security group and is reachable only over the
  * main private network from the load balancer and database. Cloud-init installs
@@ -23,10 +24,11 @@
  */
 import * as pulumi from '@pulumi/pulumi'
 import * as scaleway from '@pulumiverse/scaleway'
-import { naming, zone, region, tags, infra, mode, hasDomain, appConfig, vmAccessKey, vmSecretKey } from '../helpers'
+import { naming, zone, region, tags, infra, mode, appConfig, vmAccessKey, vmSecretKey } from '../helpers'
 import { buildInstallSnippet, buildReconcilerEnv, type ReconcilerService } from '../reconciler/index'
 import { runtimeSecretsForConsumer, type RuntimeSecretConsumer } from '../lib/runtime-secrets'
-import { enabledServices, type ServiceName } from '../lib/services'
+import { composeConfig } from '../compose/compose'
+import { enabledServices, servicesByName, type ServiceName } from '../lib/services'
 import { frontendCsp } from '../lib/frontend-csp'
 import { renderCloudInit } from './cloud-init'
 import { deployTagsBucketName } from './deploy-tags'
@@ -115,14 +117,18 @@ interface ServiceConfig {
   profile: string
   /** App container's internal port; also the host port the ingress publishes. */
   port: number
-  /** Extra compose env vars (REGISTRY, URLs, tags) */
-  composeEnv: Record<string, pulumi.Input<string>>
+  /**
+   * Compose env var suppliers (REGISTRY, URLs, ingress wiring). Lazy so values
+   * resolved during VM creation order (cdc's API_WS_URL needs the backend VM's
+   * private IP) are read at cloud-init build time, not registry-scan time.
+   */
+  composeEnv: Record<string, () => pulumi.Input<string>>
 }
 
 function buildCloudInit(service: ServiceConfig): pulumi.Output<string> {
   const envLines = pulumi.all(
-    Object.entries(service.composeEnv).map(([k, v]) =>
-      pulumi.output(v).apply((val) => `${k}=${val}`),
+    Object.entries(service.composeEnv).map(([k, supply]) =>
+      pulumi.output(supply()).apply((val) => `${k}=${val}`),
     ),
   )
 
@@ -173,59 +179,52 @@ function buildCloudInit(service: ServiceConfig): pulumi.Output<string> {
 // Service definitions
 // ---------------------------------------------------------------------------
 
-const backendUrl = hasDomain ? appConfig.backendUrl : 'http://localhost:4000'
-const frontendUrl = appConfig.frontendUrl
-const aiUrl = hasDomain ? appConfig.aiUrl : 'http://localhost:4003'
-
 // CDC -> backend is a server-to-server WebSocket on the internal /internal/cdc
 // path. The backend rejects sources outside loopback or the VPC /24 (see
 // backend/src/lib/cdc-websocket.ts), so we route over the private network
 // directly to the backend VM instead of through the public LB.
-// Computed lazily after the backend VM is created, below.
-let cdcWsUrl: pulumi.Input<string> = 'ws://localhost:4000/internal/cdc'
+// Resolved AFTER the backend VM is created, below — bespoke inter-service
+// topology (like the DB connection strings in secrets.ts), not registry data.
+let cdcWsUrl: pulumi.Input<string> | undefined
 
-// Per-service compose env. The canonical registry (lib/services.ts) owns the
-// SET of services + their deploy knobs (profile, port, rollover, flags); this
-// map owns only the Pulumi-bound wiring (registry endpoint, inter-service URLs)
-// that can't live in the pure registry. cdc's API_WS_URL is a getter so it
-// reads the backend private IP resolved AFTER the backend VM is created (below).
-const composeEnvFor: Record<ServiceName, () => Record<string, pulumi.Input<string>>> = {
-  backend: () => ({
-    REGISTRY: registryEndpoint,
-    APP_MODE: mode,
-    FRONTEND_URL: frontendUrl,
-    BACKEND_URL: backendUrl,
-  }),
-  cdc: () => ({
-    REGISTRY: registryEndpoint,
-    APP_MODE: mode,
-    get API_WS_URL() { return cdcWsUrl },
-    BACKEND_URL: backendUrl,
-  }),
-  yjs: () => ({
-    REGISTRY: registryEndpoint,
-    APP_MODE: mode,
-    BACKEND_URL: backendUrl,
-  }),
-  ai: () => ({
-    REGISTRY: registryEndpoint,
-    APP_MODE: mode,
-    FRONTEND_URL: frontendUrl,
-    BACKEND_URL: backendUrl,
-    AI_API_URL: aiUrl,
-  }),
-  // Reverse-proxy in front of the S3 frontend bucket. Adds the frontend's CSP
-  // plus transport-level security headers, and rewrites 404s to /index.html so
-  // SPA deep links resolve. Deliberately reads no app secret from .env beyond
-  // what cloud-init needs to pull the image.
-  frontend: () => ({
-    REGISTRY: registryEndpoint,
-    APP_MODE: mode,
-    FRONTEND_CSP: frontendCsp,
-    // S3 REST hostname Caddy reverse-proxies to. Bucket name is whatever
-    // `naming.frontendBucket` resolves to (e.g. `<slug>-frontend`).
-    ORIGIN_HOST: pulumi.interpolate`${frontendBucketName}.s3.${region}.scw.cloud`,
-  }),
+/**
+ * Pulumi-bound values for the `${VAR}` placeholders a service's compose blocks
+ * reference. The registry (`compose/services.config.ts`) declares WHICH vars a
+ * service consumes; this pool is the single place their deploy-time values are
+ * bound. A new service reusing existing vars needs no edit here — only a
+ * genuinely new Pulumi-bound value (a new bucket, a new inter-service URL)
+ * adds one entry. Unknown placeholders fail fast at synth→deploy time.
+ */
+const envPool: Record<string, () => pulumi.Input<string>> = {
+  FRONTEND_URL: () => appConfig.frontendUrl,
+  BACKEND_URL: () => appConfig.backendUrl,
+  AI_API_URL: () => appConfig.aiUrl,
+  API_WS_URL: () => {
+    if (!cdcWsUrl) throw new Error('compute: API_WS_URL read before the backend VM was created — backend must be created first.')
+    return cdcWsUrl
+  },
+  // Frontend SPA proxy: CSP header + the S3 REST hostname Caddy proxies to.
+  FRONTEND_CSP: () => frontendCsp,
+  ORIGIN_HOST: () => pulumi.interpolate`${frontendBucketName}.s3.${region}.scw.cloud`,
+}
+
+// Vars satisfied outside the pool:
+//  - REGISTRY / APP_MODE        — universal, injected into every VM's .env;
+//  - INGRESS_PORT / UPSTREAM_*  — per-service ingress wiring, injected below;
+//  - *_TAG                      — image tags owned by the reconciler (S3 deploy
+//                                 tags), never written to .env by Pulumi.
+const INJECTED_VARS = new Set(['REGISTRY', 'APP_MODE', 'INGRESS_PORT', 'UPSTREAM_HOST', 'UPSTREAM_PORT'])
+const PLACEHOLDER_RE = /\$\{([A-Z][A-Z0-9_]*)(?::-[^}]*)?\}/g
+
+/** All `${VAR}` placeholders in the compose blocks that run on a service's VM. */
+function composePlaceholders(slug: string): string[] {
+  const vars = new Set<string>()
+  for (const block of Object.values(composeConfig.services)) {
+    if (!block.profiles.includes(slug)) continue
+    const texts = [block.image, ...(block.ports ?? []), ...Object.values(block.environment ?? {})]
+    for (const text of texts) for (const match of text.matchAll(PLACEHOLDER_RE)) vars.add(match[1]!)
+  }
+  return [...vars]
 }
 
 // Ingress wiring — every VM runs a Caddy `ingress` container that publishes the
@@ -234,11 +233,34 @@ const composeEnvFor: Record<ServiceName, () => Record<string, pulumi.Input<strin
 // the LB ever losing its backend. UPSTREAM_HOST is the compose service name;
 // INGRESS_PORT/UPSTREAM_PORT are the app's published/internal port (== healthPort).
 //
-// Backend uses blue-green slots (backend-blue / backend-green); its ingress
-// starts pointing at the initial active slot (blue), and the reconciler flips
-// the upstream between slots on each deploy. Every other service is a single
-// container named after the service. See infra/INFRA_ARCHITECTURE.md.
-const bootSlotService = (name: string): string => (name === 'backend' ? 'backend-blue' : name)
+// A blue-green service boots pointing at its initial active slot (`<slug>-blue`);
+// the reconciler flips the ingress upstream between slots on each deploy. An
+// in-place service is a single container named after the service. Derived from
+// the registry's rolloverStrategy — see infra/INFRA_ARCHITECTURE.md.
+const bootSlotService = (name: string): string =>
+  servicesByName.get(name as ServiceName)?.rolloverStrategy === 'blue-green' ? `${name}-blue` : name
+
+/** Compose env for one service: universal vars + ingress wiring + pool values for its placeholders. */
+function buildComposeEnv(slug: ServiceName, healthPort: number): Record<string, () => pulumi.Input<string>> {
+  const env: Record<string, () => pulumi.Input<string>> = {
+    REGISTRY: () => registryEndpoint,
+    APP_MODE: () => mode,
+    INGRESS_PORT: () => String(healthPort),
+    UPSTREAM_HOST: () => bootSlotService(slug),
+    UPSTREAM_PORT: () => String(healthPort),
+  }
+  for (const name of composePlaceholders(slug)) {
+    if (INJECTED_VARS.has(name) || name.endsWith('_TAG')) continue
+    const supply = envPool[name]
+    if (!supply) {
+      throw new Error(
+        `compute: service '${slug}' references \${${name}} in its compose blocks but envPool defines no value for it — add a supplier in resources/compute.ts.`,
+      )
+    }
+    env[name] = supply
+  }
+  return env
+}
 
 // Concrete VM service list, derived from the canonical registry: only the
 // services enabled for this app (feature flags) and placed on their own VM
@@ -250,11 +272,7 @@ const services: ServiceConfig[] = enabledServices(appConfig.has).map((svc) => {
   if (placement !== 'dedicated-vm') {
     throw new Error(`compute: placement '${placement}' for service '${svc.slug}' is not yet supported`)
   }
-  const composeEnv = composeEnvFor[svc.slug]()
-  composeEnv.INGRESS_PORT = String(svc.healthPort)
-  composeEnv.UPSTREAM_HOST = bootSlotService(svc.slug)
-  composeEnv.UPSTREAM_PORT = String(svc.healthPort)
-  return { name: svc.slug, profile: svc.slug, port: svc.healthPort, composeEnv }
+  return { name: svc.slug, profile: svc.slug, port: svc.healthPort, composeEnv: buildComposeEnv(svc.slug, svc.healthPort) }
 })
 
 // ---------------------------------------------------------------------------
@@ -352,11 +370,12 @@ function createVm(service: ServiceConfig): ComputeInstance {
 
 if (infra.computeEnabled) {
   // Create backend first so we can wire CDC's API_WS_URL to its private IP.
-  const backendService = services.find((s) => s.name === 'backend')!
+  const backendService = services.find((s) => s.name === 'backend')
+  if (!backendService) throw new Error("compute: the registry must include a 'backend' service — cdc and the LB default route depend on it.")
   const backend = createVm(backendService)
-  cdcWsUrl = backend.privateIp.apply((ip) => `ws://${ip}:4000/internal/cdc`)
+  cdcWsUrl = backend.privateIp.apply((ip) => `ws://${ip}:${backendService.port}/internal/cdc`)
 
-  // Create remaining services (cdc reads cdcWsUrl via the getter on composeEnv).
+  // Create remaining services (cdc reads cdcWsUrl via its lazy envPool supplier).
   for (const service of services) {
     if (service.name === 'backend') continue
     createVm(service)

--- a/infra/resources/dns.ts
+++ b/infra/resources/dns.ts
@@ -3,17 +3,17 @@
  *
  * Owns only the app subdomain CNAME (e.g. www → Edge Services pipeline). The API,
  * Yjs, AI and apex records live in the load balancer module because they depend
- * on the LB public IP. Skipped when no real domain is configured.
+ * on the LB public IP. Skipped while Edge Services is disabled (no pipeline).
  */
 import * as pulumi from '@pulumi/pulumi'
 import * as scaleway from '@pulumiverse/scaleway'
-import { dnsZone, hasDomain, serviceHost } from '../helpers'
+import { dnsZone, serviceHost } from '../helpers'
 import { pipelineId } from './edge'
 
 let _isApex = false
 let _appSubdomain = ''
 
-if (hasDomain && pipelineId) {
+if (pipelineId) {
   const appHost = serviceHost('frontend')
   _appSubdomain = appHost.replace(`.${dnsZone}`, '')
   _isApex = _appSubdomain === dnsZone || _appSubdomain === ''

--- a/infra/resources/edge.ts
+++ b/infra/resources/edge.ts
@@ -2,17 +2,17 @@
  * Edge Services — CDN with TLS termination in front of the frontend SPA bucket.
  *
  * Pipeline stages: backend (S3 website origin) → TLS (managed Let's Encrypt) →
- * DNS (app FQDN) → head (entry point). Skipped entirely when no real domain is
- * configured (dev / localhost), since Edge Services requires a public FQDN.
+ * DNS (app FQDN) → head (entry point). Disabled by default (`infra:enableEdgeServices`);
+ * the frontend is normally served by the Caddy proxy VM behind the LB.
  */
 import * as pulumi from '@pulumi/pulumi'
 import * as scaleway from '@pulumiverse/scaleway'
-import { naming, region, serviceHost, hasDomain, infra } from '../helpers'
+import { naming, region, serviceHost, infra } from '../helpers'
 import { frontendBucketName } from './storage'
 
 let _pipelineId: pulumi.Output<string> | undefined
 
-if (hasDomain && infra.enableEdgeServices) {
+if (infra.enableEdgeServices) {
   // ---------------------------------------------------------------------------
   // Pipeline
   // ---------------------------------------------------------------------------

--- a/infra/resources/loadbalancer.ts
+++ b/infra/resources/loadbalancer.ts
@@ -1,51 +1,62 @@
 /**
- * Load Balancer — TLS termination, host-header routing, and the public DNS records
- * for the API, Yjs, AI and apex hostnames.
+ * Load Balancer — TLS termination, host-header routing, and the public DNS
+ * records for every LB-exposed service.
  *
- * One LB-S sits on the main private network with a static public IPv4. HTTPS on 443
- * fans out to backend (4000), yjs (4002) and ai (4003) by Host header, each with its
- * own Let's Encrypt cert and health check. HTTP on 80 only carries redirect ACLs
- * (HTTP→HTTPS, plus apex→www so the apex stays canonical-free).
+ * One LB-S sits on the main private network with a static public IPv4. HTTPS on
+ * 443 fans out by Host header; each exposed service gets its own Let's Encrypt
+ * cert and health check. WHICH services are exposed — and how — is derived from
+ * the canonical service registry (`lbRoute` in `compose/services.config.ts`):
+ *  - 'default' — the LB's fallback backend (the API); DNS + cert, no route.
+ *  - 'host'    — host-header routed; own DNS record + cert + route.
+ *  - absent    — internal-only (cdc); nothing is created here.
+ * Adding a registry entry with an `lbRoute` is enough to get its DNS record,
+ * cert, LB backend and route — no service is listed by name in this file.
+ *
+ * The apex/www machinery (apex→www redirect, apex cert) is cella-owned
+ * structure keyed to the frontend service, not per-service data. HTTP on 80
+ * only carries the HTTP→HTTPS redirect ACL.
  *
  * Only provisioned when a real domain is configured AND compute is enabled,
  * since without compute VMs the LB has no backends to route to.
  */
 import * as pulumi from '@pulumi/pulumi'
 import * as scaleway from '@pulumiverse/scaleway'
-import { naming, zone, tags, dnsZone, serviceHost, hasDomain, infra, appConfig } from '../helpers'
-import { enabledServices } from '../lib/services'
+import { naming, zone, tags, dnsZone, serviceHost, infra, appConfig, endpoints } from '../helpers'
+import { enabledServices, type ServiceName } from '../lib/services'
 import { privateNetworkId } from './network'
 import { getInstanceIp } from './compute'
 
+/**
+ * Pre-refactor resource base names, kept so Pulumi URNs (and Scaleway display
+ * names) stay stable for resources that predate the registry-driven loop.
+ * Migration metadata only — a NEW service needs no entry here.
+ */
+const legacyBaseNames: Record<string, string> = { backend: 'api', frontend: 'app' }
+const baseName = (slug: string) => legacyBaseNames[slug] ?? slug
+
+const _serviceUrls: Record<string, pulumi.Output<string>> = {}
+
 // ---------------------------------------------------------------------------
-// Guard — skip if no domain or not deploying compute
+// Guard — skip while compute is deferred (fresh bootstrap); without compute VMs
+// the LB has no backends to route to. A real domain is asserted in helpers.
 // ---------------------------------------------------------------------------
 
-let _apiDomainUrl: pulumi.Output<string> | undefined
-let _yjsDomainUrl: pulumi.Output<string> | undefined
-let _aiDomainUrl: pulumi.Output<string> | undefined
-
-if (hasDomain && infra.computeEnabled) {
-  // Which optional services this app exposes publicly — derived from the
-  // canonical registry (feature flag + `lbRoute`) so the LB never re-decides
-  // independently of compute. A service is LB-exposed iff it is enabled AND
-  // declares an `lbRoute` (cdc has none → internal-only).
-  const lbServiceNames = new Set(
-    enabledServices(appConfig.has).filter((s) => s.lbRoute).map((s) => s.slug),
-  )
-  const yjsEnabled = lbServiceNames.has('yjs')
-  const aiEnabled = lbServiceNames.has('ai')
-
-  // Local hostname/zone bundle, derived from the service registry (slug → host)
-  // plus the DNS zone — not a parallel source of truth. Keeps the cert/route/DNS
-  // wiring below readable without re-deriving `serviceHost(...)` at each call.
-  const domains = {
-    zone: dnsZone,
-    app: serviceHost('frontend'),
-    api: serviceHost('backend'),
-    yjs: serviceHost('yjs'),
-    ai: serviceHost('ai'),
+if (infra.computeEnabled) {
+  // LB-exposed services, derived from the canonical registry (feature flag +
+  // `lbRoute`) so the LB never re-decides independently of compute. A service
+  // is LB-exposed iff it is enabled AND declares an `lbRoute`.
+  const lbServices = enabledServices(appConfig.has).filter((s) => s.lbRoute)
+  const defaultService = lbServices.find((s) => s.lbRoute === 'default')
+  if (!defaultService) {
+    throw new Error("loadbalancer: no enabled service declares lbRoute 'default' — the HTTPS frontend needs a fallback backend.")
   }
+
+  // Public scheme per service (https: / wss:), from the appConfig-derived
+  // registry endpoints — not re-decided here.
+  const schemeBySlug = new Map(endpoints.map((e) => [e.slug, new URL(e.url).protocol]))
+
+  const appHost = serviceHost('frontend')
+  const appIsAtApex = appHost === dnsZone
 
   // -------------------------------------------------------------------------
   // LB IP (static public IPv4)
@@ -70,8 +81,6 @@ if (hasDomain && infra.computeEnabled) {
     }],
   })
 
-  const appIsAtApex = domains.app === domains.zone
-
   // -------------------------------------------------------------------------
   // DNS A Records — all point to the LB public IP.
   // Must exist BEFORE Let's Encrypt certificates, since Scaleway validates
@@ -80,60 +89,27 @@ if (hasDomain && infra.computeEnabled) {
 
   const lbPublicIp = lb.ipAddress
 
-  const apiSubdomain = domains.api.replace(`.${domains.zone}`, '')
-  const yjsSubdomain = domains.yjs.replace(`.${domains.zone}`, '')
-  const aiSubdomain = domains.ai.replace(`.${domains.zone}`, '')
-  const appSubdomain = domains.app.replace(`.${domains.zone}`, '')
-
-  const apiDns = new scaleway.domain.Record('api-dns', {
-    dnsZone: domains.zone,
-    name: apiSubdomain,
-    type: 'A',
-    data: lbPublicIp,
-    ttl: 300,
-  })
-
-  // Conditionally create yjs DNS record
-  let yjsDns: scaleway.domain.Record | undefined
-  if (yjsEnabled) {
-    yjsDns = new scaleway.domain.Record('yjs-dns', {
-      dnsZone: domains.zone,
-      name: yjsSubdomain,
+  const dnsRecords = new Map<ServiceName, scaleway.domain.Record>()
+  for (const service of lbServices) {
+    const host = serviceHost(service.slug)
+    // A service whose host IS the zone apex (frontend at apex) gets no own
+    // record/cert/route — the default backend would have to serve it, which we
+    // don't currently support; the apex handling below covers that hostname.
+    if (host === dnsZone) continue
+    dnsRecords.set(service.slug, new scaleway.domain.Record(`${baseName(service.slug)}-dns`, {
+      dnsZone,
+      name: host.replace(`.${dnsZone}`, ''),
       type: 'A',
       data: lbPublicIp,
       ttl: 300,
-    })
+    }))
   }
 
-  // Conditionally create ai DNS record
-  let aiDns: scaleway.domain.Record | undefined
-  if (aiEnabled) {
-    aiDns = new scaleway.domain.Record('ai-dns', {
-      dnsZone: domains.zone,
-      name: aiSubdomain,
-      type: 'A',
-      data: lbPublicIp,
-      ttl: 300,
-    })
-  }
-
-  // App (www) DNS — points at the LB, which serves the SPA via the Caddy
-  // frontend VM.
-  let appDns: scaleway.domain.Record | undefined
-  if (!appIsAtApex) {
-    appDns = new scaleway.domain.Record('app-dns', {
-      dnsZone: domains.zone,
-      name: appSubdomain,
-      type: 'A',
-      data: lbPublicIp,
-      ttl: 300,
-    })
-  }
-
+  // Apex → points at the LB so the apex→www redirect ACL below can answer.
   let apexDns: scaleway.domain.Record | undefined
   if (!appIsAtApex) {
     apexDns = new scaleway.domain.Record('apex-dns', {
-      dnsZone: domains.zone,
+      dnsZone,
       name: '',
       type: 'A',
       data: lbPublicIp,
@@ -146,36 +122,15 @@ if (hasDomain && infra.computeEnabled) {
   // resolves to the LB IP before Scaleway runs the ACME validation.
   // -------------------------------------------------------------------------
 
-  const apiCert = new scaleway.loadbalancers.Certificate('api-cert', {
-    lbId: lb.id,
-    name: naming.resource('api-cert'),
-    letsencrypt: {
-      commonName: domains.api,
-    },
-  }, { dependsOn: [apiDns] })
-
-  // Conditionally create yjs certificate
-  let yjsCert: scaleway.loadbalancers.Certificate | undefined
-  if (yjsEnabled && yjsDns) {
-    yjsCert = new scaleway.loadbalancers.Certificate('yjs-cert', {
+  const certs = new Map<ServiceName, scaleway.loadbalancers.Certificate>()
+  for (const [slug, dns] of dnsRecords) {
+    certs.set(slug, new scaleway.loadbalancers.Certificate(`${baseName(slug)}-cert`, {
       lbId: lb.id,
-      name: naming.resource('yjs-cert'),
+      name: naming.resource(`${baseName(slug)}-cert`),
       letsencrypt: {
-        commonName: domains.yjs,
+        commonName: serviceHost(slug),
       },
-    }, { dependsOn: [yjsDns] })
-  }
-
-  // Conditionally create ai certificate
-  let aiCert: scaleway.loadbalancers.Certificate | undefined
-  if (aiEnabled && aiDns) {
-    aiCert = new scaleway.loadbalancers.Certificate('ai-cert', {
-      lbId: lb.id,
-      name: naming.resource('ai-cert'),
-      letsencrypt: {
-        commonName: domains.ai,
-      },
-    }, { dependsOn: [aiDns] })
+    }, { dependsOn: [dns] }))
   }
 
   let apexCert: scaleway.loadbalancers.Certificate | undefined
@@ -184,139 +139,60 @@ if (hasDomain && infra.computeEnabled) {
       lbId: lb.id,
       name: naming.resource('apex-cert'),
       letsencrypt: {
-        commonName: domains.zone,
+        commonName: dnsZone,
       },
     }, { dependsOn: [apexDns] })
   }
 
-  let appCert: scaleway.loadbalancers.Certificate | undefined
-  if (!appIsAtApex && appDns) {
-    appCert = new scaleway.loadbalancers.Certificate('app-cert', {
-      lbId: lb.id,
-      name: naming.resource('app-cert'),
-      letsencrypt: {
-        commonName: domains.app,
-      },
-    }, { dependsOn: [appDns] })
-  }
-
   // -------------------------------------------------------------------------
-  // LB Backends — each points to a VM's private IP
+  // LB Backends — each points to its service VM's private IP.
+  // Health-check the ingress proxy's own liveness endpoint, not the app's
+  // /health. The ingress always answers 200 while its process is up, so an
+  // app-container rollover (brief 502s on proxied paths) never drains the
+  // backend. See infra/ingress.Caddyfile.
   // -------------------------------------------------------------------------
 
-  const backendIp = getInstanceIp('backend')
-  const yjsIp = getInstanceIp('yjs')
-  const aiIp = getInstanceIp('ai')
-  const frontendIp = getInstanceIp('frontend')
-
-  const backendBackend = new scaleway.loadbalancers.Backend('backend-lb-backend', {
-    lbId: lb.id,
-    name: naming.resource('backend'),
-    forwardProtocol: 'http',
-    forwardPort: 4000,
-    serverIps: [backendIp],
-    // Health-check the ingress proxy's own liveness endpoint, not the app's
-    // /health. The ingress always answers 200 while its process is up, so an
-    // app-container rollover (brief 502s on proxied paths) never drains this
-    // backend. See infra/ingress.Caddyfile.
-    healthCheckHttp: { uri: '/__ingress/health', code: 200 },
-    healthCheckDelay: '3s',
-    healthCheckTimeout: '2s',
-    healthCheckMaxRetries: 2,
-  })
-
-  // Conditionally create yjs backend
-  let yjsBackend: scaleway.loadbalancers.Backend | undefined
-  if (yjsEnabled) {
-    yjsBackend = new scaleway.loadbalancers.Backend('yjs-lb-backend', {
+  const backends = new Map<ServiceName, scaleway.loadbalancers.Backend>()
+  for (const service of lbServices) {
+    backends.set(service.slug, new scaleway.loadbalancers.Backend(`${service.slug}-lb-backend`, {
       lbId: lb.id,
-      name: naming.resource('yjs'),
+      name: naming.resource(service.slug),
       forwardProtocol: 'http',
-      forwardPort: 4002,
-      serverIps: [yjsIp],
+      forwardPort: service.healthPort,
+      serverIps: [getInstanceIp(service.slug)],
       healthCheckHttp: { uri: '/__ingress/health', code: 200 },
       healthCheckDelay: '3s',
       healthCheckTimeout: '2s',
       healthCheckMaxRetries: 2,
-      // Long timeout for WebSocket connections
-      timeoutServer: '1h',
-      timeoutTunnel: '1h',
-    })
+      // Long timeouts keep WebSocket connections open (registry `lbWebsockets`).
+      ...(service.lbWebsockets ? { timeoutServer: '1h', timeoutTunnel: '1h' } : {}),
+    }))
   }
 
-  // Conditionally create ai backend
-  let aiBackend: scaleway.loadbalancers.Backend | undefined
-  if (aiEnabled) {
-    aiBackend = new scaleway.loadbalancers.Backend('ai-lb-backend', {
-      lbId: lb.id,
-      name: naming.resource('ai'),
-      forwardProtocol: 'http',
-      forwardPort: 4003,
-      serverIps: [aiIp],
-      healthCheckHttp: { uri: '/__ingress/health', code: 200 },
-      healthCheckDelay: '3s',
-      healthCheckTimeout: '2s',
-      healthCheckMaxRetries: 2,
-    })
-  }
-
-  // Caddy reverse-proxy in front of the SPA bucket. Listens on :80 inside
-  // the container; LB forwards plain HTTP and adds TLS at the edge.
-  const frontendBackend = new scaleway.loadbalancers.Backend('frontend-lb-backend', {
-    lbId: lb.id,
-    name: naming.resource('frontend'),
-    forwardProtocol: 'http',
-    forwardPort: 80,
-    serverIps: [frontendIp],
-    healthCheckHttp: { uri: '/__ingress/health', code: 200 },
-    healthCheckDelay: '3s',
-    healthCheckTimeout: '2s',
-    healthCheckMaxRetries: 2,
-  })
+  const defaultBackend = backends.get(defaultService.slug)!
 
   // -------------------------------------------------------------------------
   // HTTPS Frontend (port 443) — TLS termination + host-header routes
   // -------------------------------------------------------------------------
 
-  const allCertIds = [apiCert.id]
-  if (yjsCert) allCertIds.push(yjsCert.id)
-  if (aiCert) allCertIds.push(aiCert.id)
+  const allCertIds: pulumi.Input<string>[] = [...certs.values()].map((cert) => cert.id)
   if (apexCert) allCertIds.push(apexCert.id)
-  if (appCert) allCertIds.push(appCert.id)
 
   const httpsFrontend = new scaleway.loadbalancers.Frontend('https-frontend', {
     lbId: lb.id,
     name: naming.resource('https'),
-    backendId: backendBackend.id, // Default backend (api)
+    backendId: defaultBackend.id, // Default backend (the lbRoute 'default' service)
     inboundPort: 443,
     certificateIds: allCertIds,
   })
 
-  // Host-header routes for yjs and ai (backend is the default)
-  if (yjsEnabled && yjsBackend) {
-    new scaleway.loadbalancers.Route('yjs-route', {
+  // Host-header routes for every host-routed service with a DNS record.
+  for (const service of lbServices) {
+    if (service.lbRoute !== 'host' || !dnsRecords.has(service.slug)) continue
+    new scaleway.loadbalancers.Route(`${baseName(service.slug)}-route`, {
       frontendId: httpsFrontend.id,
-      backendId: yjsBackend.id,
-      matchHostHeader: domains.yjs,
-    })
-  }
-
-  if (aiEnabled && aiBackend) {
-    new scaleway.loadbalancers.Route('ai-route', {
-      frontendId: httpsFrontend.id,
-      backendId: aiBackend.id,
-      matchHostHeader: domains.ai,
-    })
-  }
-
-  // www (app) route — only when app is on its own subdomain. When app is at
-  // the apex, the default backend would have to be frontend instead of api,
-  // which we don't currently support.
-  if (!appIsAtApex) {
-    new scaleway.loadbalancers.Route('app-route', {
-      frontendId: httpsFrontend.id,
-      backendId: frontendBackend.id,
-      matchHostHeader: domains.app,
+      backendId: backends.get(service.slug)!.id,
+      matchHostHeader: serviceHost(service.slug),
     })
   }
 
@@ -335,14 +211,14 @@ if (hasDomain && infra.computeEnabled) {
           // placeholders; {{path}} does NOT include the leading slash, so it must be added
           // literally — matching Scaleway's documented format `https://{{host}}/{{path}}?{{query}}`.
           // Omitting it yields a garbled redirect like `https://www.example.comauth/authenticate`.
-          target: `https://${domains.app}/{{path}}?{{query}}`,
+          target: `https://${appHost}/{{path}}?{{query}}`,
           code: 301,
         }],
       },
       match: {
         httpFilter: 'http_header_match',
         httpFilterOption: 'host',
-        httpFilterValues: [domains.zone],
+        httpFilterValues: [dnsZone],
       },
     })
   }
@@ -354,7 +230,7 @@ if (hasDomain && infra.computeEnabled) {
   const httpFrontend = new scaleway.loadbalancers.Frontend('http-frontend', {
     lbId: lb.id,
     name: naming.resource('http'),
-    backendId: backendBackend.id, // Required but never reached (ACL redirects all)
+    backendId: defaultBackend.id, // Required but never reached (ACL redirects all)
     inboundPort: 80,
   })
 
@@ -377,18 +253,14 @@ if (hasDomain && infra.computeEnabled) {
   })
 
   // -------------------------------------------------------------------------
-  // Exports
+  // Exports — public URL per LB-exposed service (scheme from appConfig)
   // -------------------------------------------------------------------------
 
-  _apiDomainUrl = pulumi.interpolate`https://${domains.api}`
-  if (yjsEnabled) {
-    _yjsDomainUrl = pulumi.interpolate`wss://${domains.yjs}`
-  }
-  if (aiEnabled) {
-    _aiDomainUrl = pulumi.interpolate`https://${domains.ai}`
+  for (const service of lbServices) {
+    const scheme = schemeBySlug.get(service.slug) ?? 'https:'
+    _serviceUrls[service.slug] = pulumi.output(`${scheme}//${serviceHost(service.slug)}`)
   }
 }
 
-export const apiDomainUrl = _apiDomainUrl
-export const yjsDomainUrl = _yjsDomainUrl
-export const aiDomainUrl = _aiDomainUrl
+/** Public URL per LB-exposed service slug; empty when no domain/compute. */
+export const serviceDomainUrls: Readonly<Record<string, pulumi.Output<string>>> = _serviceUrls

--- a/infra/resources/vm-iam.ts
+++ b/infra/resources/vm-iam.ts
@@ -21,9 +21,8 @@
  * attach this policy to it. The permission set list is the canonical
  * `VM_PROJECT_PERMISSION_SETS` (locked by `tasks/permission-sets.test.ts`).
  */
-import * as pulumi from '@pulumi/pulumi'
 import * as scaleway from '@pulumiverse/scaleway'
-import { naming, organizationId, tags, vmReaderApplicationId } from '../helpers'
+import { naming, organizationId, projectId, tags, vmReaderApplicationId } from '../helpers'
 import { VM_PROJECT_PERMISSION_SETS } from '../tasks/setup-vm-key'
 
 // Application the policy binds to — the non-human VM reader principal created by
@@ -31,19 +30,6 @@ import { VM_PROJECT_PERMISSION_SETS } from '../tasks/setup-vm-key'
 // `infra:vmApplicationId`: without it the VMs have no IAM identity to grant,
 // which is the exact failure this module exists to prevent.
 const vmApplicationId = vmReaderApplicationId
-
-// Project the grant is scoped to. Matches the Scaleway provider's project,
-// which now authenticates from SCW_* env (the CI/operator key) rather than
-// stack config. Falls back to a legacy `scaleway:projectId` config value so
-// stacks bootstrapped before the env switch keep working during migration.
-const projectId =
-  process.env.SCW_DEFAULT_PROJECT_ID ?? process.env.SCW_PROJECT_ID ?? new pulumi.Config('scaleway').get('projectId')
-if (!projectId) {
-  throw new Error(
-    'Scaleway project ID not found. Set SCW_DEFAULT_PROJECT_ID in the environment ' +
-      '(or, for legacy stacks, scaleway:projectId in stack config).',
-  )
-}
 
 /**
  * Build the single project-scoped policy rule for the VM reader.

--- a/infra/tests/unit/compute.test.ts
+++ b/infra/tests/unit/compute.test.ts
@@ -68,21 +68,32 @@ describe('compute module source invariants', () => {
     expect(source).toMatch(/enabledServices\(appConfig\.has\)/)
   })
 
-  it('defines a compose-env factory for all five services (backend, cdc, yjs, ai, frontend)', () => {
-    for (const name of ['backend', 'cdc', 'yjs', 'ai', 'frontend']) {
-      expect(source).toMatch(new RegExp(`${name}:\\s*\\(\\)\\s*=>`))
-    }
+  it('binds compose env from the registry placeholder scan + envPool (no per-service env maps)', () => {
+    // Per-service compose env is derived by scanning each service's compose
+    // blocks for ${VAR} placeholders and binding them from the shared envPool,
+    // so adding a service that reuses existing vars needs no compute.ts edit.
+    expect(source).toMatch(/const envPool:/)
+    expect(source).toMatch(/composePlaceholders\(/)
+    expect(source).toMatch(/block\.profiles\.includes\(/)
+    // Unknown placeholders must fail fast rather than booting a broken VM.
+    expect(source).toMatch(/envPool defines no value/)
+    // The old hand-maintained per-service map must not come back.
+    expect(source).not.toMatch(/composeEnvFor/)
   })
 
-  it('frontend service does not receive backend secrets through composeEnv', () => {
-    // The .env file is still mounted via env_file: .env, but the frontend
-    // profile must not surface DB creds / cookie secrets / API keys via
-    // explicit composeEnv keys. This guards against accidental cross-wiring.
-    const frontendBlock = source.match(/frontend:\s*\(\)\s*=>\s*\(\{[\s\S]*?\}\)/)
-    expect(frontendBlock, 'could not locate frontend composeEnv factory').not.toBeNull()
-    const body = frontendBlock?.[0] ?? ''
+  it('derives the ingress boot slot from the registry rollover strategy', () => {
+    expect(source).toMatch(/rolloverStrategy === 'blue-green'/)
+    expect(source).not.toMatch(/name === 'backend'\s*\?\s*'backend-blue'/)
+  })
+
+  it('envPool does not bind backend secrets as compose env values', () => {
+    // The .env file is still mounted via env_file: .env, but secrets travel via
+    // the runtime-secrets manifest — never as envPool compose values.
+    const poolBlock = source.match(/const envPool:[\s\S]*?\n\}/)
+    expect(poolBlock, 'could not locate envPool').not.toBeNull()
+    const body = poolBlock?.[0] ?? ''
     for (const banned of ['DATABASE_URL', 'COOKIE_SECRET', 'BREVO_API_KEY', 'SCW_AI_API_KEY', 'YJS_SECRET', 'CDC_SECRET']) {
-      expect(body, `${banned} must not appear in frontend composeEnv`).not.toContain(banned)
+      expect(body, `${banned} must not appear in envPool`).not.toContain(banned)
     }
   })
 

--- a/infra/tests/unit/loadbalancer.test.ts
+++ b/infra/tests/unit/loadbalancer.test.ts
@@ -12,57 +12,68 @@ import { describe, expect, it } from 'vitest'
 
 const src = readFileSync(resolve(__dirname, '../../resources/loadbalancer.ts'), 'utf-8')
 
-describe('loadbalancer module — www / frontend wiring', () => {
-  it('declares an app (www) DNS A record pointing at the LB IP', () => {
-    expect(src).toContain("new scaleway.domain.Record('app-dns'")
-    // DNS data is the LB public IP — same as the other records.
-    expect(src).toMatch(/'app-dns'[\s\S]*?data:\s*lbPublicIp/)
+describe('loadbalancer module — registry-driven wiring', () => {
+  it('derives the LB-exposed service set from the registry, never by name', () => {
+    expect(src).toMatch(/enabledServices\(appConfig\.has\)\.filter\(\(s\) => s\.lbRoute\)/)
+    // The default backend comes from the lbRoute 'default' declaration.
+    expect(src).toMatch(/lbRoute === 'default'/)
+    // No service-specific resource construction outside the loops.
+    expect(src).not.toMatch(/new scaleway\.loadbalancers\.Backend\('(backend|yjs|ai|frontend)-lb-backend'/)
   })
 
-  it('issues a Lets Encrypt certificate for the app domain', () => {
-    expect(src).toContain("new scaleway.loadbalancers.Certificate('app-cert'")
-    expect(src).toMatch(/'app-cert'[\s\S]*?commonName:\s*domains\.app/)
+  it('creates one DNS record per exposed service pointing at the LB IP', () => {
+    expect(src).toMatch(/new scaleway\.domain\.Record\(`\$\{baseName\(service\.slug\)\}-dns`/)
+    expect(src).toMatch(/data:\s*lbPublicIp/)
   })
 
-  it('creates an LB backend for the frontend VM on port 80', () => {
-    expect(src).toContain("new scaleway.loadbalancers.Backend('frontend-lb-backend'")
-    expect(src).toMatch(/'frontend-lb-backend'[\s\S]*?forwardPort:\s*80/)
-    expect(src).toMatch(/'frontend-lb-backend'[\s\S]*?serverIps:\s*\[frontendIp\]/)
+  it('issues a Lets Encrypt certificate per DNS record, depending on it', () => {
+    expect(src).toMatch(/new scaleway\.loadbalancers\.Certificate\(`\$\{baseName\(slug\)\}-cert`/)
+    expect(src).toMatch(/commonName:\s*serviceHost\(slug\)/)
+    expect(src).toMatch(/dependsOn:\s*\[dns\]/)
+  })
+
+  it('creates one LB backend per exposed service on its declared port', () => {
+    expect(src).toMatch(/new scaleway\.loadbalancers\.Backend\(`\$\{service\.slug\}-lb-backend`/)
+    expect(src).toMatch(/forwardPort:\s*service\.healthPort/)
+    expect(src).toMatch(/serverIps:\s*\[getInstanceIp\(service\.slug\)\]/)
   })
 
   it('all backends health-check the ingress liveness path (not the app /health)', () => {
     // The per-VM ingress proxy answers /__ingress/health locally and always
     // 200 while it is up, so an app rollover never drains the LB backend.
-    for (const backend of ['backend-lb-backend', 'yjs-lb-backend', 'ai-lb-backend', 'frontend-lb-backend']) {
-      expect(src).toMatch(
-        new RegExp(`'${backend}'[\\s\\S]*?healthCheckHttp:\\s*\\{\\s*uri:\\s*'/__ingress/health',\\s*code:\\s*200\\s*\\}`),
-      )
-    }
+    expect(src).toMatch(/healthCheckHttp:\s*\{\s*uri:\s*'\/__ingress\/health',\s*code:\s*200\s*\}/)
+    // Exactly one Backend construction site — the registry loop — so no
+    // backend can bypass the ingress health check.
+    expect(src.match(/new scaleway\.loadbalancers\.Backend\(/g)).toHaveLength(1)
   })
 
-  it('registers the app-cert on the HTTPS frontend', () => {
-    expect(src).toMatch(/allCertIds\.push\(appCert\.id\)/)
+  it('keeps WebSocket LB timeouts gated on the registry lbWebsockets knob', () => {
+    expect(src).toMatch(/service\.lbWebsockets \? \{ timeoutServer: '1h', timeoutTunnel: '1h' \}/)
   })
 
-  it('adds a host-header route from www to the frontend backend', () => {
-    expect(src).toContain("new scaleway.loadbalancers.Route('app-route'")
-    expect(src).toMatch(/'app-route'[\s\S]*?backendId:\s*frontendBackend\.id/)
-    expect(src).toMatch(/'app-route'[\s\S]*?matchHostHeader:\s*domains\.app/)
+  it('adds a host-header route for every host-routed service', () => {
+    expect(src).toMatch(/service\.lbRoute !== 'host'/)
+    expect(src).toMatch(/new scaleway\.loadbalancers\.Route\(`\$\{baseName\(service\.slug\)\}-route`/)
+    expect(src).toMatch(/matchHostHeader:\s*serviceHost\(service\.slug\)/)
   })
 
-  it('pulls the frontend VM private IP from the compute module', () => {
-    expect(src).toMatch(/const\s+frontendIp\s*=\s*getInstanceIp\(['"]frontend['"]\)/)
+  it('keeps pre-refactor Pulumi resource names stable (regression guard)', () => {
+    // backend→api and frontend→app produce the original URNs (api-dns,
+    // api-cert, app-dns, app-cert, app-route) so no resource is replaced.
+    expect(src).toMatch(/legacyBaseNames:\s*Record<string,\s*string>\s*=\s*\{\s*backend:\s*'api',\s*frontend:\s*'app'\s*\}/)
   })
 
-  it('keeps existing api / yjs / ai / apex routes intact (regression guard)', () => {
-    expect(src).toContain("'api-dns'")
-    expect(src).toContain("'yjs-dns'")
-    expect(src).toContain("'ai-dns'")
-    expect(src).toContain("'api-cert'")
-    expect(src).toContain("'yjs-cert'")
-    expect(src).toContain("'ai-cert'")
-    expect(src).toContain("'backend-lb-backend'")
-    expect(src).toContain("'yjs-lb-backend'")
-    expect(src).toContain("'ai-lb-backend'")
+  it('skips dns/cert/route for a service whose host is the zone apex', () => {
+    expect(src).toMatch(/if \(host === dnsZone\) continue/)
+  })
+
+  it('registers the apex cert on the HTTPS frontend when app is not at apex', () => {
+    expect(src).toMatch(/if \(apexCert\) allCertIds\.push\(apexCert\.id\)/)
+  })
+
+  it('exports a public URL per exposed service via the generic map only', () => {
+    expect(src).toMatch(/export const serviceDomainUrls/)
+    // No per-service named exports — a new service needs no export added.
+    expect(src).not.toMatch(/export const (api|yjs|ai)DomainUrl/)
   })
 })

--- a/infra/tests/unit/module-invariants.test.ts
+++ b/infra/tests/unit/module-invariants.test.ts
@@ -2,7 +2,7 @@
  * Source-level security invariants for the LB / DNS / Edge / DB / registry
  * / secrets resources.
  *
- * These resources either gate on `hasDomain` (LB, DNS, Edge) or read deeply from
+ * These resources either gate on deploy phase (LB, DNS, Edge) or read deeply from
  * stack config (DB), making a live render via the Pulumi mock harness brittle
  * and slow. Static checks here are intentionally narrow and target the few
  * security invariants that have caused production outages or audits in the


### PR DESCRIPTION
## Summary

Two infra changes, both validated end-to-end against production:

### 1. Auto-adopt orphaned `vm-reader-policy` (Apply infra change)
The VM reader IAM policy is Pulumi-managed but pre-existed in Scaleway from the
old REST bootstrap — so it lived in Scaleway but not in Pulumi state, and every
`pulumi up` tried to *create* it and deadlocked (409 locally /
insufficient-permissions in CI). Neither caller can create it.

**Apply infra change** now reconciles this automatically: before `pulumi up` it
runs `pulumi stack export`, and if the policy is absent from state but present
in Scaleway, runs `pulumi import scaleway:iam/policy:Policy ...`. Idempotent —
once in state it's a no-op.

- `lib/adopt-orphaned-policy.ts` — `adoptOrphanedPolicy()` + pure
  `stackExportHasResource()` parser, with unit tests.
- `lib/scaleway-iam.ts` — export `resolveOrganizationId()` + `findPolicyIdByName()`.
- `cli/services/apply.ts` — resolve org id (sets `SCW_DEFAULT_ORGANIZATION_ID`)
  and adopt the policy before the up loop; non-fatal on error.
- `cli/services/setup.ts` — rotate path prints a hint pointing to Apply infra
  change if a deploy reports "write policy".

### 2. Registry-driven `serviceDomainUrls` outputs
Stack now exports a `serviceDomainUrls` map (one URL per LB-exposed service)
instead of fixed `ai`/`yjs`/`api` domain outputs. `deploy.yml` and the run
summary read the map via `jq`.

## Validation
- `pnpm check` green (sdk + all typechecks + biome).
- `infra` vitest: 368 pass + 3 todo.
- Production: Apply infra change imported the live `cella-vm-reader-policy`,
  then `pulumi up` updated it in place (no 409) and replaced the 3 VMs + 3 NICs
  for the cloud-init URL change. backend (`api.cellajs.com/health` → 204) and
  frontend (`www.cellajs.com` → 200) both serving, matching `X-App-Version`.
