### PR TITLE
feat: autolink repo file paths in docs inline code to GitHub

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,6 +23,7 @@ import { execSync } from 'node:child_process';
 import { sdkWatch } from './vite/sdk-watch';
 import { localesHMR } from './vite/locales-hmr';
 import { docsFrontmatter } from './vite/docs-frontmatter';
+import { remarkLinkRepoPaths } from './vite/remark-link-repo-paths';
 
 // Repo docs (cella/*.md) start with an h1 for GitHub readers, but the docs page view
 // already renders the frontmatter title as h1 — drop the leading h1 when such a file
@@ -110,7 +111,17 @@ const viteConfig = {
         // `components` prop does not cross into imported modules, and wrapper pages
         // render imported repo docs (cella/*.md) as their body.
         providerImportSource: '@mdx-js/react',
-        remarkPlugins: [remarkFrontmatter, remarkMdxFrontmatter, remarkGfm, remarkStripRepoDocH1],
+        remarkPlugins: [
+          remarkFrontmatter,
+          remarkMdxFrontmatter,
+          remarkGfm,
+          remarkStripRepoDocH1,
+          // Autolink inline code that names a real repo file to its GitHub blob URL.
+          [
+            remarkLinkRepoPaths,
+            { repoRoot: path.resolve(__dirname, '..'), repoUrl: appConfig.company.githubUrl },
+          ],
+        ],
         // Heading ids for anchor links + scroll spy. The `spy-` DOM id prefix follows the
         // spy store convention (hooks/use-scroll-spy-store.ts); the slug part is
         // github-slugger, so URL hashes match GitHub's anchors for the same markdown.

--- a/frontend/vite/remark-link-repo-paths.test.ts
+++ b/frontend/vite/remark-link-repo-paths.test.ts
@@ -1,0 +1,59 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { remarkLinkRepoPaths } from './remark-link-repo-paths';
+
+const repoRoot = path.resolve(__dirname, '../..');
+const repoUrl = 'https://github.com/cellajs/cella';
+const transform = remarkLinkRepoPaths({ repoRoot, repoUrl });
+
+type Node = { type: string; value?: string; url?: string; children?: Node[] };
+
+/** Minimal mdast: a paragraph wrapping the given inline children. */
+const para = (...children: Node[]): Node => ({ type: 'root', children: [{ type: 'paragraph', children }] });
+const code = (value: string): Node => ({ type: 'inlineCode', value });
+const firstInline = (tree: Node): Node => tree.children?.[0].children?.[0] as Node;
+
+/** The (possibly rewritten) first inline node after running the plugin. */
+function runOn(value: string): Node {
+  const tree = para(code(value));
+  transform(tree as never);
+  return firstInline(tree);
+}
+
+describe('remarkLinkRepoPaths', () => {
+  it('links inline code that resolves to a real repo file', () => {
+    const node = runOn('frontend/vite.config.ts');
+    expect(node.type).toBe('link');
+    expect(node.url).toBe(`${repoUrl}/blob/main/frontend/vite.config.ts`);
+    expect(node.children?.[0]).toEqual(code('frontend/vite.config.ts'));
+  });
+
+  it('maps a :line suffix to #L and a range to #L-L', () => {
+    expect(runOn('frontend/vite.config.ts:12').url).toBe(`${repoUrl}/blob/main/frontend/vite.config.ts#L12`);
+    expect(runOn('frontend/vite.config.ts:12-20').url).toBe(`${repoUrl}/blob/main/frontend/vite.config.ts#L12-L20`);
+  });
+
+  it('leaves paths that do not resolve to a file as plain code', () => {
+    expect(runOn('backend/src/does-not-exist.ts').type).toBe('inlineCode');
+    expect(runOn('index.ts').type).toBe('inlineCode'); // ambiguous bare name, no root file
+  });
+
+  it('ignores inline code that is not a file path', () => {
+    expect(runOn('pnpm test').type).toBe('inlineCode');
+    expect(runOn('TEST_MODE').type).toBe('inlineCode');
+    expect(runOn('--project=backend').type).toBe('inlineCode');
+  });
+
+  it('rejects traversal and absolute paths without touching the fs', () => {
+    expect(runOn('../package.json').type).toBe('inlineCode');
+    expect(runOn('/etc/passwd').type).toBe('inlineCode');
+  });
+
+  it('does not re-link code already inside a link', () => {
+    const tree = para({ type: 'link', url: 'https://example.com', children: [code('frontend/vite.config.ts')] });
+    transform(tree as never);
+    const link = firstInline(tree);
+    expect(link.url).toBe('https://example.com');
+    expect(link.children?.[0].type).toBe('inlineCode');
+  });
+});

--- a/frontend/vite/remark-link-repo-paths.ts
+++ b/frontend/vite/remark-link-repo-paths.ts
@@ -1,0 +1,63 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Remark plugin: turn inline code that names a repo file into a link to that file on
+ * GitHub. `` `backend/src/server.ts` `` → a link to the blob URL, with an optional
+ * `:line` / `:line-line` suffix mapped to `#L..`. Only paths that resolve to a real
+ * file (checked against the repo root at build time) are linked, so dead links can't
+ * be introduced and ambiguous bare names (e.g. `index.ts`) stay plain code.
+ *
+ * Runs at the mdast stage (before rehype), so it applies to content/docs pages and the
+ * repo docs they import alike. Dependency-free: a manual walk avoids pulling in
+ * unist-util-visit for one visitor.
+ */
+
+interface Options {
+  /** Absolute path to the repo root; candidate paths are resolved against it. */
+  repoRoot: string;
+  /** Repo URL without trailing slash, e.g. https://github.com/cellajs/cella. */
+  repoUrl: string;
+  /** Branch the blob URLs point at. */
+  branch?: string;
+}
+
+type MdNode = { type: string; value?: string; url?: string; children?: MdNode[] };
+
+// `dir/file.ext` with a known source extension, optionally `:12` or `:12-20`.
+const PATH_RE = /^([\w.][\w./-]*\.(?:tsx?|jsx?|mjs|cjs|json|ya?ml|css|md|sh|toml))(?::(\d+)(?:-(\d+))?)?$/;
+
+export function remarkLinkRepoPaths({ repoRoot, repoUrl, branch = 'main' }: Options) {
+  const base = `${repoUrl.replace(/\/+$/, '')}/blob/${branch}/`;
+
+  const linkFor = (value: string): string | null => {
+    const match = PATH_RE.exec(value);
+    if (!match) return null;
+    const [, filePath, startLine, endLine] = match;
+    // Stay inside the repo — reject traversal/absolute paths before touching the fs.
+    if (filePath.startsWith('/') || filePath.split('/').includes('..')) return null;
+    if (!existsSync(path.join(repoRoot, filePath))) return null;
+    const hash = startLine ? `#L${startLine}${endLine ? `-L${endLine}` : ''}` : '';
+    return `${base}${filePath}${hash}`;
+  };
+
+  return (tree: MdNode) => {
+    const walk = (node: MdNode, insideLink: boolean) => {
+      const children = node.children;
+      if (!children) return;
+      for (let i = 0; i < children.length; i++) {
+        const child = children[i];
+        // Don't re-link code that already sits inside a link.
+        if (!insideLink && child.type === 'inlineCode' && typeof child.value === 'string') {
+          const url = linkFor(child.value);
+          if (url) {
+            children[i] = { type: 'link', url, children: [child] };
+            continue;
+          }
+        }
+        walk(child, insideLink || child.type === 'link');
+      }
+    };
+    walk(tree, false);
+  };
+}


### PR DESCRIPTION
## What

A small remark plugin ([frontend/vite/remark-link-repo-paths.ts](frontend/vite/remark-link-repo-paths.ts)) that turns inline code naming a real repo file into a link to that file on GitHub. Authors write `` `backend/src/server.ts` `` in any doc and get a clickable link — no manual `[text](https://github.com/.../blob/main/...)` boilerplate.

There is no maintained off-the-shelf plugin for this (the unified ecosystem only autolinks headings and bare URLs), so this is a ~40-line dependency-free plugin tailored to our conventions.

## How it works

- Runs at the mdast stage (before rehype), so it applies to `content/docs` pages **and** the repo docs they import (`cella/*.md`, package READMEs) alike.
- Matches inline code against a repo-root-relative path with a known source extension, optionally a `:12` / `:12-20` line suffix → `#L12` / `#L12-L20` (mirrors our `file_path:line` reference convention).
- **Only links paths that resolve to a real file** (`existsSync` against the repo root at build time). This means:
  - dead links can't be introduced;
  - ambiguous bare names (e.g. `` `index.ts` ``) stay plain code;
  - a stale doc reference simply stays unlinked (it surfaced one already: `shared/src/propagation-targets.ts` in the sync-engine doc no longer exists).
- Skips inline code already inside a link, and rejects `..`/absolute paths before touching the fs.
- The blob base is derived from `appConfig.company.githubUrl`, so it stays fork-agnostic; branch defaults to `main`.

Generated GitHub links flow through the existing `MdxLink` component, so they open in a new tab like other external doc links.

## Testing

- New unit test ([frontend/vite/remark-link-repo-paths.test.ts](frontend/vite/remark-link-repo-paths.test.ts)) covering: linking real files, `:line`/range suffixes, non-existent paths left plain, non-path inline code ignored, traversal/absolute rejected, and no double-linking inside existing links.
- Verified against a real build: `yjs/src/data/permissions.ts` (exists) is autolinked in the sync-engine page chunk; `shared/src/propagation-targets.ts` (doesn't exist is correctly left as plain code.
- Scope: 11 of 12 workspace projects
shared ts$ cd .. && tsgo -p shared/tsconfig.json --pretty
shared ts: Done
bench ts$ tsgo --pretty
infra ts$ cd .. && tsgo -p infra/tsconfig.json --pretty
mcp ts$ cd .. && tsgo -p mcp/tsconfig.json --pretty
sdk ts$ cd .. && tsgo -p sdk/tsconfig.json --pretty
sdk ts: Done
yjs ts$ tsgo --pretty
bench ts: Done
infra ts: Done
yjs ts: Done
mcp ts: Done
cdc ts$ tsgo --pretty
frontend ts$ cd .. && tsgo -p frontend/tsconfig.json --pretty
cdc ts: Done
frontend ts: Done
backend ts$ cd .. && tsgo -p backend/tsconfig.json --pretty
backend ts: Done, Checked 1483 files in 498ms. No fixes applied., full frontend unit+node suite (167 tests) and a dev build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)