### PR TITLE
feat(cli): add release workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,8 @@ my-cella-app
 backend/openapi.cache.json
 backend/openapi.manifest.json
 frontend/vite/temp-api-gen-*
-frontend/vite/.generate-client.lock
 sdk/src/temp-api-gen-*
-sdk/src/.generate-client.lock
+sdk/src/.generate-sdk.lock
 sdk/src/.spec-hash
 *.cache.json
 

--- a/cella.config.ts
+++ b/cella.config.ts
@@ -27,7 +27,6 @@ export default defineConfig({
       'infra/Pulumi.production.yaml',
       'infra/Pulumi.staging.yaml',
       'sdk/gen',
-      'sdk/src/.generate-sdk.lock',
       'shared/config',
       'backend/drizzle',
       'frontend/public/static/common',

--- a/cli/cella/README.md
+++ b/cli/cella/README.md
@@ -29,6 +29,7 @@ pnpm cella contributions --fork raak --json
 |---------|-------------|
 | `analyze` | Dry run to see what would change on sync |
 | `sync` | Merge upstream changes into your app |
+| `release` | Sync upstream on a fresh branch and open a squash-merge PR into `main` |
 | `audit` | Check for outdated packages & vulnerabilities |
 | `stats` | Count files by category and workspace package |
 | `forks` * | Sync downstream to local fork repositories |
@@ -48,6 +49,7 @@ Service-specific help is available via `pnpm cella <service> --help`.
 |---------|----------------|
 | analyze | `--log`, `--list`, `--json`, `--scope <all\|risk\|protected>`, `--diff <path>`, `--open-diff <path>` |
 | sync | `--log`, `--hard`, `--unpinned`, `--track <release\|branch>` |
+| release | `--merge`, `--no-push`, `--track <release\|branch>` |
 | audit | `--list`, `--force`, `--check-overrides` |
 | forks | `--fork <name>`, `--log`, `--hard`, `-V, --verbose` |
 | contributions | `--fork <name>`, `--list`, `--json`, `--diff <path>` |
@@ -93,6 +95,30 @@ sync branch from your current branch; you then open a PR into `main` and squash-
 When cella (upstream) pushes to a fork via the **forks** service, it reads that fork's own
 `settings.syncBranch` as the source of truth — there's no per-fork branch to configure on
 the cella side.
+
+### `cella release` (recommended cycle)
+
+`pnpm cella release` automates the full cycle on a **throwaway, uniquely named** branch cut
+fresh from the trunk (`settings.releaseBase`, default `main`):
+
+```
+main ──▶ cella-sync/<stamp>-<sha> ──(sync merge + commit)──▶ push ──▶ PR ──(squash)──▶ main
+```
+
+Cutting a fresh branch each cycle keeps every PR scoped to just that sync's upstream delta —
+no accumulation of previously squash-merged commits — while `main` stays linear. Upstream
+ancestry for the merge-base is carried by `refs/cella/last-sync` (and the committed
+`cella.manifest.json` for fresh clones), so the ephemeral branch is safe to delete after each cycle.
+
+```bash
+pnpm cella release            # sync on a fresh branch, push, open a PR (you squash-merge)
+pnpm cella release --merge    # also auto squash-merge and realign trunk (needs gh + perms)
+pnpm cella release --no-push   # leave the branch local; push + open the PR yourself
+```
+
+On conflicts it stops after staging so you resolve in the IDE, then finish with
+`git commit --no-edit` + push + `gh pr create`. Only `main` needs branch protection;
+ephemeral `cella-sync/*` branches are auto-deleted on merge.
 
 ## Merge Strategy
 
@@ -170,30 +196,21 @@ packageJsonSync: ['dependencies', 'devDependencies', 'scripts']
 
 This allows your fork to have extra dependencies or scripts without them being removed on each sync.
 
-## Merge Strategy
+## Merge strategy
 
-The `mergeStrategy` setting controls the ancestry of the commit a sync produces:
+A sync always uses a real git 3-way merge and leaves the result **staged for you to
+commit** (it never auto-commits). The commit you create keeps `MERGE_HEAD`, so it is a
+two-parent merge commit with full upstream ancestry (native git merge-base). Conflicts
+are surfaced with IDE 3-way support and also resolve to a merge commit.
 
-```typescript
-mergeStrategy: 'squash' // default
-```
+This is why sync runs on a dedicated long-lived integration branch (`cella-sync`): the
+merge commits bake durable upstream ancestry into the branch, so `git merge-base` keeps
+working across syncs without re-bootstrapping. `refs/cella/last-sync` is still tracked as
+a fallback for when upstream squashes its own history.
 
-Both strategies use a real git 3-way merge and leave the result **staged for you to commit** (neither auto-commits). They differ only in the commit you then create:
-
-| Strategy | Clean-sync commit | History | IDE 3-way on conflicts |
-|----------|-------------------|---------|------------------------|
-| `squash` (default) | single-parent | linear | yes (falls back to a merge commit) |
-| `merge` | two-parent merge commit, full upstream ancestry | non-linear | yes |
-
-**Use `squash` (default)** for:
-- Linear history — required when you squash-merge the sync PR into a release-please `main`
-- One clean commit per sync (`refs/cella/last-sync` tracks the merge-base)
-
-**Use `merge`** for:
-- A dedicated long-lived integration branch where you want native git upstream ancestry
-- Not compatible with a linear-history `main`
-
-> Under release-please, sync on a dedicated branch (e.g. `cella-sync`) and squash-merge the PR into `main` with a conventional commit. See [info/RELEASES.md](../../info/RELEASES.md).
+> Under release-please, sync on the dedicated `cella-sync` branch, then open a PR and
+> **squash-merge** it into `main` with a conventional commit — keeping `main` linear while
+> `cella-sync` retains true ancestry. See [info/RELEASES.md](../../info/RELEASES.md).
 
 
 ## Contributions (pull from forks)

--- a/cli/cella/config.ts
+++ b/cli/cella/config.ts
@@ -2,4 +2,4 @@
  * Public exports for cella.config.ts
  */
 export { defineConfig } from './src/config/types';
-export type { CellaCliConfig, MergeStrategy, PackageJsonSyncKey } from './src/config/types';
+export type { CellaCliConfig, PackageJsonSyncKey } from './src/config/types';

--- a/cli/cella/src/cella-cli.ts
+++ b/cli/cella/src/cella-cli.ts
@@ -15,6 +15,7 @@ import { runAudit } from './services/audit';
 import { runContributions } from './services/contributions';
 import { runForks } from './services/forks';
 import { runPackages } from './services/packages';
+import { runRelease } from './services/release';
 import { runStats } from './services/stats';
 import { runSync } from './services/sync';
 import { registerSignalHandlers } from './utils/cleanup';
@@ -71,9 +72,10 @@ async function preflight(
     await assertClean(forkPath);
   }
 
-  // Check we're on the sync branch
+  // Check we're on the sync branch (or an ephemeral child of it, e.g. cella-sync/<stamp>)
   const currentBranch = await getCurrentBranch(forkPath);
-  if (currentBranch !== syncBranch) {
+  const onSyncBranch = currentBranch === syncBranch || currentBranch.startsWith(`${syncBranch}/`);
+  if (!onSyncBranch) {
     if (options.warnOnBranch) {
       console.warn(
         `${warningMark} not on branch '${syncBranch}' (currently on '${currentBranch}'). results may differ from your sync branch.`,
@@ -108,8 +110,8 @@ async function main(): Promise<void> {
     // Parse CLI and get runtime config
     const config = await parseCli(userConfig, forkPath);
 
-    // Run preflight checks (except for audit/forks/contributions/stats which don't need clean working dir)
-    if (!['audit', 'forks', 'contributions', 'stats'].includes(config.service)) {
+    // Run preflight checks (except for services that manage their own branch/clean state)
+    if (!['audit', 'forks', 'contributions', 'stats', 'release'].includes(config.service)) {
       const isReadOnly = config.service === 'analyze';
       await preflight(forkPath, resolveSyncBranch(userConfig.settings), {
         skipCleanCheck: isReadOnly,
@@ -134,6 +136,10 @@ async function main(): Promise<void> {
         }
         break;
       }
+
+      case 'release':
+        await runRelease(config);
+        break;
 
       case 'audit':
         await runAudit(config, { force: config.force, checkOverrides: config.checkOverrides });

--- a/cli/cella/src/cli.ts
+++ b/cli/cella/src/cli.ts
@@ -9,8 +9,9 @@ import { select } from '@inquirer/prompts';
 import { Command } from 'commander';
 import type { AnalyzeScope, CellaCliConfig, RuntimeConfig, SyncService } from './config/types';
 import pc from './utils/colors';
-import { resolveUpstream } from './utils/config';
+import { isCellaTemplate, isSyncBranch, resolveUpstream } from './utils/config';
 import { NAME, printHeader, setJsonMode, VERSION } from './utils/display';
+import { getCurrentBranch } from './utils/git';
 import { printWarnings, validateOverrides } from './utils/overrides';
 
 type CliServiceSelection = {
@@ -34,10 +35,16 @@ type CliOptionState = Pick<
   | 'force'
   | 'checkOverrides'
   | 'coverage'
+  | 'releasePush'
+  | 'releaseAutoMerge'
 >;
 
 type MenuContext = {
   hasForks: boolean;
+  /** True when running inside the cella template itself (upstream services are hidden). */
+  isTemplate: boolean;
+  /** True when currently on a sync branch (or an ephemeral child of it). */
+  onSyncBranch: boolean;
 };
 
 type ServiceOptionDefinition = {
@@ -68,6 +75,8 @@ const defaultOptions: CliOptionState = {
   force: false,
   checkOverrides: false,
   coverage: false,
+  releasePush: true,
+  releaseAutoMerge: false,
 };
 
 function readOptions(opts: Record<string, unknown>): CliOptionState {
@@ -90,6 +99,8 @@ function readOptions(opts: Record<string, unknown>): CliOptionState {
     force: opts.force === true,
     checkOverrides: opts.checkOverrides === true,
     coverage: opts.coverage === true,
+    releasePush: opts.push !== false,
+    releaseAutoMerge: opts.merge === true,
   };
 }
 
@@ -97,6 +108,7 @@ const serviceDefinitions: ServiceDefinition[] = [
   {
     name: 'analyze',
     description: 'dry run to see what would change on sync',
+    includeInMenu: (context) => !context.isTemplate,
     options: [
       { flags: '--log', description: 'write complete file list to cella-sync.log' },
       { flags: '--list', description: 'non-interactive output for tooling (one file per line)' },
@@ -110,6 +122,7 @@ const serviceDefinitions: ServiceDefinition[] = [
   {
     name: 'sync',
     description: 'merge upstream changes into your app',
+    includeInMenu: (context) => !context.isTemplate,
     options: [
       { flags: '--log', description: 'write complete file list to cella-sync.log' },
       { flags: '--hard', description: 'overwrite drifted files with upstream version (aggressive realignment)' },
@@ -117,6 +130,17 @@ const serviceDefinitions: ServiceDefinition[] = [
       { flags: '--track <mode>', description: 'override upstream tracking for this run: release|branch' },
     ],
     menuDescription: () => 'merge upstream changes + sync package.json',
+  },
+  {
+    name: 'release',
+    description: 'sync upstream on a fresh branch and open a squash-merge PR',
+    includeInMenu: (context) => !context.isTemplate && context.onSyncBranch,
+    options: [
+      { flags: '--merge', description: 'auto squash-merge the PR and realign trunk (needs gh + permissions)' },
+      { flags: '--no-push', description: 'leave the branch local; skip pushing and opening a PR' },
+      { flags: '--track <mode>', description: 'override upstream tracking for this run: release|branch' },
+    ],
+    menuDescription: () => 'sync on an ephemeral branch + open a PR into main',
   },
   {
     name: 'audit',
@@ -159,9 +183,12 @@ const serviceDefinitions: ServiceDefinition[] = [
   },
 ];
 
-function getMenuContext(userConfig: CellaCliConfig): MenuContext {
+async function getMenuContext(userConfig: CellaCliConfig, forkPath: string): Promise<MenuContext> {
+  const currentBranch = await getCurrentBranch(forkPath).catch(() => '');
   return {
     hasForks: (userConfig.forks?.length ?? 0) > 0,
+    isTemplate: isCellaTemplate(forkPath),
+    onSyncBranch: currentBranch !== '' && isSyncBranch(currentBranch, userConfig.settings),
   };
 }
 
@@ -248,10 +275,10 @@ function parseCommandLine(argv: string[]): CliServiceSelection {
   return selection;
 }
 
-async function promptForService(userConfig: CellaCliConfig): Promise<SyncService> {
+async function promptForService(userConfig: CellaCliConfig, forkPath: string): Promise<SyncService> {
   const selected = await select<SyncService | 'exit'>({
     message: 'choose a service:',
-    choices: buildServiceChoices(getMenuContext(userConfig)),
+    choices: buildServiceChoices(await getMenuContext(userConfig, forkPath)),
     loop: false,
   });
 
@@ -305,7 +332,7 @@ export async function parseCli(userConfig: CellaCliConfig, forkPath: string): Pr
 
   // If no service provided, prompt for it
   if (!selection.service) {
-    selection.service = await promptForService(userConfig);
+    selection.service = await promptForService(userConfig, forkPath);
   }
 
   return buildRuntimeConfig(userConfig, forkPath, selection);

--- a/cli/cella/src/config/types.ts
+++ b/cli/cella/src/config/types.ts
@@ -22,9 +22,6 @@ export type PackageJsonSyncKey =
   | 'overrides'
   | 'pnpm';
 
-/** Merge strategy for syncing upstream changes */
-type MergeStrategy = 'merge' | 'squash';
-
 /**
  * Sync settings - all configurable options for the sync CLI.
  * Hover over each property for documentation.
@@ -61,28 +58,21 @@ export interface SyncSettings {
    * This is the single source of truth for a fork's sync branch: when cella (upstream)
    * pushes to this fork via the forks service, it reads this value from the fork's own
    * config.
+   *
+   * `pnpm cella release` also uses this value as the prefix for the ephemeral, uniquely
+   * named integration branch it cuts per cycle (e.g. `cella-sync/20260702-1430-c5a1970`).
    */
   syncBranch?: string;
 
+  /**
+   * Trunk branch that `pnpm cella release` cuts the ephemeral sync branch from and opens
+   * the squash-merge PR into. Defaults to 'main'. Cutting fresh from trunk each cycle keeps
+   * every PR limited to that cycle's upstream delta (no accumulation) and `main` linear.
+   */
+  releaseBase?: string;
+
   /** Which package.json keys to sync (default: ['dependencies', 'devDependencies']) */
   packageJsonSync?: PackageJsonSyncKey[];
-
-  /**
-   * Merge strategy for syncing upstream changes. Both use a real git 3-way merge
-   * internally and leave the result staged for you to commit (neither auto-commits).
-   * The difference is the ancestry of the commit you create:
-   * - 'squash' (default): drops `MERGE_HEAD` on a clean sync so your commit is
-   *   single-parent. Keeps linear history — the right choice under release-please,
-   *   where the sync PR is squash-merged into `main` anyway. Relies on the stored
-   *   `refs/cella/last-sync` ref for the next merge-base.
-   * - 'merge': keeps `MERGE_HEAD` so your commit is a two-parent merge commit with
-   *   full upstream ancestry (native git merge-base). Useful on a dedicated
-   *   integration branch where you want true ancestry; not compatible with a
-   *   linear-history `main`.
-   * Conflicts always fall back to a merge commit (with IDE 3-way support) regardless
-   * of strategy.
-   */
-  mergeStrategy?: MergeStrategy;
 
   /**
    * Automatically run packages sync after the sync service completes.
@@ -188,6 +178,7 @@ export const cellaConfigSchema = z
         upstreamBranch: z.string().min(1).optional(),
         upstreamTrack: z.enum(['release', 'branch']).optional(),
         syncBranch: z.string().min(1).optional(),
+        releaseBase: z.string().min(1).optional(),
         packageJsonSync: z
           .array(
             z.enum([
@@ -203,7 +194,6 @@ export const cellaConfigSchema = z
             ]),
           )
           .optional(),
-        mergeStrategy: z.enum(['merge', 'squash']).optional(),
         syncWithPackages: z.boolean().optional(),
         fileLinkMode: z.enum(['commit', 'file', 'local']).optional(),
       })
@@ -235,7 +225,7 @@ export const cellaConfigSchema = z
 // ─────────────────────────────────────────────────────────────────────────────
 
 /** Sync services available in the CLI */
-export type SyncService = 'analyze' | 'sync' | 'audit' | 'forks' | 'contributions' | 'stats';
+export type SyncService = 'analyze' | 'sync' | 'release' | 'audit' | 'forks' | 'contributions' | 'stats';
 
 /** Analyze output scope for interactive and machine-readable flows */
 export type AnalyzeScope = 'all' | 'risk' | 'protected';
@@ -300,6 +290,12 @@ export interface RuntimeConfig extends CellaCliConfig {
 
   /** Regenerate test coverage before showing the stats summary (stats service) */
   coverage?: boolean;
+
+  /** Push the ephemeral branch and open a PR (release service; default true, disable with --no-push) */
+  releasePush?: boolean;
+
+  /** Auto squash-merge the PR and clean up after a clean sync (release service; --merge) */
+  releaseAutoMerge?: boolean;
 }
 
 /** File status after analysis */

--- a/cli/cella/src/services/merge-engine.ts
+++ b/cli/cella/src/services/merge-engine.ts
@@ -32,6 +32,7 @@ import {
   countCommitsBetween,
   createWorktree,
   ensureRemote,
+  ensureSyncBase,
   fetch,
   fetchUpstreamTags,
   fileExistsAtRef,
@@ -48,11 +49,12 @@ import {
   merge,
   mergeAbort,
   removeFileFromWorktree,
-  removeMergeHead,
   resolveLatestReleaseTag,
   restoreToHead,
+  stagePath,
   storeLastSyncRef,
 } from '../utils/git';
+import { MANIFEST_FILE, type SyncManifest, writeSyncManifest } from '../utils/manifest';
 import { isIgnored, isPinnedForSync } from '../utils/overrides';
 import { type AnalyzePredicates, analyzeRefs, enrichChangeInfo } from './analyze-core';
 
@@ -151,9 +153,8 @@ async function applyDirectMerge(
     }
   }
 
-  // Phase 3: Start real merge in fork (always real merge, never --squash).
-  // Squash strategy is handled post-merge by removing MERGE_HEAD before auto-commit,
-  // which preserves correct 3-way merge behavior and merge-base ancestry.
+  // Phase 3: Start real merge in fork. Left staged with MERGE_HEAD intact so the
+  // commit the user creates is a two-parent merge commit with true upstream ancestry.
   onProgress?.('starting merge in fork...');
   await merge(forkPath, upstreamRef, { noCommit: true, noEdit: true });
 
@@ -429,6 +430,12 @@ export async function runMergeEngine(
     config.upstreamRef = upstreamRef;
     onStep?.('remote configured', `${releaseTag ?? upstreamRef} → ${config.settings.upstreamUrl}`);
 
+    // Bootstrap sync ancestry for forks with unrelated history (create-cella scaffold or an
+    // upstream history squash). No-op once a native merge-base exists. Runs after fetch so the
+    // base commit object is present, and after upstreamRef is finalized so release tags resolve.
+    onProgress?.('checking sync base...');
+    await ensureSyncBase(forkPath, 'HEAD', upstreamRef);
+
     // Get GitHub base URLs for commit links
     const upstreamGitHubUrl = getGitHubBaseUrl(config.settings.upstreamUrl);
     const forkOriginUrl = await getRemoteUrl(forkPath, 'origin');
@@ -473,17 +480,38 @@ export async function runMergeEngine(
 
       const summary = calculateSummary(analyzedFiles);
       const synced = summary.behind + summary.diverged + summary.renamed;
-      // Default to squash: forks on the release-please flow squash-merge the sync PR
-      // into a linear-history `main` anyway, so single-parent sync commits are the norm.
-      const isSquash = (config.settings.mergeStrategy ?? 'squash') === 'squash';
 
       // Count total resolved changes (includes ignored/pinned resolutions)
       const totalResolved = synced + summary.ignored + summary.pinned;
 
+      // Record the upstream sync point in lockstep: the local `refs/cella/last-sync` ref plus
+      // the committed `cella.manifest.json` (staged so it rides in the sync commit and travels
+      // with the repo for fresh-clone bootstrap).
+      const upstreamRepo = upstreamGitHubUrl ? upstreamGitHubUrl.replace('https://github.com/', '') : undefined;
+      const syncManifest: SyncManifest = {
+        upstream: {
+          repo: upstreamRepo,
+          track: releaseTag ? 'release' : 'branch',
+          commit: upstreamCommit.hash,
+          release: releaseTag ?? null,
+          url: upstreamGitHubUrl
+            ? releaseTag
+              ? `${upstreamGitHubUrl}/releases/tag/${releaseTag}`
+              : `${upstreamGitHubUrl}/commit/${upstreamCommit.hash}`
+            : undefined,
+          syncedAt: new Date().toISOString(),
+        },
+      };
+      const recordSyncPoint = async () => {
+        await storeLastSyncRef(forkPath, upstreamCommit.hash);
+        await writeSyncManifest(forkPath, syncManifest);
+        await stagePath(forkPath, MANIFEST_FILE);
+      };
+
       if (remainingConflicts.length > 0) {
         // Conflicts: leave MERGE_HEAD intact for IDE 3-way merge resolution.
         // When user commits, it becomes a merge commit (self-healing ancestry).
-        await storeLastSyncRef(forkPath, upstreamCommit.hash);
+        await recordSyncPoint();
         // Materialize the upstream view worktree so auto-merged files get exact
         // `code --diff` commands (byte-consistent with the fetched upstream ref).
         const upstreamViewPath = await refreshViewWorktree(forkPath, upstreamRef);
@@ -504,11 +532,10 @@ export async function runMergeEngine(
         );
       } else if (totalResolved > 0) {
         const label = synced > 0 ? `${synced} files from upstream` : 'upstream changes';
-        if (isSquash) {
-          // Remove MERGE_HEAD so commit becomes single-parent (squash-style)
-          await removeMergeHead(forkPath);
-        }
-        await storeLastSyncRef(forkPath, upstreamCommit.hash);
+        // Keep MERGE_HEAD so the commit the user creates is a two-parent merge commit
+        // with full upstream ancestry (native git merge-base). The sync branch is a
+        // dedicated integration branch; PRs into `main` are squash-merged separately.
+        await recordSyncPoint();
         onStep?.('synced', `${label} (staged, commit to finish)`);
       } else {
         // Truly nothing changed - clean up merge state

--- a/cli/cella/src/services/release.ts
+++ b/cli/cella/src/services/release.ts
@@ -1,0 +1,175 @@
+/**
+ * Release service for sync CLI v2.
+ *
+ * Orchestrates a full upstream-sync release cycle on a throwaway, uniquely named
+ * integration branch cut fresh from the trunk (`main`):
+ *
+ *   trunk ──▶ cella-sync/<stamp>-<sha> ──(sync merge + commit)──▶ push ──▶ PR ──(squash)──▶ trunk
+ *
+ * Cutting a fresh branch per cycle keeps every PR scoped to that sync's upstream delta
+ * (no accumulation of previously squash-merged commits) while keeping `main` linear.
+ * Upstream ancestry for the merge-base is carried by `refs/cella/last-sync` (written by
+ * the sync engine), so the ephemeral branch can be deleted after each cycle.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { RuntimeConfig } from '../config/types';
+import pc from '../utils/colors';
+import {
+  buildEphemeralSyncBranch,
+  DEFAULT_UPSTREAM_REMOTE,
+  resolveReleaseBase,
+  resolveUpstream,
+} from '../utils/config';
+import {
+  assertClean,
+  commitNoEdit,
+  createBranchFrom,
+  deleteBranch,
+  getCurrentBranch,
+  getShortSha,
+  fetch as gitFetch,
+  mergeInProgress,
+  pullFastForward,
+  pushBranch,
+  switchBranch,
+} from '../utils/git';
+import { runPackages } from './packages';
+import { runSync } from './sync';
+
+const execFileAsync = promisify(execFile);
+
+type GhResult = { ok: boolean; stdout: string; stderr: string };
+
+/** Run a `gh` command, capturing output without throwing. */
+async function gh(args: string[], cwd: string): Promise<GhResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync('gh', args, { cwd });
+    return { ok: true, stdout: stdout.trim(), stderr: stderr.trim() };
+  } catch (error) {
+    const e = error as { stdout?: string; stderr?: string; message?: string };
+    return { ok: false, stdout: (e.stdout ?? '').trim(), stderr: (e.stderr ?? e.message ?? '').trim() };
+  }
+}
+
+async function ghAvailable(cwd: string): Promise<boolean> {
+  return (await gh(['--version'], cwd)).ok;
+}
+
+/**
+ * Run the release service: sync upstream on an ephemeral branch and open (optionally
+ * squash-merge) a PR into the trunk.
+ */
+export async function runRelease(config: RuntimeConfig): Promise<void> {
+  const { forkPath, settings } = config;
+  const push = config.releasePush !== false;
+  const autoMerge = config.releaseAutoMerge === true;
+
+  await assertClean(forkPath);
+
+  const base = resolveReleaseBase(settings);
+  const startBranch = await getCurrentBranch(forkPath);
+
+  // Update the trunk so the ephemeral branch starts from the latest release-please state.
+  console.info(pc.dim(`switching to '${base}' and updating...`));
+  await switchBranch(forkPath, base);
+  await pullFastForward(forkPath);
+
+  // Fetch upstream so we can name the ephemeral branch after the upstream commit.
+  const { branchRef } = resolveUpstream(settings);
+  await gitFetch(forkPath, DEFAULT_UPSTREAM_REMOTE);
+  const shortSha = await getShortSha(forkPath, branchRef);
+  const ephemeral = buildEphemeralSyncBranch(settings, shortSha);
+
+  console.info(pc.dim(`creating ephemeral sync branch '${ephemeral}' from '${base}'...`));
+  await createBranchFrom(forkPath, ephemeral, base);
+
+  // Reuse the sync service (+ packages) on the ephemeral branch.
+  const syncConfig: RuntimeConfig = { ...config, service: 'sync' };
+  const result = await runSync(syncConfig);
+  if (settings.syncWithPackages !== false) {
+    await runPackages(syncConfig, { conflictedFiles: result.conflicts });
+  }
+
+  // Conflicts: stop and let the user resolve in the IDE, then finish manually.
+  if (result.conflicts.length > 0) {
+    console.info();
+    console.info(pc.yellow(`conflicts remain on '${ephemeral}'. resolve them, then:`));
+    console.info(pc.dim('  git commit --no-edit'));
+    console.info(pc.dim(`  git push -u origin ${ephemeral}`));
+    console.info(pc.dim(`  gh pr create --base ${base} --head ${ephemeral} --fill`));
+    return;
+  }
+
+  // No merge staged: already up to date. Clean up the ephemeral branch.
+  if (!mergeInProgress(forkPath)) {
+    console.info();
+    console.info(pc.green('already up to date with upstream — nothing to release.'));
+    await switchBranch(forkPath, startBranch === ephemeral ? base : startBranch);
+    await deleteBranch(forkPath, ephemeral);
+    return;
+  }
+
+  // Commit the two-parent merge commit.
+  await commitNoEdit(forkPath);
+  console.info(pc.green(`committed sync merge on '${ephemeral}'.`));
+
+  if (!push) {
+    console.info(pc.dim('branch left local (--no-push). push + open a PR when ready:'));
+    console.info(pc.dim(`  git push -u origin ${ephemeral}`));
+    console.info(pc.dim(`  gh pr create --base ${base} --head ${ephemeral} --fill`));
+    return;
+  }
+
+  await pushBranch(forkPath, 'origin', ephemeral);
+  console.info(pc.green(`pushed '${ephemeral}' to origin.`));
+
+  if (!(await ghAvailable(forkPath))) {
+    console.info(pc.yellow('gh CLI not found — open the PR manually:'));
+    console.info(pc.dim(`  gh pr create --base ${base} --head ${ephemeral} --fill`));
+    return;
+  }
+
+  const title = `chore: sync upstream cella ${shortSha}`;
+  const created = await gh(
+    [
+      'pr',
+      'create',
+      '--base',
+      base,
+      '--head',
+      ephemeral,
+      '--title',
+      title,
+      '--body',
+      'Automated upstream sync via `cella release`.',
+    ],
+    forkPath,
+  );
+  if (!created.ok) {
+    console.info(pc.yellow('could not create the PR automatically:'));
+    console.info(pc.dim(`  ${created.stderr}`));
+    return;
+  }
+  console.info(pc.green(`opened PR: ${created.stdout}`));
+
+  if (!autoMerge) {
+    console.info(pc.dim(`review, then: gh pr merge ${ephemeral} --squash --delete-branch`));
+    return;
+  }
+
+  const merged = await gh(['pr', 'merge', ephemeral, '--squash', '--delete-branch'], forkPath);
+  if (!merged.ok) {
+    console.info(pc.yellow('auto squash-merge failed (branch protection or checks pending):'));
+    console.info(pc.dim(`  ${merged.stderr}`));
+    return;
+  }
+  console.info(pc.green(`squash-merged into '${base}'.`));
+
+  // Realign the local trunk and drop the now-merged ephemeral branch.
+  await switchBranch(forkPath, base);
+  await pullFastForward(forkPath);
+  await deleteBranch(forkPath, ephemeral);
+  console.info(pc.green(`back on '${base}', ephemeral branch cleaned up.`));
+}

--- a/cli/cella/src/utils/config.ts
+++ b/cli/cella/src/utils/config.ts
@@ -4,7 +4,7 @@
  * Shared between main entry point and forks service.
  */
 
-import { existsSync, realpathSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { z } from 'zod';
 import { type CellaCliConfig, cellaConfigSchema, type SyncSettings } from '../config/types';
@@ -26,12 +26,45 @@ export const DEFAULT_BRANCH = 'main';
 export const DEFAULT_SYNC_BRANCH = 'cella-sync';
 
 /**
+ * Default trunk branch that `cella release` cuts from and opens PRs into.
+ */
+export const DEFAULT_RELEASE_BASE = 'main';
+
+/**
  * Resolve the branch a fork must be on to receive upstream syncs.
  *
  * The fork's own `cella.config.ts` (`settings.syncBranch`) is the source of truth.
  */
 export function resolveSyncBranch(settings: SyncSettings): string {
   return settings.syncBranch ?? DEFAULT_SYNC_BRANCH;
+}
+
+/**
+ * Whether a branch counts as a sync branch: either the exact sync branch or an
+ * ephemeral child of it (`<syncBranch>/<...>`, as created by `cella release`).
+ */
+export function isSyncBranch(branch: string, settings: SyncSettings): boolean {
+  const syncBranch = resolveSyncBranch(settings);
+  return branch === syncBranch || branch.startsWith(`${syncBranch}/`);
+}
+
+/**
+ * Resolve the trunk branch `cella release` cuts the ephemeral branch from and PRs into.
+ */
+export function resolveReleaseBase(settings: SyncSettings): string {
+  return settings.releaseBase ?? DEFAULT_RELEASE_BASE;
+}
+
+/**
+ * Build a unique ephemeral integration branch name for a release cycle, e.g.
+ * `cella-sync/20260702-1430-c5a1970`. Cutting a fresh branch per cycle keeps each PR
+ * scoped to that sync's upstream delta.
+ */
+export function buildEphemeralSyncBranch(settings: SyncSettings, shortSha: string): string {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const stamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}`;
+  return `${resolveSyncBranch(settings)}/${stamp}-${shortSha}`;
 }
 
 /**
@@ -52,6 +85,22 @@ export function resolveUpstream(settings: SyncSettings): {
   const branch = settings.upstreamBranch ?? DEFAULT_BRANCH;
   const branchRef = `${DEFAULT_UPSTREAM_REMOTE}/${branch}`;
   return { track, branchRef };
+}
+
+/**
+ * Whether the given path is the cella template itself (not a fork).
+ *
+ * The template's root `package.json` is named `cella`; any fork renames it. Used to hide
+ * upstream-facing services (analyze/sync/release) from the menu when running inside cella,
+ * where they are meaningless. Direct subcommands still work for testing.
+ */
+export function isCellaTemplate(forkPath: string): boolean {
+  try {
+    const pkg = JSON.parse(readFileSync(join(forkPath, 'package.json'), 'utf-8')) as { name?: string };
+    return pkg.name === 'cella';
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/cli/cella/src/utils/git.ts
+++ b/cli/cella/src/utils/git.ts
@@ -10,6 +10,7 @@ import { mkdir, readdir, rmdir, unlink } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import process from 'node:process';
 import { promisify } from 'node:util';
+import { readManifestBase } from './manifest';
 
 const execFileAsync = promisify(execFile);
 
@@ -86,6 +87,64 @@ export async function localBranchExists(cwd: string, branch: string): Promise<bo
  */
 export async function createBranch(cwd: string, branch: string): Promise<void> {
   await git(['switch', '-c', branch], cwd);
+}
+
+/**
+ * Switch to an existing branch.
+ */
+export async function switchBranch(cwd: string, branch: string): Promise<void> {
+  await git(['switch', branch], cwd);
+}
+
+/**
+ * Create and check out a new branch from a specific start point (branch/ref).
+ */
+export async function createBranchFrom(cwd: string, branch: string, startPoint: string): Promise<void> {
+  await git(['switch', '-c', branch, startPoint], cwd);
+}
+
+/**
+ * Delete a local branch (force). No-op if it doesn't exist.
+ */
+export async function deleteBranch(cwd: string, branch: string): Promise<void> {
+  await git(['branch', '-D', branch], cwd, { ignoreErrors: true });
+}
+
+/**
+ * Fast-forward the current branch from its upstream tracking branch.
+ * Best-effort: ignores errors (e.g. no origin, offline, or nothing to pull).
+ */
+export async function pullFastForward(cwd: string): Promise<void> {
+  await git(['pull', '--ff-only'], cwd, { ignoreErrors: true, skipEditor: true });
+}
+
+/**
+ * Push a branch to a remote, setting upstream tracking.
+ */
+export async function pushBranch(cwd: string, remote: string, branch: string): Promise<void> {
+  await git(['push', '-u', remote, branch], cwd);
+}
+
+/**
+ * Commit staged changes without opening an editor (keeps the default/merge message).
+ * With a merge in progress this produces a two-parent merge commit.
+ */
+export async function commitNoEdit(cwd: string): Promise<void> {
+  await git(['commit', '--no-edit'], cwd, { skipEditor: true });
+}
+
+/**
+ * Whether a merge is currently in progress (MERGE_HEAD present).
+ */
+export function mergeInProgress(cwd: string): boolean {
+  return existsSync(join(cwd, '.git', 'MERGE_HEAD'));
+}
+
+/**
+ * Get the abbreviated (short) SHA for a ref.
+ */
+export async function getShortSha(cwd: string, ref: string): Promise<string> {
+  return git(['rev-parse', '--short', ref], cwd);
 }
 
 /**
@@ -357,10 +416,9 @@ export async function listWorktrees(cwd: string): Promise<string[]> {
 export async function merge(
   cwd: string,
   ref: string,
-  options: { noCommit?: boolean; noEdit?: boolean; squash?: boolean } = {},
+  options: { noCommit?: boolean; noEdit?: boolean } = {},
 ): Promise<{ success: boolean; conflicts: string[] }> {
   const args = ['merge', '--no-ff', ref];
-  if (options.squash) args.push('--squash');
   if (options.noCommit) args.push('--no-commit');
   if (options.noEdit) args.push('--no-edit');
 
@@ -650,6 +708,11 @@ export async function storeLastSyncRef(cwd: string, upstreamHash: string): Promi
   }
 }
 
+/** Stage a single path (git add). Best-effort — never throws. */
+export async function stagePath(cwd: string, path: string): Promise<void> {
+  await git(['add', '--', path], cwd, { ignoreErrors: true });
+}
+
 /**
  * Get the stored last-sync upstream ref.
  * Returns null if no previous sync has been recorded.
@@ -666,6 +729,76 @@ export async function getStoredSyncRef(cwd: string): Promise<string | null> {
 export async function getStoredSyncHead(cwd: string): Promise<string | null> {
   const ref = await git(['rev-parse', 'refs/cella/last-sync-head'], cwd, { ignoreErrors: true });
   return ref || null;
+}
+
+/**
+ * Check whether a commit object is present in the local object store.
+ */
+async function commitObjectExists(cwd: string, sha: string): Promise<boolean> {
+  try {
+    await git(['cat-file', '-e', `${sha}^{commit}`], cwd);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get the root (parentless) commit of a ref's history. A create-cella scaffold has a
+ * single rootless "Initial commit". Returns null when no root is found.
+ */
+async function getRootCommit(cwd: string, ref: string): Promise<string | null> {
+  const out = await git(['rev-list', '--max-parents=0', ref], cwd, { ignoreErrors: true });
+  const roots = out.split('\n').filter(Boolean);
+  return roots.length > 0 ? roots[roots.length - 1] : null;
+}
+
+/**
+ * Ensure a native git merge-base exists between the fork and upstream.
+ *
+ * A create-cella scaffold — or a fork whose upstream squashed its history — has unrelated
+ * histories, so `git merge-base` finds nothing and every sync fails at the very first step.
+ * This bootstraps ancestry non-destructively:
+ *   1. If a native merge-base already exists, do nothing (the common case).
+ *   2. Otherwise resolve the logical base commit: the stored `refs/cella/last-sync` ref, else
+ *      the `cella.manifest.json` provenance committed by the last sync (or create-cella scaffold).
+ *   3. Graft the fork's root commit onto that base with `git replace --graft`, so every native
+ *      git operation (merge-base and the 3-way merge itself) sees correct ancestry. The replace
+ *      ref is local-only and never pushed, so the fork's own published history stays clean.
+ *
+ * Throws an actionable error when no base can be determined or the recorded base is missing.
+ */
+export async function ensureSyncBase(cwd: string, headRef: string, upstreamRef: string): Promise<void> {
+  // Native ancestry already present — nothing to bootstrap.
+  const nativeBase = await git(['merge-base', headRef, upstreamRef], cwd, { ignoreErrors: true });
+  if (nativeBase) return;
+
+  const baseSha = (await getStoredSyncRef(cwd)) ?? (await readManifestBase(cwd));
+  if (!baseSha) {
+    throw new Error(
+      `no common ancestor between the fork and '${upstreamRef}', and no sync base recorded.\n\n` +
+        'This fork has unrelated history with upstream — typical for a create-cella scaffold, or after\n' +
+        'upstream squashed its history. Seed the base with the upstream commit the fork was created from,\n' +
+        'then re-run sync:\n\n' +
+        '  git update-ref refs/cella/last-sync <upstream-sha>\n',
+    );
+  }
+
+  if (!(await commitObjectExists(cwd, baseSha))) {
+    throw new Error(
+      `recorded sync base ${baseSha.slice(0, 12)} is not present after fetching '${upstreamRef}'.\n` +
+        'It may belong to a different upstream, or have been dropped by an upstream history rewrite.',
+    );
+  }
+
+  const root = await getRootCommit(cwd, headRef);
+  if (!root) throw new Error("could not determine the fork's root commit to bootstrap sync ancestry");
+
+  // Graft the fork root onto the base (idempotent via -f) so native git sees the ancestry.
+  await git(['replace', '-f', '--graft', root, baseSha], cwd);
+
+  // Record the base as the last-sync ref so future runs and the squash strategy stay consistent.
+  await git(['update-ref', 'refs/cella/last-sync', baseSha], cwd);
 }
 
 /**
@@ -719,17 +852,4 @@ export async function getEffectiveMergeBase(
   }
 
   return { base: gitBase, isStale: false, storedRef };
-}
-
-/**
- * Remove .git/MERGE_HEAD to convert a pending merge into a regular commit.
- * Used by squash strategy to create single-parent commits while preserving
- * correct 3-way merge behavior internally.
- */
-export async function removeMergeHead(cwd: string): Promise<void> {
-  try {
-    await unlink(join(cwd, '.git', 'MERGE_HEAD'));
-  } catch {
-    // MERGE_HEAD doesn't exist - that's fine
-  }
 }

--- a/cli/cella/src/utils/manifest.ts
+++ b/cli/cella/src/utils/manifest.ts
@@ -1,0 +1,64 @@
+/**
+ * Cella sync manifest.
+ *
+ * A committed record of the last upstream sync point, living at the fork repo root as
+ * `cella.manifest.json`. It serves two purposes:
+ *  1. Machine: `upstream.commit` is the bootstrap seed `ensureSyncBase` uses to reconstruct
+ *     the merge-base on a clone that has no local `refs/cella/last-sync` (fresh clone, CI, a
+ *     second maintainer). Committed, so it travels with the repo — unlike the local ref.
+ *  2. Human: records the upstream repo, tracking mode, release/commit and a GitHub link, so
+ *     each sync PR shows exactly which upstream point you moved to.
+ *
+ * Written and staged by the sync engine on every applied sync, so it stays in lockstep with
+ * `refs/cella/last-sync` and rides along in the sync commit.
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+/** Committed manifest filename at the fork repo root. */
+export const MANIFEST_FILE = 'cella.manifest.json';
+
+/** The last upstream sync point recorded in {@link MANIFEST_FILE}. */
+export interface SyncManifest {
+  upstream: {
+    /** GitHub slug of the upstream repo, e.g. 'cellajs/cella'. */
+    repo?: string;
+    /** Tracking mode at sync time. */
+    track?: 'release' | 'branch';
+    /** Integrated upstream commit SHA — the merge-base bootstrap seed. */
+    commit: string;
+    /** Release tag when tracking releases, else null. */
+    release?: string | null;
+    /** Human-readable link to the commit or release on GitHub. */
+    url?: string;
+    /** UTC timestamp of the sync (ISO 8601). */
+    syncedAt?: string;
+  };
+}
+
+/** Read and validate the manifest. Returns null when absent or malformed. */
+export async function readSyncManifest(cwd: string): Promise<SyncManifest | null> {
+  try {
+    const parsed = JSON.parse(await readFile(join(cwd, MANIFEST_FILE), 'utf8')) as SyncManifest;
+    const commit = parsed?.upstream?.commit;
+    if (typeof commit !== 'string' || !/^[0-9a-f]{40}$/i.test(commit)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return the recorded upstream base commit SHA, or null.
+ * Bootstrap seed for {@link ensureSyncBase} when no local `refs/cella/last-sync` exists.
+ */
+export async function readManifestBase(cwd: string): Promise<string | null> {
+  const manifest = await readSyncManifest(cwd);
+  return manifest ? manifest.upstream.commit.toLowerCase() : null;
+}
+
+/** Write the manifest as pretty JSON with a trailing newline. */
+export async function writeSyncManifest(cwd: string, manifest: SyncManifest): Promise<void> {
+  await writeFile(join(cwd, MANIFEST_FILE), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+}

--- a/cli/cella/tests/e2e/helpers/test-env.ts
+++ b/cli/cella/tests/e2e/helpers/test-env.ts
@@ -186,26 +186,17 @@ export function buildRuntimeConfig(
     service?: SyncService;
     pinned?: string[];
     ignored?: string[];
-    mergeStrategy?: 'merge' | 'squash';
     track?: 'release' | 'branch';
     trackOverride?: 'release' | 'branch';
   } = {},
 ): RuntimeConfig {
-  const {
-    service = 'analyze',
-    pinned = [],
-    ignored = [],
-    mergeStrategy = 'squash',
-    track = 'branch',
-    trackOverride,
-  } = options;
+  const { service = 'analyze', pinned = [], ignored = [], track = 'branch', trackOverride } = options;
 
   const config: CellaCliConfig = {
     settings: {
       upstreamUrl: env.upstreamPath,
       upstreamBranch: 'main',
       upstreamTrack: track,
-      mergeStrategy,
     },
     overrides: {
       pinned,

--- a/cli/cella/tests/e2e/sync-e2e.test.ts
+++ b/cli/cella/tests/e2e/sync-e2e.test.ts
@@ -231,9 +231,9 @@ describe('sync e2e', () => {
         message: 'chore: add temp file',
       });
 
-      // Sync to get the file (use regular merge, not squash, for proper merge-base tracking)
+      // Sync to get the file
       fetchUpstream(env.forkPath);
-      let config = buildRuntimeConfig(env, { service: 'sync', mergeStrategy: 'merge' });
+      let config = buildRuntimeConfig(env, { service: 'sync' });
       await runSync(config);
 
       expect(fileExists(env.forkPath, 'temp.ts')).toBe(true);
@@ -262,7 +262,7 @@ describe('sync e2e', () => {
       deleteFileAndCommit(env.upstreamPath, 'temp.ts', 'chore: remove temp file');
 
       fetchUpstream(env.forkPath);
-      config = buildRuntimeConfig(env, { service: 'sync', mergeStrategy: 'merge' });
+      config = buildRuntimeConfig(env, { service: 'sync' });
       const result = await runSync(config);
 
       expect(result.success).toBe(true);
@@ -279,7 +279,7 @@ describe('sync e2e', () => {
 
       // Sync to get the file
       fetchUpstream(env.forkPath);
-      let config = buildRuntimeConfig(env, { service: 'sync', mergeStrategy: 'merge' });
+      let config = buildRuntimeConfig(env, { service: 'sync' });
       await runSync(config);
 
       expect(fileExists(env.forkPath, 'old-dir/moved-file.ts')).toBe(true);
@@ -304,7 +304,7 @@ describe('sync e2e', () => {
       );
 
       fetchUpstream(env.forkPath);
-      config = buildRuntimeConfig(env, { service: 'sync', mergeStrategy: 'merge' });
+      config = buildRuntimeConfig(env, { service: 'sync' });
       const result = await runSync(config);
 
       expect(result.success).toBe(true);
@@ -319,7 +319,7 @@ describe('sync e2e', () => {
       expect(renamedFile?.renamedFrom).toBe('old-dir/moved-file.ts');
     });
 
-    it('should handle file renames with squash strategy', async () => {
+    it('should handle file renames with squashed (single-parent) history', async () => {
       const fs = await import('node:fs');
       const { getFileChanges, getMergeBase, git } = await import('../../src/utils/git');
       const { execSync } = await import('node:child_process');
@@ -332,12 +332,16 @@ describe('sync e2e', () => {
 
       // Sync to get the file
       fetchUpstream(env.forkPath);
-      let config = buildRuntimeConfig(env, { service: 'sync', mergeStrategy: 'squash' });
+      let config = buildRuntimeConfig(env, { service: 'sync' });
       await runSync(config);
 
       expect(fileExists(env.forkPath, 'src/old-name.ts')).toBe(true);
 
-      // Complete the squash commit
+      // Simulate a squashed (single-parent) history: drop MERGE_HEAD before committing so
+      // git's native merge-base becomes stale and recovery relies on refs/cella/last-sync.
+      fs.rmSync(`${env.forkPath}/.git/MERGE_HEAD`, { force: true });
+
+      // Complete the (single-parent) commit
       try {
         execSync('git add -A && git commit --allow-empty -m "sync: squash upstream"', {
           cwd: env.forkPath,
@@ -369,7 +373,7 @@ describe('sync e2e', () => {
       };
       fs.writeFileSync('/tmp/cella-test-debug1.json', JSON.stringify(debugInfo1, null, 2));
 
-      config = buildRuntimeConfig(env, { service: 'sync', mergeStrategy: 'squash' });
+      config = buildRuntimeConfig(env, { service: 'sync' });
       const result = await runSync(config);
 
       // Debug: Check what status was detected for the files
@@ -482,7 +486,7 @@ describe('sync e2e', () => {
 
       // Sync shared.ts into the fork and finalize so it becomes part of the merge base.
       fetchUpstream(env.forkPath);
-      await runSync(buildRuntimeConfig(env, { service: 'sync', mergeStrategy: 'merge' }));
+      await runSync(buildRuntimeConfig(env, { service: 'sync' }));
       try {
         execSync('git add -A && git commit --allow-empty -m "sync: shared"', { cwd: env.forkPath });
       } catch {
@@ -550,7 +554,7 @@ describe('sync e2e', () => {
       });
 
       fetchUpstream(env.forkPath);
-      let config = buildRuntimeConfig(env, { service: 'sync', mergeStrategy: 'merge' });
+      let config = buildRuntimeConfig(env, { service: 'sync' });
       let result = await runSync(config);
 
       expect(result.success).toBe(true);
@@ -573,7 +577,7 @@ describe('sync e2e', () => {
       });
 
       fetchUpstream(env.forkPath);
-      config = buildRuntimeConfig(env, { service: 'sync', mergeStrategy: 'merge' });
+      config = buildRuntimeConfig(env, { service: 'sync' });
       result = await runSync(config);
 
       expect(result.success).toBe(true);
@@ -607,6 +611,7 @@ describe('sync e2e', () => {
 
     it('should recover from stale merge-base after squash sync', async () => {
       const { execSync } = await import('node:child_process');
+      const fs = await import('node:fs');
 
       // ── Cycle 1: squash sync ──
       makeCommit(env.upstreamPath, {
@@ -615,12 +620,16 @@ describe('sync e2e', () => {
       });
 
       fetchUpstream(env.forkPath);
-      let config = buildRuntimeConfig(env, { service: 'sync', mergeStrategy: 'squash' });
+      let config = buildRuntimeConfig(env, { service: 'sync' });
       let result = await runSync(config);
 
       expect(result.success).toBe(true);
 
-      // Complete squash commit (MERGE_HEAD was removed, so this is single-parent)
+      // Simulate a squashed (single-parent) history: drop MERGE_HEAD before committing so
+      // git's native merge-base becomes stale and recovery relies on refs/cella/last-sync.
+      fs.rmSync(`${env.forkPath}/.git/MERGE_HEAD`, { force: true });
+
+      // Complete the single-parent commit
       try {
         execSync('git add -A && git commit --allow-empty -m "sync: squash cycle 1"', {
           cwd: env.forkPath,
@@ -651,7 +660,7 @@ describe('sync e2e', () => {
       expect(effectiveBase.storedRef).not.toBeNull();
 
       // Sync should work correctly despite squash history
-      config = buildRuntimeConfig(env, { service: 'sync', mergeStrategy: 'squash' });
+      config = buildRuntimeConfig(env, { service: 'sync' });
       result = await runSync(config);
 
       expect(result.success).toBe(true);
@@ -678,7 +687,7 @@ describe('sync e2e', () => {
       });
 
       fetchUpstream(env.forkPath);
-      const config = buildRuntimeConfig(env, { service: 'sync', track: 'release', mergeStrategy: 'merge' });
+      const config = buildRuntimeConfig(env, { service: 'sync', track: 'release' });
       const result = await runSync(config);
 
       expect(result.success).toBe(true);
@@ -695,7 +704,7 @@ describe('sync e2e', () => {
       });
 
       fetchUpstream(env.forkPath);
-      const config = buildRuntimeConfig(env, { service: 'sync', track: 'release', mergeStrategy: 'merge' });
+      const config = buildRuntimeConfig(env, { service: 'sync', track: 'release' });
 
       await expect(runSync(config)).rejects.toThrow(/no upstream releases/);
     });
@@ -712,7 +721,6 @@ describe('sync e2e', () => {
         service: 'sync',
         track: 'release',
         trackOverride: 'branch',
-        mergeStrategy: 'merge',
       });
       const result = await runSync(config);
 

--- a/cli/cella/tests/overrides.test.ts
+++ b/cli/cella/tests/overrides.test.ts
@@ -14,7 +14,6 @@ function buildConfig(overrides: { pinned?: string[]; ignored?: string[] }): Cell
     settings: {
       upstreamUrl: 'test',
       upstreamBranch: 'main',
-      mergeStrategy: 'squash',
     },
     overrides: {
       pinned: overrides.pinned ?? [],
@@ -97,7 +96,6 @@ describe('overrides', () => {
         settings: {
           upstreamUrl: 'test',
           upstreamBranch: 'main',
-          mergeStrategy: 'squash',
         },
       };
       expect(isPinned('any/file.ts', config)).toBe(false);

--- a/cli/cella/tests/packages.test.ts
+++ b/cli/cella/tests/packages.test.ts
@@ -76,7 +76,6 @@ describe('packages merge', () => {
       settings: {
         upstreamUrl: upstreamPath,
         upstreamBranch: 'main',
-        mergeStrategy: 'squash',
         ...(options?.packageJsonSync ? { packageJsonSync: options.packageJsonSync } : {}),
       },
       overrides: { pinned: [], ignored: [] },


### PR DESCRIPTION
## Summary
- add the new `release` service flow and supporting git/config utilities
- hide `analyze`, `sync`, and `release` from the interactive menu when running inside the `cella` template
- only show `release` in the menu when the current branch is the configured sync branch

## Validation
- pnpm check