### PR TITLE
fix: fallback when lb server list is empty

### DIFF
--- a/infra/tasks/cutover.test.ts
+++ b/infra/tasks/cutover.test.ts
@@ -130,6 +130,17 @@ describe('sequenceCutover — lb-overlap', () => {
     expect(lb.calls).toEqual([])
   })
 
+  it('falls back to Pulumi oldIps when the LB read returns an empty server list', async () => {
+    const lb = recordingSetServers()
+    const res = await sequenceCutover(lbPlan({ getServers: async () => [], setServers: lb.fn }))
+    expect(res.ok).toBe(true)
+    expect(lb.calls).toEqual([
+      ['10.0.0.4', '10.0.0.9'],
+      ['10.0.0.9'],
+    ])
+    expect(res.steps).toContain('LB server list probe returned empty; assuming [old] from Pulumi metadata')
+  })
+
   it('drain wait happens after contract (old is removed before we wait for it to drain)', async () => {
     const order: string[] = []
     await sequenceCutover(

--- a/infra/tasks/cutover.ts
+++ b/infra/tasks/cutover.ts
@@ -222,7 +222,11 @@ export async function sequenceCutover(plan: CutoverPlan): Promise<CutoverResult>
     return normalize(actual) === normalize(expected)
   }
   const oldAndNew = [...plan.oldIps, ...plan.newIps]
-  const currentServers = plan.getServers ? await plan.getServers() : plan.oldIps
+  const probedServers = plan.getServers ? await plan.getServers() : plan.oldIps
+  const currentServers = probedServers.length > 0 ? probedServers : plan.oldIps
+  if (probedServers.length === 0 && plan.getServers) {
+    record('LB server list probe returned empty; assuming [old] from Pulumi metadata')
+  }
 
   if (sameIps(currentServers, plan.newIps)) {
     record('LB already contracted to [new]')


### PR DESCRIPTION
## Summary
- fall back to Pulumi old generation IPs when Scaleway LB backend read returns an empty server list
- keep the LB sanity check for non-empty unexpected server lists
- add a cutover regression test for the empty-read fallback

## Validation
- pnpm --filter infra exec vitest run cutover
- pnpm --filter infra ts
- git diff --check
- pre-commit/pre-push hooks ran workspace typechecks