### PR TITLE
fix: sync rollout config before deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -361,7 +361,9 @@ jobs:
           SCW_DEFAULT_ORGANIZATION_ID: ${{ secrets.SCW_ORGANIZATION_ID }}
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           STACK: ${{ needs.setup.outputs.pulumi_stack }}
-        run: pulumi up --stack "$STACK" --yes
+        run: |
+          pnpm --filter infra sync-rollout-config --stack "$STACK"
+          pulumi up --stack "$STACK" --yes
 
       - name: Verify VM reader IAM grant
         # Belt-and-suspenders for the failure that took prod down: a VM whose key

--- a/infra/package.json
+++ b/infra/package.json
@@ -12,6 +12,7 @@
     "destroy": "pulumi destroy",
     "ensure-state-bucket": "tsx tasks/ensure-state-bucket.ts",
     "print-deploy-env": "tsx tasks/print-deploy-env.ts",
+    "sync-rollout-config": "tsx tasks/sync-rollout-config.ts",
     "wait-for-version": "tsx tasks/wait-for-version.ts",
     "wait-for-images": "tsx tasks/wait-for-images.ts",
     "cutover": "tsx tasks/cutover.ts",

--- a/infra/resources/compute.ts
+++ b/infra/resources/compute.ts
@@ -13,10 +13,9 @@
  *   infra:pendingGen:<svc> next generation, set during a cutover (optional)
  *   infra:pendingSha:<svc> image SHA for the pending generation
  *   infra:stableInternalGen_<svc> generation carrying a service's stable internal IP
- * compute materialises a VM for every generation in {gen} ∪ {pendingGen}, so the
- * "create bookend" stands up the new generation alongside the old, and the
- * "destroy bookend" (after CI bumps `gen` and clears `pendingGen`) tears the old
- * one down.
+ * compute materialises a VM for every generation in {gen} ∪ {pendingGen}. CI
+ * first syncs these keys from the current stack outputs so a new runner never
+ * rolls infrastructure back from stale committed config.
  *
  * Each VM has a fully-closed inbound security group and is reachable only over the
  * main private network from the load balancer and database. Cloud-init installs
@@ -330,6 +329,8 @@ export interface GenerationInstance {
   service: ServiceName
   /** Generation number. */
   gen: number
+  /** Image SHA baked into this generation. */
+  sha: string
   /** Pulumi resource name `vm-<svc>-<gen>`. */
   name: string
   server: scaleway.instance.Server
@@ -408,6 +409,7 @@ function createGenerationVm(svc: ServiceDefinition, generation: Generation): Gen
     // (new resource name), never an in-place replacement. The vm-reader IAM
     // grant must exist before first boot so cloud-init can hydrate secrets.
     dependsOn: [vmReaderPolicy],
+    ignoreChanges: ['cloudInit'],
   })
 
   const stableServiceGenerations = stablePrivateIpService ? generationsByService.get(stablePrivateIpService.slug) : undefined
@@ -432,7 +434,7 @@ function createGenerationVm(svc: ServiceDefinition, generation: Generation): Gen
   })
 
   const privateIp = genPrivateIp.address.apply((addr) => addr.split('/')[0])
-  const inst: GenerationInstance = { service: svc.slug, gen: generation.gen, name: resourceName, server, privateIp, privateNic }
+  const inst: GenerationInstance = { service: svc.slug, gen: generation.gen, sha: generation.sha, name: resourceName, server, privateIp, privateNic }
   instances.push(inst)
   return inst
 }
