### PR TITLE
fix(ci): resolve scaffold dir via $RUNNER_TEMP in template-drift

### DIFF
--- a/.github/workflows/template-drift.yml
+++ b/.github/workflows/template-drift.yml
@@ -35,10 +35,13 @@ jobs:
       # for the throwaway scaffold so the runner needs no git identity or network remote.
       CREATE_CELLA_SKIP_GIT: "true"
       CREATE_CELLA_SKIP_REMOTE: "true"
-      # Absolute, outside-the-checkout target so create-cella's "inside template" guard
-      # is satisfied and the copy can't recurse into the source.
-      SCAFFOLD_DIR: ${{ runner.temp }}/drift-app
     steps:
+      # Absolute, outside-the-checkout target so create-cella's "inside template" guard
+      # is satisfied and the copy can't recurse into the source. The `runner` context is
+      # not available in job-level `env:`, so resolve it here via $RUNNER_TEMP instead.
+      - name: Resolve scaffold dir
+        run: echo "SCAFFOLD_DIR=$RUNNER_TEMP/drift-app" >> "$GITHUB_ENV"
+
       - name: Checkout repo (the template under test)
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 


### PR DESCRIPTION
## What
Move `SCAFFOLD_DIR` out of the job-level `env:` block in `.github/workflows/template-drift.yml` and resolve it in a step via `$RUNNER_TEMP`, exporting to `$GITHUB_ENV`.

## Why
The `runner` context is not available in job-level `env:`, so `${{ runner.temp }}` made the whole workflow file invalid:

> Invalid workflow file (Line: 40, Col: 21): Unrecognized named-value: 'runner' … within expression: runner.temp

GitHub therefore refused to run the workflow (see run 28512419862). Resolving the path in a step keeps every later `${{ env.SCAFFOLD_DIR }}` reference working unchanged.

## Testing
- `pnpm ts` passes (pre-commit).
- After merge, validate via Actions → Template drift → Run workflow.