### PR TITLE
fix: pin protobufjs to patched 8.x to clear high-severity audit advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  protobufjs@>=8.0.0 <8.4.1: 8.6.5
+
 importers:
 
   .:
@@ -5456,9 +5459,6 @@ packages:
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-
-  '@protobufjs/inquire@1.1.2':
-    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -11219,8 +11219,8 @@ packages:
     resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
     engines: {node: '>=12.0.0'}
 
-  protobufjs@8.0.1:
-    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+  protobufjs@8.6.5:
+    resolution: {integrity: sha512-zeE5LPpencAGXvsxyOYmEgJhxzHY8IsmPAFzstZVhDSVT8QH03q6gMZwZRaQGApevZbAL6u28ugs4CC+YKB2jQ==}
     engines: {node: '>=12.0.0'}
 
   pump@3.0.4:
@@ -16946,7 +16946,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      protobufjs: 8.0.1
+      protobufjs: 8.6.5
 
   '@opentelemetry/otlp-transformer@0.218.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -17653,8 +17653,6 @@ snapshots:
       '@protobufjs/aspromise': 1.1.2
 
   '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.2': {}
 
   '@protobufjs/path@1.1.2': {}
 
@@ -24033,19 +24031,8 @@ snapshots:
       '@types/node': 24.10.13
       long: 5.3.2
 
-  protobufjs@8.0.1:
+  protobufjs@8.6.5:
     dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.1
-      '@protobufjs/fetch': 1.1.1
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.2
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.1
-      '@types/node': 24.10.13
       long: 5.3.2
 
   pump@3.0.4:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,14 +8,18 @@ allowBuilds:
   msgpackr-extract: false
   protobufjs: false
   unix-dgram: false
-# Allow patches whose package isn't installed in a given filtered install
-# (e.g. backend-only Docker build excludes the frontend, where pragmatic-drag-and-drop lives).
 allowUnusedPatches: true
 blockExoticSubdeps: true
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - '@opentelemetry/core@2.8.0'
 overrides:
+  # protobufjs 8.0.0–8.4.0 carries multiple high-severity advisories (code
+  # injection GHSA-66ff-xgx4-vchm, prototype-pollution code-gen, and DoS
+  # GHSA-wcpc-wj8m-hjx6), all patched by 8.4.1. It's pulled in transitively via
+  # backend > pino-opentelemetry-transport > @opentelemetry/*. Pin the 8.x line
+  # to the latest stable; the separate 7.x line is left untouched.
+  'protobufjs@>=8.0.0 <8.4.1': 8.6.5
 packages:
   - ai
   - backend


### PR DESCRIPTION
## Problem
The `release-gate` job failed on the `0.0.2` release because `pnpm audit --audit-level=high` flagged **high-severity** advisories in `protobufjs` 8.0.0–8.4.0, pulled in transitively via `backend > pino-opentelemetry-transport > @opentelemetry/*`:

- GHSA-66ff-xgx4-vchm — code injection through bytes field defaults
- prototype-pollution code-generation gadget
- GHSA-wcpc-wj8m-hjx6 — DoS through unbounded Any

Because the gate failed, `@cellajs/create-cella` was **not published to npm**.

## Fix
Added a scoped pnpm override pinning the vulnerable 8.0.0–8.4.0 range to the latest stable `8.6.5` (all advisories patched by 8.4.1). The separate `protobufjs@7.6.4` line is untouched. `pnpm audit --audit-level=high` now passes (only low/moderate remain, below the gate threshoAdded a scoped pnpm override pinning the vulnerable 8.0.0–8.4.0 range to the latest stable `8.6.5` (all advisories patched by 8.4.1). The separate `protobufjs@7.6.4` line is untouched. `pnpm audit --audit-level=hiroceeds.