### PR TITLE
fix: verify backend after stable ip reattach

### DIFF
--- a/infra/tasks/cutover.test.ts
+++ b/infra/tasks/cutover.test.ts
@@ -89,7 +89,7 @@ describe('sequenceCutover — lb-overlap', () => {
     expect(order).toEqual(['expand', 'health', 'contract'])
   })
 
-  it('orders the steps health → expand → reattach → contract → drain', async () => {
+  it('orders the steps health → expand → reattach → health → contract → drain', async () => {
     const order: string[] = []
     const res = await sequenceCutover(
       lbPlan({
@@ -103,7 +103,26 @@ describe('sequenceCutover — lb-overlap', () => {
       }),
     )
     expect(res.ok).toBe(true)
-    expect(order).toEqual(['health', 'expand', 'reattach', 'contract', 'drain'])
+    expect(order).toEqual(['health', 'expand', 'reattach', 'health', 'contract', 'drain'])
+  })
+
+  it('aborts after stable IP reattach without contracting when the new generation stops serving', async () => {
+    const order: string[] = []
+    let healthChecks = 0
+    const res = await sequenceCutover(
+      lbPlan({
+        healthGate: async () => {
+          order.push('health')
+          healthChecks += 1
+          return healthChecks === 1
+        },
+        setServers: async (ips) => void order.push(ips.length === 2 ? 'expand' : 'contract'),
+        reattachInternalIp: async () => void order.push('reattach'),
+      }),
+    )
+    expect(res.ok).toBe(false)
+    expect(res.aborted).toBe('unhealthy')
+    expect(order).toEqual(['health', 'expand', 'reattach', 'health'])
   })
 
   it('resumes when the LB is already expanded to [old,new]', async () => {

--- a/infra/tasks/cutover.ts
+++ b/infra/tasks/cutover.ts
@@ -253,6 +253,9 @@ export async function sequenceCutover(plan: CutoverPlan): Promise<CutoverResult>
   if (plan.reattachInternalIp) {
     record('reattach stable internal IP to new generation')
     await plan.reattachInternalIp()
+
+    record('health-gate new generation after stable internal IP reattach')
+    if (!(await plan.healthGate())) return { ok: false, aborted: 'unhealthy', steps }
   }
 
   record('contract LB to [new]')


### PR DESCRIPTION
## Summary
- add a health gate after stable internal IP reattach before contracting the LB to the new backend only
- keep the LB expanded if the reattach disrupts backend reachability
- cover the abort-before-contract path in cutover tests

## Tests
- pnpm --filter infra exec vitest run tasks/cutover.test.ts
- pnpm --filter infra ts
- git diff --check
- pre-commit/pre-push workspace type checks