### PR TITLE
fix: replace private nics delete first

### DIFF
--- a/infra/resources/compute.ts
+++ b/infra/resources/compute.ts
@@ -425,6 +425,10 @@ function createGenerationVm(svc: ServiceDefinition, generation: Generation): Gen
     ipamIpIds,
     zone,
     tags,
+  }, {
+    // Scaleway allows only one private NIC per server/private-network pair.
+    // Moving the stable IP changes ipamIpIds, which the provider replaces.
+    deleteBeforeReplace: true,
   })
 
   const privateIp = genPrivateIp.address.apply((addr) => addr.split('/')[0])

--- a/infra/tests/unit/compute.test.ts
+++ b/infra/tests/unit/compute.test.ts
@@ -122,6 +122,7 @@ describe('compute module source invariants', () => {
     expect(source).toMatch(/stablePrivateIpAddress/)
     expect(source).toMatch(/stablePrivateIpId/)
     expect(source).toMatch(/stablePrivateIpServiceSlug/)
+    expect(source).toMatch(/deleteBeforeReplace: true/)
   })
 
   it('envPool does not bind backend secrets as compose env values', () => {


### PR DESCRIPTION
## Summary
- make Scaleway private NIC replacements delete-before-replace so stable internal IP moves do not hit one-NIC-per-server conflicts
- assert the stable private IP path keeps this replacement mode

## Tests
- pnpm --filter infra exec vitest run tests/unit/compute.test.ts
- pnpm --filter infra ts
- pre-commit/pre-push workspace type checks