### PR TITLE
Row policies + hostEntity: engine-level row visibility and product-to-product ownership

### DIFF
--- a/backend/src/db/utils/host-relation-columns.ts
+++ b/backend/src/db/utils/host-relation-columns.ts
@@ -1,0 +1,36 @@
+import { uuid } from 'drizzle-orm/pg-core';
+import { type HostEntityType, hierarchy, type ProductEntityType } from 'shared';
+
+/** Column builder type for a nullable uuid host id column. */
+type NullableUuid = ReturnType<typeof uuid>;
+
+/**
+ * Host-entity id column generated for a hosted product (see `host:` in the hierarchy
+ * builder): e.g. `attachment` with `host: 'task'` gets a nullable `taskId` column.
+ * Example: `HostRelationColumns<'attachment'>` → `{ taskId: NullableUuid }`.
+ *
+ * Nullable by design: a hosted row may exist unhosted (raak: project-level attachments
+ * without a task). Forks that want strictly-hosted products (e.g. comment → item) add a
+ * NOT NULL constraint in their migration; the mechanism (cascade, counters) treats null
+ * as "not hosted".
+ *
+ * No FK is generated — the reference is soft, like embedding id arrays: the CDC cascade
+ * owns lifecycle consistency, and a hard FK would force cross-module table imports.
+ * Indexes still live in the table definition.
+ */
+// TODO use EntityIdColumnKey
+export type HostRelationColumns<E extends string> = {
+  [H in HostEntityType<E> & string as `${H}Id`]: NullableUuid;
+};
+
+/**
+ * Generates the host id column for a hosted product entity from the hierarchy config.
+ * Returns an empty object for products without a declared host, so tables can spread it
+ * unconditionally.
+ */
+export const hostRelationColumns = <E extends ProductEntityType>(entityType: E): HostRelationColumns<E> => {
+  const hostType = hierarchy.getHostType(entityType);
+  const columns: Record<string, NullableUuid> = {};
+  if (hostType) columns[`${hostType}Id`] = uuid();
+  return columns as HostRelationColumns<E>;
+};

--- a/backend/src/modules/attachment/attachment-db.ts
+++ b/backend/src/modules/attachment/attachment-db.ts
@@ -2,6 +2,7 @@ import { boolean, foreignKey, index, snakeCase, uuid, varchar } from 'drizzle-or
 import { tenantSelectPolicy, writeThroughPolicies } from '#/db/rls-helpers';
 import { maxLength } from '#/db/utils/constraints';
 import { contextRelationColumns } from '#/db/utils/context-relation-columns';
+import { hostRelationColumns } from '#/db/utils/host-relation-columns';
 import { productEntityColumns } from '#/db/utils/product-entity-columns';
 import { organizationsTable } from '#/modules/organization/organization-db';
 
