### PR TITLE
feat(infra): wire appConfig.singleVM into the deploy layer

### DIFF
--- a/infra/compose.gen.yml
+++ b/infra/compose.gen.yml
@@ -9,6 +9,9 @@ services:
     restart: unless-stopped
     ports:
       - '4000:4000'
+      - '4001:4001'
+      - '4002:4002'
+      - '4003:4003'
     stop_grace_period: '30s'
     env_file:
       - .env
@@ -88,6 +91,7 @@ services:
       drainSeconds: 0
       instanceType: DEV1-S
       dockerfile: cdc/Dockerfile
+      coHosted: true
       bindings:
         API_WS_URL: ws://@{backend.privateIp}:@{backend.port}/internal/cdc
   yjs:
@@ -124,6 +128,7 @@ services:
       lbRoute: host
       lbWebsockets: true
       dockerfile: yjs/Dockerfile
+      coHosted: true
   ai:
     image: ${REGISTRY}/backend:${AI_TAG:-latest}
     profiles: [ai]
@@ -161,6 +166,7 @@ services:
       drainPolicy: requests
       lbRoute: host
       reusesImageOf: backend
+      coHosted: true
       bindings:
         AI_API_URL: '@{self.url}'
   frontend:

--- a/infra/compose/infrastructure.ts
+++ b/infra/compose/infrastructure.ts
@@ -56,6 +56,7 @@ function metaFrom(slug: string, cfg: AppServiceConfig): ServiceMeta {
   if (cfg.lbWebsockets) meta.lbWebsockets = true
   if (cfg.reusesImageOf) meta.reusesImageOf = cfg.reusesImageOf
   if (cfg.dockerfile) meta.dockerfile = cfg.dockerfile
+  if (cfg.coHosted) meta.coHosted = true
   if (cfg.bindings) meta.bindings = cfg.bindings
   return meta
 }
@@ -137,5 +138,29 @@ export function assembleCompose(appServices: AppServices): ComposeFile {
     services[slug] = appBlock(slug, cfg, { extraEnv: cfg.runMigrate ? MIGRATE_GATED_ENV : undefined })
     if (cfg.runMigrate) services.migrate = migrateBlock(slug, cfg)
   }
+  publishCoHostedPorts(appServices, services)
   return { services }
+}
+
+/**
+ * singleVM support: publish every co-hosted service's port on the host
+ * (`primaryRollout`) block so that when `appConfig.singleVM` folds the workers
+ * into the backend process, the load balancer can still reach each in-process
+ * worker at the host VM on its own port. Published unconditionally (the Compose
+ * file is shared across deploy modes); in the normal split-VM deploy the extra
+ * host ports simply have nothing bound behind them and are never reachable from
+ * the public internet (the VM security group drops all public inbound and the
+ * LB only targets a service's own VM). No-op when no service opts in.
+ */
+function publishCoHostedPorts(appServices: AppServices, blocks: Record<string, ComposeService>): void {
+  const hostSlug = Object.entries(appServices).find(([, cfg]) => cfg.primaryRollout)?.[0]
+  if (!hostSlug) return
+  const hostBlock = blocks[hostSlug]
+  if (!hostBlock) return
+  const coHostedPorts = Object.values(appServices)
+    .filter((cfg) => cfg.coHosted)
+    .map((cfg) => `${cfg.port}:${cfg.port}`)
+  if (coHostedPorts.length === 0) return
+  const existing = new Set(hostBlock.ports ?? [])
+  hostBlock.ports = [...(hostBlock.ports ?? []), ...coHostedPorts.filter((p) => !existing.has(p))]
 }

