### PR TITLE
ci: configure git identity for create-cella e2e test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,13 @@ jobs:
           node-version: 24
           cache: "pnpm"
 
+      # The create-cella e2e test scaffolds a project and runs `git commit`,
+      # which needs an author identity the runner doesn't have by default.
+      - name: Configure git identity
+        run: |
+          git config --global user.email "ci@cellajs.com"
+          git config --global user.name "cella CI"
+
       - name: Create .env files
         run: |
           cp ./backend/.env.example ./backend/.env

--- a/cdc/src/tests/transaction-buffer.test.ts
+++ b/cdc/src/tests/transaction-buffer.test.ts
@@ -167,7 +167,7 @@ describe('TransactionBuffer', () => {
     // Verify onSurvivingEvents was called once (at commit) with just 1 event
     expect(onSurvivingEvents).toHaveBeenCalledTimes(1);
     expect((onSurvivingEvents as ReturnType<typeof vi.fn>).mock.calls[0][0]).toHaveLength(1);
-  });
+  }, 30_000); // Processes 50k events; the default 10s timeout is too tight on loaded CI runners
 
   it('suppresses child deletes that arrive before parent context entity delete', async () => {
     buffer.onBegin({ tag: 'begin', xid: 101, commitLsn: null, commitTime: BigInt(0) });


### PR DESCRIPTION
The create-cella e2e test scaffolds a project and runs `git commit`, which fails on CI runners that have no git author identity (`Author identity unknown`). This blocks the `test` job and therefore the release PRs.

Adds a git identity config step to the `test` job before running `pnpm test:full`. No change to the shipped CLI.