### PR TITLE
feat: encrypt TOTP secrets at rest

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -42,8 +42,10 @@ CDC_SECRET=some_secret_for_cdc_worker
 YJS_SECRET=some_secret_for_yjs_relay
 
 # Pepper for one-way hashing of PII used as lookup keys (rate limiter, audit logs, etc.)
-# Rotate to invalidate all derived keys. Must be at least 16 characters.
 PII_HASH_SECRET=some_secret_pepper_for_pii_hashing
+
+# Root key for reversible encryption of sensitive database fields.
+DATA_ENCRYPTION_KEY=some_secret_for_reversible_data_encryption
 
 # System admin IP allowlist: 'none' to disable, '*' for any IP, or comma-separated IPv4 addresses
 SYSTEM_ADMIN_IP_ALLOWLIST=none

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -84,6 +84,7 @@ export const env = createEnv({
     YJS_SECRET: z.string().min(16, 'YJS_SECRET must be at least 16 characters'),
     CDC_SECRET: z.string().min(16, 'CDC_SECRET must be at least 16 characters'),
     PII_HASH_SECRET: z.string().min(16, 'PII_HASH_SECRET must be at least 16 characters'),
+    DATA_ENCRYPTION_KEY: z.string().min(32, 'DATA_ENCRYPTION_KEY must be at least 32 characters'),
 
     GEOIP_COUNTRY_DB_PATH: z.string().default('./geoip/dbip-country-lite.mmdb'),
     GEOIP_ASN_DB_PATH: z.string().default('./geoip/dbip-asn-lite.mmdb'),

--- a/backend/src/modules/auth/auth-queries.ts
+++ b/backend/src/modules/auth/auth-queries.ts
@@ -3,6 +3,7 @@ import type { DbContext } from '#/core/context';
 import { passkeysTable } from '#/modules/auth/passkeys/passkeys-db';
 import { sessionsTable } from '#/modules/auth/sessions-db';
 import { tokensTable } from '#/modules/auth/tokens-db';
+import { encryptTotpSecret } from '#/modules/auth/totps/helpers/totp-secret-encryption';
 import { totpsTable } from '#/modules/auth/totps/totps-db';
 import { inactiveMembershipsTable } from '#/modules/memberships/inactive-memberships-db';
 import { emailsTable } from '#/modules/user/emails-db';
@@ -106,7 +107,7 @@ interface InsertTotpOpts {
 /** Insert a TOTP record. */
 export const insertTotp = async (ctx: DbContext, { userId, secret }: InsertTotpOpts) => {
   const { db } = ctx.var;
-  return db.insert(totpsTable).values({ userId, secret });
+  return db.insert(totpsTable).values({ userId, secret: encryptTotpSecret(secret) });
 };
 
 interface LinkTokenToUserOpts {

--- a/backend/src/modules/auth/totps/helpers/totp-secret-encryption.ts
+++ b/backend/src/modules/auth/totps/helpers/totp-secret-encryption.ts
@@ -1,0 +1,7 @@
+import { decryptData, encryptData } from '#/utils/data-encryption';
+
+const TOTP_SECRET_PURPOSE = 'auth:totp-secret:v1';
+
+export const encryptTotpSecret = (secret: string): string => encryptData(secret, TOTP_SECRET_PURPOSE);
+
+export const decryptTotpSecret = (encryptedSecret: string): string => decryptData(encryptedSecret, TOTP_SECRET_PURPOSE);

--- a/backend/src/modules/auth/totps/helpers/totps.ts
+++ b/backend/src/modules/auth/totps/helpers/totps.ts
@@ -4,6 +4,7 @@ import { eq } from 'drizzle-orm';
 import { appConfig } from 'shared';
 import { AppError } from '#/core/error';
 import { baseDb as db } from '#/db/db';
+import { decryptTotpSecret } from '#/modules/auth/totps/helpers/totp-secret-encryption';
 import { totpsTable } from '#/modules/auth/totps/totps-db';
 
 const { intervalInSeconds, digits, gracePeriodInSeconds } = appConfig.totpConfig;
@@ -36,6 +37,7 @@ export const validateTOTP = async ({ code, userId }: { code: string; userId: str
   if (!credentials) throw new AppError(404, 'not_found', 'warn');
 
   // Verify TOTP code using stored secret
-  const isValid = signInWithTotp(code, credentials.secret);
+  const secret = decryptTotpSecret(credentials.secret);
+  const isValid = signInWithTotp(code, secret);
   if (!isValid) throw new AppError(401, 'invalid_token', 'warn');
 };

--- a/backend/src/utils/data-encryption.test.ts
+++ b/backend/src/utils/data-encryption.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { decryptData, encryptData, isEncryptedData } from './data-encryption';
+
+const PURPOSE = 'test:data-encryption:v1';
+
+describe('data encryption', () => {
+  it('round trips plaintext through a versioned ciphertext envelope', () => {
+    const encrypted = encryptData('JBSWY3DPEHPK3PXP', PURPOSE);
+
+    expect(encrypted).toMatch(/^v1:/);
+    expect(isEncryptedData(encrypted)).toBe(true);
+    expect(decryptData(encrypted, PURPOSE)).toBe('JBSWY3DPEHPK3PXP');
+  });
+
+  it('uses a random IV for each encryption', () => {
+    const first = encryptData('same plaintext', PURPOSE);
+    const second = encryptData('same plaintext', PURPOSE);
+
+    expect(first).not.toBe(second);
+    expect(decryptData(first, PURPOSE)).toBe('same plaintext');
+    expect(decryptData(second, PURPOSE)).toBe('same plaintext');
+  });
+
+  it('fails when the ciphertext is tampered with', () => {
+    const encrypted = encryptData('sensitive', PURPOSE);
+    const parts = encrypted.split(':');
+    parts[2] = Buffer.from('tampered', 'utf8').toString('base64url');
+
+    expect(() => decryptData(parts.join(':'), PURPOSE)).toThrow();
+  });
+
+  it('keeps purposes cryptographically separated', () => {
+    const encrypted = encryptData('sensitive', PURPOSE);
+
+    expect(() => decryptData(encrypted, 'test:other-purpose:v1')).toThrow();
+  });
+});

--- a/backend/src/utils/data-encryption.ts
+++ b/backend/src/utils/data-encryption.ts
@@ -1,0 +1,48 @@
+import { createCipheriv, createDecipheriv, hkdfSync, randomBytes } from 'node:crypto';
+import { env } from '#/env';
+
+const VERSION = 'v1';
+const ALGORITHM = 'aes-256-gcm';
+const KEY_BYTES = 32;
+const IV_BYTES = 12;
+const AUTH_TAG_BYTES = 16;
+const HKDF_SALT = 'cella:data-encryption';
+
+const encode = (value: Buffer) => value.toString('base64url');
+const decode = (value: string) => Buffer.from(value, 'base64url');
+
+const deriveKey = (purpose: string): Buffer =>
+  Buffer.from(
+    hkdfSync(
+      'sha256',
+      Buffer.from(env.DATA_ENCRYPTION_KEY, 'utf8'),
+      Buffer.from(HKDF_SALT, 'utf8'),
+      Buffer.from(purpose, 'utf8'),
+      KEY_BYTES,
+    ),
+  );
+
+export const isEncryptedData = (value: string): boolean => value.startsWith(`${VERSION}:`);
+
+export const encryptData = (plaintext: string, purpose: string): string => {
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, deriveKey(purpose), iv, { authTagLength: AUTH_TAG_BYTES });
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return [VERSION, encode(iv), encode(ciphertext), encode(authTag)].join(':');
+};
+
+export const decryptData = (encryptedValue: string, purpose: string): string => {
+  const [version, encodedIv, encodedCiphertext, encodedAuthTag, ...extra] = encryptedValue.split(':');
+  if (version !== VERSION || !encodedIv || !encodedCiphertext || !encodedAuthTag || extra.length) {
+    throw new Error('Invalid encrypted data format');
+  }
+
+  const decipher = createDecipheriv(ALGORITHM, deriveKey(purpose), decode(encodedIv), {
+    authTagLength: AUTH_TAG_BYTES,
+  });
+  decipher.setAuthTag(decode(encodedAuthTag));
+
+  return Buffer.concat([decipher.update(decode(encodedCiphertext)), decipher.final()]).toString('utf8');
+};

--- a/backend/tests/helpers.ts
+++ b/backend/tests/helpers.ts
@@ -7,6 +7,7 @@ import { baseDb as db } from '#/db/db';
 import { mockPastIsoDate } from '#/mocks';
 import { sessionsTable } from '#/modules/auth/sessions-db';
 import { tokensTable } from '#/modules/auth/tokens-db';
+import { encryptTotpSecret } from '#/modules/auth/totps/helpers/totp-secret-encryption';
 import { totpsTable } from '#/modules/auth/totps/totps-db';
 import { membershipsTable } from '#/modules/memberships/memberships-db';
 import { type OrganizationModel, organizationsTable } from '#/modules/organization/organization-db';
@@ -61,7 +62,7 @@ export async function createTotpUser(email: string) {
   await verifyUserEmail(email);
   await db.insert(totpsTable).values({
     userId: user.id,
-    secret: 'JBSWY3DPEHPK3PXP',
+    secret: encryptTotpSecret('JBSWY3DPEHPK3PXP'),
     createdAt: mockPastIsoDate(),
   });
   await enableMFAForUser(user.id);

--- a/backend/tests/sign-in/totp.test.ts
+++ b/backend/tests/sign-in/totp.test.ts
@@ -3,6 +3,7 @@ import { createTotp, generateTotpKey, signInWithTotp } from 'sdk';
 import { appConfig } from 'shared';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { baseDb as db } from '#/db/db';
+import { decryptTotpSecret } from '#/modules/auth/totps/helpers/totp-secret-encryption';
 import { totpsTable } from '#/modules/auth/totps/totps-db';
 import { defaultHeaders, signUpUser } from '../fixtures';
 import {
@@ -68,11 +69,12 @@ describe('TOTP Authentication', async () => {
       const sessionCookie = await createTestSession(user);
 
       // First generate TOTP key
-      const { response: generateRes } = await call(generateTotpKey, {
+      const { response: generateRes, data: generateData } = await call(generateTotpKey, {
         headers: { ...defaultHeaders, Cookie: sessionCookie },
       });
 
       expect(generateRes.status).toBe(200);
+      const generatedTotp = generateData as { manualKey: string };
 
       // Get totp-challenge cookie from generate response
       const generateCookies = generateRes.headers.get('set-cookie');
@@ -89,7 +91,9 @@ describe('TOTP Authentication', async () => {
       // Verify TOTP was created in database
       const totpRecord = await db.select().from(totpsTable).where(eq(totpsTable.userId, user.id));
       expect(totpRecord).toHaveLength(1);
-      expect(totpRecord[0].secret).toBeTruthy();
+      expect(totpRecord[0].secret).toMatch(/^v1:/);
+      expect(totpRecord[0].secret).not.toBe(generatedTotp.manualKey);
+      expect(decryptTotpSecret(totpRecord[0].secret)).toBe(generatedTotp.manualKey);
     });
   });
 

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
       CDC_SECRET: 'test-cdc-secret-min16chars',
       YJS_SECRET: 'test-yjs-secret-min16',
       PII_HASH_SECRET: 'test-pii-hash-secret-min16',
+      DATA_ENCRYPTION_KEY: 'test-data-encryption-key-minimum-32-chars',
       SYSTEM_ADMIN_IP_ALLOWLIST: '*',
       DATABASE_URL: testDatabaseUrl,
     },

--- a/infra/config/runtime-secrets.config.ts
+++ b/infra/config/runtime-secrets.config.ts
@@ -109,6 +109,15 @@ export default defineRuntimeSecrets({
     generation: 'random',
     services: ['backend', 'mcp'],
   },
+  dataEncryptionKey: {
+    secretName: 'data-encryption-key',
+    description: 'Root key for reversible encryption of sensitive database fields',
+    envVar: 'DATA_ENCRYPTION_KEY',
+    required: true,
+    valueSource: 'pulumi',
+    generation: 'random',
+    services: ['backend', 'mcp'],
+  },
   adminEmail: {
     secretName: 'admin-email',
     description: 'Primary administrative contact email',


### PR DESCRIPTION
## Summary
- add a DATA_ENCRYPTION_KEY runtime secret for reversible sensitive-field encryption
- encrypt TOTP secrets on insert and decrypt them only during verification
- add crypto and TOTP storage assertions

## Verification
- pnpm --filter backend ts
- pnpm biome check backend/src/utils/data-encryption.ts backend/src/utils/data-encryption.test.ts backend/src/modules/auth/totps/helpers/totp-secret-encryption.ts backend/src/modules/auth/auth-queries.ts backend/src/modules/auth/totps/helpers/totps.ts backend/tests/helpers.ts backend/tests/sign-in/totp.test.ts backend/src/env.ts backend/vitest.config.ts infra/config/runtime-secrets.config.ts
- pnpm --filter infra exec vitest run tests/unit/runtime-secrets.test.ts
- pnpm --filter backend exec vitest run src/utils/data-encryption.test.ts tests/sign-in/totp.test.ts