### PR TITLE
test(backend): pre-create RLS roles in global-setup

### DIFF
--- a/backend/tests/global-setup.ts
+++ b/backend/tests/global-setup.ts
@@ -65,5 +65,23 @@ export default async function globalSetup() {
   // apply all functions + triggers directly from the source definition.
   await pool.query(immutabilityTriggersSQL);
 
+  // Ensure RLS roles exist (idempotent) before any test module is evaluated.
+  // The RLS test suites gate themselves at module-load time on the presence of
+  // `runtime_role`; on a fresh database those roles would otherwise only be
+  // created later in the suites' own `beforeAll`, causing the whole suite to be
+  // skipped on the first run (e.g. in CI). Creating them here guarantees the
+  // guard sees them. Grants/ownership are still applied per-suite in `beforeAll`.
+  await pool.query(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'runtime_role') THEN
+        CREATE ROLE runtime_role WITH LOGIN PASSWORD 'dev_password';
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'admin_role') THEN
+        CREATE ROLE admin_role WITH LOGIN BYPASSRLS PASSWORD 'dev_password';
+      END IF;
+    END $$;
+  `);
+
   await pool.end();
 }


### PR DESCRIPTION
## What
Create the RLS database roles (`runtime_role`, `admin_role`) idempotently in `backend/tests/global-setup.ts`, right after migrations (alongside the existing immutability-triggers re-apply).

## Why
The RLS test suites (`rls-security.test.ts`, and similarly `schema-verification.test.ts` / `defense-in-depth.test.ts`) gate themselves at **module-load time** on the presence of `runtime_role` via a `rlsSuiteReady` guard. But those roles were only created later, in each suite's own `beforeAll` (`ensureRlsRoles()`).

On a **fresh database** (e.g. CI's ephemeral Postgres) the roles don't exist yet when the module is evaluated, so the guard flips to `describe.skip` and the entire RLS policy suite is skipped on the first run — this is the source of the **52 skipped** tests in CI. Locally the roles persist in the docker volume from a prior run, so the suite runs and nothing is skipped, hiding the discrepancy.