### PR TITLE
ci: configure git identity in release-gate for create-cella e2e

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,13 @@ jobs:
       - name: Security audit (high+ severity)
         run: pnpm audit --audit-level=high
 
+      # The create-cella e2e test scaffolds a project and runs `git commit`,
+      # which needs an author identity the runner doesn't have by default.
+      - name: Configure git identity
+        run: |
+          git config --global user.email "ci@cellajs.com"
+          git config --global user.name "cella CI"
+
       - name: Create .env files
         run: |
           cp ./backend/.env.example ./backend/.env


### PR DESCRIPTION
The `release-gate` job in release.yml runs `pnpm test:full`, which includes the create-cella e2e test that does `git commit` inside a scaffolded project. The runner has no git identity, so it failed with `Author identity unknown` — the same root cause fixed for the CI `test` job in #809, but the gate job never got the step.

This blocked the `create-cella 0.2.3` npm publish (gate failed → publish skipped). Adds the identity step (mirrors ci.yml) so the gate passes.