### PR TITLE
fix(infra): drop STARDUST1-S for in-quota clean deploy

### DIFF
--- a/infra/compose.gen.yml
+++ b/infra/compose.gen.yml
@@ -35,7 +35,7 @@ services:
       replacementStrategy: lb-overlap
       drainSeconds: 10
       instanceType:
-        production: DEV1-M
+        production: DEV1-S
         staging: DEV1-S
       drainPolicy: requests
       lbRoute: default

--- a/infra/config/services.config.ts
+++ b/infra/config/services.config.ts
@@ -48,7 +48,7 @@ export default defineServices({
     // generation boots warm and contends for the slot the old one releases on
     // drain. No lbRoute → internal-only, reached over the private network.
     replacementStrategy: 'exclusive',
-    instanceType: 'STARDUST1-S',
+    instanceType: 'DEV1-S',
     env: {
       API_WS_URL: '${API_WS_URL}',
       BACKEND_URL: '${BACKEND_URL}',
@@ -77,7 +77,7 @@ export default defineServices({
     lbWebsockets: true,
     // Only deployed when the app enables collaborative editing (appConfig.features.yjs).
     featureFlag: 'yjs',
-    instanceType: 'STARDUST1-S',
+    instanceType: 'DEV1-S',
     env: {
       BACKEND_URL: '${BACKEND_URL}',
       YJS_PORT: '4002',
@@ -97,7 +97,7 @@ export default defineServices({
     lbRoute: 'host',
     // Only deployed when the app enables the AI worker (appConfig.features.ai).
     featureFlag: 'ai',
-    instanceType: 'STARDUST1-S',
+    instanceType: 'DEV1-S',
     env: {
       MODE: 'ai-worker',
       PORT: '4003',
@@ -125,7 +125,7 @@ export default defineServices({
     // The SPA proxy reads no app secret — no standard env, no .env files.
     includeStandardEnv: false,
     includeEnvFile: false,
-    instanceType: 'STARDUST1-S',
+    instanceType: 'DEV1-S',
     env: {
       FRONTEND_CSP: '${FRONTEND_CSP}',
       ORIGIN_HOST: '${ORIGIN_HOST}',


### PR DESCRIPTION
Follow-up to #768. The pulumi cutover failed on `cp_servers_type_STARDUST1_S quota (1/1)` while creating vm-cdc-246, aborting mid-deploy and taking api+www to 503.

Immutable lb-overlap is create-before-destroy and needs 2 VMs of a type at once (old + new gen); STARDUST1_S cap is 1. Switch cdc/yjs/ai/frontend (and confirm backend) to DEV1-S, which has ample quota (8 already running). Regenerated compose.gen.yml.