@@ -13,6 +14,8 @@ export const attachmentsTable = snakeCase.table(
   'attachments',
   {
     ...productEntityColumns('attachment'),
+    // Host relation columns (hierarchy `host:`) — empty unless a fork declares a host for attachments
+    ...hostRelationColumns('attachment'),
     public: boolean().notNull().default(false),
     bucketName: varchar({ length: maxLength.field }).notNull(),
     groupId: uuid(),

--- a/backend/src/modules/attachment/operations/get-attachments.ts
+++ b/backend/src/modules/attachment/operations/get-attachments.ts
@@ -7,6 +7,8 @@ import { attachmentsTable } from '#/modules/attachment/attachment-db';
 import type { attachmentListQuerySchema } from '#/modules/attachment/attachment-schema';
 import { productCountersTable } from '#/modules/entities/product-counters-db';
 import { auditUserSelect, coalesceAuditUsers, createdByUser, updatedByUser } from '#/modules/user/helpers/audit-user';
+import { resolveCollectionReadFilter } from '#/permissions/collection-scope';
+import { buildCollectionReadWhere } from '#/permissions/row-predicates';
 import { getOrderColumn } from '#/utils/order-column';
 import { seqCursorFilters } from '#/utils/seq-cursor';
 import { prepareStringForILikeFilter } from '#/utils/sql';
@@ -17,7 +19,25 @@ export async function getAttachmentsOp(ctx: AuthContext, input: GetAttachmentsIn
   const organizationId = ctx.var.organization.id;
   const { q, sort, order, limit, offset, seqCursor } = input;
 
+  // Resolve the caller's readable scope (unconditional + row-conditional read grants,
+  // e.g. `read: 'own'`) and compile it to a single row predicate.
+  const readFilter = resolveCollectionReadFilter(ctx.var.memberships, 'attachment', organizationId);
+  const scopeWhere = buildCollectionReadWhere(
+    readFilter,
+    attachmentsTable,
+    attachmentsTable.organizationId,
+    ctx.var.user.id,
+  );
+
+  if (scopeWhere.kind === 'none') {
+    const data = { items: [], total: 0 };
+    return { success: true, data } as OperationResult<typeof data>;
+  }
+
   const filters: SQL[] = [eq(attachmentsTable.organizationId, organizationId)];
+
+  // Restrict to the caller's readable scope unless org-wide (kind 'all').
+  if (scopeWhere.kind === 'where') filters.push(scopeWhere.where);
 
   if (!seqCursor) {
     filters.push(isNull(attachmentsTable.deletedAt));

--- a/backend/src/modules/entities/helpers/cascade-hosted.ts
+++ b/backend/src/modules/entities/helpers/cascade-hosted.ts
@@ -1,0 +1,59 @@
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+import type { AnyPgTable, PgColumn } from 'drizzle-orm/pg-core';
+import { hierarchy, type ProductEntityType } from 'shared';
+import type { AuthContext } from '#/core/context';
+import { entityTables } from '#/tables';
+
+/** Structural shape a hosted product table must have for the cascade update. */
+type HostedTable = AnyPgTable & {
+  id: PgColumn;
+  deletedAt: PgColumn;
+  organizationId: PgColumn;
+};
+
+/**
+ * Soft-delete all hosted rows of the given host rows (hierarchy `host:` relationships,
+ * e.g. deleting tasks soft-deletes their attachments). The API-layer half of the
+ * host lifecycle cascade — the CDC pipeline handles hard-delete suppression and host
+ * counter deltas from the resulting tombstone events.
+ *
+ * Tombstones intentionally flow per hosted row (no event suppression here): delta-sync
+ * clients need each one to drop cached rows.
+ *
+ * @returns The soft-deleted row ids per hosted entity type.
+ */
+export const cascadeSoftDeleteHosted = async (
+  ctx: AuthContext,
+  {
+    hostType,
+    hostIds,
+    deletedAt,
+    deletedBy,
+  }: { hostType: ProductEntityType; hostIds: string[]; deletedAt: string; deletedBy: string },
+): Promise<Partial<Record<ProductEntityType, string[]>>> => {
+  const { db, organizationId } = ctx.var;
+  const deleted: Partial<Record<ProductEntityType, string[]>> = {};
+  if (hostIds.length === 0) return deleted;
+
+  for (const relation of hierarchy.getHostRelations()) {
+    if (relation.hostType !== hostType) continue;
+
+    const table = entityTables[relation.hostedType as keyof typeof entityTables] as HostedTable;
+    const hostIdColumn = (table as unknown as Record<string, PgColumn | undefined>)[relation.hostIdColumn];
+    if (!hostIdColumn) {
+      throw new Error(
+        `[HostEntity] Hosted table for "${relation.hostedType}" is missing its host id column "${relation.hostIdColumn}"`,
+      );
+    }
+
+    const rows = await db
+      .update(table)
+      .set({ deletedAt, deletedBy, updatedAt: deletedAt, updatedBy: deletedBy } as never)
+      .where(and(inArray(hostIdColumn, hostIds), eq(table.organizationId, organizationId), isNull(table.deletedAt)))
+      .returning({ id: table.id });
+
+    deleted[relation.hostedType as ProductEntityType] = rows.map(({ id }) => id as string);
+  }
+
+  return deleted;
+};

--- a/backend/src/modules/entities/helpers/recalculate-counters.ts
+++ b/backend/src/modules/entities/helpers/recalculate-counters.ts
@@ -144,6 +144,25 @@ export const recalculateCounters = async (db: DbOrTx) => {
     );
   }
 
+  // 4c: Hosted-row counters → context_counters, keyed by host id (hierarchy `host:`,
+  // e.g. e:attachment per owning task). Live rows only — the CDC deltas decrement on
+  // soft-delete transitions, so recalculation must exclude tombstones to agree.
+  for (const relation of hierarchy.getHostRelations()) {
+    const src = tbl(relation.hostedType as EntityType);
+    const key = `e:${relation.hostedType}`;
+    const hostFk = fkCol(relation.hostType);
+
+    await upsertContextCounters(
+      db,
+      `
+      SELECT h.${hostFk}, jsonb_build_object('${key}', COUNT(*)::int), NOW()
+      FROM ${src} h
+      WHERE h.${hostFk} IS NOT NULL AND h.deleted_at IS NULL
+      GROUP BY h.${hostFk}
+    `,
+    );
+  }
+
   // Return row counts
   const [{ contextRows }] = await db
     .select({ contextRows: sql<number>`count(*)`.mapWith(Number) })

--- a/backend/src/permissions/build-subject.ts
+++ b/backend/src/permissions/build-subject.ts
@@ -32,7 +32,12 @@ const translateMissingScope = (e: unknown): never => {
 export const buildSubject = (
   entityType: ContextEntityType | ProductEntityType,
   ancestorContextIds: Partial<ContextEntityIdColumns>,
-  options?: { id?: string; createdBy?: string | null },
+  options?: {
+    id?: string;
+    createdBy?: string | null;
+    row?: Record<string, unknown>;
+    parentRow?: Record<string, unknown>;
+  },
 ): SubjectForPermission => {
   try {
     return sharedBuildSubject(entityType, ancestorContextIds, options);

--- a/backend/src/permissions/collection-scope.ts
+++ b/backend/src/permissions/collection-scope.ts
@@ -1,74 +1,223 @@
 import {
+  type AccessPolicies,
   accessPolicies,
   type ContextEntityType,
   getPolicyPermissions,
   getSubjectPolicies,
   hierarchy,
+  isRowCondition,
+  type NormalizedPermissionValue,
   type ProductEntityType,
+  type RowCondition,
+  type RowRestriction,
+  type RowRestrictions,
+  rowRestrictions,
 } from 'shared';
 import { AppError } from '#/core/error';
 import type { MembershipBaseModel } from '#/modules/memberships/helpers/select';
 
-/** Whether a role grants unconditional `read` on the entity type within the given context. */
-const roleGrantsRead = (entityType: ProductEntityType, contextType: ContextEntityType, role: string): boolean => {
-  const policies = getSubjectPolicies(entityType, accessPolicies);
-  const permissions = getPolicyPermissions(policies, contextType, role as never);
-  // Only an unconditional grant (1) widens collection scope; 'own' is row-conditional, not a context grant.
-  return permissions?.read === 1;
-};
-
-/**
- * Returns undefined for org-wide access; otherwise the readable sub-context ids.
- */
-const getReadableSubContextIds = (
-  memberships: MembershipBaseModel[],
+/** The `read` policy value a role grants for the entity type within the given context. */
+const roleReadValue = (
+  policies: AccessPolicies,
   entityType: ProductEntityType,
-  organizationId: string,
-): string[] | undefined => {
-  const ancestors = hierarchy.getOrderedAncestors(entityType); // most-specific → root, e.g. [project, organization]
-  const rootContext = ancestors.at(-1) ?? null; // organization
-  const subContextType = ancestors.find((context) => context !== rootContext) ?? null; // project
-
-  const readableSubContextIds = new Set<string>();
-
-  for (const membership of memberships) {
-    // Root-context (e.g. organization) read grant → full org visibility.
-    if (
-      rootContext &&
-      membership.contextType === rootContext &&
-      membership.contextId === organizationId &&
-      roleGrantsRead(entityType, rootContext, membership.role)
-    ) {
-      return undefined;
-    }
-
-    // Sub-context (e.g. project) read grant → scope to those ids within this organization.
-    if (
-      subContextType &&
-      membership.contextType === subContextType &&
-      membership.organizationId === organizationId &&
-      membership.contextId &&
-      roleGrantsRead(entityType, subContextType, membership.role)
-    ) {
-      readableSubContextIds.add(membership.contextId);
-    }
-  }
-
-  return [...readableSubContextIds];
+  contextType: ContextEntityType,
+  role: string,
+): NormalizedPermissionValue => {
+  const subjectPolicies = getSubjectPolicies(entityType, policies);
+  const permissions = getPolicyPermissions(subjectPolicies, contextType, role as never);
+  return permissions?.read ?? 0;
 };
 
 /**
- * Result of resolving the effective sub-context id filter for a collection read.
- * - `subContextIds === undefined` → no sub-context filter (org-wide read, e.g. org admin).
- * - `subContextIds === []` → caller has no readable scope → the op should return an empty list.
- * - `subContextIds === [..]` → restrict rows to these sub-context ids.
+ * A row-conditional slice of the caller's readable scope: rows within `subContextIds`
+ * (undefined = org-wide) are readable only where `condition` matches.
+ * Compiled to SQL by `buildCollectionReadWhere` (`row-predicates.ts`).
  */
-export interface CollectionReadFilter {
+export interface ConditionalScope {
+  condition: RowCondition;
   subContextIds: string[] | undefined;
 }
 
 /**
- * Resolve the effective sub-context id filter for a product collection read, scoping the result to
+ * A restricted membership grant: rows within `subContextIds` (undefined = org-wide) are
+ * readable only where the entity's row restriction qualifies THIS grant (its context
+ * level vs `visibilityDepth`, its role vs `audienceRoles`). Non-exempt grants of a
+ * restricted entity always resolve here instead of into the merged unconditional scope.
+ */
+export interface RestrictedGrantScope {
+  contextType: ContextEntityType;
+  role: string;
+  subContextIds: string[] | undefined;
+}
+
+/** Restriction context for SQL compilation, resolved once per filter. */
+export interface RestrictedScope {
+  restriction: RowRestriction;
+  /** The entity's ancestor chain (most specific first) for depth qualification. */
+  orderedContexts: ContextEntityType[];
+  grants: RestrictedGrantScope[];
+}
+
+/** Accumulator for scope resolution: unconditional ids + per-condition ids, org-wide flags. */
+interface ScopeAccumulator {
+  unconditionalOrgWide: boolean;
+  unconditionalIds: Set<string>;
+  /** Keyed by condition name; conditions sharing a name must be the same rule. */
+  conditional: Map<string, { condition: RowCondition; orgWide: boolean; ids: Set<string> }>;
+  /** Keyed by `${contextType}:${role}`; only populated when the entity has a row restriction. */
+  restrictedGrants: Map<string, { contextType: ContextEntityType; role: string; orgWide: boolean; ids: Set<string> }>;
+}
+
+/**
+ * Resolve the caller's readable scope for a product entity within an organization.
+ *
+ * - Unconditional grants (`read: 1`) widen the plain sub-context scope, as before.
+ * - Row-conditional grants (`read: <condition>`, e.g. `'own'`) contribute a
+ *   {@link ConditionalScope}: those contexts' rows are readable where the condition
+ *   matches. This is what makes condition-only roles listable at all — previously a
+ *   role with only `read: 'own'` listed nothing.
+ */
+const resolveScopes = (
+  policies: AccessPolicies,
+  memberships: MembershipBaseModel[],
+  entityType: ProductEntityType,
+  organizationId: string,
+  restriction: RowRestriction | undefined,
+): ScopeAccumulator => {
+  const ancestors = hierarchy.getOrderedAncestors(entityType); // most-specific → root, e.g. [project, organization]
+  const rootContext = ancestors.at(-1) ?? null; // organization
+  const subContextType = ancestors.find((context) => context !== rootContext) ?? null; // project
+
+  const acc: ScopeAccumulator = {
+    unconditionalOrgWide: false,
+    unconditionalIds: new Set(),
+    conditional: new Map(),
+    restrictedGrants: new Map(),
+  };
+
+  const addConditional = (condition: RowCondition, contextId: string | null) => {
+    const entry = acc.conditional.get(condition.name) ?? { condition, orgWide: false, ids: new Set<string>() };
+    if (contextId === null) entry.orgWide = true;
+    else entry.ids.add(contextId);
+    acc.conditional.set(condition.name, entry);
+  };
+
+  const addRestrictedGrant = (contextType: ContextEntityType, role: string, contextId: string | null) => {
+    const key = `${contextType}:${role}`;
+    const entry = acc.restrictedGrants.get(key) ?? { contextType, role, orgWide: false, ids: new Set<string>() };
+    if (contextId === null) entry.orgWide = true;
+    else entry.ids.add(contextId);
+    acc.restrictedGrants.set(key, entry);
+  };
+
+  // Unconditional membership grants of a restricted entity qualify PER ROW (depth/roles)
+  // unless the role is exempt — route them to restricted grants instead of merged scope.
+  // Row-conditional grants (e.g. 'own') are never narrowed by restrictions.
+  const addUnconditional = (contextType: ContextEntityType, role: string, contextId: string | null) => {
+    if (restriction && !restriction.exemptRoles.includes(role)) {
+      addRestrictedGrant(contextType, role, contextId);
+      return;
+    }
+    if (contextId === null) acc.unconditionalOrgWide = true;
+    else acc.unconditionalIds.add(contextId);
+  };
+
+  for (const membership of memberships) {
+    // Root-context (e.g. organization) grant → org-wide scope.
+    if (rootContext && membership.contextType === rootContext && membership.contextId === organizationId) {
+      const value = roleReadValue(policies, entityType, rootContext, membership.role);
+      if (value === 1) addUnconditional(rootContext, membership.role, null);
+      else if (isRowCondition(value)) addConditional(value, null);
+    }
+
+    // Sub-context (e.g. project) grant → scope to those ids within this organization.
+    if (
+      subContextType &&
+      membership.contextType === subContextType &&
+      membership.organizationId === organizationId &&
+      membership.contextId
+    ) {
+      const value = roleReadValue(policies, entityType, subContextType, membership.role);
+      if (value === 1) addUnconditional(subContextType, membership.role, membership.contextId);
+      else if (isRowCondition(value)) addConditional(value, membership.contextId);
+    }
+  }
+
+  return acc;
+};
+
+/**
+ * Result of resolving the effective scope filter for a collection read.
+ *
+ * Unconditional scope (rows readable outright):
+ * - `subContextIds === undefined` → no sub-context filter (org-wide read, e.g. org admin).
+ * - `subContextIds === []` → no unconditional scope.
+ * - `subContextIds === [..]` → restrict rows to these sub-context ids.
+ *
+ * Conditional scopes (`conditionalScopes`): additional rows readable where a row
+ * condition matches (OR-ed with the unconditional scope). Empty for callers whose roles
+ * carry no row-conditional read grants — existing call sites that only consume
+ * `subContextIds` keep their exact previous behavior.
+ *
+ * Restricted scope (`restricted`): present only for entities with a declared row
+ * restriction. Each entry is one membership grant whose rows must additionally satisfy
+ * the restriction's depth/role predicates for THAT grant (OR-ed with everything else).
+ *
+ * A read is empty only when `subContextIds` is `[]`, `conditionalScopes` is empty AND
+ * no restricted grants exist.
+ */
+export interface CollectionReadFilter {
+  subContextIds: string[] | undefined;
+  conditionalScopes: ConditionalScope[];
+  restricted?: RestrictedScope;
+}
+
+/** Whether the resolved filter yields no readable rows at all (op should return an empty list). */
+export const hasNoReadScope = (filter: CollectionReadFilter): boolean => {
+  return (
+    filter.subContextIds !== undefined &&
+    filter.subContextIds.length === 0 &&
+    filter.conditionalScopes.length === 0 &&
+    (filter.restricted?.grants.length ?? 0) === 0
+  );
+};
+
+const toConditionalScopes = (acc: ScopeAccumulator): ConditionalScope[] => {
+  // Org-wide unconditional scope subsumes every conditional slice.
+  if (acc.unconditionalOrgWide) return [];
+
+  const scopes: ConditionalScope[] = [];
+  for (const { condition, orgWide, ids } of acc.conditional.values()) {
+    if (orgWide) {
+      scopes.push({ condition, subContextIds: undefined });
+      continue;
+    }
+    // Ids already unconditionally readable don't need the conditional slice.
+    const remaining = [...ids].filter((id) => !acc.unconditionalIds.has(id));
+    if (remaining.length > 0) scopes.push({ condition, subContextIds: remaining });
+  }
+  return scopes;
+};
+
+const toRestrictedGrantScopes = (acc: ScopeAccumulator): RestrictedGrantScope[] => {
+  // Org-wide unconditional (exempt) scope subsumes every restricted slice.
+  if (acc.unconditionalOrgWide) return [];
+
+  const scopes: RestrictedGrantScope[] = [];
+  for (const { contextType, role, orgWide, ids } of acc.restrictedGrants.values()) {
+    if (orgWide) {
+      scopes.push({ contextType, role, subContextIds: undefined });
+      continue;
+    }
+    // Ids already unconditionally readable (via exempt-role grants) don't need the slice.
+    const remaining = [...ids].filter((id) => !acc.unconditionalIds.has(id));
+    if (remaining.length > 0) scopes.push({ contextType, role, subContextIds: remaining });
+  }
+  return scopes;
+};
+
+/**
+ * Resolve the effective scope filter for a product collection read, scoping the result to
  * the caller's membership-derived access.
  *
  * @param memberships - The caller's memberships.
@@ -78,7 +227,8 @@ export interface CollectionReadFilter {
  *   - `subContextId`: a single explicit id (e.g. `projectId` query param).
  *   - `subContextIds`: a pre-resolved set (e.g. all project ids of a requested workspace).
  *   When neither is provided the read is an aggregate over the caller's readable scope.
- * @throws AppError 403 `forbidden` when an explicitly requested id is outside the caller's readable scope.
+ * @throws AppError 403 `forbidden` when an explicitly requested id is outside the caller's
+ *   readable scope entirely (neither unconditional nor covered by any conditional scope).
  */
 export const resolveCollectionReadFilter = (
   memberships: MembershipBaseModel[],
@@ -86,25 +236,91 @@ export const resolveCollectionReadFilter = (
   organizationId: string,
   requested?: { subContextId?: string; subContextIds?: string[] },
 ): CollectionReadFilter => {
-  const readableSubContextIds = getReadableSubContextIds(memberships, entityType, organizationId);
+  return resolveCollectionReadFilterForPolicies(
+    accessPolicies,
+    memberships,
+    entityType,
+    organizationId,
+    requested,
+    rowRestrictions,
+  );
+};
+
+/**
+ * Same as {@link resolveCollectionReadFilter} but against an explicit policy set,
+ * mirroring `getAllDecisions(policies, …)`. Used by the check/SQL parity property test
+ * to exercise synthetic policies; handlers use the bound wrapper above.
+ */
+export const resolveCollectionReadFilterForPolicies = (
+  policies: AccessPolicies,
+  memberships: MembershipBaseModel[],
+  entityType: ProductEntityType,
+  organizationId: string,
+  requested?: { subContextId?: string; subContextIds?: string[] },
+  restrictions?: RowRestrictions,
+): CollectionReadFilter => {
+  const restriction = restrictions?.[entityType];
+  const acc = resolveScopes(policies, memberships, entityType, organizationId, restriction);
+  const conditionalScopes = toConditionalScopes(acc);
+  const restrictedGrantScopes = toRestrictedGrantScopes(acc);
+  const orderedContexts = hierarchy.getOrderedAncestors(entityType) as ContextEntityType[];
+
+  const withRestricted = (filter: Omit<CollectionReadFilter, 'restricted'>, grants: RestrictedGrantScope[]) => {
+    if (!restriction || grants.length === 0) return filter as CollectionReadFilter;
+    return { ...filter, restricted: { restriction, orderedContexts, grants } };
+  };
+
+  const unconditionallyReadable = (id: string): boolean => acc.unconditionalOrgWide || acc.unconditionalIds.has(id);
+  const conditionalScopesFor = (ids: string[]): ConditionalScope[] => {
+    const remaining = ids.filter((id) => !unconditionallyReadable(id));
+    if (remaining.length === 0) return [];
+    return conditionalScopes
+      .map(({ condition, subContextIds }) => ({
+        condition,
+        subContextIds: subContextIds === undefined ? remaining : remaining.filter((id) => subContextIds.includes(id)),
+      }))
+      .filter((scope) => scope.subContextIds.length > 0);
+  };
+  const restrictedGrantsFor = (ids: string[]): RestrictedGrantScope[] => {
+    const remaining = ids.filter((id) => !unconditionallyReadable(id));
+    if (remaining.length === 0) return [];
+    return restrictedGrantScopes
+      .map(({ contextType, role, subContextIds }) => ({
+        contextType,
+        role,
+        subContextIds: subContextIds === undefined ? remaining : remaining.filter((id) => subContextIds.includes(id)),
+      }))
+      .filter((scope) => scope.subContextIds.length > 0);
+  };
 
   // Explicit single id (e.g. ?projectId=…): must be within the caller's readable scope.
   if (requested?.subContextId !== undefined) {
-    if (readableSubContextIds !== undefined && !readableSubContextIds.includes(requested.subContextId)) {
+    const id = requested.subContextId;
+    if (unconditionallyReadable(id)) return { subContextIds: [id], conditionalScopes: [] };
+
+    const scopes = conditionalScopesFor([id]);
+    const restrictedScopes = restrictedGrantsFor([id]);
+    if (scopes.length === 0 && restrictedScopes.length === 0) {
       throw new AppError(403, 'forbidden', 'warn', { entityType });
     }
-    return { subContextIds: [requested.subContextId] };
+    return withRestricted({ subContextIds: [], conditionalScopes: scopes }, restrictedScopes);
   }
 
-  // Explicit set (e.g. all projects of a workspace): intersect with readable scope unless org-wide.
+  // Explicit set (e.g. all projects of a workspace): intersect with the caller's scope.
   if (requested?.subContextIds !== undefined) {
-    const ids =
-      readableSubContextIds === undefined
-        ? requested.subContextIds
-        : requested.subContextIds.filter((id) => readableSubContextIds.includes(id));
-    return { subContextIds: ids };
+    const unconditional = requested.subContextIds.filter((id) => unconditionallyReadable(id));
+    return withRestricted(
+      { subContextIds: unconditional, conditionalScopes: conditionalScopesFor(requested.subContextIds) },
+      restrictedGrantsFor(requested.subContextIds),
+    );
   }
 
   // Aggregate read: org-wide for ancestor-level grants, otherwise the caller's readable sub-contexts.
-  return { subContextIds: readableSubContextIds };
+  return withRestricted(
+    {
+      subContextIds: acc.unconditionalOrgWide ? undefined : [...acc.unconditionalIds],
+      conditionalScopes,
+    },
+    restrictedGrantScopes,
+  );
 };

--- a/backend/src/permissions/get-product-entity.ts
+++ b/backend/src/permissions/get-product-entity.ts
@@ -1,11 +1,34 @@
-import type { EntityActionType, ProductEntityType } from 'shared';
+import { type EntityActionType, hierarchy, hostDelegation, type ProductEntityType } from 'shared';
 import type { AuthContext } from '#/core/context';
 import { AppError } from '#/core/error';
 import { baseDb } from '#/db/db';
 import { tenantRead } from '#/db/tenant-context';
 import { type EntityModel, resolveEntity } from '#/modules/entities/entities-queries';
 import { checkPermission } from '#/permissions';
-import { buildSubjectFromEntity } from '#/permissions/build-subject';
+import { buildSubject } from '#/permissions/build-subject';
+
+/**
+ * Resolve the host row for a hosted entity when its type delegates actions to the host
+ * (`delegateToHost`). Returns undefined for non-delegated types and unhosted rows.
+ */
+const resolveHostRow = async (
+  ctx: AuthContext,
+  entityType: ProductEntityType,
+  entity: Record<string, unknown>,
+): Promise<Record<string, unknown> | undefined> => {
+  if (!hostDelegation[entityType]?.length) return undefined;
+  const hostType = hierarchy.getHostType(entityType);
+  if (!hostType) return undefined;
+
+  const hostId = entity[`${hostType}Id`];
+  if (typeof hostId !== 'string') return undefined;
+
+  const hostRow =
+    ctx.var.db === baseDb && ctx.var.tenantId
+      ? await tenantRead(ctx, (readCtx) => resolveEntity(readCtx, hostType, hostId))
+      : await resolveEntity(ctx, hostType, hostId);
+  return hostRow ?? undefined;
+};
 
 /**
  * Result type for product entity validation including the can object.
@@ -48,8 +71,17 @@ export const getValidProductEntity = async <K extends ProductEntityType>(
       : await resolveEntity(ctx, entityType, id);
   if (!entity) throw new AppError(404, 'not_found', 'warn', { entityType });
 
+  // Host delegation (hierarchy `host:` + delegateToHost): resolve the host row once so the
+  // engine can union the host's decision into this row's (load-at-check — the engine never
+  // loads rows itself). Only for hosted rows of delegated entity types.
+  const hostRow = await resolveHostRow(ctx, entityType, entity);
+
   // Step 2: Check permission for the requested action.
-  const subject = buildSubjectFromEntity(entityType, entity);
+  const subject = buildSubject(entityType, entity, {
+    id: entity.id,
+    createdBy: 'createdBy' in entity ? (entity.createdBy as string | null) : undefined,
+    ...(hostRow && { hostRow }),
+  });
   const { isAllowed } = checkPermission(memberships, action, subject, { isSystemAdmin, userId });
 
   if (!isAllowed) {

--- a/backend/src/permissions/index.ts
+++ b/backend/src/permissions/index.ts
@@ -7,9 +7,14 @@ export {
 } from './check-permission';
 export {
   type CollectionReadFilter,
+  type ConditionalScope,
+  hasNoReadScope,
+  type RestrictedGrantScope,
+  type RestrictedScope,
   resolveCollectionReadFilter,
 } from './collection-scope';
 export { getValidContextEntity, type ValidContextEntityResult } from './get-context-entity';
 export { getValidProductEntity, type ValidProductEntityResult } from './get-product-entity';
+export { buildCollectionReadWhere, type CollectionReadWhere, compileRowConditionSql } from './row-predicates';
 export { splitByPermission } from './split-by-permission';
 export { validateAncestorScope } from './validate-ancestor-scope';

--- a/backend/src/permissions/row-predicates.test.ts
+++ b/backend/src/permissions/row-predicates.test.ts
@@ -1,0 +1,251 @@
+import { sql } from 'drizzle-orm';
+import { pgTable, varchar } from 'drizzle-orm/pg-core';
+import {
+  type AccessPolicies,
+  appConfig,
+  computeCan,
+  configureAccessPolicies,
+  getAllDecisions,
+  type PermissionValue,
+  type RowRestrictions,
+  resolvePermission,
+  type SubjectForPermission,
+} from 'shared';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { seedDb } from '#/db/db';
+import type { MembershipBaseModel } from '#/modules/memberships/helpers/select';
+import { resolveCollectionReadFilterForPolicies } from './collection-scope';
+import { buildCollectionReadWhere } from './row-predicates';
+
+/**
+ * Check-form / SQL-form / compute-can parity property test — merge blocker.
+ *
+ * One policy definition drives three enforcement paths:
+ * 1. the permission engine's per-subject decision (`getAllDecisions`),
+ * 2. the compiled SQL row predicate for collection reads (`buildCollectionReadWhere`,
+ *    executed against real Postgres here),
+ * 3. the frontend `can` states (`computeCan` + `resolvePermission`).
+ *
+ * Any divergence between them is a security bug: a row readable via SQL but denied by
+ * the engine leaks data; the reverse silently hides rows. This test generates random
+ * policy sets (including row-conditional `'own'` grants and row restrictions),
+ * memberships and actors, and asserts the paths agree row-for-row.
+ *
+ * Cella's chain (attachment → organization) is single-level, so sub-context scoping and
+ * multi-level depth qualification are exercised by the raak fork's parity suite; this
+ * one covers the org-level grants, conditions, restrictions and anonymous actors.
+ */
+
+/** Scratch table (real Postgres, admin connection): the minimal shape of a product table. */
+const parityTable = pgTable('test_permission_parity_rows', {
+  id: varchar('id').primaryKey(),
+  createdBy: varchar('created_by'),
+  visibilityDepth: varchar('visibility_depth'),
+  audienceRoles: varchar('audience_roles').array(),
+});
+
+const USERS = ['u1', 'u2'] as const;
+const ORG_ID = 'org1';
+
+interface ParityRow {
+  id: string;
+  createdBy: string | null;
+  visibilityDepth: string | null;
+  audienceRoles: string[] | null;
+}
+
+/** Depth × audience combinations, incl. an unknown depth (not in attachment's chain). */
+const VISIBILITY_COMBOS: Array<{ key: string; visibilityDepth: string | null; audienceRoles: string[] | null }> = [
+  { key: 'open', visibilityDepth: null, audienceRoles: null },
+  { key: 'org', visibilityDepth: 'organization', audienceRoles: null },
+  { key: 'org-member', visibilityDepth: 'organization', audienceRoles: ['member'] },
+  { key: 'admin-only', visibilityDepth: null, audienceRoles: ['admin'] },
+  { key: 'unknown-depth', visibilityDepth: 'project', audienceRoles: ['member'] },
+  { key: 'empty-roles', visibilityDepth: 'organization', audienceRoles: [] },
+];
+
+/** Fixed row set: every creator (each user + null) × visibility combination. */
+const ROWS: ParityRow[] = [...USERS, null].flatMap((createdBy) =>
+  VISIBILITY_COMBOS.map(({ key, visibilityDepth, audienceRoles }) => ({
+    id: `${createdBy ?? 'nobody'}:${key}`,
+    createdBy,
+    visibilityDepth,
+    audienceRoles,
+  })),
+);
+
+/** Deterministic PRNG (mulberry32) so failures reproduce exactly. */
+const mulberry32 = (seed: number) => {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const pick = <T>(random: () => number, values: readonly T[]): T => {
+  const value = values[Math.floor(random() * values.length)];
+  if (value === undefined) throw new Error('pick: empty values');
+  return value;
+};
+
+/** Random read policy value; other actions stay denied (only `read` matters here). */
+const randomReadValue = (random: () => number): PermissionValue => pick(random, [0, 1, 'own'] as const);
+
+/** Policies for `attachment` with random read cells for every role. */
+const randomPolicies = (random: () => number): AccessPolicies =>
+  configureAccessPolicies(appConfig.entityTypes, ({ subject, contexts }) => {
+    if (subject.name !== 'attachment') return;
+    contexts.organization.admin({ read: randomReadValue(random) });
+    contexts.organization.member({ read: randomReadValue(random) });
+  });
+
+interface Scenario {
+  policies: AccessPolicies;
+  memberships: MembershipBaseModel[];
+  userId: string | undefined;
+  restrictions: RowRestrictions;
+}
+
+/** Random restriction config: none, depth-only, roles-only or both; exemption on or off. */
+const randomRestrictions = (random: () => number): RowRestrictions => {
+  const shape = pick(random, ['none', 'none', 'depth', 'roles', 'both', 'both'] as const);
+  if (shape === 'none') return {};
+  const exemptRoles = random() < 0.5 ? (['admin'] as const) : ([] as const);
+  return {
+    attachment: {
+      ...(shape !== 'roles' && { depthColumn: 'visibilityDepth' }),
+      ...(shape !== 'depth' && { rolesColumn: 'audienceRoles' }),
+      exemptRoles,
+    },
+  };
+};
+
+const membership = (role: string): MembershipBaseModel =>
+  ({
+    id: `mem-organization-${ORG_ID}-${role}`,
+    userId: 'actor',
+    contextType: 'organization',
+    contextId: ORG_ID,
+    organizationId: ORG_ID,
+    role,
+  }) as unknown as MembershipBaseModel;
+
+const randomScenario = (random: () => number): Scenario => {
+  const anonymous = random() < 0.15;
+  if (anonymous) {
+    return {
+      policies: randomPolicies(random),
+      memberships: [],
+      userId: undefined,
+      restrictions: randomRestrictions(random),
+    };
+  }
+
+  const memberships: MembershipBaseModel[] = [];
+  if (random() < 0.8) memberships.push(membership(pick(random, ['admin', 'member'])));
+  return {
+    policies: randomPolicies(random),
+    memberships,
+    userId: pick(random, USERS),
+    restrictions: randomRestrictions(random),
+  };
+};
+
+const rowSubject = (row: ParityRow): SubjectForPermission => ({
+  entityType: 'attachment',
+  id: row.id,
+  createdBy: row.createdBy,
+  contextIds: { organization: ORG_ID },
+  row: { visibilityDepth: row.visibilityDepth, audienceRoles: row.audienceRoles },
+});
+
+/** Path 1: the engine's per-row read decision. */
+const engineReadableIds = (scenario: Scenario): Set<string> => {
+  const readable = new Set<string>();
+  for (const row of ROWS) {
+    const { can } = getAllDecisions(scenario.policies, scenario.memberships, rowSubject(row), {
+      userId: scenario.userId,
+      restrictions: scenario.restrictions,
+    });
+    if (can.read) readable.add(row.id);
+  }
+  return readable;
+};
+
+/** Path 2: the compiled SQL predicate executed against Postgres. */
+const sqlReadableIds = async (scenario: Scenario): Promise<Set<string>> => {
+  const filter = resolveCollectionReadFilterForPolicies(
+    scenario.policies,
+    scenario.memberships,
+    'attachment',
+    ORG_ID,
+    undefined,
+    scenario.restrictions,
+  );
+  // Single-level chain: scopes are org-wide or nothing, so the sub-context column is never
+  // referenced by the compiled predicate; pass the id column to satisfy the signature.
+  const where = buildCollectionReadWhere(filter, parityTable, parityTable.id, scenario.userId);
+
+  if (where.kind === 'none') return new Set();
+  const query = seedDb.select({ id: parityTable.id }).from(parityTable);
+  const rows = where.kind === 'all' ? await query : await query.where(where.where);
+  return new Set(rows.map((r) => r.id));
+};
+
+beforeAll(async () => {
+  await seedDb.execute(sql`drop table if exists test_permission_parity_rows`);
+  await seedDb.execute(sql`
+    create table test_permission_parity_rows (
+      id varchar primary key,
+      created_by varchar,
+      visibility_depth varchar,
+      audience_roles varchar[]
+    )
+  `);
+  await seedDb.insert(parityTable).values(ROWS);
+});
+
+afterAll(async () => {
+  await seedDb.execute(sql`drop table if exists test_permission_parity_rows`);
+});
+
+describe('row-condition parity: engine check ⊆⊇ compiled SQL ⊆⊇ compute-can', () => {
+  it('agrees on every row across random policies, memberships and actors', async () => {
+    const random = mulberry32(0xa11ce);
+
+    for (let i = 0; i < 250; i++) {
+      const scenario = randomScenario(random);
+      const label = `seed 0xa11ce scenario ${i} (memberships: ${scenario.memberships
+        .map((m) => `${m.contextType}:${m.contextId}:${m.role}`)
+        .join(', ')}; user: ${scenario.userId ?? 'anonymous'})`;
+
+      // Engine ⊆⊇ SQL: identical readable row sets.
+      const fromEngine = engineReadableIds(scenario);
+      const fromSql = await sqlReadableIds(scenario);
+      expect(fromSql, label).toEqual(fromEngine);
+
+      // Engine ⊆⊇ compute-can: per single membership, the frontend-resolved state must
+      // match the engine's decision for every row.
+      // KNOWN LIMITATION: computeCan is restriction-blind (context-level, no row data) —
+      // restricted entities must resolve per row via the decision API, so parity with
+      // compute-can is only asserted when no restriction is declared.
+      if (scenario.restrictions.attachment) continue;
+      for (const m of scenario.memberships) {
+        const canMap = computeCan('organization', m, scenario.policies);
+        const state = canMap.attachment?.read ?? false;
+
+        for (const row of ROWS) {
+          const resolved = resolvePermission(state, row.createdBy, scenario.userId);
+          const { can } = getAllDecisions(scenario.policies, [m], rowSubject(row), { userId: scenario.userId });
+          expect(resolved, `${label}; membership ${m.contextType}:${m.contextId}:${m.role}; row ${row.id}`).toBe(
+            can.read,
+          );
+        }
+      }
+    }
+  });
+});

--- a/backend/src/permissions/row-predicates.ts
+++ b/backend/src/permissions/row-predicates.ts
@@ -1,0 +1,136 @@
+import { and, eq, inArray, isNull, or, type SQL, sql } from 'drizzle-orm';
+import type { AnyPgTable, PgColumn } from 'drizzle-orm/pg-core';
+import { qualifyingDepths, type RowCondition, type RowConditionSqlForm } from 'shared';
+import type { CollectionReadFilter, RestrictedScope } from './collection-scope';
+
+/**
+ * Compiles row-condition SQL forms (declared ORM-free in `shared`, see
+ * `shared/src/permissions/row-conditions.ts`) into drizzle predicates, and assembles the
+ * full WHERE clause for a conditionally-scoped collection read.
+ *
+ * The compiled SQL must agree with each condition's check-form — asserted by the parity
+ * property test (`row-predicates.test.ts`).
+ */
+
+/** A never-matching predicate: the SQL analogue of a check-form returning `false`. */
+const NEVER: SQL = sql`false`;
+
+const resolveColumn = (table: AnyPgTable, columnName: string, conditionName: string): PgColumn => {
+  const column = (table as unknown as Record<string, PgColumn | undefined>)[columnName];
+  if (!column) {
+    throw new Error(
+      `[Permission] Row condition "${conditionName}" reads column "${columnName}" which does not exist on the queried table`,
+    );
+  }
+  return column;
+};
+
+/**
+ * Compile a single row condition to a predicate over `table`'s rows for the acting user.
+ * Anonymous actors (`userId` undefined) never match actor-bound forms, mirroring the check-form.
+ */
+export const compileRowConditionSql = (condition: RowCondition, table: AnyPgTable, userId: string | undefined): SQL => {
+  const form: RowConditionSqlForm = condition.sqlForm;
+  switch (form.kind) {
+    case 'columnEqualsActor': {
+      if (!userId) return NEVER;
+      return eq(resolveColumn(table, form.column, condition.name), userId);
+    }
+  }
+};
+
+/**
+ * Assembled WHERE clause for a collection read. Discriminated so "no restriction" can
+ * never be confused with "no rows" — returning a bare `undefined` where-clause for an
+ * empty scope would leak the whole table.
+ */
+export type CollectionReadWhere =
+  | { kind: 'all' } // org-wide unconditional read: no scope restriction needed
+  | { kind: 'none' } // no readable scope: op should return an empty list without querying
+  | { kind: 'where'; where: SQL };
+
+/**
+ * SQL-form of a row restriction for ONE membership grant (see
+ * `shared/src/permissions/row-restrictions.ts` for semantics; this must agree with
+ * `membershipGrantQualifies` — asserted by the parity property test):
+ * - depth: row depth is NULL or among the depths this grant's context level qualifies for
+ * - roles: row audience is NULL/empty or contains this grant's role
+ */
+const restrictionPredicates = (
+  restricted: RestrictedScope,
+  grant: { contextType: (typeof restricted.orderedContexts)[number]; role: string },
+  table: AnyPgTable,
+): SQL[] => {
+  const predicates: SQL[] = [];
+  const { restriction, orderedContexts } = restricted;
+
+  if (restriction.depthColumn) {
+    const column = resolveColumn(table, restriction.depthColumn, 'visibilityDepth restriction');
+    const depths = qualifyingDepths(orderedContexts, grant.contextType);
+    const predicate = depths.length > 0 ? or(isNull(column), inArray(column, depths)) : isNull(column);
+    if (predicate) predicates.push(predicate);
+  }
+
+  if (restriction.rolesColumn) {
+    const column = resolveColumn(table, restriction.rolesColumn, 'audienceRoles restriction');
+    const predicate = or(isNull(column), sql`cardinality(${column}) = 0`, sql`${grant.role} = any(${column})`);
+    if (predicate) predicates.push(predicate);
+  }
+
+  return predicates;
+};
+
+/**
+ * Build the row-scope WHERE clause for a collection read from a resolved filter:
+ * `(subContext IN unconditional ids) OR (condition SQL AND subContext IN conditional ids)
+ *  OR (restriction predicates for grant AND subContext IN grant ids) OR …`.
+ *
+ * @param filter - Resolved scope filter (`resolveCollectionReadFilter`).
+ * @param table - The product table being queried.
+ * @param subContextColumn - The table's sub-context id column (e.g. `tasks.projectId`).
+ * @param userId - The acting user id; undefined for anonymous actors.
+ */
+export const buildCollectionReadWhere = (
+  filter: CollectionReadFilter,
+  table: AnyPgTable,
+  subContextColumn: PgColumn,
+  userId: string | undefined,
+): CollectionReadWhere => {
+  // Org-wide unconditional read (conditional scopes are subsumed and already dropped).
+  if (filter.subContextIds === undefined) return { kind: 'all' };
+
+  const clauses: SQL[] = [];
+
+  if (filter.subContextIds.length > 0) {
+    clauses.push(inArray(subContextColumn, filter.subContextIds));
+  }
+
+  for (const { condition, subContextIds } of filter.conditionalScopes) {
+    const conditionSql = compileRowConditionSql(condition, table, userId);
+    if (subContextIds === undefined) {
+      // Org-wide conditional grant: condition alone bounds the rows.
+      clauses.push(conditionSql);
+      continue;
+    }
+    if (subContextIds.length === 0) continue;
+    const scoped = and(inArray(subContextColumn, subContextIds), conditionSql);
+    if (scoped) clauses.push(scoped);
+  }
+
+  if (filter.restricted) {
+    for (const grant of filter.restricted.grants) {
+      const predicates = restrictionPredicates(filter.restricted, grant, table);
+      if (grant.subContextIds !== undefined) {
+        if (grant.subContextIds.length === 0) continue;
+        predicates.unshift(inArray(subContextColumn, grant.subContextIds));
+      }
+      const scoped = predicates.length === 1 ? predicates[0] : and(...predicates);
+      if (scoped) clauses.push(scoped);
+    }
+  }
+
+  if (clauses.length === 0) return { kind: 'none' };
+  const where = clauses.length === 1 ? clauses[0] : or(...clauses);
+  if (!where) return { kind: 'none' };
+  return { kind: 'where', where };
+};

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -37,6 +37,8 @@ export default defineConfig({
       DATA_ENCRYPTION_KEY: 'test-data-encryption-key-minimum-32-chars',
       SYSTEM_ADMIN_IP_ALLOWLIST: '*',
       DATABASE_URL: testDatabaseUrl,
+      // Public routes read via the admin connection (tenant-less); point it at the test DB
+      DATABASE_ADMIN_URL: testDatabaseUrl,
     },
   },
 });

--- a/cdc/src/services/transaction-buffer.ts
+++ b/cdc/src/services/transaction-buffer.ts
@@ -1,5 +1,5 @@
 import type { Pgoutput } from 'pg-logical-replication';
-import { isContextEntity, appConfig } from 'shared';
+import { isContextEntity, appConfig, hierarchy } from 'shared';
 import type { ParseMessageResult } from '../pipeline/parse-message';
 import type { PendingEvent } from '../types';
 import { log } from '../lib/pino';
@@ -11,6 +11,14 @@ for (const { embeddedEntity, hostEntity } of appConfig.entityEmbeddings) {
   const sources = softCascadeTargets.get(hostEntity) ?? new Set<string>();
   sources.add(embeddedEntity);
   softCascadeTargets.set(hostEntity, sources);
+}
+
+/** Host relationships (hierarchy `host:`): product types that host others, and each hosted type's host id column. */
+const hostTypes = new Set<string>();
+const hostIdColumnByHostedType = new Map<string, string>();
+for (const { hostedType, hostType, hostIdColumn } of hierarchy.getHostRelations()) {
+  hostTypes.add(hostType);
+  hostIdColumnByHostedType.set(hostedType, hostIdColumn);
 }
 
 const { transactionTimeoutMs } = RESOURCE_LIMITS.buffers;
@@ -35,6 +43,9 @@ export class TransactionBuffer {
 
   /** Context entity IDs deleted in the current transaction (streaming suppression). */
   private deletedContextIds = new Set<string>();
+
+  /** Host product IDs deleted in the current transaction (hosted-row cascade suppression). */
+  private deletedHostIds = new Set<string>();
 
   /** Count of events suppressed in the current transaction. */
   private suppressedCount = 0;
@@ -65,6 +76,7 @@ export class TransactionBuffer {
     this.activeXid = msg.xid;
     this.pendingEvents = [];
     this.deletedContextIds.clear();
+    this.deletedHostIds.clear();
     this.suppressedCount = 0;
     this.startTimeout();
   }
@@ -88,8 +100,13 @@ export class TransactionBuffer {
       this.deletedContextIds.add(activity.subjectId);
     }
 
+    // Track host product deletes: hosted-row deletes in the same tx are cascades
+    if (activity.action === 'delete' && activity.entityType && hostTypes.has(activity.entityType) && activity.subjectId) {
+      this.deletedHostIds.add(activity.subjectId);
+    }
+
     // Drop cascaded child deletes inline — never buffer them
-    if (this.deletedContextIds.size > 0 && this.isCascadedDelete(result)) {
+    if ((this.deletedContextIds.size > 0 || this.deletedHostIds.size > 0) && this.isCascadedDelete(result)) {
       this.suppressedCount++;
       return;
     }
@@ -108,21 +125,24 @@ export class TransactionBuffer {
     let events = this.pendingEvents;
     let suppressedCount = this.suppressedCount;
     const deletedContextIds = this.deletedContextIds.size > 0 ? [...this.deletedContextIds] : null;
+    const deletedHostIds = this.deletedHostIds.size > 0 ? [...this.deletedHostIds] : null;
 
     this.activeXid = null;
     this.pendingEvents = [];
     this.deletedContextIds.clear();
+    this.deletedHostIds.clear();
     this.suppressedCount = 0;
 
-    // Second pass: catch child deletes that arrived before their parent context entity delete.
-    // Most children are dropped inline in onEvent(), but WAL order isn't always parent-first
-    // (e.g., application-level batch deletes). This pass is cheap since only surviving events
-    // remain (typically context entity deletes + non-delete mutations).
-    if (deletedContextIds && events.length > 1) {
-      const deletedSet = new Set(deletedContextIds);
+    // Second pass: catch child deletes that arrived before their parent context entity or
+    // host delete. Most children are dropped inline in onEvent(), but WAL order isn't always
+    // parent-first (e.g., application-level batch deletes). This pass is cheap since only
+    // surviving events remain (typically context entity deletes + non-delete mutations).
+    if ((deletedContextIds || deletedHostIds) && events.length > 1) {
+      const deletedContextSet = new Set(deletedContextIds ?? []);
+      const deletedHostSet = new Set(deletedHostIds ?? []);
       const filtered: PendingEvent[] = [];
       for (const event of events) {
-        if (this.isCascadedDeleteByIds(event.result, deletedSet)) {
+        if (this.isCascadedDeleteByIds(event.result, deletedContextSet, deletedHostSet)) {
           suppressedCount++;
         } else {
           filtered.push(event);
@@ -185,14 +205,19 @@ export class TransactionBuffer {
    * Used in onEvent() for streaming suppression.
    */
   private isCascadedDelete(result: ParseMessageResult): boolean {
-    return this.isCascadedDeleteByIds(result, this.deletedContextIds);
+    return this.isCascadedDeleteByIds(result, this.deletedContextIds, this.deletedHostIds);
   }
 
   /**
-   * Check if an event is a cascaded delete from one of the deleted context entities.
-   * Matches by checking if the event's context entity ID columns reference a deleted context.
+   * Check if an event is a cascaded delete from a deleted context entity or a deleted host.
+   * Context cascades match via the activity's context entity ID columns; host cascades match
+   * via the hosted row's host id column in rowData (host ids are product ids, not on the activity).
    */
-  private isCascadedDeleteByIds(result: ParseMessageResult, deletedContextIds: Set<string>): boolean {
+  private isCascadedDeleteByIds(
+    result: ParseMessageResult,
+    deletedContextIds: Set<string>,
+    deletedHostIds: Set<string>,
+  ): boolean {
     const { activity } = result;
     if (activity.action !== 'delete') return false;
 
@@ -200,11 +225,25 @@ export class TransactionBuffer {
     if (activity.entityType && isContextEntity(activity.entityType)) return false;
 
     // Check all context entity ID columns on this activity
-    for (const contextType of appConfig.contextEntityTypes) {
-      const idColumn = appConfig.entityIdColumnKeys[contextType];
-      const value = (activity as Record<string, unknown>)[idColumn];
-      if (typeof value === 'string' && deletedContextIds.has(value)) {
-        return true;
+    if (deletedContextIds.size > 0) {
+      for (const contextType of appConfig.contextEntityTypes) {
+        const idColumn = appConfig.entityIdColumnKeys[contextType];
+        const value = (activity as Record<string, unknown>)[idColumn];
+        if (typeof value === 'string' && deletedContextIds.has(value)) {
+          return true;
+        }
+      }
+    }
+
+    // Hosted-row cascade: the row's host id references a host deleted in this transaction
+    if (deletedHostIds.size > 0 && activity.entityType) {
+      const hostIdColumn = hostIdColumnByHostedType.get(activity.entityType);
+      if (hostIdColumn) {
+        const row = result.rowData ?? result.oldRowData;
+        const hostId = row?.[hostIdColumn];
+        if (typeof hostId === 'string' && deletedHostIds.has(hostId)) {
+          return true;
+        }
       }
     }
 

--- a/cdc/src/utils/update-counts.ts
+++ b/cdc/src/utils/update-counts.ts
@@ -67,6 +67,30 @@ export function getCountDeltas(
     const countAction = isSoftDeleteTransition(newRow, oldRow) ? 'delete' : action;
     const deltas = getEntityDeltas(countAction, organizationId, tableMeta.type, newRow, oldRow);
 
+    // Host counters: track e:<hostedType> counts per host row (hierarchy `host:`, e.g.
+    // e:attachment on the owning task). Mirrors embedding counters, keyed by host id.
+    const hostType = hierarchy.getHostType(tableMeta.type);
+    if (hostType) {
+      const hostIdColumn = `${hostType}Id`;
+      const counterKey = `e:${tableMeta.type}`;
+
+      if (countAction === 'delete') {
+        const hostId = getStringValue(oldRow ?? newRow, hostIdColumn);
+        if (hostId) deltas.push({ contextKey: hostId, deltas: { [counterKey]: -1 } });
+      } else if (countAction === 'create') {
+        const hostId = getStringValue(newRow, hostIdColumn);
+        if (hostId) deltas.push({ contextKey: hostId, deltas: { [counterKey]: 1 } });
+      } else if (countAction === 'update' && oldRow) {
+        // Re-host: decrement the old host, increment the new one
+        const oldHostId = getStringValue(oldRow, hostIdColumn);
+        const newHostId = getStringValue(newRow, hostIdColumn);
+        if (oldHostId !== newHostId) {
+          if (oldHostId) deltas.push({ contextKey: oldHostId, deltas: { [counterKey]: -1 } });
+          if (newHostId) deltas.push({ contextKey: newHostId, deltas: { [counterKey]: 1 } });
+        }
+      }
+    }
+
     // Embedding counters: track e:<hostEntity> counts per embedded entity ID
     for (const embedding of appConfig.entityEmbeddings) {
       if (embedding.hostEntity !== tableMeta.type) continue;

--- a/shared/config/hierarchy-config.ts
+++ b/shared/config/hierarchy-config.ts
@@ -22,12 +22,11 @@ export const roles = createRoleRegistry(['admin', 'member'] as const);
  * Parents are defined before children. Order determines ancestor chain.
  *
  * Optional `relatedContexts` on products declare non-ancestor context references (nullable id columns).
+ * Optional `host` on products declares product-to-product ownership (e.g. attachment -> task):
+ * generated nullable `<host>Id` column, lifecycle cascade, per-host CDC counters.
  *
- * publicRead declares how an entity becomes publicly readable:
- * - 'publicSelf': Public when own publicAt timestamp is set
- * - 'publicParent': Public when parent context's publicAt is set
- * - 'publicParentOrSelf': Public when either own or parent's publicAt is set
- * Entities without publicRead are always private.
+ * Public readability is NOT declared here — it is a permission concern, declared per
+ * subject via `publicRead(mode)` in `permissions-config.ts`.
  */
 export const hierarchy = createEntityHierarchy(roles)
   .user()
@@ -42,10 +41,10 @@ export const hierarchy = createEntityHierarchy(roles)
  *   .user()
  *   .context('organization', { parent: null, roles: ['admin', 'member'] })
  *   .context('workspace', { parent: 'organization', roles: roles.all })
- *   .context('project', { parent: 'organization', roles: roles.all, publicRead: 'publicSelf' })
- *   .product('task', { parent: 'project', publicRead: 'publicParent' })
+ *   .context('project', { parent: 'organization', roles: roles.all })
+ *   .product('task', { parent: 'project' })
  *   .product('label', { parent: 'project' })
- *   .product('attachment', { parent: 'project', publicRead: 'publicParent' })
+ *   .product('attachment', { parent: 'project', host: 'task' })
  *   .product('chat', { parent: 'organization', relatedContexts: ['project', 'workspace'] })
  *   .product('message', { parent: 'organization', relatedContexts: ['project', 'workspace'] })
  *   .build();

--- a/shared/config/permissions-config.ts
+++ b/shared/config/permissions-config.ts
@@ -1,5 +1,5 @@
 import { appConfig } from '../src/config-builder/app-config';
-import { configureAccessPolicies } from '../src/permissions/access-policies';
+import { configurePermissions } from '../src/permissions/access-policies';
 
 /**
  * Access policies for each entity type.
@@ -28,7 +28,9 @@ import { configureAccessPolicies } from '../src/permissions/access-policies';
  * 4. Create DB schema in `backend/src/db/schema/`
  * 5. Run `pnpm generate` to create migrations
  */
-export const accessPolicies = configureAccessPolicies(appConfig.entityTypes, ({ subject, contexts }) => {
+export const { accessPolicies, publicReadGrants, rowRestrictions, hostDelegation } = configurePermissions(
+  appConfig.entityTypes,
+  ({ subject, contexts }) => {
   switch (subject.name) {
     case 'organization':
       // self (this organization) — create is inert here: org creation is gated by tenant quota, not this policy
@@ -40,4 +42,5 @@ export const accessPolicies = configureAccessPolicies(appConfig.entityTypes, ({ 
       contexts.organization.member({ create: 1, read: 1, update: 0, delete: 0 });
       break;
   }
-});
+  },
+);

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -17,11 +17,10 @@ export type {
   EntityHierarchy,
   EntityKind,
   EntityView,
+  HostRelation,
   ProductEntityView,
   RoleFromRegistry,
   UserEntityView,
-  PublicReadMode,
-  ContextPublicReadMode,
 } from './src/config-builder/entity-hierarchy';
 export {
   createEntityHierarchy,
@@ -45,6 +44,7 @@ export type {
   EntityIdColumnKeysShape,
   EntityRole,
   EntityType,
+  HostEntityType,
   Language,
   MenuSection,
   ProductEntityType,
@@ -80,12 +80,16 @@ export type {
   AccessPolicyEntry,
   ContextPolicyBuilder,
   EntityActionPermissions,
+  NormalizedPermissionValue,
   PermissionValue,
   SubjectAccessPolicies,
 } from './src/permissions';
-export { configureAccessPolicies, getPolicyPermissions, getSubjectPolicies } from './src/permissions';
+export { isRowCondition, membershipGrantQualifies, normalizeRestriction, own, publicReadMatches, qualifyingDepths } from './src/permissions';
+export type { ConditionActor, HostDelegation, PublicReadGrants, PublicReadMode, RowCondition, RowConditionSqlForm, RowForCondition, RowRestriction, RowRestrictionInput, RowRestrictions } from './src/permissions';
+export { configureAccessPolicies, configurePermissions, getPolicyPermissions, getSubjectPolicies } from './src/permissions';
+export type { PermissionsConfigResult } from './src/permissions';
 export { allActionsAllowed, allActionsDenied, createActionRecord, isUnconditionalPermission, resolvePermission } from './src/permissions';
-export { accessPolicies, computeCan } from './src/permissions';
+export { accessPolicies, computeCan, hostDelegation, publicReadGrants, rowRestrictions } from './src/permissions';
 export type { ActionPermissionState, EntityCanMap } from './src/permissions';
 
 // Permission engine (tier-neutral decision logic, shared by backend + yjs)

--- a/shared/src/config-builder/entity-hierarchy.ts
+++ b/shared/src/config-builder/entity-hierarchy.ts
@@ -1,20 +1,12 @@
 /**
- * Entity hierarchy builder with compile-time validation, parent inheritance, and public read config.
+ * Entity hierarchy builder with compile-time validation and parent inheritance.
+ *
+ * Public readability is a permission concern, declared per subject via `publicRead(mode)`
+ * in the permissions config (`shared/src/permissions/public-read.ts`) — not here.
  *
  * Fork contract: Every tenant-scoped table must have tenant_id. Tables with an organization
  * parent must also have organization_id with a composite FK to organizations(tenant_id, id).
  */
-
-/**
- * Public read mode — declares how an entity becomes publicly readable (via publicGuard REST reads).
- * - 'publicSelf': Public when own publicAt is set (e.g., project with a toggle).
- * - 'publicParent': Public when parent context's publicAt is set (e.g., tasks inherit from project).
- * - 'publicParentOrSelf': Public when either own or parent's publicAt is set.
- */
-export type PublicReadMode = 'publicSelf' | 'publicParent' | 'publicParentOrSelf';
-
-/** Modes allowed on context entities (they cannot inherit from a parent context). */
-export type ContextPublicReadMode = 'publicSelf';
 
 // Role Registry
 function buildRoleMap<T extends readonly string[]>(roleNames: T): { readonly [K in T[number]]: K } {
@@ -38,31 +30,40 @@ interface ContextEntry<R extends string = string> {
   kind: 'context';
   parent: string | null;
   roles: readonly R[];
-  publicRead?: ContextPublicReadMode;
   /** Non-ancestor context entities referenced as optional denormalized columns. */
   relatedContexts?: readonly string[];
 }
 interface ProductEntry {
   kind: 'product';
   parent: string;
-  publicRead?: PublicReadMode;
+  /** Host product this entity belongs to (product-to-product ownership, e.g. attachment → task). */
+  host?: string;
   /** Non-ancestor context entities referenced as optional denormalized columns. */
   relatedContexts?: readonly string[];
 }
 type EntityEntry = UserEntry | ContextEntry | ProductEntry;
 
+/** A host relationship between two products, with the hosted table's host id column. */
+export interface HostRelation {
+  /** The hosted product (e.g. 'attachment'). */
+  hostedType: string;
+  /** The host product (e.g. 'task'). */
+  hostType: string;
+  /** Generated nullable id column on the hosted table (e.g. 'taskId'). */
+  hostIdColumn: string;
+}
+
 export interface ContextEntityView<R extends string = string> {
   readonly kind: 'context';
   readonly parent: string | null;
   readonly roles: readonly R[];
-  readonly publicRead?: ContextPublicReadMode;
   readonly relatedContexts?: readonly string[];
 }
 
 export interface ProductEntityView {
   readonly kind: 'product';
   readonly parent: string;
-  readonly publicRead?: PublicReadMode;
+  readonly host?: string;
   readonly relatedContexts?: readonly string[];
 }
 
@@ -79,6 +80,7 @@ class EntityHierarchyBuilder<
   TProducts extends string = never,
   TParentMap extends Record<string, string | null> = Record<never, never>,
   TRelatedMap extends Record<string, string> = Record<never, never>,
+  THostMap extends Record<string, string> = Record<never, never>,
 > {
   private readonly entities: Map<string, EntityEntry>;
   private readonly roles: TRoles;
@@ -96,9 +98,9 @@ class EntityHierarchyBuilder<
   }
 
   /** Add user entity (required, once). */
-  user(): EntityHierarchyBuilder<TRoles, TContexts, TProducts, TParentMap, TRelatedMap> {
+  user(): EntityHierarchyBuilder<TRoles, TContexts, TProducts, TParentMap, TRelatedMap, THostMap> {
     if (this.entities.has('user')) throw new Error('EntityHierarchy: user() can only be called once');
-    return new EntityHierarchyBuilder<TRoles, TContexts, TProducts, TParentMap, TRelatedMap>(
+    return new EntityHierarchyBuilder<TRoles, TContexts, TProducts, TParentMap, TRelatedMap, THostMap>(
       this.roles,
       this.withEntity('user', { kind: 'user' }),
     );
@@ -107,13 +109,14 @@ class EntityHierarchyBuilder<
   /** Add a context entity with parent reference and roles. */
   context<N extends string, P extends TContexts | null, const RC extends readonly TContexts[] = []>(
     name: N,
-    options: { parent: P; roles: readonly RoleFromRegistry<TRoles>[]; publicRead?: ContextPublicReadMode; relatedContexts?: RC },
+    options: { parent: P; roles: readonly RoleFromRegistry<TRoles>[]; relatedContexts?: RC },
   ): EntityHierarchyBuilder<
     TRoles,
     TContexts | N,
     TProducts,
     TParentMap & { [K in N]: P },
-    TRelatedMap & { [K in N]: RC[number] }
+    TRelatedMap & { [K in N]: RC[number] },
+    THostMap
   > {
     this.validateName(name);
     this.validateParent(name, options.parent, 'context');
@@ -124,14 +127,14 @@ class EntityHierarchyBuilder<
       TContexts | N,
       TProducts,
       TParentMap & { [K in N]: P },
-      TRelatedMap & { [K in N]: RC[number] }
+      TRelatedMap & { [K in N]: RC[number] },
+      THostMap
     >(
       this.roles,
       this.withEntity(name, {
         kind: 'context',
         parent: options.parent,
         roles: options.roles,
-        publicRead: options.publicRead,
         relatedContexts: options.relatedContexts,
       }),
     );
@@ -148,40 +151,53 @@ class EntityHierarchyBuilder<
    *
    * Optional `relatedContexts` declare non-ancestor context references (nullable id columns); they
    * are cross-links, not homes.
+   *
+   * Optional `host` declares product-to-product ownership (e.g. attachment → task): the hosted
+   * product gets a generated nullable `<host>Id` column (see `hostRelationColumns`), host deletes
+   * cascade to hosted rows (API + CDC), and the CDC counter machinery maintains per-host
+   * `e:<hostedType>` counts. The host must be a previously declared product sharing the same home
+   * context, and cannot itself be hosted.
    */
-  product<N extends string, P extends TContexts, const RC extends readonly TContexts[] = []>(
+  product<
+    N extends string,
+    P extends TContexts,
+    const RC extends readonly TContexts[] = [],
+    H extends TProducts = never,
+  >(
     name: N,
-    options: { parent: P; publicRead?: PublicReadMode; relatedContexts?: RC },
+    options: { parent: P; host?: H; relatedContexts?: RC },
   ): EntityHierarchyBuilder<
     TRoles,
     TContexts,
     TProducts | N,
     TParentMap & { [K in N]: P },
-    TRelatedMap & { [K in N]: RC[number] }
+    TRelatedMap & { [K in N]: RC[number] },
+    THostMap & ([H] extends [never] ? Record<never, never> : { [K in N]: H })
   > {
     this.validateName(name);
     this.validateParent(name, options.parent, 'product');
-    this.validatePublicRead(name, options.parent, options.publicRead);
+    this.validateHost(name, options.parent, options.host);
     this.validateRelatedContexts(name, options.parent, options.relatedContexts);
     return new EntityHierarchyBuilder<
       TRoles,
       TContexts,
       TProducts | N,
       TParentMap & { [K in N]: P },
-      TRelatedMap & { [K in N]: RC[number] }
+      TRelatedMap & { [K in N]: RC[number] },
+      THostMap & ([H] extends [never] ? Record<never, never> : { [K in N]: H })
     >(
       this.roles,
       this.withEntity(name, {
         kind: 'product',
         parent: options.parent,
-        publicRead: options.publicRead,
+        host: options.host,
         relatedContexts: options.relatedContexts,
       }),
     );
   }
 
   /** Build and freeze the hierarchy. */
-  build(): EntityHierarchy<TRoles, TContexts, TProducts, TParentMap, TRelatedMap> {
+  build(): EntityHierarchy<TRoles, TContexts, TProducts, TParentMap, TRelatedMap, THostMap> {
     if (!this.entities.has('user')) throw new Error('EntityHierarchy: user() must be called before build()');
     if (!this.entities.has('organization')) throw new Error('EntityHierarchy: organization context is required');
     return new EntityHierarchy(this.roles, this.entities);
@@ -219,6 +235,36 @@ class EntityHierarchyBuilder<
       throw new Error(
         `EntityHierarchy: ${kind} "${name}" parent "${parent}" must be a context entity, ` +
           `but it is a ${parentEntry.kind} entity.`,
+      );
+    }
+  }
+
+  private validateHost(name: string, parent: string, host?: string): void {
+    if (!host) return;
+
+    const hostEntry = this.entities.get(host);
+    if (!hostEntry) {
+      throw new Error(
+        `EntityHierarchy: product "${name}" references unknown host "${host}". ` +
+          'Hosts must be defined before hosted products.',
+      );
+    }
+    if (hostEntry.kind !== 'product') {
+      throw new Error(
+        `EntityHierarchy: product "${name}" host "${host}" must be a product entity, but it is a ${hostEntry.kind} entity.`,
+      );
+    }
+    if (hostEntry.host) {
+      throw new Error(
+        `EntityHierarchy: product "${name}" host "${host}" is itself hosted — host chains are not supported.`,
+      );
+    }
+    // Hosted rows inherit the host's context scope; sharing the home context is what keeps
+    // the existing ancestor/permission machinery working unchanged.
+    if (hostEntry.parent !== parent) {
+      throw new Error(
+        `EntityHierarchy: product "${name}" (parent "${parent}") and its host "${host}" (parent "${hostEntry.parent}") ` +
+          'must share the same home context.',
       );
     }
   }
@@ -287,19 +333,6 @@ class EntityHierarchyBuilder<
     }
   }
 
-  private validatePublicRead(name: string, parent: string, publicRead?: PublicReadMode): void {
-    if (!publicRead) return;
-
-    if (publicRead === 'publicParent' || publicRead === 'publicParentOrSelf') {
-      const parentEntry = this.entities.get(parent);
-      if (!parentEntry || parentEntry.kind !== 'context' || parentEntry.publicRead !== 'publicSelf') {
-        throw new Error(
-          `EntityHierarchy: product "${name}" has publicRead '${publicRead}' ` +
-            `but parent "${parent}" doesn't have publicRead 'publicSelf'.`,
-        );
-      }
-    }
-  }
 }
 
 // Entity Hierarchy (Frozen Result)
@@ -311,17 +344,21 @@ export class EntityHierarchy<
   TProducts extends string = string,
   TParentMap extends Record<string, string | null> = Record<string, string | null>,
   TRelatedMap extends Record<string, string> = Record<string, string>,
+  THostMap extends Record<string, string> = Record<string, string>,
 > {
   /** Phantom type carrier: maps each entity to its strict parent (null = root). Type-only, no runtime value. */
   declare readonly _parentMap: TParentMap;
   /** Phantom type carrier: maps each entity to its related (non-ancestor) context union. Type-only, no runtime value. */
   declare readonly _relatedMap: TRelatedMap;
+  /** Phantom type carrier: maps each hosted product to its host product. Type-only, no runtime value. */
+  declare readonly _hostMap: THostMap;
 
   private readonly entities: ReadonlyMap<string, EntityEntry>;
   private readonly roleRegistry: TRoles;
   private readonly ancestorCache = new Map<string, readonly string[]>();
   private readonly childrenCache = new Map<string, readonly (TContexts | TProducts)[]>();
   private readonly descendantsCache = new Map<string, readonly (TContexts | TProducts)[]>();
+  private readonly hostRelations: readonly HostRelation[];
 
   readonly contextTypes: readonly TContexts[];
   readonly productTypes: readonly TProducts[];
@@ -338,6 +375,8 @@ export class EntityHierarchy<
     const all: ('user' | TContexts | TProducts)[] = [];
     const relatableContexts = new Set<TContexts>();
 
+    const hostRelations: HostRelation[] = [];
+
     for (const [name, entry] of entities) {
       all.push(name as 'user' | TContexts | TProducts);
 
@@ -346,6 +385,9 @@ export class EntityHierarchy<
       } else if (entry.kind === 'product') {
         products.push(name as TProducts);
         relatableContexts.add(entry.parent as TContexts);
+        if (entry.host) {
+          hostRelations.push({ hostedType: name, hostType: entry.host, hostIdColumn: `${entry.host}Id` });
+        }
       }
     }
 
@@ -353,6 +395,7 @@ export class EntityHierarchy<
     this.productTypes = Object.freeze(products);
     this.allTypes = Object.freeze(all);
     this.relatableContextTypes = Object.freeze([...relatableContexts]);
+    this.hostRelations = Object.freeze(hostRelations);
     Object.freeze(this);
   }
 
@@ -415,9 +458,9 @@ export class EntityHierarchy<
     if (!entry) return undefined;
     if (entry.kind === 'user') return { kind: 'user' };
     if (entry.kind === 'context') {
-      return { kind: 'context', parent: entry.parent, roles: entry.roles, publicRead: entry.publicRead, relatedContexts: entry.relatedContexts };
+      return { kind: 'context', parent: entry.parent, roles: entry.roles, relatedContexts: entry.relatedContexts };
     }
-    return { kind: 'product', parent: entry.parent, publicRead: entry.publicRead, relatedContexts: entry.relatedContexts };
+    return { kind: 'product', parent: entry.parent, host: entry.host, relatedContexts: entry.relatedContexts };
   }
 
   /** Get product entity view. */
@@ -477,12 +520,24 @@ export class EntityHierarchy<
     return this.roleRegistry;
   }
 
-  // Public Read Methods
+  // Host relationships (product-to-product ownership)
 
-  /** Get public read mode. Returns undefined if entity has no public read config. */
-  getPublicReadMode(entityType: string): PublicReadMode | undefined {
+  /** The host product this entity belongs to (e.g. attachment → 'task'). Undefined if not hosted. */
+  getHostType(entityType: string): TProducts | undefined {
     const entry = this.entities.get(entityType);
-    return entry && entry.kind !== 'user' ? entry.publicRead : undefined;
+    return entry?.kind === 'product' ? (entry.host as TProducts | undefined) : undefined;
+  }
+
+  /** Product types hosted by the given product (e.g. task → ['attachment']). */
+  getHostedTypes(hostType: string): readonly TProducts[] {
+    return this.getHostRelations()
+      .filter((relation) => relation.hostType === hostType)
+      .map((relation) => relation.hostedType as TProducts);
+  }
+
+  /** All host relationships with their generated host id column names. */
+  getHostRelations(): readonly HostRelation[] {
+    return this.hostRelations;
   }
 }
 

--- a/shared/src/config-builder/tests/entity-hierarchy.test.ts
+++ b/shared/src/config-builder/tests/entity-hierarchy.test.ts
@@ -188,89 +188,73 @@ describe('EntityHierarchyBuilder', () => {
     });
   });
 
-  describe('public read configuration', () => {
-    const publicHierarchy = createEntityHierarchy(roles)
+  describe('host relationships (product-to-product ownership)', () => {
+    const hostHierarchy = createEntityHierarchy(roles)
       .user()
       .context('organization', { parent: null, roles: roles.all })
-      .context('project', {
-        parent: 'organization',
-        roles: roles.all,
-        publicRead: 'publicSelf',
-      })
-      .product('task', { parent: 'project', publicRead: 'publicParent' })
-      .product('attachment', { parent: 'project' }) // No public read
+      .context('project', { parent: 'organization', roles: roles.all })
+      .product('task', { parent: 'project' })
+      .product('attachment', { parent: 'project', host: 'task' })
+      .product('label', { parent: 'project' })
       .build();
 
-    it('getPublicReadMode returns undefined for entities without publicRead', () => {
-      expect(publicHierarchy.getPublicReadMode('attachment')).toBeUndefined();
-      expect(publicHierarchy.getPublicReadMode('organization')).toBeUndefined();
-      expect(publicHierarchy.getPublicReadMode('user')).toBeUndefined();
+    it('exposes host type, hosted types and relations with id columns', () => {
+      expect(hostHierarchy.getHostType('attachment')).toBe('task');
+      expect(hostHierarchy.getHostType('task')).toBeUndefined();
+      expect(hostHierarchy.getHostType('label')).toBeUndefined();
+      expect(hostHierarchy.getHostedTypes('task')).toEqual(['attachment']);
+      expect(hostHierarchy.getHostedTypes('label')).toEqual([]);
+      expect(hostHierarchy.getHostRelations()).toEqual([
+        { hostedType: 'attachment', hostType: 'task', hostIdColumn: 'taskId' },
+      ]);
     });
 
-    it('getPublicReadMode returns configured mode', () => {
-      expect(publicHierarchy.getPublicReadMode('project')).toBe('publicSelf');
-      expect(publicHierarchy.getPublicReadMode('task')).toBe('publicParent');
-      expect(publicHierarchy.getPublicReadMode('attachment')).toBeUndefined();
-      expect(publicHierarchy.getPublicReadMode('organization')).toBeUndefined();
-      expect(publicHierarchy.getPublicReadMode('user')).toBeUndefined();
+    it('includes host in the product view', () => {
+      expect(hostHierarchy.getProductConfig('attachment')?.host).toBe('task');
+      expect(hostHierarchy.getProductConfig('task')?.host).toBeUndefined();
     });
 
-    it('getContextConfig includes publicRead', () => {
-      const projectConfig = publicHierarchy.getContextConfig('project');
-      expect(projectConfig?.publicRead).toBe('publicSelf');
-
-      const orgConfig = publicHierarchy.getContextConfig('organization');
-      expect(orgConfig?.publicRead).toBeUndefined();
-    });
-
-    it('getProductConfig includes publicRead', () => {
-      const taskConfig = publicHierarchy.getProductConfig('task');
-      expect(taskConfig?.publicRead).toBe('publicParent');
-
-      const attachmentConfig = publicHierarchy.getProductConfig('attachment');
-      expect(attachmentConfig?.publicRead).toBeUndefined();
-    });
-
-    it('supports publicParentOrSelf mode', () => {
-      const h = createEntityHierarchy(roles)
-        .user()
-        .context('organization', { parent: null, roles: roles.all })
-        .context('project', { parent: 'organization', roles: roles.all, publicRead: 'publicSelf' })
-        .product('task', { parent: 'project', publicRead: 'publicParentOrSelf' })
-        .build();
-
-      expect(h.getPublicReadMode('task')).toBe('publicParentOrSelf');
-    });
-  });
-
-  describe('public read validation', () => {
-    it("throws if publicParent but parent lacks publicRead 'publicSelf'", () => {
-      expect(() => {
+    it('throws when the host is not defined before the hosted product', () => {
+      expect(() =>
         createEntityHierarchy(roles)
           .user()
           .context('organization', { parent: null, roles: roles.all })
-          .product('task', { parent: 'organization', publicRead: 'publicParent' });
-      }).toThrow("doesn't have publicRead 'publicSelf'");
+          .context('project', { parent: 'organization', roles: roles.all })
+          .product('attachment', { parent: 'project', host: 'task' as never }),
+      ).toThrow('unknown host');
     });
 
-    it("throws if publicParentOrSelf but parent lacks publicRead 'publicSelf'", () => {
-      expect(() => {
+    it('throws when the host is not a product', () => {
+      expect(() =>
         createEntityHierarchy(roles)
           .user()
           .context('organization', { parent: null, roles: roles.all })
-          .product('task', { parent: 'organization', publicRead: 'publicParentOrSelf' });
-      }).toThrow("doesn't have publicRead 'publicSelf'");
+          .context('project', { parent: 'organization', roles: roles.all })
+          .product('attachment', { parent: 'project', host: 'project' as never }),
+      ).toThrow('must be a product entity');
     });
 
-    it('allows publicSelf on context entity', () => {
-      expect(() => {
+    it('throws when host and hosted do not share the home context', () => {
+      expect(() =>
         createEntityHierarchy(roles)
           .user()
           .context('organization', { parent: null, roles: roles.all })
-          .context('project', { parent: 'organization', roles: roles.all, publicRead: 'publicSelf' })
-          .build();
-      }).not.toThrow();
+          .context('project', { parent: 'organization', roles: roles.all })
+          .product('task', { parent: 'project' })
+          .product('attachment', { parent: 'organization', host: 'task' }),
+      ).toThrow('must share the same home context');
     });
 
+    it('throws on host chains', () => {
+      expect(() =>
+        createEntityHierarchy(roles)
+          .user()
+          .context('organization', { parent: null, roles: roles.all })
+          .context('project', { parent: 'organization', roles: roles.all })
+          .product('task', { parent: 'project' })
+          .product('comment', { parent: 'project', host: 'task' })
+          .product('reaction', { parent: 'project', host: 'comment' }),
+      ).toThrow('host chains are not supported');
+    });
   });
 });

--- a/shared/src/permissions/access-policies.ts
+++ b/shared/src/permissions/access-policies.ts
@@ -1,6 +1,10 @@
 import { appConfig } from '../config-builder/app-config';
+import { hierarchy } from '../../config/hierarchy-config';
 import { getContextRoles } from '../entity-guards';
 import type { ContextEntityType, EntityActionType, EntityRole, EntityType, ProductEntityType } from '../../types';
+import type { PublicReadGrants, PublicReadMode } from './public-read';
+import { own } from './row-conditions';
+import { normalizeRestriction, type RowRestrictionInput, type RowRestrictions } from './row-restrictions';
 import type {
   AccessPolicies,
   AccessPolicyCallback,
@@ -8,8 +12,16 @@ import type {
   AccessPolicyEntry,
   ContextPolicyBuilder,
   EntityActionPermissions,
+  HostDelegation,
+  NormalizedPermissionValue,
+  PermissionValue,
   SubjectAccessPolicies,
 } from './types';
+
+/** Resolves the `'own'` sugar literal to the built-in condition; passes everything else through. */
+const normalizePermissionValue = (value: PermissionValue): NormalizedPermissionValue => {
+  return value === 'own' ? own : value;
+};
 
 /**
  * Creates a context policy builder for fluent role-permission configuration.
@@ -22,12 +34,13 @@ const createContextPolicyBuilder = (
   const builder = {} as ContextPolicyBuilder;
 
   for (const role of roles) {
-    builder[role as EntityRole] = (permissions: Partial<EntityActionPermissions>) => {
+    builder[role as EntityRole] = (permissions: Partial<Record<EntityActionType, PermissionValue>>) => {
       // Normalize to a full record so the engine always reads an explicit value: any action the
-      // policy omits defaults to 0 (denied). Omitting an action is therefore equivalent to `0`.
+      // policy omits defaults to 0 (denied), and the `'own'` sugar literal resolves to the
+      // built-in row condition. Omitting an action is therefore equivalent to `0`.
       const fullPermissions = {} as EntityActionPermissions;
       for (const action of appConfig.entityActions as readonly EntityActionType[]) {
-        fullPermissions[action] = permissions[action] ?? 0;
+        fullPermissions[action] = normalizePermissionValue(permissions[action] ?? 0);
       }
       entries.push({ contextType, role: role as EntityRole, permissions: fullPermissions });
     };
@@ -50,27 +63,39 @@ const createContextBuilders = (entries: AccessPolicyEntry[]): Record<ContextEnti
   return contexts;
 };
 
+/** Result of `configurePermissions`: role×context policies + subject-level grants/restrictions. */
+export interface PermissionsConfigResult {
+  accessPolicies: AccessPolicies;
+  publicReadGrants: PublicReadGrants;
+  rowRestrictions: RowRestrictions;
+  hostDelegation: HostDelegation;
+}
+
 /**
- * Configures access policies for all entity types using a callback pattern.
- * The callback receives subject info and context builders for fluent configuration.
+ * Configures the full permission set for all entity types using a callback pattern.
+ * The callback receives the subject, context builders for role×context grants, and
+ * `publicRead(mode)` for the subject-level public read grant (see `public-read.ts`).
  *
  * @example
  * ```ts
- * const policies = configureAccessPolicies(entityTypes, ({ subject, contexts }) => {
+ * const { accessPolicies, publicReadGrants } = configurePermissions(entityTypes, ({ subject, contexts, publicRead }) => {
  *   switch (subject.name) {
- *     case 'organization':
+ *     case 'project':
+ *       publicRead('publicSelf'); // readable by anyone once its publicAt is set
  *       contexts.organization.admin({ create: 1, read: 1, update: 1, delete: 1 });
- *       contexts.organization.member({ create: 0, read: 1, update: 0, delete: 0 });
  *       break;
  *   }
  * });
  * ```
  */
-export const configureAccessPolicies = (
+export const configurePermissions = (
   entityTypes: readonly EntityType[],
   callback: AccessPolicyCallback,
-): AccessPolicies => {
+): PermissionsConfigResult => {
   const policies: AccessPolicies = {};
+  const publicReadGrants: PublicReadGrants = {};
+  const rowRestrictions: RowRestrictions = {};
+  const hostDelegation: HostDelegation = {};
 
   const permissionableTypes = entityTypes.filter(
     (type): type is ContextEntityType | ProductEntityType => type !== 'user',
@@ -83,6 +108,32 @@ export const configureAccessPolicies = (
     const config: AccessPolicyConfiguration = {
       subject: { name: entityType },
       contexts,
+      publicRead: (mode: PublicReadMode) => {
+        if (publicReadGrants[entityType]) {
+          throw new Error(`[Permission] publicRead() called twice for "${entityType}"`);
+        }
+        publicReadGrants[entityType] = mode;
+      },
+      restrict: (restriction: RowRestrictionInput) => {
+        if (rowRestrictions[entityType]) {
+          throw new Error(`[Permission] restrict() called twice for "${entityType}"`);
+        }
+        rowRestrictions[entityType] = normalizeRestriction(restriction);
+      },
+      delegateToHost: (actions: readonly EntityActionType[]) => {
+        if (hostDelegation[entityType]) {
+          throw new Error(`[Permission] delegateToHost() called twice for "${entityType}"`);
+        }
+        if (actions.length === 0) {
+          throw new Error(`[Permission] delegateToHost() for "${entityType}" needs at least one action`);
+        }
+        if (!hierarchy.getHostType(entityType)) {
+          throw new Error(
+            `[Permission] delegateToHost() for "${entityType}" requires a host declared in the hierarchy (host:)`,
+          );
+        }
+        hostDelegation[entityType] = actions;
+      },
     };
 
     callback(config);
@@ -92,7 +143,40 @@ export const configureAccessPolicies = (
     }
   }
 
-  return policies;
+  validatePublicReadGrants(publicReadGrants);
+
+  return { accessPolicies: policies, publicReadGrants, rowRestrictions, hostDelegation };
+};
+
+/**
+ * A parent-dependent public grant only works if the parent itself can become public:
+ * its own grant must include self-publication. Mirrors the validation the entity
+ * hierarchy performed when `publicRead` lived there.
+ */
+const validatePublicReadGrants = (grants: PublicReadGrants): void => {
+  for (const [entityType, mode] of Object.entries(grants) as [ContextEntityType | ProductEntityType, PublicReadMode][]) {
+    if (mode !== 'publicParent' && mode !== 'publicParentOrSelf') continue;
+
+    const parent = hierarchy.getParent(entityType);
+    const parentMode = parent ? grants[parent as ContextEntityType | ProductEntityType] : undefined;
+    if (parentMode !== 'publicSelf' && parentMode !== 'publicParentOrSelf') {
+      throw new Error(
+        `[Permission] "${entityType}" declares publicRead '${mode}' but its parent "${parent}" has no self-publication grant (publicRead 'publicSelf').`,
+      );
+    }
+  }
+};
+
+/**
+ * Configures access policies only (no public read grants) — kept for tests and callers
+ * that drive the engine with synthetic policies. App configs should use
+ * `configurePermissions`.
+ */
+export const configureAccessPolicies = (
+  entityTypes: readonly EntityType[],
+  callback: AccessPolicyCallback,
+): AccessPolicies => {
+  return configurePermissions(entityTypes, callback).accessPolicies;
 };
 
 /**

--- a/shared/src/permissions/action-helpers.ts
+++ b/shared/src/permissions/action-helpers.ts
@@ -22,13 +22,14 @@ export const allActionsAllowed = Object.freeze(createActionRecord(() => true as 
 >;
 
 /**
- * Resolves a three-state permission (`true | false | 'own'`) to a boolean
- * by checking the implicit "owner" relation.
+ * Resolves a three-state permission (`true | false | condition name`) to a boolean.
  *
- * In Zanzibar terms: evaluates `check(userId, action, entity)` where an `'own'` policy
- * is resolved via the implicit `owner` relation derived from `entity.createdBy`.
+ * Handles the built-in `'own'` condition (actor created the entity, derived from
+ * `entity.createdBy`). Any other condition name resolves to `false` here — secure
+ * default; call sites using a custom row condition must resolve it via the
+ * condition's own check-form.
  *
- * @param permission - The permission state from `EntityCanMap` (`true`, `false`, or `'own'`)
+ * @param permission - The permission state from `EntityCanMap` (`true`, `false`, or a condition name)
  * @param entityCreatedBy - The `createdBy` field of the entity being checked
  * @param userId - The current user's ID (the actor)
  * @returns `true` if action is allowed, `false` otherwise. Defaults to `false` for safety.

--- a/shared/src/permissions/build-subject.ts
+++ b/shared/src/permissions/build-subject.ts
@@ -21,12 +21,21 @@ import { validateAncestorScope } from './validate-ancestor-scope';
  * @param ancestorContextIds - Object containing ancestor ID values (e.g., route params, event data)
  * @param options.id - Entity ID (defaults to a generated ID for collection-level checks)
  * @param options.createdBy - Creator for ownership checks
+ * @param options.row - Row fields for row-condition / public read evaluation
+ * @param options.parentRow - Parent context row for parent-dependent rules (e.g. `publicRead: 'publicParent'`),
+ *   resolved by the caller once per request/event
  * @throws MissingScopeError if any required ancestor context ID is missing (undefined)
  */
 export const buildSubject = (
   entityType: ContextEntityType | ProductEntityType,
   ancestorContextIds: Partial<ContextEntityIdColumns>,
-  options?: { id?: string; createdBy?: string | null },
+  options?: {
+    id?: string;
+    createdBy?: string | null;
+    row?: Record<string, unknown>;
+    parentRow?: Record<string, unknown>;
+    hostRow?: Record<string, unknown>;
+  },
 ): SubjectForPermission => {
   const contextIds: ContextScope = {};
 
@@ -43,6 +52,9 @@ export const buildSubject = (
     id: options?.id ?? generateId(),
     contextIds,
     ...(options?.createdBy !== undefined && { createdBy: options.createdBy }),
+    ...(options?.row !== undefined && { row: options.row }),
+    ...(options?.parentRow !== undefined && { parentRow: options.parentRow }),
+    ...(options?.hostRow !== undefined && { hostRow: options.hostRow }),
   };
 
   validateAncestorScope(subject);

--- a/shared/src/permissions/check-permission.ts
+++ b/shared/src/permissions/check-permission.ts
@@ -1,5 +1,5 @@
 import type { EntityActionType } from '../../types';
-import { accessPolicies } from '../../config/permissions-config';
+import { accessPolicies, hostDelegation, publicReadGrants, rowRestrictions } from '../../config/permissions-config';
 import { getAllDecisions } from './permission-manager/check';
 import type {
   PermissionCheckOptions,
@@ -65,12 +65,20 @@ export function checkPermission<T extends PermissionMembership>(
 ): PermissionResult<T> | BatchPermissionResult<T> {
   const isSingle = !Array.isArray(entityOrEntities);
 
+  // Inject the configured grants/restrictions; explicit options (tests) take precedence.
+  const optionsWithGrants: PermissionCheckOptions = {
+    publicGrants: publicReadGrants,
+    restrictions: rowRestrictions,
+    hostDelegation,
+    ...options,
+  };
+
   if (isSingle) {
-    const { can, membership } = getAllDecisions(accessPolicies, memberships, entityOrEntities, options);
+    const { can, membership } = getAllDecisions(accessPolicies, memberships, entityOrEntities, optionsWithGrants);
     return { isAllowed: can[action], membership };
   }
 
-  const decisions = getAllDecisions(accessPolicies, memberships, entityOrEntities, options);
+  const decisions = getAllDecisions(accessPolicies, memberships, entityOrEntities, optionsWithGrants);
   const results = new Map<string, PermissionResult<T>>();
 
   for (const [id, decision] of decisions) {

--- a/shared/src/permissions/compute-can.ts
+++ b/shared/src/permissions/compute-can.ts
@@ -4,6 +4,7 @@ import type { ContextEntityType, EntityActionType, EntityRole, EntityType } from
 import { recordFromKeys } from '../config-builder/utils';
 import { getPolicyPermissions, getSubjectPolicies } from './access-policies';
 import { allActionsDenied } from './action-helpers';
+import { isRowCondition } from './row-conditions';
 import type { AccessPolicies, ActionPermissionState } from './types';
 
 /**
@@ -11,12 +12,12 @@ import type { AccessPolicies, ActionPermissionState } from './types';
  *
  * - `true` = unconditionally allowed (policy value `1`)
  * - `false` = denied (policy value `0`)
- * - `'own'` = allowed only when the actor owns the entity (policy value `'own'`).
- *   This is an implicit "owner" relation — the frontend must compare `entity.createdBy`
- *   against the current user ID to resolve to a final boolean.
+ * - condition name (e.g. `'own'`) = allowed only for rows satisfying that row condition.
+ *   The frontend resolves it per row: `resolvePermission` handles the built-in `'own'`
+ *   (compare `entity.createdBy` against the current user ID); custom conditions resolve
+ *   via their check-form.
  *
- * This three-state model preserves the Zanzibar-style relation semantics at the UI layer,
- * making it straightforward to later introduce explicit relation tuples.
+ * Keeping the state three-valued preserves row-condition semantics at the UI layer.
  */
 type ActionStates = Record<EntityActionType, ActionPermissionState>;
 
@@ -41,7 +42,9 @@ function computeEntityPermissions(
   return recordFromKeys(appConfig.entityActions, (action) => {
     const value = permissions[action];
     if (value === 1) return true;
-    if (value === 'own') return 'own';
+    // Row-conditional grant → surface the condition name (e.g. 'own'); the frontend
+    // resolves it per row via resolvePermission / the condition's check-form.
+    if (isRowCondition(value)) return value.name;
     return false;
   }) as ActionStates;
 }

--- a/shared/src/permissions/host-delegation.test.ts
+++ b/shared/src/permissions/host-delegation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { appConfig } from '../config-builder/app-config';
+import { configurePermissions } from './access-policies';
+
+/**
+ * Host permission delegation (`delegateToHost`) — declaration validation.
+ *
+ * Engine semantics (host verdict union incl. the host's own/public/restriction rules,
+ * fail-closed without a resolved hostRow, per-action scoping) need a hierarchy with a
+ * `host:` relationship; cella's config has none, so those are covered by the raak
+ * fork's suites (host: task↔attachment) and, ahead, projectcampus (comment → item).
+ */
+
+describe('delegateToHost declaration', () => {
+  it('throws for subjects without a hierarchy host', () => {
+    expect(() =>
+      configurePermissions(appConfig.entityTypes, ({ subject, delegateToHost }) => {
+        if (subject.name === 'attachment') delegateToHost(['read']);
+      }),
+    ).toThrow('requires a host declared in the hierarchy');
+  });
+
+  it('throws on empty actions', () => {
+    expect(() =>
+      configurePermissions(appConfig.entityTypes, ({ subject, delegateToHost }) => {
+        if (subject.name === 'attachment') delegateToHost([]);
+      }),
+    ).toThrow('at least one action');
+  });
+});

--- a/shared/src/permissions/index.ts
+++ b/shared/src/permissions/index.ts
@@ -6,15 +6,24 @@ export type {
   ActionPermissionState,
   ContextPolicyBuilder,
   EntityActionPermissions,
+  HostDelegation,
+  NormalizedPermissionValue,
   PermissionValue,
   SubjectAccessPolicies,
 } from './types';
+export { publicReadMatches } from './public-read';
+export type { PublicReadGrants, PublicReadMode } from './public-read';
+export { isRowCondition, own } from './row-conditions';
+export type { ConditionActor, RowCondition, RowConditionSqlForm, RowForCondition } from './row-conditions';
+export { membershipGrantQualifies, normalizeRestriction, qualifyingDepths } from './row-restrictions';
+export type { RowRestriction, RowRestrictionInput, RowRestrictions } from './row-restrictions';
 
-export { configureAccessPolicies, getPolicyPermissions, getSubjectPolicies } from './access-policies';
+export { configureAccessPolicies, configurePermissions, getPolicyPermissions, getSubjectPolicies } from './access-policies';
+export type { PermissionsConfigResult } from './access-policies';
 export { allActionsAllowed, allActionsDenied, createActionRecord, isUnconditionalPermission, resolvePermission } from './action-helpers';
 export { computeCan } from './compute-can';
 export type { EntityCanMap } from './compute-can';
-export { accessPolicies } from '../../config/permissions-config';
+export { accessPolicies, hostDelegation, publicReadGrants, rowRestrictions } from '../../config/permissions-config';
 
 // Permission engine (tier-neutral decision logic)
 export { getAllDecisions } from './permission-manager/check';

--- a/shared/src/permissions/permission-manager/check.ts
+++ b/shared/src/permissions/permission-manager/check.ts
@@ -3,6 +3,9 @@ import { hierarchy } from '../../../config/hierarchy-config';
 import type { ContextEntityType, ProductEntityType } from '../../../types';
 import { getContextRoles, isContextEntity } from '../../entity-guards';
 import { allActionsAllowed, createActionRecord } from '../action-helpers';
+import { type PublicReadGrants, publicReadMatches } from '../public-read';
+import { type ConditionActor, isRowCondition, type RowForCondition } from '../row-conditions';
+import { membershipGrantQualifies, type RowRestrictions } from '../row-restrictions';
 import type { AccessPolicies, EntityActionPermissions } from '../types';
 import { formatBatchPermissionSummary, formatPermissionDecision } from './format';
 import type {
@@ -84,8 +87,9 @@ const getSubjectContextId = (
  * Internal function to check permissions for a single subject using pre-built indices.
  * This is the core logic shared by both single and batch permission checks.
  *
- * Supports Zanzibar-style implicit "owner" relation: when a policy value is `'own'`,
- * the engine checks if `subject.createdBy === userId` to determine grant.
+ * Supports row-conditional grants: when a policy value is a `RowCondition` (e.g. the
+ * built-in `own`, normalized from the `'own'` literal), the engine evaluates its
+ * check-form against the subject's row fields to determine the grant.
  */
 const checkWithIndices = <T extends PermissionMembership>(
   membershipIndex: MembershipIndex<T>,
@@ -94,6 +98,8 @@ const checkWithIndices = <T extends PermissionMembership>(
   orderedContexts: ContextEntityType[],
   isSystemAdmin: boolean,
   userId?: string,
+  publicGrants?: PublicReadGrants,
+  restrictions?: RowRestrictions,
   debug?: boolean,
 ): PermissionDecision<T> => {
   // Primary context is always the first (most specific) in the hierarchy.
@@ -138,6 +144,13 @@ const checkWithIndices = <T extends PermissionMembership>(
   // Collect resolved context IDs for debugging
   const contextIds: ResolvedContextIds = {};
 
+  // Row fields + actor for row-condition evaluation, built once per subject
+  const conditionRow: RowForCondition = { ...subject.row, createdBy: subject.createdBy };
+  const conditionActor: ConditionActor = { userId };
+
+  // Row restriction for this entity type (narrows membership grants; see row-restrictions.ts)
+  const restriction = restrictions?.[subject.entityType];
+
   // Walk through each context level (most specific first, then ancestors)
   for (const contextType of orderedContexts) {
     // Strict: context in hierarchy must have roles defined
@@ -174,12 +187,19 @@ const checkWithIndices = <T extends PermissionMembership>(
         );
       }
 
+      // Row restriction: does this membership grant qualify for this row? Narrows
+      // membership grants only; row-condition and public grants are never narrowed,
+      // and `create` is never restricted (no row exists yet). Fail-closed without row data.
+      const grantQualifies =
+        !restriction || membershipGrantQualifies(restriction, subject, orderedContexts, contextType, m.role);
+
       // Attribute each granted action to this membership
       for (const action of appConfig.entityActions) {
         const policyValue = permissions[action];
 
         // Unconditional grant
         if (policyValue === 1) {
+          if (!grantQualifies && action !== 'create') continue;
           actions[action].enabled = true;
           actions[action].grantedBy.push({
             type: 'membership',
@@ -190,14 +210,22 @@ const checkWithIndices = <T extends PermissionMembership>(
           continue;
         }
 
-        // Implicit "owner" relation check: grant if actor created this entity.
-        // In Zanzibar terms: check(actor, action, object) where relation(actor, 'owner', object) exists.
-        if (policyValue === 'own' && userId && subject.createdBy === userId) {
+        // Row-conditional grant: allowed only when the row satisfies the condition for this
+        // actor (e.g. built-in `own`: actor created the row). Attributed by condition name.
+        if (isRowCondition(policyValue) && policyValue.matches(conditionRow, conditionActor)) {
           actions[action].enabled = true;
-          actions[action].grantedBy.push({ type: 'relation', relation: 'owner' });
+          actions[action].grantedBy.push({ type: 'relation', relation: policyValue.name });
         }
       }
     }
+  }
+
+  // Subject-level public read grant: rows can be readable by ANY actor — anonymous
+  // included — based on row data (see `public-read.ts`). Membership-independent.
+  const publicMode = publicGrants?.[subject.entityType];
+  if (publicMode && publicReadMatches(publicMode, subject)) {
+    actions.read.enabled = true;
+    actions.read.grantedBy.push({ type: 'public', mode: publicMode });
   }
 
   // Derive simple `can` map from actions table
@@ -265,6 +293,9 @@ export function getAllDecisions<T extends PermissionMembership>(
   const subjectArray = isSingle ? [subjects] : subjects;
   const isSystemAdmin = options?.isSystemAdmin === true;
   const userId = options?.userId;
+  const publicGrants = options?.publicGrants;
+  const restrictions = options?.restrictions;
+  const hostDelegation = options?.hostDelegation;
   const debug = options?.debug === true;
 
   const results = new Map<string, PermissionDecision<T>>();
@@ -286,23 +317,76 @@ export function getAllDecisions<T extends PermissionMembership>(
   // Cache for relevant contexts by entity type
   const contextCache = new Map<ContextEntityType | ProductEntityType, ContextEntityType[]>();
 
-  for (const subject of subjectArray) {
-    // Get or compute ordered contexts for this entity type (most specific → root).
-    // For context entities (e.g., project): [project, organization] — includes self + ancestors
-    // For product entities (e.g., attachment): [organization] — just ancestors
-    // The first element [0] is always the primary context used for membership capture.
-    let orderedContexts = contextCache.get(subject.entityType);
-
+  // Ordered contexts for an entity type (most specific → root), cached.
+  // For context entities (e.g., project): [project, organization] — includes self + ancestors
+  // For product entities (e.g., attachment): [organization] — just ancestors
+  // The first element [0] is always the primary context used for membership capture.
+  const resolveOrderedContexts = (entityType: ContextEntityType | ProductEntityType): ContextEntityType[] => {
+    let orderedContexts = contextCache.get(entityType);
     if (!orderedContexts) {
-      const ancestors = hierarchy.getOrderedAncestors(subject.entityType) as ContextEntityType[];
-      orderedContexts = isContextEntity(subject.entityType) ? [subject.entityType, ...ancestors] : [...ancestors];
-      contextCache.set(subject.entityType, orderedContexts);
+      const ancestors = hierarchy.getOrderedAncestors(entityType) as ContextEntityType[];
+      orderedContexts = isContextEntity(entityType) ? [entityType, ...ancestors] : [...ancestors];
+      contextCache.set(entityType, orderedContexts);
     }
+    return orderedContexts;
+  };
+
+  for (const subject of subjectArray) {
+    const orderedContexts = resolveOrderedContexts(subject.entityType);
     // Get or build policy index for this entity type
     const policyIndex = getOrBuildPolicyIndex(policies, subject.entityType, policyIndexCache);
 
     // Perform the permission check using pre-built indices
-    const decision = checkWithIndices(membershipIndex, policyIndex, subject, orderedContexts, isSystemAdmin, userId, debug);
+    const decision = checkWithIndices(
+      membershipIndex,
+      policyIndex,
+      subject,
+      orderedContexts,
+      isSystemAdmin,
+      userId,
+      publicGrants,
+      restrictions,
+      debug,
+    );
+
+    // Host delegation: a hosted row allows a delegated action if the HOST row allows it,
+    // including the host's row conditions, public grants and restrictions. Additive —
+    // unions with the subject's own decision, attributed as {type:'host'}. Requires the
+    // caller-resolved subject.hostRow (load-at-check); absent → contributes nothing.
+    const delegatedActions = hostDelegation?.[subject.entityType];
+    const hostType = delegatedActions?.length ? hierarchy.getHostType(subject.entityType) : undefined;
+    if (!isSystemAdmin && delegatedActions && hostType && subject.hostRow) {
+      const hostRow = subject.hostRow;
+      const hostSubject: SubjectForPermission = {
+        entityType: hostType as ProductEntityType,
+        ...(typeof hostRow.id === 'string' && { id: hostRow.id }),
+        ...(hostRow.createdBy !== undefined && { createdBy: hostRow.createdBy as string | null }),
+        // Host and hosted share the home context (enforced by the hierarchy builder)
+        contextIds: subject.contextIds,
+        row: hostRow,
+        ...(subject.parentRow !== undefined && { parentRow: subject.parentRow }),
+        // deliberately no hostRow: hosts cannot themselves be hosted (no chains)
+      };
+      const hostDecision = checkWithIndices(
+        membershipIndex,
+        getOrBuildPolicyIndex(policies, hostType as ProductEntityType, policyIndexCache),
+        hostSubject,
+        resolveOrderedContexts(hostType as ProductEntityType),
+        false,
+        userId,
+        publicGrants,
+        restrictions,
+        debug,
+      );
+      for (const action of delegatedActions) {
+        if (hostDecision.can[action]) {
+          decision.actions[action].enabled = true;
+          decision.actions[action].grantedBy.push({ type: 'host', hostType });
+          decision.can[action] = true;
+        }
+      }
+    }
+
     const key = subject.id ?? `_idx:${subjectArray.indexOf(subject)}`;
     results.set(key, decision);
   }

--- a/shared/src/permissions/permission-manager/format.ts
+++ b/shared/src/permissions/permission-manager/format.ts
@@ -4,8 +4,12 @@ import { createActionRecord } from '../action-helpers';
 import type { GrantSource, PermissionDecision, PermissionMembership } from './types';
 
 /** Format a grant source for debug output. */
-const formatGrant = (g: GrantSource): string =>
-  g.type === 'membership' ? `${g.contextType}:${g.contextId}/${g.role}` : `relation:${g.relation}`;
+const formatGrant = (g: GrantSource): string => {
+  if (g.type === 'membership') return `${g.contextType}:${g.contextId}/${g.role}`;
+  if (g.type === 'public') return `public:${g.mode}`;
+  if (g.type === 'host') return `host:${g.hostType}`;
+  return `relation:${g.relation}`;
+};
 
 /**
  * Formats a PermissionDecision for debug logging.

--- a/shared/src/permissions/permission-manager/index.test.ts
+++ b/shared/src/permissions/permission-manager/index.test.ts
@@ -473,7 +473,7 @@ describe('own permission — grant attribution', () => {
 
   const userId = 'user-actor';
 
-  it('attributes own-granted actions to relation:owner', () => {
+  it('attributes own-granted actions to the condition name (relation:own)', () => {
     const memberships: TestMembership[] = [
       createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member', userId }),
     ];
@@ -482,15 +482,15 @@ describe('own permission — grant attribution', () => {
     });
     const decision = getAllDecisions(ownPolicies, memberships, subject, { userId });
 
-    // Update was granted via 'own' → should be attributed to relation:owner
+    // Update was granted via the built-in `own` condition → attributed by condition name
     expect(decision.actions.update.enabled).toBe(true);
     expect(decision.actions.update.grantedBy).toHaveLength(1);
-    expect(decision.actions.update.grantedBy[0]).toEqual({ type: 'relation', relation: 'owner' });
+    expect(decision.actions.update.grantedBy[0]).toEqual({ type: 'relation', relation: 'own' });
 
     // Delete same
     expect(decision.actions.delete.enabled).toBe(true);
     expect(decision.actions.delete.grantedBy).toHaveLength(1);
-    expect(decision.actions.delete.grantedBy[0]).toEqual({ type: 'relation', relation: 'owner' });
+    expect(decision.actions.delete.grantedBy[0]).toEqual({ type: 'relation', relation: 'own' });
   });
 
   it('attributes unconditional grants to membership (not relation)', () => {

--- a/shared/src/permissions/permission-manager/types.ts
+++ b/shared/src/permissions/permission-manager/types.ts
@@ -1,4 +1,7 @@
 import type { ContextEntityType, EntityActionType, EntityIdColumnKeys, EntityRole, ProductEntityType } from '../../../types';
+import type { PublicReadGrants, PublicReadMode } from '../public-read';
+import type { RowRestrictions } from '../row-restrictions';
+import type { HostDelegation } from '../types';
 
 export type ContextEntityIdColumns = {
   [K in ContextEntityType as EntityIdColumnKeys[K]]: string | null;
@@ -34,16 +37,39 @@ export interface PermissionMembership {
 export type SubjectForPermission = {
   entityType: ContextEntityType | ProductEntityType;
   id?: string;
-  /** The user who created this entity. Enables implicit "owner" relation for `'own'` policies. */
+  /** The user who created this entity. Enables the built-in `own` row condition. */
   createdBy?: string | null;
   /** Ancestor context IDs keyed by context entity type. `null` means explicitly not scoped to that context. */
   contextIds: ContextScope;
+  /**
+   * Additional row fields for row-condition evaluation (see `row-conditions.ts`) and
+   * public read grants (see `public-read.ts`). Only needed when a policy uses a rule
+   * that reads columns beyond `createdBy`.
+   */
+  row?: Record<string, unknown>;
+  /**
+   * The parent context row's fields, for rules that depend on another row (e.g.
+   * `publicRead: 'publicParent'`). Resolved by the caller once per request/event —
+   * the engine never loads rows (see `design-cross-row-visibility.md`).
+   */
+  parentRow?: Record<string, unknown>;
+  /**
+   * The host product row's fields (hierarchy `host:`), for host-delegated decisions
+   * (`delegateToHost`). Resolved by the caller like `parentRow`; without it, delegation
+   * contributes nothing (fail closed).
+   */
+  hostRow?: Record<string, unknown>;
 };
 
-/** Source that granted an action — either a context membership or an implicit relation. */
+/**
+ * Source that granted an action — a context membership, a row condition
+ * (`relation` is the condition's name, e.g. `'own'`), or a public read grant.
+ */
 export type GrantSource =
   | { type: 'membership'; contextType: ContextEntityType; contextId: string; role: string }
-  | { type: 'relation'; relation: 'owner' };
+  | { type: 'relation'; relation: string }
+  | { type: 'public'; mode: PublicReadMode }
+  | { type: 'host'; hostType: string };
 
 export interface ActionAttribution {
   enabled: boolean;
@@ -73,6 +99,22 @@ export interface PermissionCheckOptions {
   isSystemAdmin?: boolean;
   /** The acting user's ID. Required when evaluating `'own'` policies (implicit owner relation). */
   userId?: string;
+  /**
+   * Subject-level public read grants to evaluate (see `public-read.ts`). The
+   * `checkPermission` wrapper injects the configured grants; pass explicitly only when
+   * driving the engine with synthetic policies (tests).
+   */
+  publicGrants?: PublicReadGrants;
+  /**
+   * Subject-level row restrictions to evaluate (see `row-restrictions.ts`). Injected by
+   * the `checkPermission` wrapper like `publicGrants`.
+   */
+  restrictions?: RowRestrictions;
+  /**
+   * Host-delegated actions per hosted entity type (`delegateToHost`). Injected by the
+   * `checkPermission` wrapper like `publicGrants`.
+   */
+  hostDelegation?: HostDelegation;
   /** When `true`, emit debug logging of the decision tree. Off by default to keep the engine quiet. */
   debug?: boolean;
 }

--- a/shared/src/permissions/public-read.test.ts
+++ b/shared/src/permissions/public-read.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { appConfig } from '../config-builder/app-config';
+import { configurePermissions } from './access-policies';
+import { getAllDecisions } from './permission-manager/check';
+import type { SubjectForPermission } from './permission-manager/types';
+import type { PublicReadGrants } from './public-read';
+
+/**
+ * Public read grants: subject-level, membership-independent read access based on row
+ * data. Evaluated for anonymous actors (no memberships, no userId) and members alike.
+ */
+
+const NOW = '2026-07-06T12:00:00Z';
+
+const grants: PublicReadGrants = {
+  organization: 'publicSelf',
+  attachment: 'publicParent',
+};
+
+const orgSubject = (publicAt: string | null): SubjectForPermission => ({
+  entityType: 'organization',
+  id: 'org1',
+  contextIds: {},
+  row: { publicAt },
+});
+
+const attachmentSubject = (parentPublicAt: string | null): SubjectForPermission => ({
+  entityType: 'attachment',
+  id: 'a1',
+  contextIds: { organization: 'org1' },
+  parentRow: { publicAt: parentPublicAt },
+});
+
+// No policies at all: everything below must come from public grants alone.
+const noPolicies = {};
+
+describe('public read grants — anonymous actor', () => {
+  it('publicSelf grants read when the row publicAt is set', () => {
+    const { can, actions } = getAllDecisions(noPolicies, [], orgSubject(NOW), { publicGrants: grants });
+    expect(can.read).toBe(true);
+    expect(actions.read.grantedBy).toEqual([{ type: 'public', mode: 'publicSelf' }]);
+  });
+
+  it('publicSelf denies when publicAt is null or row data is absent', () => {
+    expect(getAllDecisions(noPolicies, [], orgSubject(null), { publicGrants: grants }).can.read).toBe(false);
+
+    const noRow: SubjectForPermission = { entityType: 'organization', id: 'org1', contextIds: {} };
+    expect(getAllDecisions(noPolicies, [], noRow, { publicGrants: grants }).can.read).toBe(false);
+  });
+
+  it('publicParent grants read from the resolved parent row only', () => {
+    expect(getAllDecisions(noPolicies, [], attachmentSubject(NOW), { publicGrants: grants }).can.read).toBe(true);
+    expect(getAllDecisions(noPolicies, [], attachmentSubject(null), { publicGrants: grants }).can.read).toBe(false);
+
+    // Own row publicAt must NOT satisfy publicParent
+    const ownPublicOnly: SubjectForPermission = {
+      entityType: 'attachment',
+      id: 'a1',
+      contextIds: { organization: 'org1' },
+      row: { publicAt: NOW },
+    };
+    expect(getAllDecisions(noPolicies, [], ownPublicOnly, { publicGrants: grants }).can.read).toBe(false);
+  });
+
+  it('publicParentOrSelf grants from either row', () => {
+    const orSelfGrants: PublicReadGrants = { organization: 'publicSelf', attachment: 'publicParentOrSelf' };
+    const self: SubjectForPermission = {
+      entityType: 'attachment',
+      id: 'a1',
+      contextIds: { organization: 'org1' },
+      row: { publicAt: NOW },
+    };
+    const parent: SubjectForPermission = { ...self, row: {}, parentRow: { publicAt: NOW } };
+    const neither: SubjectForPermission = { ...self, row: {}, parentRow: {} };
+
+    expect(getAllDecisions(noPolicies, [], self, { publicGrants: orSelfGrants }).can.read).toBe(true);
+    expect(getAllDecisions(noPolicies, [], parent, { publicGrants: orSelfGrants }).can.read).toBe(true);
+    expect(getAllDecisions(noPolicies, [], neither, { publicGrants: orSelfGrants }).can.read).toBe(false);
+  });
+
+  it('grants read only — other actions stay denied', () => {
+    const { can } = getAllDecisions(noPolicies, [], orgSubject(NOW), { publicGrants: grants });
+    expect(can.read).toBe(true);
+    expect(can.create).toBe(false);
+    expect(can.update).toBe(false);
+    expect(can.delete).toBe(false);
+  });
+
+  it('no grant declared for the entity type → no public read', () => {
+    const noGrantForOrg: PublicReadGrants = { attachment: 'publicSelf' };
+    expect(getAllDecisions(noPolicies, [], orgSubject(NOW), { publicGrants: noGrantForOrg }).can.read).toBe(false);
+  });
+
+  it('no publicGrants passed → engine behaves exactly as before', () => {
+    expect(getAllDecisions(noPolicies, [], orgSubject(NOW)).can.read).toBe(false);
+  });
+});
+
+describe('configurePermissions — publicRead declaration', () => {
+  it('collects grants per subject and returns them alongside policies', () => {
+    const { publicReadGrants } = configurePermissions(appConfig.entityTypes, ({ subject, publicRead }) => {
+      if (subject.name === 'organization') publicRead('publicSelf');
+      if (subject.name === 'attachment') publicRead('publicParent');
+    });
+    expect(publicReadGrants).toEqual({ organization: 'publicSelf', attachment: 'publicParent' });
+  });
+
+  it('throws when publicRead is declared twice for a subject', () => {
+    expect(() =>
+      configurePermissions(appConfig.entityTypes, ({ subject, publicRead }) => {
+        if (subject.name === 'organization') {
+          publicRead('publicSelf');
+          publicRead('publicSelf');
+        }
+      }),
+    ).toThrow('publicRead() called twice');
+  });
+
+  it("throws when a parent-dependent grant's parent has no self-publication grant", () => {
+    expect(() =>
+      configurePermissions(appConfig.entityTypes, ({ subject, publicRead }) => {
+        if (subject.name === 'attachment') publicRead('publicParent');
+      }),
+    ).toThrow('no self-publication grant');
+
+    expect(() =>
+      configurePermissions(appConfig.entityTypes, ({ subject, publicRead }) => {
+        if (subject.name === 'attachment') publicRead('publicParentOrSelf');
+      }),
+    ).toThrow('no self-publication grant');
+  });
+});

--- a/shared/src/permissions/public-read.ts
+++ b/shared/src/permissions/public-read.ts
@@ -1,0 +1,41 @@
+import type { ContextEntityType, ProductEntityType } from '../../types';
+import type { SubjectForPermission } from './permission-manager/types';
+
+/**
+ * Public read: subject-level grants that make rows readable by ANY actor — anonymous
+ * included — based on row data, independent of memberships.
+ *
+ * - `publicSelf`: readable when the row's own `publicAt` timestamp is set.
+ * - `publicParent`: readable when the parent context row's `publicAt` is set.
+ * - `publicParentOrSelf`: either of the above.
+ *
+ * Declared per subject in the permissions config (`configurePermissions` →
+ * `publicRead(mode)`), evaluated by the permission engine for the `read` action, and
+ * attributed as `grantedBy: { type: 'public', mode }`. This replaces the former
+ * `publicRead` key on the entity hierarchy and the hand-rolled `if (!row.publicAt)`
+ * checks in public route handlers — one declaration, every path.
+ *
+ * `publicParent` reads *another row's* field. Per the cross-row design decision
+ * (load-at-check, resolved once per request/event), the caller resolves the parent row
+ * and passes it as `subject.parentRow`; the engine never loads rows itself. A subject
+ * without `row`/`parentRow` simply never matches — paths that don't resolve row data
+ * (e.g. stream dispatch today) are unaffected.
+ */
+export type PublicReadMode = 'publicSelf' | 'publicParent' | 'publicParentOrSelf';
+
+/** Per-subject public read grants, keyed by entity type. */
+export type PublicReadGrants = Partial<Record<ContextEntityType | ProductEntityType, PublicReadMode>>;
+
+const publicAtSet = (row: Record<string, unknown> | undefined): boolean => !!row?.publicAt;
+
+/** Check-form: does the subject's row data satisfy the public read grant? */
+export const publicReadMatches = (mode: PublicReadMode, subject: SubjectForPermission): boolean => {
+  switch (mode) {
+    case 'publicSelf':
+      return publicAtSet(subject.row);
+    case 'publicParent':
+      return publicAtSet(subject.parentRow);
+    case 'publicParentOrSelf':
+      return publicAtSet(subject.row) || publicAtSet(subject.parentRow);
+  }
+};

--- a/shared/src/permissions/row-conditions.ts
+++ b/shared/src/permissions/row-conditions.ts
@@ -1,0 +1,71 @@
+/**
+ * Row conditions: per-row qualifications on access-policy grants.
+ *
+ * A policy cell value of `1` grants an action on every row the context scope reaches.
+ * A `RowCondition` cell value grants the action only on rows that satisfy the condition
+ * (e.g. "rows the actor created"). Conditions are declared once and consumed by every
+ * enforcement path:
+ *
+ * - **check-form** (`matches`): evaluated by the permission engine per subject, and by
+ *   the frontend to resolve conditional `can` states per row.
+ * - **SQL-form** (`sqlForm`): a declarative descriptor — this package is ORM-free — that
+ *   the backend compiles into a row predicate for collection reads and any other
+ *   set-based path. Keeping it declarative (instead of a SQL-building function) is what
+ *   makes the check-form/SQL-form parity property testable and the descriptor safe to
+ *   evaluate in shared code.
+ *
+ * The legacy `'own'` policy literal is sugar for the built-in {@link own} condition and
+ * is normalized away when policies are configured; engine and consumers only ever see
+ * `0 | 1 | RowCondition`.
+ */
+
+/**
+ * Declarative SQL form of a row condition. Compiled by the backend
+ * (`backend/src/permissions/row-predicates.ts`) into an ORM predicate.
+ *
+ * - `columnEqualsActor`: `row[column] = <acting user id>`. Never matches without an
+ *   acting user (anonymous), mirroring the check-form.
+ */
+export type RowConditionSqlForm = { kind: 'columnEqualsActor'; column: string };
+
+/** The acting user for condition evaluation. `userId` is absent for anonymous actors. */
+export type ConditionActor = { userId?: string };
+
+/**
+ * Row fields available to a condition's check-form. `createdBy` is first-class (carried
+ * by `SubjectForPermission`); additional fields come from `SubjectForPermission.row`.
+ */
+export type RowForCondition = { createdBy?: string | null } & Record<string, unknown>;
+
+export interface RowCondition {
+  /**
+   * Stable identifier. Surfaces as the conditional state in `can` maps
+   * (`ActionPermissionState`) and as `grantedBy: { type: 'relation', relation: name }`
+   * in decision attribution — treat it as part of the public contract.
+   */
+  name: string;
+  /**
+   * Check-form: does this row satisfy the condition for this actor?
+   * Must be pure and must agree with `sqlForm` — the parity property test asserts this.
+   */
+  matches: (row: RowForCondition, actor: ConditionActor) => boolean;
+  /** SQL-form descriptor, compiled by the backend for set-based reads. */
+  sqlForm: RowConditionSqlForm;
+}
+
+/** Type guard: distinguishes a RowCondition cell value from `0 | 1`. */
+export const isRowCondition = (value: unknown): value is RowCondition => {
+  return typeof value === 'object' && value !== null && 'matches' in value && 'sqlForm' in value;
+};
+
+/**
+ * Built-in "owner" condition: the actor created the row.
+ *
+ * In Zanzibar terms this is an implicit `owner` relation derived from `createdBy`.
+ * The `'own'` policy literal normalizes to this condition.
+ */
+export const own: RowCondition = {
+  name: 'own',
+  matches: (row, actor) => !!actor.userId && !!row.createdBy && row.createdBy === actor.userId,
+  sqlForm: { kind: 'columnEqualsActor', column: 'createdBy' },
+};

--- a/shared/src/permissions/row-restrictions.test.ts
+++ b/shared/src/permissions/row-restrictions.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { appConfig } from '../config-builder/app-config';
+import { configurePermissions } from './access-policies';
+import { getAllDecisions } from './permission-manager/check';
+import type { PermissionMembership, SubjectForPermission } from './permission-manager/types';
+import type { RowRestrictions } from './row-restrictions';
+
+/**
+ * Row restriction semantics at the engine level (cella's chain: attachment →
+ * organization, roles admin/member). Restrictions narrow membership grants per row;
+ * row-condition grants ('own'), public grants and `create` are never narrowed;
+ * fail-closed without row data; admin exemption is explicit.
+ *
+ * Multi-level depth qualification ("grant must be at least as specific as the row's
+ * depth" across context levels) needs a deeper hierarchy than cella's — covered by the
+ * raak fork's suites and, ahead, projectcampus's 4-level chain.
+ */
+
+const { accessPolicies: policies } = configurePermissions(appConfig.entityTypes, ({ subject, contexts }) => {
+  if (subject.name !== 'attachment') return;
+  contexts.organization.admin({ create: 1, read: 1, update: 1, delete: 1 });
+  contexts.organization.member({ create: 1, read: 1, update: 1 });
+});
+
+const restrictions: RowRestrictions = {
+  attachment: { depthColumn: 'visibilityDepth', rolesColumn: 'audienceRoles', exemptRoles: ['admin'] },
+};
+
+const membership = (role: string): PermissionMembership =>
+  ({ contextType: 'organization', contextId: 'org1', role }) as PermissionMembership;
+
+const orgMember = membership('member');
+const orgAdmin = membership('admin');
+
+const attachment = (row: Record<string, unknown> | undefined): SubjectForPermission => ({
+  entityType: 'attachment',
+  id: 'a1',
+  contextIds: { organization: 'org1' },
+  ...(row !== undefined && { row }),
+});
+
+const readableBy = (m: PermissionMembership, row: Record<string, unknown> | undefined, userId = 'u1') =>
+  getAllDecisions(policies, [m], attachment(row), { userId, restrictions }).can.read;
+
+describe('visibilityDepth (single-level chain)', () => {
+  it('null depth: unrestricted — every read grant qualifies', () => {
+    expect(readableBy(orgMember, { visibilityDepth: null })).toBe(true);
+  });
+
+  it("depth 'organization': org grants qualify", () => {
+    expect(readableBy(orgMember, { visibilityDepth: 'organization' })).toBe(true);
+  });
+
+  it('unknown depth value never qualifies (fail closed)', () => {
+    expect(readableBy(orgMember, { visibilityDepth: 'project' })).toBe(false);
+    expect(readableBy(orgMember, { visibilityDepth: 'nonsense' })).toBe(false);
+  });
+});
+
+describe('audienceRoles', () => {
+  it('null or empty audience: unrestricted', () => {
+    expect(readableBy(orgMember, { audienceRoles: null })).toBe(true);
+    expect(readableBy(orgMember, { audienceRoles: [] })).toBe(true);
+  });
+
+  it('grant role must be in the audience set', () => {
+    expect(readableBy(orgMember, { audienceRoles: ['member'] })).toBe(true);
+    expect(readableBy(orgMember, { audienceRoles: ['nobody'] })).toBe(false);
+  });
+
+  it('combines with depth: both must qualify', () => {
+    expect(readableBy(orgMember, { visibilityDepth: 'organization', audienceRoles: ['member'] })).toBe(true);
+    expect(readableBy(orgMember, { visibilityDepth: 'organization', audienceRoles: ['nobody'] })).toBe(false);
+    expect(readableBy(orgMember, { visibilityDepth: 'project', audienceRoles: ['member'] })).toBe(false);
+  });
+});
+
+describe('exemption and bypass rules', () => {
+  it('exempt roles bypass the restriction entirely', () => {
+    const row = { visibilityDepth: 'project', audienceRoles: ['nobody'] };
+    expect(readableBy(orgAdmin, row)).toBe(true);
+  });
+
+  it("row-condition grants ('own') are never narrowed — creator sees own restricted row", () => {
+    const { accessPolicies: ownPolicies } = configurePermissions(appConfig.entityTypes, ({ subject, contexts }) => {
+      if (subject.name !== 'attachment') return;
+      contexts.organization.member({ read: 'own' });
+    });
+    const row = { visibilityDepth: 'project', audienceRoles: ['nobody'] };
+    const subject: SubjectForPermission = { ...attachment(row), createdBy: 'u1' };
+    const { can } = getAllDecisions(ownPolicies, [orgMember], subject, { userId: 'u1', restrictions });
+    expect(can.read).toBe(true);
+  });
+
+  it('public read grants are never narrowed', () => {
+    const row = { visibilityDepth: 'project', audienceRoles: ['nobody'], publicAt: '2026-01-01' };
+    const { can } = getAllDecisions({}, [], attachment(row), {
+      restrictions,
+      publicGrants: { attachment: 'publicSelf' },
+    });
+    expect(can.read).toBe(true);
+  });
+
+  it('create is never restricted; other actions are', () => {
+    const row = { visibilityDepth: 'organization', audienceRoles: ['nobody'] };
+    const { can } = getAllDecisions(policies, [orgMember], attachment(row), { userId: 'u1', restrictions });
+    expect(can.create).toBe(true);
+    expect(can.read).toBe(false);
+    expect(can.update).toBe(false);
+  });
+
+  it('system admin bypasses restrictions like everything else', () => {
+    const row = { visibilityDepth: 'project', audienceRoles: ['nobody'] };
+    const { can } = getAllDecisions(policies, [], attachment(row), { isSystemAdmin: true, restrictions });
+    expect(can.read).toBe(true);
+  });
+});
+
+describe('fail-closed without row data', () => {
+  it('restriction declared + no subject row → non-exempt membership grants do not qualify', () => {
+    expect(readableBy(orgMember, undefined)).toBe(false);
+    expect(readableBy(orgAdmin, undefined)).toBe(true); // exempt role still qualifies
+  });
+
+  it('no restriction declared for the entity type → unchanged behavior', () => {
+    const { can } = getAllDecisions(policies, [orgMember], attachment(undefined), {
+      userId: 'u1',
+      restrictions: {},
+    });
+    expect(can.read).toBe(true);
+  });
+});

--- a/shared/src/permissions/row-restrictions.ts
+++ b/shared/src/permissions/row-restrictions.ts
@@ -1,0 +1,117 @@
+import type { ContextEntityType, ProductEntityType } from '../../types';
+import type { SubjectForPermission } from './permission-manager/types';
+
+/**
+ * Row restrictions: subject-level rules that NARROW membership grants per row.
+ *
+ * Where grants (policy cells, row conditions, public read) only ever widen access,
+ * a restriction shrinks a row's audience within the members who would otherwise see it:
+ *
+ * - `visibilityDepth`: the row column names the least specific context level whose
+ *   members may act on the row. A membership grant qualifies only if it was granted by
+ *   a context AT LEAST AS SPECIFIC as the row's depth. Example (chain
+ *   `project > organization`): a row with depth `'project'` is invisible to grants from
+ *   the organization level; a row with depth `'organization'` is visible to grants from
+ *   both levels. `null` = no depth restriction.
+ * - `audienceRoles`: the row column holds the roles allowed to act on the row; a grant
+ *   qualifies only if its role is in the set. Roles qualify per grant at the grant's own
+ *   level, so one set can span levels (e.g. course `staff` ∪ project `owner`).
+ *   `null` or `[]` = no role restriction.
+ * - `exemptRoles`: grants with these roles bypass the restriction entirely. Without an
+ *   exemption a depth restriction would lock org admins out of restricted rows — the
+ *   exemption must be explicit and declared.
+ *
+ * Semantics, deliberately:
+ * - Restrictions narrow MEMBERSHIP grants only. Row-condition grants (e.g. `'own'` — a
+ *   creator always sees their own row) and public read grants are not narrowed.
+ * - `create` is never restricted — there is no row yet to restrict on.
+ * - **Fail closed**: if a restriction is declared for an entity type but the subject
+ *   carries no `row` data, non-exempt membership grants do NOT qualify. Every enforcement
+ *   path for a restricted entity must resolve row data (or rely on exempt roles).
+ * - No time-based rules: lifecycle changes (e.g. widening a submission after a deadline)
+ *   are API-level column rewrites, not engine concepts.
+ */
+
+/** Restriction declaration as written in the permissions config. */
+export interface RowRestrictionInput {
+  /** Enable depth restriction; `true` uses the `visibilityDepth` column. */
+  visibilityDepth?: true | { column: string };
+  /** Enable audience-role restriction; `true` uses the `audienceRoles` column. */
+  audienceRoles?: true | { column: string };
+  /** Role names whose grants bypass this restriction (e.g. `['admin']`). */
+  exemptRoles?: readonly string[];
+}
+
+/** Normalized restriction (column names resolved). */
+export interface RowRestriction {
+  depthColumn?: string;
+  rolesColumn?: string;
+  exemptRoles: readonly string[];
+}
+
+/** Per-subject row restrictions, keyed by entity type. */
+export type RowRestrictions = Partial<Record<ContextEntityType | ProductEntityType, RowRestriction>>;
+
+/** Normalize a restriction declaration: resolve default column names. */
+export const normalizeRestriction = (input: RowRestrictionInput): RowRestriction => {
+  if (!input.visibilityDepth && !input.audienceRoles) {
+    throw new Error('[Permission] restrict() needs at least one of visibilityDepth / audienceRoles');
+  }
+  return {
+    ...(input.visibilityDepth && {
+      depthColumn: input.visibilityDepth === true ? 'visibilityDepth' : input.visibilityDepth.column,
+    }),
+    ...(input.audienceRoles && {
+      rolesColumn: input.audienceRoles === true ? 'audienceRoles' : input.audienceRoles.column,
+    }),
+    exemptRoles: input.exemptRoles ?? [],
+  };
+};
+
+/**
+ * The depth values a grant at `grantContextType` qualifies for, given the subject's
+ * ordered context chain (most specific first): the grant's own level and every LESS
+ * specific level. Shared by the check-form below and the backend SQL compiler so both
+ * forms derive qualification from the same list.
+ */
+export const qualifyingDepths = (
+  orderedContexts: readonly ContextEntityType[],
+  grantContextType: ContextEntityType,
+): ContextEntityType[] => {
+  const grantIndex = orderedContexts.indexOf(grantContextType);
+  if (grantIndex === -1) return [];
+  return orderedContexts.slice(grantIndex);
+};
+
+/**
+ * Check-form: does a membership grant (context type + role) qualify for this row under
+ * the restriction? Fail-closed on missing row data; unknown depth values never qualify.
+ */
+export const membershipGrantQualifies = (
+  restriction: RowRestriction,
+  subject: SubjectForPermission,
+  orderedContexts: readonly ContextEntityType[],
+  grantContextType: ContextEntityType,
+  grantRole: string,
+): boolean => {
+  if (restriction.exemptRoles.includes(grantRole)) return true;
+
+  const row = subject.row;
+
+  if (restriction.depthColumn) {
+    if (!row) return false;
+    const depth = row[restriction.depthColumn];
+    if (depth != null) {
+      if (typeof depth !== 'string') return false;
+      if (!qualifyingDepths(orderedContexts, grantContextType).includes(depth as ContextEntityType)) return false;
+    }
+  }
+
+  if (restriction.rolesColumn) {
+    if (!row) return false;
+    const roles = row[restriction.rolesColumn];
+    if (roles != null && (!Array.isArray(roles) || (roles.length > 0 && !roles.includes(grantRole)))) return false;
+  }
+
+  return true;
+};

--- a/shared/src/permissions/types.ts
+++ b/shared/src/permissions/types.ts
@@ -1,21 +1,29 @@
 import type { ContextEntityType, EntityActionType, EntityRole, EntityType, ProductEntityType } from '../../types';
+import type { PublicReadMode } from './public-read';
+import type { RowCondition } from './row-conditions';
+import type { RowRestrictionInput } from './row-restrictions';
 
 /**
- * Permission value for access policy entries.
+ * Permission value accepted in access policy configuration.
  *
  * - `1` = allowed for all entities of this type (unconditional)
  * - `0` = denied
- * - `'own'` = allowed only when the actor is the entity's creator (implicit "owner" relation).
- *   This is equivalent to a Zanzibar-style `owner` relation check on the entity,
- *   derived from the `createdBy` field rather than an explicit relation tuple.
- *   Evaluates to `true` when `entity.createdBy === userId`, `false` otherwise.
+ * - `RowCondition` = allowed only for rows satisfying the condition (see `row-conditions.ts`)
+ * - `'own'` = sugar for the built-in `own` condition (actor is the entity's creator);
+ *   normalized to the condition object when policies are configured.
  */
-export type PermissionValue = 0 | 1 | 'own';
+export type PermissionValue = 0 | 1 | 'own' | RowCondition;
 
 /**
- * Entity action permission set mapping each action to a permission value.
+ * Permission value after configuration-time normalization (`'own'` sugar resolved).
+ * This is the only vocabulary the engine and downstream consumers see.
  */
-export type EntityActionPermissions = Record<EntityActionType, PermissionValue>;
+export type NormalizedPermissionValue = 0 | 1 | RowCondition;
+
+/**
+ * Entity action permission set mapping each action to a normalized permission value.
+ */
+export type EntityActionPermissions = Record<EntityActionType, NormalizedPermissionValue>;
 
 /**
  * Access policy entry for a specific context and role combination.
@@ -46,7 +54,7 @@ export type AccessPolicies = Partial<Record<ContextEntityType | ProductEntityTyp
  * an entity can never be created from inside itself (creation is granted on ancestor rows).
  */
 export type ContextPolicyBuilder = {
-  [R in EntityRole]: (permissions: Partial<EntityActionPermissions>) => void;
+  [R in EntityRole]: (permissions: Partial<Record<EntityActionType, PermissionValue>>) => void;
 };
 
 /**
@@ -55,7 +63,23 @@ export type ContextPolicyBuilder = {
 export interface AccessPolicyConfiguration {
   subject: { name: EntityType };
   contexts: Record<ContextEntityType, ContextPolicyBuilder>;
+  /** Declare the subject-level public read grant for this subject (see `public-read.ts`). */
+  publicRead: (mode: PublicReadMode) => void;
+  /** Declare the subject-level row restriction for this subject (see `row-restrictions.ts`). */
+  restrict: (restriction: RowRestrictionInput) => void;
+  /**
+   * Delegate the listed actions to the host row's decision (hierarchy `host:`): a hosted
+   * row allows an action if the HOST row allows it — including the host's row conditions,
+   * public grants and restrictions. Additive (unions with the subject's own grants);
+   * strictly-inherited subjects (e.g. comments) simply declare no own grants for the
+   * delegated actions. Requires the caller to resolve `subject.hostRow` (load-at-check);
+   * without it, delegation contributes nothing.
+   */
+  delegateToHost: (actions: readonly EntityActionType[]) => void;
 }
+
+/** Per-subject host-delegated actions, keyed by hosted entity type. */
+export type HostDelegation = Partial<Record<ContextEntityType | ProductEntityType, readonly EntityActionType[]>>;
 
 /**
  * Callback function for configuring access policies.
@@ -67,6 +91,7 @@ export type AccessPolicyCallback = (config: AccessPolicyConfiguration) => void;
  *
  * - `true` = unconditionally allowed
  * - `false` = denied
- * - `'own'` = allowed only when the actor owns the entity
+ * - condition name (e.g. `'own'`) = allowed only for rows satisfying that row condition;
+ *   resolve per row via `resolvePermission` (built-in `'own'`) or the condition's `matches`.
  */
-export type ActionPermissionState = boolean | 'own';
+export type ActionPermissionState = boolean | string;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -145,6 +145,15 @@ export type RelatedContextType<E extends string> = E extends keyof HierarchyRela
   ? HierarchyRelatedMap[E]
   : never;
 
+/** Type-level map of each hosted product to its host product. */
+type HierarchyHostMap = typeof hierarchy._hostMap;
+
+/**
+ * Host product type declared for a hosted product via `host:`.
+ * Example (Raak): `HostEntityType<'attachment'>` → `'task'`.
+ */
+export type HostEntityType<E extends string> = E extends keyof HierarchyHostMap ? HierarchyHostMap[E] : never;
+
 /** Entity actions that can be performed (CRUD + search) */
 export type EntityActionType = (typeof appConfig.entityActions)[number];
 


### PR DESCRIPTION
## What

One permission definition now drives every enforcement path — the engine check, the collection-read SQL, and the client can-flags — and products can declare a **host product** (product-to-product ownership). Developed and proven live in the raak fork (**cellajs/raak#26**), extracted here as one squashed commit and adapted to cella's entity set, per the mechanisms-upstream / declarations-in-forks principle.

## Row policies — `configurePermissions`

The access-policy builder becomes the single home for who-can-do-what, returning `{ accessPolicies, publicReadGrants, rowRestrictions, hostDelegation }` (`configureAccessPolicies` remains for synthetic-policy callers):

- **Row conditions** — `'own'` generalized into a `RowCondition` vocabulary (`PermissionValue: 0 | 1 | RowCondition`, normalized at config time). Conditional read grants become **listable**: `collection-scope` resolves them into conditional scopes and `row-predicates` compiles a *discriminated* WHERE (`all`/`none`/`where` — an empty scope can never leak an unfiltered query). Closes the live gap where a role with only `read: 'own'` listed nothing.
- **Public read grants + anonymous actor** — `publicRead(mode)` moves from the entity hierarchy into the permissions config, evaluated by the engine for *any* actor (empty memberships, no userId). `publicRead` is fully removed from the hierarchy builder: hierarchy is structure-only again. Parent-dependent grants validate against the parent's self-publication grant.
- **Row restrictions** — `restrict({visibilityDepth, audienceRoles, exemptRoles})` narrows membership grants per row. Deliberate semantics: admin exemption is explicit (a naive depth rule locks org admins out); `'own'` and public grants are never narrowed (a creator always sees their own row); `create` is never restricted; **fail-closed** without row data.
- **Cross-row data is caller-resolved** (`subject.parentRow` / `subject.hostRow`, once per request/event) — the engine never loads rows; subjects without row data simply never match.

## hostEntity — hierarchy `host:`

- `.product('comment', { parent, host: 'item' })` — validated (host must be a previously declared product sharing the same home context; no chains), typed phantom host map (`HostEntityType<E>`), `hostRelationColumns()` generating a nullable `<host>Id` column.
- **Lifecycle cascade**: `cascadeSoftDeleteHosted` (API layer; tombstones flow per row for delta sync) + CDC hard-delete streaming suppression extended from context ids to host ids.
- **Host counters**: CDC maintains `e:<hostedType>` per host row (create / soft-delete / re-host), mirroring embedding counters; `recalculate-counters` gains a hosted-rows phase (live rows only).
- **Permission delegation**: `delegateToHost(actions)` — a hosted row allows a delegated action if the HOST row allows it, evaluated through the full engine (the host's own/public/restriction verdicts carry over). Additive with own grants, load-at-check, fail-closed, per-action.

## Testing

- **Parity property test (merge blocker)**: engine check ⊆⊇ compiled SQL executed against real Postgres ⊆⊇ compute-can, seeded scenarios over grants, `'own'` conditions, restrictions and anonymous actors.
- Engine suites for public grants, restrictions, host declaration validation; hierarchy builder host tests.
- Cella's minimal chain (attachment → organization) can't exercise multi-level depth qualification, sub-context scoping, or live host pairs — those are covered end-to-end in raak (task/project hierarchy, `host: 'task'` port incl. cascade e2e and CDC host tests): see cellajs/raak#26. First consumers of the full surface: the projectcampus fork (items/comments privacy, comment → item hosting).

## Behavior

**No behavior change for cella's current config**: no conditional grants, no public grants, no restrictions, no hosts are declared — all registries are empty and every code path degrades to today's semantics. All suites green (shared 205, cdc 121, backend 366). `get-attachments` now resolves its scope through the engine (compiles to org-wide for the current `read: 1` policy). The test env gains `DATABASE_ADMIN_URL` pointing at the test DB (tenant-less admin-connection reads were untestable before).

## Known follow-ups

- `compute-can` is restriction-blind by design (no row data at context level) — restricted entities resolve `can` per row via the decision API; documented at the parity test.
- SQL-form for public grants in aggregate anonymous lists: no consumer yet (public routes check the parent grant once); first consumer decides the shape.
- Engine/scope read the global hierarchy — a future injectable-hierarchy refactor would allow synthetic deep-hierarchy tests upstream (relevant for the planned CDC deepest-non-null-ancestor work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