@@ -477,6 +479,7 @@ export const stablePrivateIpServiceSlug = pulumi.output(stablePrivateIpService?.
 export const computeGenerationMetadata = pulumi.all(instances.map((i) => pulumi.all([i.server.id, i.privateIp, i.privateNic.id]).apply(([serverId, privateIp, privateNicId]) => ({
   service: i.service,
   gen: i.gen,
+  sha: i.sha,
   name: i.name,
   serverId,
   privateIp,

--- a/infra/tasks/sync-rollout-config.test.ts
+++ b/infra/tasks/sync-rollout-config.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { generationsByService, selectGeneration } from './sync-rollout-config'
+
+describe('sync rollout config helpers', () => {
+  it('selects the newest observed generation per service', () => {
+    const services = generationsByService([
+      { service: 'backend', gen: 5, sha: 'old' },
+      { service: 'frontend', gen: 2, sha: 'old' },
+      { service: 'backend', gen: 257, sha: 'new' },
+    ])
+
+    expect(selectGeneration(services.get('backend')!)).toEqual({ service: 'backend', gen: 257, sha: 'new' })
+    expect(selectGeneration(services.get('frontend')!)).toEqual({ service: 'frontend', gen: 2, sha: 'old' })
+  })
+})

--- a/infra/tasks/sync-rollout-config.ts
+++ b/infra/tasks/sync-rollout-config.ts
@@ -1,0 +1,94 @@
+import { spawnSync } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+import { getFlag } from './args'
+
+interface GenerationMetadata {
+  service: string
+  gen: number
+  sha?: string
+}
+
+function runPulumi(args: string[], opts: { allowFailure?: boolean } = {}): string {
+  const res = spawnSync('pulumi', args, {
+    cwd: new URL('..', import.meta.url).pathname,
+    env: process.env,
+    encoding: 'utf-8',
+    stdio: ['inherit', 'pipe', 'pipe'],
+  })
+  if (res.stdout) process.stdout.write(res.stdout)
+  if (res.stderr) process.stderr.write(res.stderr)
+  if (res.status !== 0 && !opts.allowFailure) throw new Error(`pulumi ${args.join(' ')} failed with exit ${res.status}`)
+  return res.stdout.trim()
+}
+
+function configKey(service: string, key: 'gen' | 'sha' | 'pendingGen' | 'pendingSha' | 'stableInternalGen'): string {
+  if (key === 'stableInternalGen') return `infra:stableInternalGen_${service}`
+  return `infra:${key}_${service}`
+}
+
+function currentConfig(stack: string, key: string): string | undefined {
+  const out = runPulumi(['config', 'get', key, '--stack', stack], { allowFailure: true }).trim()
+  return out || undefined
+}
+
+function setConfig(stack: string, key: string, value: string | number): void {
+  runPulumi(['config', 'set', key, String(value), '--stack', stack])
+}
+
+function rmConfig(stack: string, key: string): void {
+  runPulumi(['config', 'rm', key, '--stack', stack], { allowFailure: true })
+}
+
+function stackOutput(stack: string, name: string): string | undefined {
+  return runPulumi(['stack', 'output', name, '--stack', stack, '--json'], { allowFailure: true }).trim() || undefined
+}
+
+export function selectGeneration(items: GenerationMetadata[]): GenerationMetadata {
+  return [...items].sort((a, b) => b.gen - a.gen)[0]!
+}
+
+export function generationsByService(metadata: GenerationMetadata[]): Map<string, GenerationMetadata[]> {
+  const services = new Map<string, GenerationMetadata[]>()
+  for (const item of metadata) {
+    const generations = services.get(item.service) ?? []
+    generations.push(item)
+    services.set(item.service, generations)
+  }
+  return services
+}
+
+export async function syncRolloutConfig(argv = process.argv.slice(2)): Promise<void> {
+  const stack = getFlag(argv, '--stack')
+  if (!stack) throw new Error('Usage: sync-rollout-config.ts --stack <stack>')
+
+  const rawMetadata = stackOutput(stack, 'computeGenerationMetadata')
+  if (!rawMetadata) {
+    console.info('[sync-rollout-config] no computeGenerationMetadata output yet; skipping')
+    return
+  }
+
+  const metadata = JSON.parse(rawMetadata) as GenerationMetadata[]
+  const byService = generationsByService(metadata)
+
+  for (const [service, generations] of byService) {
+    const generation = selectGeneration(generations)
+    const sha = generation.sha ?? currentConfig(stack, configKey(service, 'sha')) ?? 'latest'
+
+    console.info(`[sync-rollout-config] ${service}: gen=${generation.gen} sha=${sha}`)
+    setConfig(stack, configKey(service, 'gen'), generation.gen)
+    setConfig(stack, configKey(service, 'sha'), sha)
+    rmConfig(stack, configKey(service, 'pendingGen'))
+    rmConfig(stack, configKey(service, 'pendingSha'))
+  }
+
+  const stableServiceRaw = stackOutput(stack, 'stablePrivateIpServiceSlug')
+  const stableService = stableServiceRaw ? (JSON.parse(stableServiceRaw) as string | undefined) : undefined
+  const stableGeneration = stableService ? byService.get(stableService) : undefined
+  if (stableService && stableGeneration) {
+    const generation = selectGeneration(stableGeneration)
+    console.info(`[sync-rollout-config] ${stableService}: stableInternalGen=${generation.gen}`)
+    setConfig(stack, configKey(stableService, 'stableInternalGen'), generation.gen)
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) await syncRolloutConfig()

--- a/infra/tests/unit/compute.test.ts
+++ b/infra/tests/unit/compute.test.ts
@@ -107,6 +107,7 @@ describe('compute module source invariants', () => {
     expect(source).toMatch(/activeGenerations\(/)
     expect(source).toMatch(/vm-\$\{svc\.slug\}-\$\{generation\.gen\}/)
     expect(source).toMatch(/ipam-\$\{svc\.slug\}-\$\{generation\.gen\}/)
+    expect(source).toMatch(/ignoreChanges: \['cloudInit'\]/)
     // The old lifelong reserved-IP map must not come back.
     expect(source).not.toMatch(/reservedIps\.set\(/)
     expect(source).not.toMatch(/Create backend first/)
@@ -123,6 +124,7 @@ describe('compute module source invariants', () => {
     expect(source).toMatch(/stablePrivateIpId/)
     expect(source).toMatch(/stablePrivateIpServiceSlug/)
     expect(source).toMatch(/deleteBeforeReplace: true/)
+    expect(source).toMatch(/syncs these keys from the current stack outputs/)
   })
 
   it('envPool does not bind backend secrets as compose env values', () => {


### PR DESCRIPTION
## Summary
- sync local Pulumi rollout config from current stack outputs before base deploy
- emit per-generation SHA in compute metadata
- keep existing VM generation cloud-init immutable to avoid stale config replacements

## Tests
- pnpm --filter infra exec vitest run tasks/sync-rollout-config.test.ts tests/unit/compute.test.ts tasks/cutover.test.ts
- pnpm --filter infra ts
- git --no-pager diff --check