--- a/infra/compose/types.ts
+++ b/infra/compose/types.ts
@@ -93,6 +93,8 @@ export interface ServiceMeta {
   reusesImageOf?: string
   /** Dockerfile path for services that build their own image. Omit when `reusesImageOf` is set. */
   dockerfile?: string
+  /** Under `appConfig.singleVM`, this service runs in-process on the host VM (backend) */
+  coHosted?: boolean
   /** Per-service VM size; a fork resizes its fleet by editing this. Required — every service declares its own box. */
   instanceType: ServiceInstanceType
   /**
@@ -204,6 +206,15 @@ export interface AppServiceConfig {
   reusesImageOf?: string
   /** Dockerfile path for services that build their own image. Omit when `reusesImageOf` is set. */
   dockerfile?: string
+  /**
+   * Under `appConfig.singleVM`, co-host this service in-process on the host
+   * (backend) VM instead of giving it its own VM — the cost escape hatch for
+   * zero/low-traffic apps. Mirrors the in-process worker startup in
+   * `backend/src/main.api.ts`; set on the backend's worker subsystems (cdc, yjs,
+   * ai), never on the host service or the SPA proxy. Ignored when `singleVM` is
+   * false.
+   */
+  coHosted?: boolean
   /**
    * Per-service VM size — a fork resizes its fleet by editing this. Required:
    * every service declares its own box (there is no fleet-wide fallback). A

--- a/infra/config/services.config.ts
+++ b/infra/config/services.config.ts
@@ -52,6 +52,8 @@ export default defineServices({
     // drain. No lbRoute → internal-only, reached over the private network.
     replacementStrategy: 'exclusive',
     instanceType: 'DEV1-S',
+    // singleVM: fold into the backend process in-process (holds the same slot).
+    coHosted: true,
     env: {
       API_WS_URL: '${API_WS_URL}',
       BACKEND_URL: '${BACKEND_URL}',
@@ -81,6 +83,8 @@ export default defineServices({
     lbWebsockets: true,
     // Only deployed when appConfig.services.yjs.enabled is true.
     instanceType: 'DEV1-S',
+    // singleVM: fold into the backend process (LB still routes to the host VM).
+    coHosted: true,
     env: {
       BACKEND_URL: '${BACKEND_URL}',
       YJS_PORT: '4002',
@@ -100,6 +104,8 @@ export default defineServices({
     lbRoute: 'host',
     // Only deployed when appConfig.services.ai.enabled is true.
     instanceType: 'DEV1-S',
+    // singleVM: fold into the backend process (LB still routes to the host VM).
+    coHosted: true,
     env: {
       MODE: 'ai-worker',
       PORT: '4003',

--- a/infra/lib/services.test.ts
+++ b/infra/lib/services.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { enabledServices, services } from './services'
+import { coHostedServices, deployedServices, enabledServices, services } from './services'
 
 const allOn = { yjs: { enabled: true }, ai: { enabled: true } }
 const allOff = { yjs: { enabled: false }, ai: { enabled: false } }
@@ -33,6 +33,41 @@ describe('service registry — enabledServices', () => {
     const yjsOnly = enabledServices({ yjs: { enabled: true }, ai: { enabled: false } }).map((s) => s.slug)
     expect(yjsOnly).toContain('yjs')
     expect(yjsOnly).not.toContain('ai')
+  })
+})
+
+describe('service registry — singleVM (deployedServices / coHostedServices)', () => {
+  it('split-VM (singleVM off) deploys every enabled service on its own VM', () => {
+    const deployed = deployedServices(allOn, false).map((s) => s.slug)
+    expect(deployed).toEqual(enabledServices(allOn).map((s) => s.slug))
+    expect(deployed).toContain('cdc')
+    expect(deployed).toContain('yjs')
+    expect(deployed).toContain('ai')
+  })
+
+  it('singleVM folds co-hosted workers off their own VM but keeps the host + SPA proxy', () => {
+    const deployed = deployedServices(allOn, true).map((s) => s.slug)
+    expect(deployed).toContain('backend')
+    expect(deployed).toContain('frontend')
+    expect(deployed).not.toContain('cdc')
+    expect(deployed).not.toContain('yjs')
+    expect(deployed).not.toContain('ai')
+  })
+
+  it('coHostedServices lists only enabled co-hosted workers, and only under singleVM', () => {
+    expect(coHostedServices(allOn, false)).toEqual([])
+    const folded = coHostedServices(allOn, true).map((s) => s.slug)
+    expect(folded).toContain('cdc')
+    expect(folded).toContain('yjs')
+    expect(folded).toContain('ai')
+    expect(folded).not.toContain('backend')
+    expect(folded).not.toContain('frontend')
+  })
+
+  it('a disabled co-hosted worker is neither deployed nor folded under singleVM', () => {
+    const cfg = { yjs: { enabled: false }, ai: { enabled: true } }
+    expect(coHostedServices(cfg, true).map((s) => s.slug)).not.toContain('yjs')
+    expect(deployedServices(cfg, true).map((s) => s.slug)).not.toContain('yjs')
   })
 })
 

--- a/infra/lib/services.ts
+++ b/infra/lib/services.ts
@@ -62,6 +62,39 @@ export function enabledServices(serviceConfig: Record<string, AppServiceEndpoint
   return services.filter((s) => serviceConfig[s.slug]?.enabled !== false)
 }
 
+/**
+ * Services that get their OWN dedicated VM for a given app. In the normal
+ * split-VM deploy this is every enabled service. Under `singleVM` the enabled
+ * `coHosted` workers (cdc/yjs/ai) are dropped — they run in-process on the host
+ * (backend) VM instead — so only the host and any non-co-hosted service (the
+ * SPA proxy) keep their own VM. The load balancer still derives its routes from
+ * `enabledServices`, so a co-hosted service keeps its public endpoint; only its
+ * backend target changes (see `serviceGenerationIps`).
+ */
+export function deployedServices(
+  serviceConfig: Record<string, AppServiceEndpointConfig>,
+  singleVM: boolean,
+): readonly ServiceDefinition[] {
+  const enabled = enabledServices(serviceConfig)
+  if (!singleVM) return enabled
+  return enabled.filter((s) => !s.coHosted)
+}
+
+/**
+ * Enabled co-hosted worker services for an app under singleVM (empty when
+ * singleVM is off) — the workers folded into the host process, used to union
+ * their runtime secrets onto the host VM and to gate the host's replacement
+ * strategy (a co-hosted `exclusive` worker forces the host to cut over
+ * exclusively).
+ */
+export function coHostedServices(
+  serviceConfig: Record<string, AppServiceEndpointConfig>,
+  singleVM: boolean,
+): readonly ServiceDefinition[] {
+  if (!singleVM) return []
+  return enabledServices(serviceConfig).filter((s) => s.coHosted)
+}
+
 /** A public service's resolved endpoint, derived from appConfig by the registry. */
 export interface ServiceEndpoint {
   slug: ServiceName

--- a/infra/resources/compute.ts
+++ b/infra/resources/compute.ts
@@ -46,7 +46,7 @@ import { appConfig } from '../../shared'
 import { naming, zone, region, tags, infra, mode, endpoints, vmAccessKey, vmSecretKey } from '../pulumi-context'
 import { runtimeSecretsForConsumer, type RuntimeSecretConsumer } from '../lib/runtime-secrets'
 import { composeConfig } from '../compose/compose'
-import { enabledServices, servicesByName, type ServiceDefinition } from '../lib/services'
+import { deployedServices, coHostedServices, servicesByName, type ServiceDefinition } from '../lib/services'
 import type { ServiceName } from '../compose/compose'
 import { deriveGenId } from '../lib/gen-id'
 import { frontendCsp } from '../lib/frontend-csp'
@@ -89,8 +89,15 @@ const securityGroup = new scaleway.instance.SecurityGroup('compute-sg', {
 // from Secret Manager before the app boots.
 // ---------------------------------------------------------------------------
 
-function buildRuntimeSecretsManifest(serviceName: string): pulumi.Output<string> {
-  const definitions = runtimeSecretsForConsumer(serviceName as RuntimeSecretConsumer)
+function buildRuntimeSecretsManifest(consumers: RuntimeSecretConsumer[]): pulumi.Output<string> {
+  // Union the definitions across consumers (singleVM host carries its workers'
+  // secrets too), deduplicated by id and kept in registry order.
+  const seen = new Set<string>()
+  const definitions = consumers.flatMap((consumer) => runtimeSecretsForConsumer(consumer)).filter((definition) => {
+    if (seen.has(definition.id)) return false
+    seen.add(definition.id)
+    return true
+  })
   return pulumi.all(definitions.map((definition) => secretIds[definition.id]!)).apply((ids) =>
     JSON.stringify(
       definitions.map((definition, index) => ({
@@ -131,6 +138,12 @@ interface ServiceConfig {
   /** Whether this service runs the one-shot migrate companion before the app. */
   runMigrate: boolean
   /**
+   * Runtime-secret consumers whose secrets this VM's `.env.runtime` manifest
+   * carries. Usually just the service itself; the singleVM host also lists the
+   * co-hosted workers folded into its process.
+   */
+  secretConsumers: RuntimeSecretConsumer[]
+  /**
    * Compose env var suppliers (REGISTRY, URLs, the baked image tag). Lazy so
    * values backed by Pulumi resources (bucket names, the internal backend IP)
    * are only resolved when VMs are actually created.
@@ -147,7 +160,7 @@ function buildCloudInit(service: ServiceConfig, releaseSha: string): pulumi.Outp
 
   return pulumi.all([
     envLines,
-    buildRuntimeSecretsManifest(service.name),
+    buildRuntimeSecretsManifest(service.secretConsumers),
     scwAccessKey,
     scwSecretKey,
     registryEndpoint,
@@ -289,16 +302,46 @@ function buildComposeEnv(svc: ServiceDefinition, releaseSha: string): Record<str
   return env
 }
 
-// Concrete enabled service list, derived from the canonical registry (feature
-// flags). Each runs on its own dedicated VM (the multi-fork shared-workers
-// placement is not yet implemented here — guard loudly).
-const enabled = enabledServices(appConfig.services).map((svc) => {
+// Services that get their own dedicated VM. Under `appConfig.singleVM` the
+// enabled `coHosted` workers (cdc/yjs/ai) are folded into the backend process
+// and do NOT get their own VM (see `deployedServices`); the load balancer still
+// routes to them via the host VM (see `serviceGenerationIps`). Each remaining
+// service runs on its own dedicated VM (the multi-fork shared-workers placement
+// is not yet implemented here — guard loudly).
+const enabled = deployedServices(appConfig.services, appConfig.singleVM).map((svc) => {
   const placement = svc.placement ?? 'dedicated-vm'
   if (placement !== 'dedicated-vm') {
     throw new Error(`compute: placement '${placement}' for service '${svc.slug}' is not yet supported`)
   }
   return svc
 })
+
+// Workers folded into the host (backend) process under singleVM — empty in the
+// normal split-VM deploy. Their runtime secrets are unioned onto the host VM and
+// an `exclusive` one among them forces the host to cut over exclusively.
+const coHosted = coHostedServices(appConfig.services, appConfig.singleVM)
+const hostSlug = enabled.find((s) => s.primaryRollout)?.slug
+
+/** Runtime-secret consumers whose secrets a service's VM must carry. In singleVM
+ *  the host VM additionally carries every co-hosted worker's secrets (the folded
+ *  workers read them from the same process). */
+function secretConsumersFor(svc: ServiceDefinition): RuntimeSecretConsumer[] {
+  if (appConfig.singleVM && svc.slug === hostSlug) {
+    return [svc.slug, ...coHosted.map((s) => s.slug)] as RuntimeSecretConsumer[]
+  }
+  return [svc.slug as RuntimeSecretConsumer]
+}
+
+/** The replacement strategy a service's VM actually uses. Under singleVM a host
+ *  co-hosting an `exclusive` worker (cdc holds the single replication slot) must
+ *  itself cut over exclusively — two overlapping host generations would double-
+ *  consume the slot. */
+function effectiveStrategy(svc: ServiceDefinition): ServiceDefinition['replacementStrategy'] {
+  if (appConfig.singleVM && svc.slug === hostSlug && coHosted.some((s) => s.replacementStrategy === 'exclusive')) {
+    return 'exclusive'
+  }
+  return svc.replacementStrategy
+}
 
 // ---------------------------------------------------------------------------
 // Generation state (from the S3 control object, written by the orchestrator
@@ -326,15 +369,25 @@ function serviceFingerprint(svc: ServiceDefinition): unknown {
   const blocks = Object.values(composeConfig.services)
     .filter((block) => block.profiles.includes(svc.slug))
     .map((block) => ({ image: block.image, ports: block.ports ?? [], environment: block.environment ?? {} }))
-  const secrets = runtimeSecretsForConsumer(svc.slug as RuntimeSecretConsumer).map((definition) => ({
-    secretName: definition.secretName,
-    envVar: definition.envVar,
-    required: definition.required,
-  }))
+  // Union across secret consumers so the singleVM host's genId also captures the
+  // co-hosted workers' secret manifest (any change rolls a new generation).
+  const seenSecrets = new Set<string>()
+  const secrets = secretConsumersFor(svc)
+    .flatMap((consumer) => runtimeSecretsForConsumer(consumer))
+    .filter((definition) => (seenSecrets.has(definition.id) ? false : (seenSecrets.add(definition.id), true)))
+    .map((definition) => ({
+      secretName: definition.secretName,
+      envVar: definition.envVar,
+      required: definition.required,
+    }))
   return {
     slug: svc.slug,
     port: svc.healthPort,
     runMigrate: svc.runMigrate ?? false,
+    // Only fold in the strategy when singleVM changes it (host co-hosting an
+    // exclusive worker) — keeps the split-VM fingerprint byte-stable so this
+    // feature doesn't churn every existing service's genId.
+    ...(effectiveStrategy(svc) !== svc.replacementStrategy ? { singleVmStrategy: effectiveStrategy(svc) } : {}),
     bindings: svc.bindings ?? {},
     blocks,
     secrets,
@@ -368,8 +421,9 @@ function activeGenerations(svc: ServiceDefinition): Generation[] {
   // Exclusive services (cdc) hold a single resource the platform permits one
   // consumer of (the replication slot), so there is no overlap: materialise
   // ONLY the live generation (the pending intent, else active), which replaces
-  // the old VM in place.
-  if (svc.replacementStrategy === 'exclusive') {
+  // the old VM in place. Under singleVM the host inherits this when it co-hosts
+  // an exclusive worker (it now holds the slot in-process).
+  if (effectiveStrategy(svc) === 'exclusive') {
     add(pending ?? active)
     if (generations.length === 0) add({ id: deriveGenId('latest', fingerprint), sha: 'latest' })
     return generations
@@ -458,6 +512,7 @@ function createGenerationVm(svc: ServiceDefinition, generation: Generation): Gen
     profile: svc.slug,
     port: svc.healthPort,
     runMigrate: svc.runMigrate ?? false,
+    secretConsumers: secretConsumersFor(svc),
     composeEnv: buildComposeEnv(svc, generation.sha),
   }
 
@@ -553,7 +608,13 @@ export const computeGenerationMetadata = pulumi.all(instances.map((i) => pulumi.
  * Private IPs of every active generation of a service — the initial LB backend
  * server list. The live list is then owned by the cutover task (the LB backend
  * declares `ignoreChanges: ['serverIps']`).
+ *
+ * Under singleVM a co-hosted worker (cdc/yjs/ai) has no VM of its own — it runs
+ * in the host (backend) process — so its LB backend targets the HOST VM's
+ * generation IPs (on the worker's own port, which the host block publishes).
  */
 export function serviceGenerationIps(slug: string): pulumi.Output<string>[] {
-  return instances.filter((i) => i.service === slug).map((i) => i.privateIp)
+  const target =
+    appConfig.singleVM && hostSlug && coHosted.some((s) => s.slug === slug) ? hostSlug : slug
+  return instances.filter((i) => i.service === target).map((i) => i.privateIp)
 }

--- a/infra/tests/unit/compute.test.ts
+++ b/infra/tests/unit/compute.test.ts
@@ -70,10 +70,11 @@ describe('compute module source invariants', () => {
     expect(source).not.toMatch(/image:\s*'ubuntu_noble'/)
   })
 
-  it('derives the VM service list from the canonical registry (enabledServices)', () => {
-    // compute filters the canonical registry by feature flag rather than
-    // re-declaring the service set, so LB / image-wait / compose wiring can't drift.
-    expect(source).toMatch(/enabledServices\(appConfig\.services\)/)
+  it('derives the VM service list from the canonical registry (deployedServices)', () => {
+    // compute filters the canonical registry by feature flag (and folds
+    // co-hosted workers into the host under singleVM) rather than re-declaring
+    // the service set, so LB / image-wait / compose wiring can't drift.
+    expect(source).toMatch(/deployedServices\(appConfig\.services, appConfig\.singleVM\)/)
   })
 
   it('binds compose env from the registry placeholder scan + bindings + envPool (no per-service env maps)', () => {
@@ -155,7 +156,7 @@ describe('compute module source invariants', () => {
     // Under immutable releases every change replaces the VM anyway, so the
     // manifest (metadata only) is baked into the new generation's cloud-init
     // rather than published as a deploy-bucket object the VM fetches.
-    expect(source).toMatch(/buildRuntimeSecretsManifest\(service\.name\)/)
+    expect(source).toMatch(/buildRuntimeSecretsManifest\(service\.secretConsumers\)/)
     expect(source).not.toMatch(/new scaleway\.object\.Item\(`runtime-manifest-/)
     expect(source).not.toMatch(/runtimeSecretsManifestKey/)
     expect(source).not.toContain('COOKIE_SECRET=')


### PR DESCRIPTION
## Summary

Wires the existing `appConfig.singleVM` flag into the Pulumi deploy layer. Until now `singleVM` was runtime-only (the backend co-hosts cdc/yjs/ai in-process — see `backend/src/main.api.ts`) but infra always provisioned one VM per enabled service. This makes infra honour the flag: the co-hosted workers fold onto the backend VM, so a zero/low-traffic fork runs on one worker VM instead of up to four.

Both infra (plan-time) and the backend runtime read the same `appConfig.singleVM`, so setting it in a mode config (e.g. `config.production`) drives everything — no env injection needed.

## Design decisions

1. **One flag, per-mode** — infra reads `appConfig.singleVM` directly at plan time; `SINGLE_VM` env stays a dev-only convenience (`dev:single`).
2. **cdc + cutover** — a host co-hosting cdc holds the single replication 2. **cdc + cutover** — a host co-hosting cdc holds the single replication 2. **cdc + cutover** — a host co-hosting cdc holds the single replication 2. **cdc + cutover** bl2c** — yjs/ai keep their DNS record, cert and LB route; only their backend target changes to the host VM (not internal-only).
4. **Sizing** — only the backend's `instanceType` matters, since it's the sole worker VM.

## Changes

- **registry** — `coHosted` flag added to `ServiceMeta`/`AppServiceConfig`; set on cdc/yjs/ai.
- **compose** — the host block publishes the co-hosted workers' ports so the LB can reach the in-process workers on the backend VM (`compose.gen.yml` regenerated).
- **services.ts** — `deployedServices()` / `coHostedServices()` derive the per-app VM set.
- **compute.ts**- **compute.ts**- ted runtime secrets onto the host VM, applies the exclusive-cutover downgrade, and retargets co-hosted services' LB backends to the host VM. Fingerpri- **compute.ts**- **compute.ts**- ted runtime secrets onto the host VM, applies the exclusive-cutover downgrade, and retargets co-hosted services' LB backends to the host VM. Fingerpri- **compute.ts**- **compute.ts**- ted runtime secrets onto the host VM, applies the exclusive-cutover downgrade, and retargets co-hosted services' LB backends to the host VM. Fingerpri- **compu w- **compute.ts**- **compute.ts**- ted runtime secrets onto the host VM, applies the exclus- CI still buil- **compute.ts**- **compute.ts**- ted runtime secrets onto the host VM, applies the exclusive-cll packages — pass
- 
 RUN  v4.1.9 /Users/flip/Sites/cella/infra


 Test Files  49 passed (49)
      Tests  414 passed | 3 todo (417)
   Start at  13:12:49
   Duration  2.21s (transform 1.94s, setup 0ms, import 2.33s, tests 5.53s, environment 3ms) — 417 passing
EOF
)