### PR TITLE
ci: gate production deploy via reusable workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,13 @@ name: Deploy
 permissions: {}
 
 on:
-  # Automatic deployment to production only when a release is cut.
-  release:
-    types: [published]
+  # Called by the Release workflow after release-gate passes.
+  workflow_call:
+    inputs:
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        type: string
 
   # Manual deployment for any environment
   workflow_dispatch:
@@ -22,7 +26,7 @@ on:
 
 # Prevent concurrent deployments to the same environment
 concurrency:
-  group: deploy-${{ github.event.inputs.environment || 'production' }}
+  group: deploy-${{ inputs.environment || 'production' }}
   cancel-in-progress: false
 
 env:
@@ -69,7 +73,7 @@ jobs:
       - name: Derive resource names from shared config
         id: derive
         env:
-          ENV: ${{ github.event.inputs.environment || 'production' }}
+          ENV: ${{ inputs.environment || 'production' }}
           GIT_REF: ${{ github.ref }}
           GIT_SHA: ${{ github.sha }}
         run: pnpm --silent --filter infra print-deploy-env "$ENV" --git-ref "$GIT_REF" --git-sha "$GIT_SHA" >> $GITHUB_OUTPUT
@@ -606,4 +610,3 @@ jobs:
             deleted=$((deleted + 1))
           done <<< "$ids"
           echo "Kept newest deployment ${kept:-<none>} for '${ENVIRONMENT}'; deleted ${deleted} stale record(s)."
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 # release-please maintains a "release PR" per package from Conventional Commits.
 # Merging that PR bumps the version, updates the CHANGELOG, creates the git tag
 # and publishes the GitHub Release. When a release is cut, the `release-gate` job
-# runs heavy security + e2e checks before the GitHub Release is finalized.
+# runs heavy security + e2e checks before production deploy starts.
 #
 # Add a new releasable package by adding an entry to .github/release-please-config.json
 # and .github/release-please-manifest.json — no workflow changes needed.
@@ -46,7 +46,7 @@ jobs:
           manifest-file: .github/release-please-manifest.json
 
   # Release-only gate: heavy security + e2e checks that we don't want on every
-  # feature PR. Nothing is published unless this passes (publish jobs `needs` it).
+  # feature PR. Production deploy is called only after this passes.
   # Runs only when a release was actually cut this push.
   release-gate:
     needs: release-please
@@ -108,3 +108,14 @@ jobs:
         run: pnpm test:full
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+
+  deploy-production:
+    needs: [release-please, release-gate]
+    if: ${{ always() && needs.release-please.outputs.releases-created == 'true' && needs.release-gate.result == 'success' }}
+    permissions:
+      contents: read
+      deployments: write
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: production
+    secrets: inherit


### PR DESCRIPTION
## Summary
- remove the automatic release.published trigger from Deploy
- expose Deploy as a reusable workflow with workflow_call while keeping manual workflow_dispatch
- call production Deploy from Release only after release-gate succeeds

## Validation
- ruby YAML parse for deploy.yml and release.yml
- git diff --check
- pre-commit hooks: SDK generation unchanged; pnpm -r ts passed