### PR TITLE
fix: restore cold-boot health gate budget

### DIFF
--- a/infra/tasks/deploy-service.test.ts
+++ b/infra/tasks/deploy-service.test.ts
@@ -5,8 +5,8 @@ import { describe, expect, it } from 'vitest'
 const source = readFileSync(resolve(__dirname, 'deploy-service.ts'), 'utf-8')
 
 describe('deploy-service source invariants', () => {
-  it('keeps public deploy health gates short enough to fail fast', () => {
-    expect(source).toMatch(/const deployHealthAttempts = 30/)
+  it('keeps the public deploy health gate budget above cold-boot time', () => {
+    expect(source).toMatch(/const deployHealthAttempts = 120/)
     expect(source).toMatch(/attempts: deployHealthAttempts/)
   })
 

--- a/infra/tasks/deploy-service.ts
+++ b/infra/tasks/deploy-service.ts
@@ -72,7 +72,10 @@ function healthUrlFromFlag(explicit?: string): string | undefined {
   return explicit.endsWith('/health') ? explicit : `${explicit.replace(/\/$/, '')}/health`
 }
 
-const deployHealthAttempts = 30
+// Cold-boot budget: a fresh VM generation pulls its image, runs migrate, and
+// starts the app before it serves the new SHA (~110s observed). The gate must
+// outlast that, so keep a generous attempt count (120 * 3s = 360s).
+const deployHealthAttempts = 120
 const deployHealthIntervalMs = 3000
 const deployHealthTimeoutMs = 8000
 


### PR DESCRIPTION
Restores the public health gate to 120 attempts. The 30-attempt budget starved the first (cold-boot) cutover gate, which must outlast image pull + migrate + app start (~110s).