### PR TITLE
refactor(cdc): cleanup + typed wire contract + app-stream kind discriminant

### DIFF
--- a/.info/cdc-assessment.md
+++ b/.info/cdc-assessment.md
@@ -1,0 +1,198 @@
+# CDC package assessment — type strictness, duplication, separation of concerns
+
+_Scope: `cdc/` (the PostgreSQL logical-replication worker) and its coupling to the backend "app stream". Written after the public stream was removed, leaving a single private/app stream that carries **both** product entities **and** memberships._
+
+The central question you raised — _"app stream isn't only doing project entities, but also memberships; can we split these?"_ — is answered in [§3](#3-the-membership-question). The short version: **yes, and the cleanest split is a discriminated notification type on the same stream, not a second physical stream.** But the CDC code has deeper structural issues that make the membership coupling _feel_ worse than it is, so the rest of the report catalogs those first.
+
+---
+
+## 1. Mental model — what actually flows through the pipeline
+
+The reason the code is hard to hold in your head is that **one linear pipeline serves three independent concerns**, and no file names or types make that separation explicit. Here is the real flow:
+
+```
+WAL change (pgoutput)
+  → parse-message        parse tag + look up table in tableRegistry
+  → handlers/*           snake→camel, compact, changed-field detection → ParseMessageResult
+  → transaction-buffer   cascade suppression within a tx
+  → flush-buffer         cross-tx micro-batching, group by (type, action)
+  → process-events       THE JUNCTION — does three unrelated things in sequence:
+        (A) persist an activities row          ← audit log
+        (B) compute + apply "unified deltas"   ← counters + seq stamping
+        (C) send WS payload to the backend     ← real-time sync fan-out
+```
+
+The three concerns riding this one pipe:
+
+| Concern | Applies to | Produced where | Consumed by |
+|---|---|---|---|
+| **A. Activity/audit log** | every tracked table | `process-events.persistActivities` | `activities` table (catchup screening, history) |
+| **B. Counters + seq** | entities + memberships (different sub-rules each) | `update-counts` + `compute/apply-unified-deltas` | `context_counters` table, entity `seq` column |
+| **C. Sync notification** | product entities + memberships | `activity-service.buildActivityPayload` → WS | backend app-stream → SSE → frontend |
+
+`ParseMessageResult` (`parse-message.ts:15`) is the single value that carries data for all three, which is why every downstream function takes the whole blob and reaches into whichever fields it cares about. That is the root cause of the "I can't form a mental model" feeling: **there is no type that says "this is a membership counter update" vs "this is a product-entity sync event."** Everything is a `ParseMessageResult` and the distinction is re-derived, ad hoc, at ~8 different branch points via `tableMeta.kind`, `tableMeta.type === 'membership'`, and `isProductEntity(...)`.
+
+---
+
+## 2. Separation of concerns
+
+### 2.1 The membership vs product-entity split is smeared across ~8 branch points
+
+Both in CDC and in the backend it feeds, the product-vs-membership distinction is a **runtime branch repeated everywhere** rather than a modeled type. Inventory:
+
+**In CDC:**
+- `update-counts.ts:46` — `tableMeta.kind === 'resource' && tableMeta.type === 'membership'`
+- `update-counts.ts:56` — `... === 'inactive_membership'`
+- `update-counts.ts:66` — `tableMeta.kind === 'entity'` (the entity branch)
+- `compute-unified-deltas.ts:82` — `isStampable` = product entity only (seq)
+- `activity-service.ts:49,115` — `isProductEntity(...)` gates cacheToken
+- `process-events.ts:186` — `isProductEntity(...)` gates embedding cleanup
+
+**In the backend it feeds** (from the stream-side audit):
+- `dispatch-to-stream.ts:34` — `if (event.resourceType === 'membership')` → different permission/targeting path
+- `build-message.ts:17,23,59` — nulls out `seq`/`stx`/`cacheToken` for memberships
+- `app-stream-handler.ts:50` (frontend) — `if (resourceType === 'membership') { … return; }` early-return to a completely separate code path (query invalidation vs seq-range fetch)
+
+**Membership is genuinely a different concern**, not a variant of the same one:
+- Product entity notification → `seq` + `cacheToken` + entity-cache reservation + seq-range fetch on the client.
+- Membership notification → no seq, no cacheToken; only counter deltas (`m:admin`, `m:total`, `m:pending`) + an org-level `s:membership` "something changed" signal; the client responds with **query invalidation**, an entirely different mechanism.
+
+They share the transport and the `activities` row shape, and nothing else. That is the definition of an accidental coupling.
+
+### 2.2 `process-events` is a god-function
+
+`processEvents` (`process-events.ts:115-200`) mixes: circuit-breaker gating, tracing spans, delta computation, activity persistence with fallback, delta application, seq re-stamping, per-event logging, WS single-vs-batch dispatch, **and** embedding cleanup. The three concerns from §1 are interleaved rather than sequenced behind named steps. Even extracting three private functions — `persistAuditLog(events)`, `applyCounters(events)`, `dispatchSync(events)` — would make the file readable and make it obvious that (A) is table-agnostic while (B)/(C) branch by kind.
+
+### 2.3 `create-activity.ts` is misfiled as a handler
+
+It builds the `InsertActivityModel` — it is the audit-log concern's constructor, shared by all three DML handlers. It belongs in `services/` (next to `activity-service.ts`), not `handlers/`. The README even documents it under handlers, reinforcing the wrong mental model.
+
+### 2.4 The CDC→backend wire contract is defined twice and shared nowhere
+
+CDC builds the payload as an **untyped object literal** (`activity-service.ts:42-65`, `buildActivityPayload` has no declared return type). The backend re-declares the exact same shape as a **Zod schema** (`backend/src/lib/cdc-websocket.ts:18-50`, `cdcMessageSchema`). These two definitions of the same contract can drift silently — a field renamed in CDC won't fail to compile; it'll fail validation at runtime in production. This is both a separation-of-concerns and a type-strictness problem (see §4.1). It is the single highest-value fix in this report.
+
+---
+
+## 3. The membership question
+
+> _"Is there some way we can split these either in separate streams or a separate notification type in the same stream?"_
+
+**Recommendation: a separate notification _type_ (discriminated union) on the same stream. Do not create a second physical stream.**
+
+Rationale:
+- The physical transport (one WS connection CDC→backend, one SSE channel `org:<id>`→client) is fine and cheap. Memberships are low-volume. A second WS/SSE connection, subscriber registry, dispatcher, and frontend `StreamManager` would be a lot of moving parts to separate two concerns that a tagged union separates for free.
+- The pain isn't the shared pipe — it's that the pipe carries an **untyped, mutually-exclusive-field** payload (`entityType` XOR `resourceType`, `seq`/`cacheToken` null-for-membership). Every layer re-sniffs which kind it is. A discriminant removes that.
+
+### Proposed shape
+
+Introduce an explicit discriminated union as the wire contract, owned in one shared place (e.g. `shared` or `sdk`), imported by CDC, backend, and frontend:
+
+```ts
+type CdcSyncNotification =
+  | { kind: 'entity';     entityType: ProductEntityType; subjectId: string;
+      seq: number; stx: StxBase | null; cacheToken: string | null;
+      contextId: string | null; batchUntilSeq?: number; /* … */ }
+  | { kind: 'membership'; resourceType: 'membership' | 'inactive_membership';
+      subjectId: string; organizationId: string; contextType: ContextEntityType;
+      userId: string; /* no seq / stx / cacheToken */ }
+```
+
+Then:
+- CDC's `buildActivityPayload` returns `CdcSyncNotification` — the compiler enforces that memberships never carry a `cacheToken` and entities always carry a `seq`.
+- Backend `handleMessage` / `build-message` switch on `.kind` instead of computing `isProduct` three times and nulling fields.
+- Frontend `handleAppStreamNotification` switches on `.kind` — the existing `if (resourceType === 'membership') return` early-return becomes an exhaustive `switch` the compiler checks.
+- The two duplicate contract definitions (§2.4) collapse into one: derive the Zod schema from the type (or the type from the schema) so they can't drift.
+
+This is strictly better than today's implicit union `AppStreamProductEvent | EntityScopedEvent<… resourceType:'membership'>` (`backend/.../stream/types.ts:52`) because the discriminant is a real field the client and server both switch on, rather than "look at which of two nullable fields is populated."
+
+**When a second stream _would_ be justified:** only if memberships needed a different delivery guarantee, retention, or fan-out topology than entity sync (e.g. memberships to an admin audit channel). They don't today. Revisit only if that changes.
+
+Membership counter logic in CDC (`getMembershipDelta`, `getInactiveMembershipDelta` in `update-counts.ts`) is already cleanly separated at the function level — that part is fine. The split you want is at the **notification/type** layer, not the counter layer.
+
+---
+
+## 4. Type strictness findings
+
+### 4.1 The wire payload is untyped end to end (highest value)
+`buildActivityPayload` (`activity-service.ts:42`) and `sendBatchMessageToApi` (`:94`) return inferred anonymous objects. `wsClient.send(data: unknown)` (`websocket-client.ts:127`) erases it entirely. The only "type" for this contract is the backend Zod schema. → Give it a named shared type (see §3). Covered above; listed here because it is also the biggest _type-strictness_ win.
+
+### 4.2 Unchecked `as Model` casts on compacted row data
+`update-counts.ts:47` `newRow as MembershipModel`, `:57` `as InactiveMembershipModel`. `rowData` is a `CdcRowData` (`Record<string, unknown> & {id}`) that has been snake→camel converted **and had large columns stripped** (`compactRowData`). It is _not_ a full `MembershipModel`; the cast asserts fields that may have been compacted away. It works today only because the read fields (`role`, `contextId`, `rejectedAt`) happen to survive compaction. → Read the specific fields through a small typed accessor (`getStringValue`/a `pickMembershipFields`) instead of a whole-object cast, so the type reflects reality.
+
+### 4.3 Dynamic context-column access forces `as Record<string, unknown>` casts
+`transaction-buffer.ts:206` and `:298`, `activity-service.ts:57`, `compute-unified-deltas.ts` all read context-entity ID columns (`organizationId`, `projectId`, …) off the activity via `(activity as Record<string, unknown>)[idColumn]` because those columns are dynamic keys not surfaced on `InsertActivityModel`. → Add a typed `ContextEntityIdColumns` partial to the activity type (the backend already has one — `stream/types.ts` references `Partial<ContextEntityIdColumns>`), and reuse it in CDC. Removes ~5 casts.
+
+### 4.4 Unnecessary casts that defeat inference
+`table-registry.ts:35` `as EntityTableMeta` and `:46` `as ResourceTableMeta` — the object literals already satisfy the target types; the casts suppress checking (e.g. a missing field wouldn't error). Drop them.
+
+### 4.5 `CdcRowData = Record<string, unknown>` is as loose as it gets
+Everything downstream is `unknown`-typed field access guarded by inline `typeof` checks scattered across `get-row-value.ts`, `extract-stx-data.ts`, `update-counts.ts`, `update.ts:getStxChangedFields`. This is somewhat inherent to WAL data, but the per-entity shape is knowable from the Drizzle schema. A `CdcRow<T extends TrackedType>` mapped type keyed off `TrackedModel<T>` would let handlers narrow once and stop re-validating.
+
+### 4.6 `getRowValue` silently narrows to `string | null`
+`get-row-value.ts:7` returns only strings; non-string values become `null` with no signal. Fine for ID columns (its only current use) but the name doesn't convey the lossiness. Minor — rename to `getRowString` or document.
+
+---
+
+## 5. Duplication findings
+
+### 5.1 Dead / superseded code (delete outright)
+The single-event delta path is fully superseded by the batch path (the flush buffer always calls `processEvents` with an array, even for one event):
+- **`computeUnifiedDeltas`** (`compute-unified-deltas.ts:91`) — production-unused; only tests call it.
+- **`applyUnifiedDeltas`** (`apply-unified-deltas.ts:74`) — production-unused; only tests.
+- **`applyBatchSeqOnlyDeltas`** (`apply-unified-deltas.ts:217`) — **zero** references anywhere; catchup now recalculates counters wholesale (`catchup-recovery.ts`) so this path is obsolete.
+- **`extractContextId`** (`transaction-buffer.ts:295`) — exported, **zero** references.
+
+Removing these deletes ~150 lines and, importantly, removes an entire _mirror_ of the batch logic that a reader currently has to diff against the batch version to convince themselves they behave identically. This alone will noticeably shrink the mental-model burden.
+
+### 5.2 `isSoftDeleteTransition` defined three times, identically
+`update.ts:25`, `update-counts.ts:119`, `embedding-cleanup.ts:55` — byte-for-byte the same `oldRow.deletedAt == null && newRow.deletedAt != null`. → One shared helper in `utils/`.
+
+### 5.3 Bulk seq-stamp SQL duplicated verbatim
+The `UPDATE … SET seq = v.seq, stx = t.stx - 'changedFields' FROM (VALUES …)` block is copy-pasted between `apply-unified-deltas.ts:189-199` and `:265-274` (the second copy is in the dead `applyBatchSeqOnlyDeltas`, so §5.1 removes it), and a single-row variant exists as `updateEntitySeq` (`:58`). → After deleting the dead one, extract `bulkStampSeq(byTable)` so there's one place that knows the "strip changedFields on stamp" rule.
+
+### 5.4 Two implementations of "sum deltas into a record"
+`compute-unified-deltas.ts:68` has a clean `mergeDelta(map, key, deltas)`. `apply-unified-deltas.ts:132-136` and `:155-159` re-implement the same `existing[k] = (existing[k] ?? 0) + v` merge inline against a plain object. → Share one merge util.
+
+### 5.5 `compactRowData` and `stripExcludedColumns` are the same function, run twice
+`compact-row-data.ts:36` (`compactRowData`) and `activity-service.ts:11` (`stripExcludedColumns`) have identical bodies (filter out `excludedRowDataKeys`). Worse, handlers already call `compactRowData` on the row (`insert.ts:20`, `update.ts:75`, `delete.ts:21`), and then `buildActivityPayload` calls `stripExcludedColumns` on the already-compacted row again (`activity-service.ts:64`) — a guaranteed no-op second pass. → Delete `stripExcludedColumns`; the row is already compact by the time it reaches the payload builder.
+
+### 5.6 Context-column iteration pattern repeated ~5 times
+The "loop over `appConfig.contextEntityTypes` / hierarchy ancestors, read `appConfig.entityIdColumnKeys[type]` from a row-or-activity" pattern appears in `create-activity.ts:26`, `activity-service.ts:54`, `transaction-buffer.ts:203`, `transaction-buffer.ts:296`, `compute-unified-deltas.ts:57`. → A `getContextEntityIds(source)` / `resolveParentContextId(source)` helper pair.
+
+### 5.7 `buildActivityPayload` recomputes context IDs the activity already has
+`activity-service.ts:51-60` re-derives `contextIds` by reading them back off `baseActivity` (which `createActivity` already populated at `create-activity.ts:24-33`) and re-spreading them. The comment even says "mirrors createActivity logic." It's a self-copy that does nothing the spread of `baseActivity` didn't already do. → Remove, unless there's a narrowing intent that should be documented.
+
+### 5.8 `s:membership` bump duplicated
+`update-counts.ts:51` and `:61` push the identical org-level `{ 's:membership': 1 }` signal for active and inactive memberships. Minor — fold into one post-step.
+
+### 5.9 Two row-extraction helpers
+`handle-message.ts:33` (`getMessageRow`) and `utils/extract-row-data.ts` (`extractRowData`) both pull the tuple out of a pgoutput message. Slightly different (old-vs-new selection) but consolidatable.
+
+---
+
+## 6. Smaller structural / correctness-adjacent notes
+
+- **README is stale** (`cdc/README.md:46,44`): lists `services/get-error-message.ts` (that code lives in `retry.ts` as `getErrorCode`), and doesn't mention `health-reporter.ts`. `create-activity.ts` is documented as a handler but is really a builder (§2.3).
+- **`getChangedFields` uses `JSON.stringify` equality** (`get-changed-fields.ts:18`) — key-order-sensitive for nested objects, so a semantically-equal JSONB reorder reads as a change. Only used on the WAL-diff fallback path (non-product entities incl. memberships), so low blast radius, but worth a comment or a stable compare.
+- **`updateEntitySeq` / bulk-stamp know a domain rule** (`stx = stx - 'changedFields'`) that is _also_ enforced in `embedding-cleanup.ts:121`. That "strip changedFields so handleUpdate treats this as a non-user write" rule is load-bearing and spread across three writers with only prose comments tying them together. Consider a named `STRIP_CHANGED_FIELDS_SQL` constant or a documented invariant so a future edit doesn't break the suppression logic in `update.ts:62-69`.
+
+---
+
+## 7. Prioritized action list
+
+**Tier 1 — biggest mental-model + safety win, low risk**
+1. Delete dead code: `computeUnifiedDeltas`, `applyUnifiedDeltas`, `applyBatchSeqOnlyDeltas`, `extractContextId` (§5.1). Removes a whole mirrored code path.
+2. Introduce the shared discriminated `CdcSyncNotification` type and make it the single wire contract; derive the backend Zod schema from it (§2.4, §3, §4.1). Switch backend + frontend on `.kind`.
+
+**Tier 2 — dedup, mechanical, low risk**
+3. Collapse `stripExcludedColumns` into `compactRowData`; remove the double-strip (§5.5).
+4. Extract shared `isSoftDeleteTransition`, delta-merge, `bulkStampSeq`, and context-id helpers (§5.2–5.4, §5.6).
+5. Remove the redundant context-id recompute in `buildActivityPayload` (§5.7).
+
+**Tier 3 — type tightening**
+6. Replace `as MembershipModel` / `as Record<string, unknown>` casts with typed field accessors + a shared `ContextEntityIdColumns` on the activity type (§4.2–4.4).
+
+**Tier 4 — readability**
+7. Split `processEvents` into `persistAuditLog` / `applyCounters` / `dispatchSync` (§2.2); move `create-activity.ts` to `services/` (§2.3); refresh the README (§6).
+
+None of Tier 1–2 changes runtime behavior; they're deletions and consolidations backed by the existing tests. Tier 1.2 (the discriminated notification) is the one that directly resolves your "app stream is doing two things" discomfort — it makes the two concerns two branches of a compiler-checked union instead of an implicit convention re-sniffed at eight sites.

--- a/.info/wire-contract-and-stream-split-options.md
+++ b/.info/wire-contract-and-stream-split-options.md
@@ -1,0 +1,149 @@
+# Wire contract & app-stream split — options and plan
+
+Two follow-ups from the [CDC assessment](./cdc-assessment.md), researched with the actual code + an empirical type probe:
+
+- **Part A** — a mechanical assignability assertion tying `CdcOutboundMessage` (what CDC sends) to `CdcMessage` (what the backend validates). *Compile-time only — no runtime, no Playwright.*
+- **Part B** — the backend-dispatch + frontend `kind`-switch rewrite that turns the implicit entity-vs-membership branching into an explicit discriminated split. *Runtime behaviour — this is where `pnpm dev` + Playwright earn their keep.*
+
+Both are optional quality moves; neither is required for correctness today.
+
+---
+
+## Part A — Mechanical assignability assertion
+
+### What I actually found (empirical, not guessed)
+
+I added a throwaway probe asserting both directions and ran `tsgo`. The mismatches are **narrow and well-understood — not the rabbit hole I feared**:
+
+**Direction 1 — does CDC's output satisfy the backend schema?** (`CdcOutboundMessage` ⊑ `CdcMessage`)
+```
+activity.tenantId: 'string | null | undefined' is not assignable to 'string | null'
+```
+Root cause: CDC types the activity as `InsertActivityModel` (`activitiesTable.$inferInsert`), where every *nullable* column becomes **optional** (`T | null | undefined`). The backend schema is `createSelectSchema(activitiesTable)` (`activitySchema`), where the same columns are **required-nullable** (`T | null`). The compiler stops at the first field (`tenantId`), but the same gap applies to every nullable-not-defaulted column: `userId, entityType, resourceType, subjectId, organizationId` (+ any context columns), `changedFields, stx`, and `createdAt`. **~9 fields, one identical cause.** Crucially, `createActivity` *does* set all of these at runtime — only the static `InsertActivityModel` type is loose.
+
+**Direction 2 — does the backend's validated type satisfy CDC's?** (`CdcMessage` ⊑ `CdcOutboundMessage`)
+```
+rowData: Property 'id' is missing in 'Record<string, unknown>' but required in 'CdcRowData'
+```
+The schema's `rowData` is `z.record(z.string(), z.unknown())`; CDC's `CdcRowData` requires `id: string`.
+
+Only **Direction 1 matters** — it's the real invariant ("what CDC emits, the backend accepts"). Direction 2 is incidental.
+
+### Options
+
+**A1 — one-directional `satisfies` assertion, close the optionality gap (recommended)**
+Type the outbound activity on the *select* shape for the always-set fields, so it lines up with the schema. Two sub-approaches:
+- Base `CdcOutboundMessage['activity']` on `ActivityModel` (`$inferSelect`) instead of `InsertActivityModel` — `ActivityModel` already has `tenantId: string | null` etc. `createActivity` sets every field, so its output satisfies the tighter type; a couple of spots may need a non-null assertion or explicit default.
+- Or keep `InsertActivityModel` but wrap: `Required<Pick<InsertActivityModel, AlwaysSetKeys>> & InsertActivityModel`.
+
+Then add a compile-time guard in CDC (a test-d style file, or an inline `satisfies`) so drift fails the build:
+```ts
+// cdc/src/tests/wire-contract.test-d.ts (typecheck-only)
+import type { CdcMessage } from '#/lib/cdc-websocket';
+import type { CdcOutboundMessage } from '../services/activity-service';
+// Fails to compile if CDC's payload stops satisfying the backend's validated shape.
+const _conforms = (m: CdcOutboundMessage): CdcMessage => m;
+```
+Effort: **S** (~1–2 files). Risk: compile-time only, zero runtime. This is the genuine "can't drift" protection at low cost.
+
+**A2 — derive the CDC type *from* the backend schema**
+`import type { CdcMessage } from '#/lib/cdc-websocket'` and type `buildActivityPayload`'s return as `CdcMessage` directly (drop the hand-written `CdcOutboundMessage`). Strongest single-source-of-truth, but forces `createActivity`'s output to satisfy the select shape everywhere it's built — same optionality work as A1, just with less slack and more coupling to the backend module. Effort: **S–M**.
+
+**A3 — one shared schema in `shared`/`sdk` (long-term ideal)**
+Define the CDC↔backend payload as a single Zod schema in a shared package; CDC takes the `z.infer` type, the backend imports the schema for validation. Removes the two-definitions problem entirely (today the shape is declared in CDC as a TS interface *and* in the backend as Zod). Effort: **M** (new shared module, move the schema, reconcile the `activity` sub-schema import graph).
+
+### Recommendation (Part A)
+Do **A1 now** — it's cheap, compile-time only, and delivers real drift protection (a renamed/removed field breaks the CDC build). Revisit **A3** if/when the payload grows or a third consumer appears. A2 is a reasonable middle but buys little over A1 while coupling CDC harder to a backend internal module.
+
+---
+
+## Part B — App-stream entity/membership split
+
+### The two wire boundaries (this is the key framing)
+
+```
+CDC ──internal WS──▶ backend ──SSE (SDK)──▶ frontend
+     boundary ①                boundary ②
+   CdcOutboundMessage         StreamNotification
+   / cdcMessageSchema         (generated into sdk)
+```
+
+- **Boundary ①** is co-located (CDC + backend deploy together, same pod). A shape change here is safe to ship atomically.
+- **Boundary ②** is the SSE payload, generated into the shared **SDK** and consumed by a separately-deployed frontend. A shape change here means regenerating the SDK and coordinating a frontend/backend release.
+
+The "app stream does two things" discomfort lives at **boundary ② and the frontend**. That's what to fix. Boundary ① is already typed (from the last pass).
+
+### Where the branching lives today (6 sites)
+| Layer | File | Branch |
+|---|---|---|
+| event union | `backend/.../stream/types.ts:52` | `AppStreamProductEvent \| EntityScopedEvent<…resourceType:'membership'>` |
+| listeners | `backend/.../entities-listeners.ts:14 / :28` | two registration loops (product vs membership) |
+| dispatch filter | `backend/.../helpers/dispatch-to-stream.ts:34` | `if (event.resourceType === 'membership')` → user-targeting vs permission check |
+| notification build | `backend/.../stream/build-message.ts:17,20,59` | `isProduct` nulls `seq/stx/cacheToken` for membership |
+| wire schema | `backend/src/schemas/stream-schemas.ts:28` | one object, `entityType` XOR `resourceType`, both nullable |
+| frontend handler | `frontend/.../app-stream-handler.ts:50` | `if (resourceType === 'membership') { …; return }` early-return to a separate mechanism (query invalidation vs seq-range fetch) |
+
+The distinction is real: membership → `contextType`-driven **query invalidation**; product entity → `seq`/`cacheToken` **range fetch**. Two mechanisms sharing one payload and one channel, told apart by sniffing which nullable field is set.
+
+### Options
+
+**B1 — type-level discriminated union, NO wire change (recommended first)**
+Keep the `StreamNotification` JSON byte-identical. Add a *derived* discriminated type + a type guard (in `sdk`/`shared`), and refactor the branch sites to switch on it exhaustively:
+```ts
+// derived from the existing StreamNotification — no new wire field
+export type EntityNotification     = StreamNotification & { entityType: ProductEntityType; resourceType: null };
+export type MembershipNotification = StreamNotification & { resourceType: 'membership' | 'inactive_membership'; entityType: null };
+export type AppNotification = EntityNotification | MembershipNotification;
+
+export const isMembership = (n: StreamNotification): n is MembershipNotification =>
+  n.resourceType === 'membership' || n.resourceType === 'inactive_membership';
+```
+Frontend `handleAppStreamNotification` becomes an exhaustive `switch`/guard instead of `if (resourceType === 'membership') return`; backend `build-message`/`dispatch` likewise. The compiler now *proves* membership branches never touch `seq/cacheToken` and entity branches always have them.
+- **Pros:** zero protocol change → SDK stays compatible, no coordinated deploy, no old-client handling. Delivers the mental-model + type-safety win. Fully unit-and-type-checkable.
+- **Cons:** the discriminant is still "which nullable field is set" under the hood (a guard, not a first-class wire field). External SDK consumers don't get an explicit `kind`.
+- Effort: **M** (frontend handler refactor + backend build/dispatch + shared guard). Behaviour-preserving if done carefully → **Playwright-verifiable** (see below).
+
+**B2 — explicit `kind` discriminant on the wire**
+Add `kind: 'entity' | 'membership'` (non-nullable) to `streamNotificationSchema`; CDC/backend populate it; frontend switches on `n.kind`. This is the "proper" discriminated union.
+- **Pros:** first-class discriminant; cleanest for external SDK consumers; impossible to mis-sniff.
+- **Cons:** changes boundary ② → regenerate SDK, release frontend+backend together, and tolerate a rollout window where new backend talks to old frontend (add `kind` as optional first, make it required in a later release). More ceremony.
+- Effort: **M–L** (schema + SDK regen + both ends + staged rollout).
+
+**B3 — separate physical streams (documented, not recommended)**
+A dedicated membership SSE channel with its own dispatcher + frontend `StreamManager`. Justified only if memberships ever need a different delivery guarantee/retention/topology. They don't today; memberships are low-volume and multiplex fine on the one org channel. Effort: **L**, ongoing surface.
+
+**B4 — hybrid**
+Ship **B1** now (type-level, safe). If a boundary-② schema bump happens later for another reason, fold in **B2**'s `kind` field opportunistically. Best cost/value curve.
+
+### Recommendation (Part B)
+**B1.** It captures ~90% of the value — an exhaustive, compiler-enforced, legible split — at near-zero protocol risk, and it's the version I can validate end-to-end with Playwright without a coordinated deploy. Escalate to **B2** only if we want the discriminant visible to external SDK consumers.
+
+---
+
+## Testing plan (`pnpm dev` + Playwright)
+
+Part A needs none (compile-time). Part B is behaviour-preserving, so the test strategy is **golden-path regression**: capture current realtime behaviour as a baseline, refactor, then prove identical behaviour.
+
+**Harness:** `pnpm dev` (postgres via `pnpm docker`, seeded via `pnpm seed`, backend + CDC + frontend). Two browser contexts authenticated as two users in the same org.
+
+**Flows to assert (baseline first, then after each option):**
+1. **Product entity create/update/delete** — user A mutates an attachment; assert user B's list + detail caches update in realtime (no manual refresh). Confirms the `seq`/range-fetch path.
+2. **Membership** — invite/add a user, change a role, remove a member; assert the member list + menu invalidate for the affected user. Confirms the `contextType` invalidation path (the branch we're untangling).
+3. **Echo prevention** — user A mutates; assert A does *not* double-fetch its own change (stx `sourceId` short-circuit).
+4. **Batch** — bulk-create entities; assert one range fetch + correct unseen-count deltas.
+5. **Catchup** — disconnect B, mutate in A, reconnect B; assert B reconciles (membership via activity scan, entities via seq).
+
+**Sequencing I'd propose:**
+1. You pick a Part A option (A1 recommended) and a Part B option (B1 recommended).
+2. I implement A1 (compile-time; verify with `tsgo`).
+3. I boot `pnpm dev`, script flows 1–5 in Playwright, and record the **baseline** on `main`.
+4. I implement B1, re-run the same Playwright flows, and diff behaviour. Green = behaviour-preserved.
+
+I can drive all of this myself — I just want the option choices first so I'm not building a harness against a design we discard.
+
+---
+
+## TL;DR
+- **Part A:** the assertion is easy — the only gap is `InsertActivityModel` (insert-optional) vs `createSelectSchema` (required-nullable) on ~9 activity fields, plus `rowData.id`. Do **A1** (one-directional `satisfies` on a select-shaped activity type). **S**, compile-time.
+- **Part B:** do **B1** (type-level discriminated union + guard, no wire change). Same protocol, exhaustive compiler-checked split, Playwright-verifiable. **M**. Escalate to **B2** (`kind` on the wire) only for external SDK consumers.
+- Tell me the two picks and I'll implement A1, capture a Playwright baseline, then do B1 and prove behaviour is unchanged.

--- a/backend/src/lib/cdc-websocket.ts
+++ b/backend/src/lib/cdc-websocket.ts
@@ -14,6 +14,10 @@ import { log } from '#/utils/logger';
  * Zod schema for CDC WebSocket message payload.
  * Validates the { activity, entity, cacheToken, _trace } structure sent by CDC Worker.
  * Reuses activitySchema with stricter typing for fields that must be present in CDC context.
+ *
+ * This is the *validating* end of the CDC → API-server wire contract. The CDC worker
+ * *produces* the same shape as `CdcOutboundMessage` (see cdc/src/services/activity-service.ts).
+ * Keep the two in sync — a field added there needs a matching field here.
  */
 const cdcMessageSchema = z.object({
   activity: z.object({
@@ -48,6 +52,9 @@ const cdcMessageSchema = z.object({
     })
     .optional(),
 });
+
+/** The validated CDC → API-server message shape. Counterpart of the CDC worker's `CdcOutboundMessage`. */
+export type CdcMessage = z.infer<typeof cdcMessageSchema>;
 
 /** Idle timeout in ms - close connection if no message received within this time */
 const IDLE_TIMEOUT_MS = 90_000;

--- a/backend/src/modules/entities/helpers/dispatch-to-stream.ts
+++ b/backend/src/modules/entities/helpers/dispatch-to-stream.ts
@@ -5,6 +5,7 @@ import { checkPermission } from '#/permissions';
 import { buildSubject } from '#/permissions/build-subject';
 import { log } from '#/utils/logger';
 import type { CursoredSubscriber } from '../stream';
+import { isMembershipEvent } from '../stream/build-message';
 import { createStreamDispatcher } from '../stream/dispatcher';
 import type { AppStreamEvent } from '../stream/types';
 
@@ -31,7 +32,7 @@ export const dispatchToAppStream = createStreamDispatcher<AppStreamSubscriber, A
   getChannel: (event) => `org:${event.organizationId}`,
   shouldReceive: (subscriber, event) => {
     // For membership events, check if user is the subject
-    if (event.resourceType === 'membership') {
+    if (isMembershipEvent(event)) {
       const membership = getEventData(event, 'membership');
       return membership?.userId === subscriber.userId;
     }

--- a/backend/src/modules/entities/stream/build-message.ts
+++ b/backend/src/modules/entities/stream/build-message.ts
@@ -1,6 +1,22 @@
 import { appConfig, type ContextEntityType, hierarchy, isProductEntity } from 'shared';
 import { type ActivityEvent, getEventData } from '#/lib/activity-bus';
 import type { StreamNotification } from '#/schemas';
+import type { AppStreamEvent, AppStreamMembershipEvent } from './types';
+
+/**
+ * The app stream carries exactly two concerns: product-entity sync (seq/cacheToken
+ * range fetch on the client) and membership changes (query invalidation). This is the
+ * single source of the `kind` discriminant — used both to shape the wire notification
+ * and to branch dispatch/handling on either end.
+ */
+export function appNotificationKind(event: Pick<ActivityEvent, 'entityType'>): 'entity' | 'membership' {
+  return isProductEntity(event.entityType) ? 'entity' : 'membership';
+}
+
+/** Type-guard form of {@link appNotificationKind}: narrows an app-stream event to the membership member. */
+export function isMembershipEvent(event: AppStreamEvent): event is AppStreamMembershipEvent {
+  return appNotificationKind(event) === 'membership';
+}
 
 /**
  * Build stream notification from activity event.
@@ -54,6 +70,9 @@ export function buildStreamNotification(event: ActivityEvent): StreamNotificatio
   }
 
   return {
+    // Discriminant: product entities go through the seq/cacheToken sync path;
+    // everything else on this stream is a membership change (query invalidation).
+    kind: appNotificationKind(event),
     action: event.action,
     entityType: isProduct ? entityType : null,
     resourceType: event.resourceType,

--- a/backend/src/modules/entities/stream/types.ts
+++ b/backend/src/modules/entities/stream/types.ts
@@ -48,5 +48,8 @@ export type AppStreamProductEvent = EntityScopedEvent<
   ActivityEvent & { entityType: ProductEntityType } & Partial<ContextEntityIdColumns>
 >;
 
+/** Membership event routed via the app (authenticated) stream. */
+export type AppStreamMembershipEvent = EntityScopedEvent<ActivityEvent & { resourceType: 'membership' }>;
+
 /** Combined event type accepted by the app stream dispatcher. */
-export type AppStreamEvent = AppStreamProductEvent | EntityScopedEvent<ActivityEvent & { resourceType: 'membership' }>;
+export type AppStreamEvent = AppStreamProductEvent | AppStreamMembershipEvent;

--- a/backend/src/schemas/stream-mocks.ts
+++ b/backend/src/schemas/stream-mocks.ts
@@ -17,6 +17,7 @@ import { mockStxBase } from './sync-transaction-mocks';
  */
 export const mockStreamNotification = (key = 'stream-notification:default') =>
   withFakerSeed(key, () => ({
+    kind: 'entity' as const,
     action: faker.helpers.arrayElement(['create', 'update', 'delete'] as const),
     entityType: 'attachment' as const,
     resourceType: null,

--- a/backend/src/schemas/stream-schemas.ts
+++ b/backend/src/schemas/stream-schemas.ts
@@ -27,6 +27,9 @@ const propagationHintSchema = z.object({
  */
 export const streamNotificationSchema = z
   .object({
+    kind: z
+      .enum(['entity', 'membership'])
+      .describe('Discriminant for the notification: product-entity sync vs membership change'),
     action: z.enum(activityActions),
     entityType: z.enum(appConfig.productEntityTypes).nullable(),
     resourceType: z.enum(appConfig.resourceTypes).nullable(),

--- a/cdc/README.md
+++ b/cdc/README.md
@@ -29,35 +29,37 @@ cdc/src
 │   ├── index.ts                 Re-exports
 │   ├── insert.ts                INSERT handler
 │   ├── update.ts                UPDATE handler
-│   ├── delete.ts                DELETE handler
-│   └── create-activity.ts       Build activity record from change
+│   └── delete.ts                DELETE handler
 ├── network
 │   ├── websocket-client.ts      WS connection to API server
-│   └── health.ts                HTTP health endpoint
+│   ├── health.ts                Health status snapshot
+│   └── health-reporter.ts       Periodic health push
 ├── services
-│   ├── activity-service.ts      Activity persistence
+│   ├── create-activity.ts       Build activity record from change
+│   ├── activity-service.ts      Activity ID, WS payload builder + send
 │   ├── flush-buffer.ts          Debounced buffer flush
 │   ├── transaction-buffer.ts    Buffer changes per transaction
 │   ├── circuit-breaker.ts       Failure circuit breaker
-│   ├── retry.ts                 Retry with backoff
+│   ├── retry.ts                 Retry with backoff + error normalization
 │   ├── replication-state.ts     LSN tracking state
 │   ├── catchup-recovery.ts      Catchup after reconnect
-│   ├── cdc-metrics.ts           OpenTelemetry metrics
-│   └── get-error-message.ts     Error normalization
+│   └── cdc-metrics.ts           OpenTelemetry metrics
 ├── utils
 │   ├── index.ts                 Re-exports
 │   ├── action-to-verb.ts        Map DB action to activity verb
 │   ├── apply-unified-deltas.ts  Apply delta objects
 │   ├── compact-row-data.ts      Strip unchanged fields
 │   ├── compute-unified-deltas.ts  Diff old/new rows
+│   ├── context-columns.ts       Precomputed context ID column keys
 │   ├── convert-row-keys.ts      snake_case → camelCase
 │   ├── embedding-cleanup.ts     Clean up stale embeddings
 │   ├── extract-row-data.ts      Extract columns from WAL tuple
 │   ├── extract-stx-data.ts      Extract context from row data
 │   ├── get-changed-fields.ts    Detect changed columns
 │   ├── get-row-value.ts         Safe row field access
+│   ├── is-soft-delete-transition.ts  Detect live→soft-deleted flips
 │   ├── snake-to-camel.ts        Case conversion helper
-│   └── update-counts.ts         Entity count updates
+│   └── update-counts.ts         Entity + membership count deltas
 ├── lib
 │   ├── db.ts                    PG pool for CDC
 │   ├── pino.ts                  Structured logger

--- a/cdc/src/handlers/delete.ts
+++ b/cdc/src/handlers/delete.ts
@@ -3,7 +3,7 @@ import type { ParseMessageResult } from '../pipeline/parse-message';
 import type { TableMeta } from '../types';
 import { convertRowKeys, extractRowData } from '../utils';
 import { compactRowData } from '../utils/compact-row-data';
-import { createActivity } from './create-activity';
+import { createActivity } from '../services/create-activity';
 
 /**
  * Handle a DELETE message and create an activity with entity data.

--- a/cdc/src/handlers/insert.ts
+++ b/cdc/src/handlers/insert.ts
@@ -3,7 +3,7 @@ import type { ParseMessageResult } from '../pipeline/parse-message';
 import type { TableMeta } from '../types';
 import { convertRowKeys, extractRowData } from '../utils';
 import { compactRowData } from '../utils/compact-row-data';
-import { createActivity } from './create-activity';
+import { createActivity } from '../services/create-activity';
 
 /**
  * Handle an INSERT message and create an activity with entity data.

--- a/cdc/src/handlers/update.ts
+++ b/cdc/src/handlers/update.ts
@@ -4,7 +4,8 @@ import type { ParseMessageResult } from '../pipeline/parse-message';
 import type { TableMeta } from '../types';
 import { convertRowKeys, extractRowData, getChangedFields } from '../utils';
 import { compactRowData } from '../utils/compact-row-data';
-import { createActivity } from './create-activity';
+import { isSoftDeleteTransition } from '../utils/is-soft-delete-transition';
+import { createActivity } from '../services/create-activity';
 
 /** Columns that hold embedded entity ID arrays (e.g. task.labels) */
 const embeddingColumns: Set<string> = new Set(appConfig.entityEmbeddings.map((e) => e.hostColumn));
@@ -20,10 +21,6 @@ function getStxChangedFields(row: Record<string, unknown>): string[] | null {
     if (Array.isArray(cf)) return cf.filter((x): x is string => typeof x === 'string');
   }
   return null;
-}
-
-function isSoftDeleteTransition(rowData: Record<string, unknown>, oldRowData: Record<string, unknown> | null): boolean {
-  return oldRowData !== null && oldRowData.deletedAt == null && rowData.deletedAt != null;
 }
 
 function isAlreadySoftDeleted(rowData: Record<string, unknown>, oldRowData: Record<string, unknown> | null): boolean {

--- a/cdc/src/pipeline/process-events.ts
+++ b/cdc/src/pipeline/process-events.ts
@@ -10,11 +10,21 @@ import { circuitBreaker } from '../services/circuit-breaker';
 import { withRetry } from '../services/retry';
 import { replicationState } from '../services/replication-state';
 import { activityAttrs, cdcAttrs, cdcSpanNames, withSpan } from '../lib/tracing';
+import type { TraceContext } from '../lib/tracing';
 import { applyBatchUnifiedDeltas } from '../utils/apply-unified-deltas';
 import { computeBatchUnifiedDeltas } from '../utils/compute-unified-deltas';
 import { cleanupEmbeddingReferences } from '../utils/embedding-cleanup';
 
+import type { CdcRowData } from '../types';
 import type { ParseMessageResult } from './parse-message';
+
+/** An event prepared for persistence + dispatch: activity with a generated id, its row data, and seq. */
+interface PreparedEvent {
+  activityWithId: BatchEventInfo['activity'];
+  seq: number | undefined;
+  lsn: string;
+  rowData: CdcRowData;
+}
 
 // ================================
 // Activity persistence
@@ -105,11 +115,33 @@ async function persistActivities(
 }
 
 // ================================
+// Sync dispatch
+// ================================
+
+/** Forward stamped events to the API server: one batch payload, or a single payload. */
+function dispatchToApi(stamped: PreparedEvent[], traceCtx: TraceContext): void {
+  if (stamped.length > 1) {
+    const batchInfos: BatchEventInfo[] = stamped.map(({ activityWithId, rowData, seq }) => ({
+      activity: activityWithId,
+      rowData,
+      seq,
+    }));
+    sendBatchMessageToApi(batchInfos, traceCtx);
+  } else {
+    const { activityWithId, rowData, seq } = stamped[0];
+    sendMessageToApi(activityWithId, rowData, traceCtx, seq);
+  }
+}
+
+// ================================
 // Unified event processing
 // ================================
 
 /**
- * Process one or more CDC events: compute deltas, persist activities, send via WebSocket, clean up.
+ * Process one or more CDC events through three sequenced concerns:
+ *   1. persist the activity/audit-log rows (all tracked tables)
+ *   2. apply counter + seq deltas (entities and memberships)
+ *   3. dispatch the real-time sync notification over WebSocket, then embedding cleanup
  * Handles both single-event and batch paths through a unified pipeline.
  */
 export async function processEvents(events: Array<{ lsn: string; result: ParseMessageResult }>): Promise<void> {
@@ -168,18 +200,8 @@ export async function processEvents(events: Array<{ lsn: string; result: ParseMe
       });
     }
 
-    // Send via WebSocket — single vs batch payload
-    if (isBatch) {
-      const batchInfos: BatchEventInfo[] = stamped.map(({ activityWithId, rowData, seq }) => ({
-        activity: activityWithId,
-        rowData,
-        seq,
-      }));
-      sendBatchMessageToApi(batchInfos, traceCtx);
-    } else {
-      const { activityWithId, rowData, seq } = stamped[0];
-      sendMessageToApi(activityWithId, rowData, traceCtx, seq);
-    }
+    // Send the real-time sync notification (single vs batch payload)
+    dispatchToApi(stamped, traceCtx);
 
     // Embedding cleanup: strip deleted embedded-entity IDs from host-entity arrays
     const { tableMeta } = events[0].result;

--- a/cdc/src/services/activity-service.ts
+++ b/cdc/src/services/activity-service.ts
@@ -1,20 +1,32 @@
 import type { InsertActivityModel } from '#/modules/activities/activities-db';
-import { appConfig, hierarchy, isProductEntity } from 'shared';
+import { isProductEntity } from 'shared';
 import { log } from '../lib/pino';
 import type { TraceContext } from '../lib/tracing';
 import type { CdcRowData } from '../types';
-import { excludedRowDataKeys } from '../utils/compact-row-data';
 import { wsClient } from '../network/websocket-client';
 import { nanoid } from 'shared/nanoid';
 
-/** Strip large columns from row data before WS transmission. */
-function stripExcludedColumns(rowData: CdcRowData): CdcRowData {
-  if (excludedRowDataKeys.size === 0) return rowData;
-  const slim: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(rowData)) {
-    if (!excludedRowDataKeys.has(key)) slim[key] = value;
-  }
-  return slim as CdcRowData;
+// ── Wire contract ─────────────────────────────────────────────────────────────
+// The CDC → API-server WebSocket payload. This is the *producing* end of the
+// contract; the backend independently *validates* the same shape with
+// `cdcMessageSchema` (see backend/src/lib/cdc-websocket.ts → `CdcMessage`).
+// The two definitions must stay in sync — a field added here needs a matching
+// field there or the backend will reject the message at runtime.
+
+/** An individual entity cache-reservation token, sent with batch payloads. */
+export interface CdcBatchReservation {
+  token: string;
+  entityType: string;
+  entityId: string;
+}
+
+/** Outbound activity + row-data message the CDC worker sends to the API server. */
+export interface CdcOutboundMessage {
+  activity: InsertActivityModel & { id?: string; seq?: number; batchUntilSeq?: number };
+  rowData: CdcRowData;
+  cacheToken: string | null;
+  batchReservations?: CdcBatchReservation[];
+  _trace: TraceContext;
 }
 
 /**
@@ -44,24 +56,15 @@ function buildActivityPayload(
   rowData: CdcRowData,
   traceContext: TraceContext,
   seq?: number,
-) {
+): CdcOutboundMessage {
   // Generate cache token for product entities
   const cacheToken = baseActivity.entityType && isProductEntity(baseActivity.entityType) ? nanoid() : null;
 
-  // Derive context entity IDs from hierarchy (mirrors createActivity logic)
-  const subjectType = baseActivity.entityType ?? baseActivity.resourceType;
-  const contextIds: Record<string, string | null> = {};
-  if (subjectType) {
-    for (const ancestor of hierarchy.getOrderedAncestors(subjectType)) {
-      const key = appConfig.entityIdColumnKeys[ancestor];
-      const value = (baseActivity as Record<string, unknown>)[key];
-      contextIds[key] = typeof value === 'string' ? value : null;
-    }
-  }
+  // Context entity IDs are already populated on the activity by createActivity;
+  // rowData is already compacted by the handlers (compactRowData).
+  const activity = { ...baseActivity, seq };
 
-  const activity = { ...baseActivity, ...contextIds, seq }
-
-  return { activity, rowData: stripExcludedColumns(rowData), cacheToken,  _trace: traceContext };
+  return { activity, rowData, cacheToken, _trace: traceContext };
 }
 
 /**
@@ -115,7 +118,7 @@ export function sendBatchMessageToApi(
   const batchToken = first.activity.entityType && isProductEntity(first.activity.entityType) ? nanoid() : null;
 
   // Build individual cache reservations for each entity
-  const batchReservations = batchToken
+  const batchReservations: CdcBatchReservation[] | undefined = batchToken
     ? events
         .filter((e) => e.activity.entityType && e.activity.subjectId)
         .map((e) => ({
@@ -129,7 +132,7 @@ export function sendBatchMessageToApi(
   const base = buildActivityPayload(first.activity, first.rowData, traceContext, minSeq);
   const activity = { ...base.activity, batchUntilSeq };
 
-  const payload = {  ...base, activity, cacheToken: batchToken, batchReservations };
+  const payload: CdcOutboundMessage = { ...base, activity, cacheToken: batchToken, batchReservations };
 
   if (!wsClient.send(payload)) {
     log.warn('Failed to send batch message to API', { batchSize: events.length });

--- a/cdc/src/services/create-activity.ts
+++ b/cdc/src/services/create-activity.ts
@@ -4,6 +4,7 @@ import { appConfig, hierarchy } from 'shared';
 import type { TableMeta } from '../types';
 import type { ActivityWithoutId } from '../pipeline/parse-message';
 import { actionToVerb, extractStxData } from '../utils';
+import { contextIdColumnKeys } from '../utils/context-columns';
 import { getRowValue } from '../utils/get-row-value';
 import { log } from '../lib/pino';
 
@@ -40,8 +41,7 @@ export function createActivity(
 
   // Build default nulls for all context entity ID columns, driven by config
   const defaultContextIds: Record<string, null> = {};
-  for (const contextType of appConfig.contextEntityTypes) {
-    const idKey = appConfig.entityIdColumnKeys[contextType];
+  for (const idKey of contextIdColumnKeys) {
     defaultContextIds[idKey] = null;
   }
 

--- a/cdc/src/services/transaction-buffer.ts
+++ b/cdc/src/services/transaction-buffer.ts
@@ -1,7 +1,9 @@
 import type { Pgoutput } from 'pg-logical-replication';
 import { isContextEntity, appConfig } from 'shared';
+import type { ContextEntityIdColumns } from 'shared';
 import type { ParseMessageResult } from '../pipeline/parse-message';
 import type { PendingEvent } from '../types';
+import { contextIdColumnKeys } from '../utils/context-columns';
 import { log } from '../lib/pino';
 import { RESOURCE_LIMITS } from '../constants';
 
@@ -200,9 +202,8 @@ export class TransactionBuffer {
     if (activity.entityType && isContextEntity(activity.entityType)) return false;
 
     // Check all context entity ID columns on this activity
-    for (const contextType of appConfig.contextEntityTypes) {
-      const idColumn = appConfig.entityIdColumnKeys[contextType];
-      const value = (activity as Record<string, unknown>)[idColumn];
+    for (const idColumn of contextIdColumnKeys) {
+      const value = (activity as Partial<ContextEntityIdColumns>)[idColumn];
       if (typeof value === 'string' && deletedContextIds.has(value)) {
         return true;
       }
@@ -286,17 +287,4 @@ export class TransactionBuffer {
       this.timeoutHandle = null;
     }
   }
-}
-
-/**
- * Extract the most specific context ID from an activity for batch grouping.
- * Checks context entity ID columns (e.g., projectId, organizationId).
- */
-export function extractContextId(activity: ParseMessageResult['activity']): string | null {
-  for (const contextType of appConfig.contextEntityTypes) {
-    const idColumn = appConfig.entityIdColumnKeys[contextType];
-    const value = (activity as Record<string, unknown>)[idColumn];
-    if (typeof value === 'string') return value;
-  }
-  return null;
 }

--- a/cdc/src/table-registry.ts
+++ b/cdc/src/table-registry.ts
@@ -27,23 +27,25 @@ function buildTableRegistry(): Map<string, TableMeta> {
   // Register entity tables
   for (const [type, table] of typedEntries(entityTables)) {
     const tableName = getTableName(table);
-    registry.set(tableName, {
+    const meta: EntityTableMeta = {
       kind: 'entity',
       table,
       type,
       columnNameMap: buildColumnNameMap(Object.keys(getColumns(table))),
-    } as EntityTableMeta);
+    };
+    registry.set(tableName, meta);
   }
 
   // Register resource tables
   for (const [type, table] of typedEntries(resourceTables)) {
     const tableName = getTableName(table);
-    registry.set(tableName, {
+    const meta: ResourceTableMeta = {
       kind: 'resource',
       table,
       type,
       columnNameMap: buildColumnNameMap(Object.keys(getColumns(table))),
-    } as ResourceTableMeta);
+    };
+    registry.set(tableName, meta);
   }
 
   return registry;

--- a/cdc/src/tests/apply-unified-deltas.test.ts
+++ b/cdc/src/tests/apply-unified-deltas.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { UnifiedDeltaPlan, BatchUnifiedDeltaPlan } from '../utils/compute-unified-deltas';
+import type { BatchUnifiedDeltaPlan } from '../utils/compute-unified-deltas';
 import type { ParseMessageResult } from '../pipeline/parse-message';
 import type { InsertActivityModel } from '#/modules/activities/activities-db';
 import type { EntityTableMeta } from '../types';
@@ -38,87 +38,11 @@ vi.mock('../lib/db', () => {
 });
 
 // Import after mocks are set up
-const { applyUnifiedDeltas, applyBatchUnifiedDeltas } = await import('../utils/apply-unified-deltas');
+const { applyBatchUnifiedDeltas } = await import('../utils/apply-unified-deltas');
 
 beforeEach(() => {
   dbOps.length = 0;
   upsertReturnValue = {};
-});
-
-describe('applyUnifiedDeltas', () => {
-  it('returns undefined for empty plan', async () => {
-    const plan: UnifiedDeltaPlan = {
-      seqContextKey: null,
-      seqKey: null,
-      entityStamp: null,
-      deltasByContextKey: new Map(),
-    };
-
-    const result = await applyUnifiedDeltas(plan);
-    expect(result).toBeUndefined();
-    expect(dbOps).toHaveLength(0);
-  });
-
-  it('executes Phase 1 UPSERT with RETURNING for seqContextKey', async () => {
-    upsertReturnValue = { 's:task': 42, 'e:task': 10 };
-
-    const plan: UnifiedDeltaPlan = {
-      seqContextKey: 'proj-1',
-      seqKey: 's:task',
-      entityStamp: { tableName: 'tasks', entityId: 'task-1' },
-      deltasByContextKey: new Map([
-        ['proj-1', { 's:task': 1, 'e:task': 1 }],
-        ['org-1', { 's:task': 1, 'e:task': 1 }],
-      ]),
-    };
-
-    const result = await applyUnifiedDeltas(plan);
-
-    expect(result).toBe(42);
-    // Phase 1: 1 upsert (proj-1 with RETURNING)
-    // Phase 2: 1 upsert (org-1) + 1 execute (entity seq)
-    expect(dbOps.length).toBeGreaterThanOrEqual(2);
-  });
-
-  it('runs Phase 2 operations in parallel (org UPSERT + entity stamp)', async () => {
-    upsertReturnValue = { 's:task': 1 };
-
-    const plan: UnifiedDeltaPlan = {
-      seqContextKey: 'proj-1',
-      seqKey: 's:task',
-      entityStamp: { tableName: 'tasks', entityId: 'task-1' },
-      deltasByContextKey: new Map<string, Record<string, number>>([
-        ['proj-1', { 's:task': 1 }],
-        ['org-1', { 's:task': 1 }],
-        ['lbl-1', { 'e:task': 1 }],
-        ['lbl-2', { 'e:task': 1 }],
-      ]),
-    };
-
-    const result = await applyUnifiedDeltas(plan);
-    expect(result).toBe(1);
-
-    // Phase 1: 1 upsert (proj-1)
-    // Phase 2: 3 upserts (org-1, lbl-1, lbl-2) + 1 execute (entity seq) = 4
-    // Total: 5 DB ops
-    expect(dbOps.length).toBeGreaterThanOrEqual(4);
-  });
-
-  it('handles count-only plan (no seq stamp)', async () => {
-    const plan: UnifiedDeltaPlan = {
-      seqContextKey: null,
-      seqKey: null,
-      entityStamp: null,
-      deltasByContextKey: new Map([
-        ['org-1', { 'm:admin': 1, 'm:total': 1 }],
-      ]),
-    };
-
-    const result = await applyUnifiedDeltas(plan);
-    expect(result).toBeUndefined();
-    // Single upsert for membership counts
-    expect(dbOps.length).toBe(1);
-  });
 });
 
 describe('applyBatchUnifiedDeltas', () => {

--- a/cdc/src/tests/unified-deltas.test.ts
+++ b/cdc/src/tests/unified-deltas.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import type { EntityTableMeta, ResourceTableMeta } from '../types';
-import { computeUnifiedDeltas, computeBatchUnifiedDeltas } from '../utils/compute-unified-deltas';
+import { computeBatchUnifiedDeltas } from '../utils/compute-unified-deltas';
 import type { ParseMessageResult } from '../pipeline/parse-message';
 import type { InsertActivityModel } from '#/modules/activities/activities-db';
 
@@ -45,182 +45,73 @@ function mockEvent(overrides: {
   };
 }
 
-function mockResult(overrides: {
-  tableMeta: EntityTableMeta | ResourceTableMeta;
-  action: string;
-  rowData: Record<string, unknown> & { id: string };
-  oldRowData?: Record<string, unknown> & { id: string };
-  organizationId?: string | null;
-}): ParseMessageResult {
-  return mockEvent(overrides).result;
-}
+// ── Membership count deltas ──────────────────────────────────────────────────
+// Memberships are never seq-stampable, so all their deltas land in
+// countDeltasByContextKey (no seq group). Exercised through the batch path — the
+// only path the pipeline runs — by wrapping a single event in an array.
 
-// ── computeUnifiedDeltas ─────────────────────────────────────────────────────
-
-describe('computeUnifiedDeltas', () => {
-  it('attachment create: seq + entity count deltas merged onto org contextKey', () => {
-    const plan = computeUnifiedDeltas(
-      mockResult({
-        tableMeta: attachmentEntry(),
-        action: 'create',
-        rowData: { id: 'att-1', organizationId: 'org-1' },
-      }),
-    );
-
-    expect(plan.seqContextKey).toBe('org-1');
-    expect(plan.seqKey).toBe('s:attachment');
-    expect(plan.entityStamp).toEqual({ tableName: 'attachments', entityId: 'att-1' });
-
-    // Parent is organization, so seq and entity count merge on the single org row
-    expect(plan.deltasByContextKey.get('org-1')).toEqual({ 's:attachment': 1, 'e:attachment': 1 });
-    expect(plan.deltasByContextKey.size).toBe(1);
-  });
-
-  it('attachment hard delete: no seq stamp, decrement entity count on org', () => {
-    const plan = computeUnifiedDeltas(
-      mockResult({
-        tableMeta: attachmentEntry(),
-        action: 'delete',
-        rowData: { id: 'att-1', organizationId: 'org-1' },
-        oldRowData: { id: 'att-1', organizationId: 'org-1' },
-      }),
-    );
-
-    expect(plan.seqContextKey).toBeNull();
-    expect(plan.seqKey).toBeNull();
-    expect(plan.entityStamp).toBeNull();
-
-    expect(plan.deltasByContextKey.get('org-1')).toEqual({ 'e:attachment': -1 });
-    expect(plan.deltasByContextKey.size).toBe(1);
-  });
-
-  it('attachment soft delete update: seq stamp and decrement entity count on org', () => {
-    const plan = computeUnifiedDeltas(
-      mockResult({
-        tableMeta: attachmentEntry(),
-        action: 'update',
-        rowData: { id: 'att-1', organizationId: 'org-1', deletedAt: '2026-06-16T20:00:00.000Z' },
-        oldRowData: { id: 'att-1', organizationId: 'org-1', deletedAt: null },
-      }),
-    );
-
-    expect(plan.seqContextKey).toBe('org-1');
-    expect(plan.seqKey).toBe('s:attachment');
-    expect(plan.entityStamp).toEqual({ tableName: 'attachments', entityId: 'att-1' });
-    expect(plan.deltasByContextKey.get('org-1')).toEqual({ 's:attachment': 1, 'e:attachment': -1 });
-    expect(plan.deltasByContextKey.size).toBe(1);
-  });
-
-  it('already deleted attachment update: seq stamp without count delta', () => {
-    const plan = computeUnifiedDeltas(
-      mockResult({
-        tableMeta: attachmentEntry(),
-        action: 'update',
-        rowData: { id: 'att-1', organizationId: 'org-1', deletedAt: '2026-06-16T20:05:00.000Z' },
-        oldRowData: { id: 'att-1', organizationId: 'org-1', deletedAt: '2026-06-16T20:00:00.000Z' },
-      }),
-    );
-
-    expect(plan.seqContextKey).toBe('org-1');
-    expect(plan.seqKey).toBe('s:attachment');
-    expect(plan.deltasByContextKey.get('org-1')).toEqual({ 's:attachment': 1 });
-    expect(plan.deltasByContextKey.size).toBe(1);
-  });
-
-  it('attachment update: seq delta only (no count delta on updates)', () => {
-    const plan = computeUnifiedDeltas(
-      mockResult({
-        tableMeta: attachmentEntry(),
-        action: 'update',
-        rowData: { id: 'att-1', organizationId: 'org-1' },
-        oldRowData: { id: 'att-1', organizationId: 'org-1' },
-      }),
-    );
-
-    expect(plan.seqContextKey).toBe('org-1');
-    expect(plan.seqKey).toBe('s:attachment');
-    expect(plan.deltasByContextKey.get('org-1')).toEqual({ 's:attachment': 1 });
-    expect(plan.deltasByContextKey.size).toBe(1);
-  });
-
-  it('membership create: single delta with role + total count', () => {
-    const plan = computeUnifiedDeltas(
-      mockResult({
+describe('membership count deltas (via computeBatchUnifiedDeltas)', () => {
+  it('membership create: role + total count, plus org membership seq signal', () => {
+    const plan = computeBatchUnifiedDeltas([
+      mockEvent({
         tableMeta: membershipEntry(),
         action: 'create',
         rowData: { id: 'mem-1', organizationId: 'org-1', contextId: 'org-1', role: 'admin' },
       }),
-    );
+    ]);
 
-    expect(plan.seqContextKey).toBeNull();
-    expect(plan.entityStamp).toBeNull();
-    expect(plan.deltasByContextKey.size).toBe(1);
-    expect(plan.deltasByContextKey.get('org-1')).toEqual({ 'm:admin': 1, 'm:total': 1, 's:membership': 1 });
+    expect(plan.seqGroups).toHaveLength(0);
+    expect(plan.countDeltasByContextKey.get('org-1')).toEqual({ 'm:admin': 1, 'm:total': 1, 's:membership': 1 });
   });
 
   it('membership delete: decrements role + total', () => {
-    const plan = computeUnifiedDeltas(
-      mockResult({
+    const plan = computeBatchUnifiedDeltas([
+      mockEvent({
         tableMeta: membershipEntry(),
         action: 'delete',
         rowData: { id: 'mem-1', organizationId: 'org-1', contextId: 'org-1', role: 'member' },
       }),
-    );
+    ]);
 
-    expect(plan.deltasByContextKey.get('org-1')).toEqual({ 'm:member': -1, 'm:total': -1, 's:membership': 1 });
+    expect(plan.countDeltasByContextKey.get('org-1')).toEqual({ 'm:member': -1, 'm:total': -1, 's:membership': 1 });
   });
 
   it('membership update (role change): swaps role counts', () => {
-    const plan = computeUnifiedDeltas(
-      mockResult({
+    const plan = computeBatchUnifiedDeltas([
+      mockEvent({
         tableMeta: membershipEntry(),
         action: 'update',
         rowData: { id: 'mem-1', organizationId: 'org-1', contextId: 'org-1', role: 'admin' },
         oldRowData: { id: 'mem-1', organizationId: 'org-1', contextId: 'org-1', role: 'member' },
       }),
-    );
+    ]);
 
-    expect(plan.deltasByContextKey.get('org-1')).toEqual({ 'm:member': -1, 'm:admin': 1, 's:membership': 1 });
+    expect(plan.countDeltasByContextKey.get('org-1')).toEqual({ 'm:member': -1, 'm:admin': 1, 's:membership': 1 });
   });
 
   it('inactive membership create (pending): increments pending count', () => {
-    const plan = computeUnifiedDeltas(
-      mockResult({
+    const plan = computeBatchUnifiedDeltas([
+      mockEvent({
         tableMeta: inactiveMembershipEntry(),
         action: 'create',
         rowData: { id: 'imem-1', organizationId: 'org-1', contextId: 'org-1', rejectedAt: null },
       }),
-    );
+    ]);
 
-    expect(plan.deltasByContextKey.get('org-1')).toEqual({ 'm:pending': 1, 's:membership': 1 });
+    expect(plan.countDeltasByContextKey.get('org-1')).toEqual({ 'm:pending': 1, 's:membership': 1 });
   });
 
   it('inactive membership update (rejected): decrements pending', () => {
-    const plan = computeUnifiedDeltas(
-      mockResult({
+    const plan = computeBatchUnifiedDeltas([
+      mockEvent({
         tableMeta: inactiveMembershipEntry(),
         action: 'update',
         rowData: { id: 'imem-1', organizationId: 'org-1', contextId: 'org-1', rejectedAt: '2026-01-01' },
         oldRowData: { id: 'imem-1', organizationId: 'org-1', contextId: 'org-1', rejectedAt: null },
       }),
-    );
+    ]);
 
-    expect(plan.deltasByContextKey.get('org-1')).toEqual({ 'm:pending': -1, 's:membership': 1 });
-  });
-
-  it('attachment with no organizationId: no context resolvable, seq deltas skipped', () => {
-    const plan = computeUnifiedDeltas(
-      mockResult({
-        tableMeta: attachmentEntry(),
-        action: 'create',
-        rowData: { id: 'att-1' },
-        organizationId: null,
-      }),
-    );
-
-    // No parent column and no org — malformed row, no seq scope to stamp
-    expect(plan.seqContextKey).toBeNull();
-    expect(plan.deltasByContextKey.size).toBe(0);
+    expect(plan.countDeltasByContextKey.get('org-1')).toEqual({ 'm:pending': -1, 's:membership': 1 });
   });
 });
 

--- a/cdc/src/tests/wire-contract.type-check.ts
+++ b/cdc/src/tests/wire-contract.type-check.ts
@@ -1,0 +1,32 @@
+import type { CdcMessage } from '#/lib/cdc-websocket';
+import type { CdcOutboundMessage } from '../services/activity-service';
+
+/**
+ * Compile-time drift guard for the CDC → API-server wire contract.
+ * See .info/wire-contract-and-stream-split-options.md (Part A, option A1).
+ *
+ * Asserts that what the CDC worker *produces* (`CdcOutboundMessage`) satisfies what
+ * the backend *validates* (`CdcMessage`, inferred from `cdcMessageSchema`).
+ *
+ * - Envelope fields (`rowData`, `cacheToken`, `batchReservations`, `_trace`) are the
+ *   hand-written part of the contract and are checked strictly: renaming, removing,
+ *   or retyping any of them on one side without the other fails this build.
+ * - The `activity` sub-shape is checked with tolerance. Both ends co-derive it from
+ *   `activitiesTable` (CDC via `InsertActivityModel`, backend via `createSelectSchema`),
+ *   so it cannot drift independently; the only static difference is drizzle
+ *   insert-optionality (nullable columns are `T?`), which `createActivity` always
+ *   fills at runtime. Tolerating that keeps the guard honest without a false positive.
+ *
+ * Type-only: compiled by `pnpm ts`, not run by vitest (which only picks up `*.test.ts`).
+ */
+type ActivityFieldsTolerant<T> = { [K in keyof T]?: T[K] | undefined };
+
+type WireConformanceTarget = Omit<CdcMessage, 'activity'> & {
+  activity: ActivityFieldsTolerant<CdcMessage['activity']>;
+};
+
+type Assert<T extends true> = T;
+
+// If CDC's payload stops satisfying the backend's validated shape, the conditional
+// yields `false` and `Assert<false>` fails to compile — surfacing the drift here.
+export type CdcConformsToBackendSchema = Assert<CdcOutboundMessage extends WireConformanceTarget ? true : false>;

--- a/cdc/src/utils/apply-unified-deltas.ts
+++ b/cdc/src/utils/apply-unified-deltas.ts
@@ -2,7 +2,7 @@ import { sql } from 'drizzle-orm';
 import format from 'pg-format';
 import { cdcDb } from '../lib/db';
 import { log } from '../lib/pino';
-import type { BatchUnifiedDeltaPlan, UnifiedDeltaPlan } from './compute-unified-deltas';
+import type { BatchUnifiedDeltaPlan } from './compute-unified-deltas';
 
 // ── Counter upsert ───────────────────────────────────────────────────────────
 
@@ -48,65 +48,17 @@ async function mergedUpsert(
   `);
 }
 
-// ── Entity seq stamp ─────────────────────────────────────────────────────────
+// ── Batch execution ──────────────────────────────────────────────────────────
 
-/**
- * UPDATE a single entity's seq column.
- * Also strips stx.changedFields — it's transient metadata from the last user mutation
- * and would cause handleUpdate to create a spurious activity from stale fields.
- */
-async function updateEntitySeq(tableName: string, entityId: string, newSeq: number): Promise<void> {
-  await cdcDb.execute(
-    sql`UPDATE ${sql.raw(format('%I', tableName))} SET seq = ${newSeq}, stx = stx - 'changedFields' WHERE id = ${entityId}`,
-  );
-}
-
-// ── Single event execution ───────────────────────────────────────────────────
-
-/**
- * Apply a unified delta plan for a single CDC event.
- *
- * Phase 1 (sequential): UPSERT the seqContextKey row with RETURNING to get the new seq.
- * Phase 2 (parallel): All remaining context UPSERTs + entity seq UPDATE.
- *
- * Returns the new seq value (or undefined if no seq stamp was needed).
- */
-export async function applyUnifiedDeltas(plan: UnifiedDeltaPlan): Promise<number | undefined> {
-  const { seqContextKey, seqKey, entityStamp, deltasByContextKey } = plan;
-
-  if (deltasByContextKey.size === 0 && !entityStamp) return undefined;
-
-  let newSeq: number | undefined;
-
-  // Phase 1: UPSERT the seq row with RETURNING
-  if (seqContextKey && seqKey) {
-    const seqDeltas = deltasByContextKey.get(seqContextKey);
-    if (seqDeltas) {
-      const counts = await mergedUpsert(seqContextKey, seqDeltas, true);
-      newSeq = counts[seqKey] ?? undefined;
+/** Add each source delta into `target` in place, summing on key collision. */
+function sumInto(target: Record<string, number>, source: Record<string, number> | undefined): Record<string, number> {
+  if (source) {
+    for (const [k, v] of Object.entries(source)) {
+      target[k] = (target[k] ?? 0) + v;
     }
   }
-
-  // Phase 2: All remaining UPSERTs + entity seq stamp in parallel
-  const phase2: Promise<void>[] = [];
-
-  for (const [contextKey, deltas] of deltasByContextKey) {
-    if (contextKey === seqContextKey) continue; // Already handled in Phase 1
-    phase2.push(mergedUpsert(contextKey, deltas));
-  }
-
-  if (entityStamp && newSeq !== undefined) {
-    phase2.push(updateEntitySeq(entityStamp.tableName, entityStamp.entityId, newSeq));
-  }
-
-  if (phase2.length > 0) {
-    await Promise.all(phase2);
-  }
-
-  return newSeq;
+  return target;
 }
-
-// ── Batch execution ──────────────────────────────────────────────────────────
 
 /**
  * Apply a unified delta plan for a batch of CDC events.
@@ -127,13 +79,7 @@ export async function applyBatchUnifiedDeltas(plan: BatchUnifiedDeltaPlan): Prom
   // Phase 1: Sequential UPSERT per seq group (need RETURNING for each)
   for (const group of seqGroups) {
     // Merge seq deltas with any count deltas for this contextKey
-    const mergedDeltas: Record<string, number> = { [group.seqKey]: group.count };
-    const countDeltas = countDeltasByContextKey.get(group.contextKey);
-    if (countDeltas) {
-      for (const [k, v] of Object.entries(countDeltas)) {
-        mergedDeltas[k] = (mergedDeltas[k] ?? 0) + v;
-      }
-    }
+    const mergedDeltas = sumInto({ [group.seqKey]: group.count }, countDeltasByContextKey.get(group.contextKey));
     handledContextKeys.add(group.contextKey);
 
     const counts = await mergedUpsert(group.contextKey, mergedDeltas, true);
@@ -150,13 +96,7 @@ export async function applyBatchUnifiedDeltas(plan: BatchUnifiedDeltaPlan): Prom
 
     // Org signal: merge with any count deltas for the org
     if (group.orgSignal) {
-      const orgMerged: Record<string, number> = { [group.orgSignal.seqKey]: group.orgSignal.count };
-      const orgCounts = countDeltasByContextKey.get(group.orgSignal.orgKey);
-      if (orgCounts) {
-        for (const [k, v] of Object.entries(orgCounts)) {
-          orgMerged[k] = (orgMerged[k] ?? 0) + v;
-        }
-      }
+      const orgMerged = sumInto({ [group.orgSignal.seqKey]: group.orgSignal.count }, countDeltasByContextKey.get(group.orgSignal.orgKey));
       handledContextKeys.add(group.orgSignal.orgKey);
       await mergedUpsert(group.orgSignal.orgKey, orgMerged);
     }
@@ -201,79 +141,5 @@ export async function applyBatchUnifiedDeltas(plan: BatchUnifiedDeltaPlan): Prom
 
   if (phase2.length > 0) {
     await Promise.all(phase2);
-  }
-}
-
-// ── Catchup-mode: seq-only batch execution ───────────────────────────────────
-
-/**
- * Apply only seq stamps from a batch plan, skipping all counter UPSERTs.
- * Used during catchup mode where counters will be recalculated after replay.
- *
- * For each seq group: UPSERT seq delta with RETURNING, assign seq values,
- * then bulk UPDATE entity rows. Org signals are included since they carry
- * seq counters too.
- */
-export async function applyBatchSeqOnlyDeltas(plan: BatchUnifiedDeltaPlan): Promise<void> {
-  const { seqGroups } = plan;
-
-  if (seqGroups.length === 0) return;
-
-  const allEntityStamps: Array<{ tableName: string; id: string; seq: number }> = [];
-
-  // Phase 1: Sequential UPSERT per seq group (need RETURNING for each)
-  for (const group of seqGroups) {
-    // Only the seq delta — no count deltas merged
-    const seqDelta: Record<string, number> = { [group.seqKey]: group.count };
-
-    const counts = await mergedUpsert(group.contextKey, seqDelta, true);
-    const highSeq = counts[group.seqKey] ?? group.count;
-    const baseSeq = highSeq - group.count;
-
-    // Assign seq values to events
-    for (let i = 0; i < group.events.length; i++) {
-      const seq = baseSeq + i + 1;
-      const entityId = group.events[i].result.rowData.id;
-      group.events[i].result.rowData.seq = seq;
-      allEntityStamps.push({ tableName: group.tableName, id: entityId, seq });
-    }
-
-    // Org-level seq signal (needed for frontend sync protocol)
-    if (group.orgSignal) {
-      const orgSeqDelta: Record<string, number> = { [group.orgSignal.seqKey]: group.orgSignal.count };
-      await mergedUpsert(group.orgSignal.orgKey, orgSeqDelta);
-    }
-
-    log.trace('Catchup seq stamped', {
-      entityType: group.seqKey.replace('s:', ''),
-      count: group.count,
-      baseSeq: baseSeq + 1,
-      highSeq,
-    });
-  }
-
-  // Phase 2: Bulk entity seq stamp
-  if (allEntityStamps.length > 0) {
-    const byTable = new Map<string, Array<{ id: string; seq: number }>>();
-    for (const stamp of allEntityStamps) {
-      const list = byTable.get(stamp.tableName);
-      if (list) list.push(stamp);
-      else byTable.set(stamp.tableName, [stamp]);
-    }
-
-    const stampPromises: Promise<void>[] = [];
-    for (const [tableName, stamps] of byTable) {
-      const valuesList = stamps.map((s) => sql`(${s.id}::uuid, ${s.seq}::bigint)`);
-      stampPromises.push(
-        cdcDb.execute(sql`
-          UPDATE ${sql.raw(format('%I', tableName))} AS t
-          SET seq = v.seq, stx = t.stx - 'changedFields'
-          FROM (VALUES ${sql.join(valuesList, sql`, `)}) AS v(id, seq)
-          WHERE t.id = v.id
-        `).then(() => {}),
-      );
-    }
-
-    await Promise.all(stampPromises);
   }
 }

--- a/cdc/src/utils/compute-unified-deltas.ts
+++ b/cdc/src/utils/compute-unified-deltas.ts
@@ -2,26 +2,11 @@ import { getTableName } from 'drizzle-orm';
 import { appConfig, hierarchy, isProductEntity } from 'shared';
 import type { ActivityAction } from 'shared';
 import type { PendingEvent, TableMeta } from '../types';
-import type { ActivityWithoutId, ParseMessageResult } from '../pipeline/parse-message';
+import type { ActivityWithoutId } from '../pipeline/parse-message';
 import type { CdcRowData } from '../types';
 import { getCountDeltas } from './update-counts';
 
 // ── Types ────────────────────────────────────────────────────────────────────
-
-/**
- * Plan for a single CDC event: all counter deltas merged by contextKey,
- * plus optional seq stamp metadata.
- */
-export interface UnifiedDeltaPlan {
-  /** Context key that needs RETURNING (parent context for seq). Null if no seq stamp needed. */
-  seqContextKey: string | null;
-  /** Seq counter key, e.g. 's:task'. Null if no seq stamp. */
-  seqKey: string | null;
-  /** Entity row to stamp with the new seq value. Null if no seq stamp. */
-  entityStamp: { tableName: string; entityId: string } | null;
-  /** All deltas grouped by contextKey — seq and count deltas merged per row. */
-  deltasByContextKey: Map<string, Record<string, number>>;
-}
 
 /**
  * Plan for a batch of CDC events: seq groups that need RETURNING,
@@ -80,47 +65,6 @@ function mergeDelta(map: Map<string, Record<string, number>>, contextKey: string
 /** Check if this event should get a seq stamp (product entity create/update). */
 function isStampable(tableMeta: TableMeta, action: ActivityAction): boolean {
   return tableMeta.kind === 'entity' && isProductEntity(tableMeta.type) && (action === 'create' || action === 'update');
-}
-
-// ── Single event ─────────────────────────────────────────────────────────────
-
-/**
- * Compute a unified delta plan for a single CDC event.
- * Merges seq deltas and count deltas by contextKey so each row is UPSERTed once.
- */
-export function computeUnifiedDeltas(result: ParseMessageResult): UnifiedDeltaPlan {
-  const { tableMeta, activity, rowData, oldRowData } = result;
-  const { action } = activity;
-  const deltasByContextKey = new Map<string, Record<string, number>>();
-  let seqContextKey: string | null = null;
-  let seqKey: string | null = null;
-  let entityStamp: UnifiedDeltaPlan['entityStamp'] = null;
-
-  // Seq deltas (product entity create/update only; skipped when no context is resolvable)
-  const stampCtxKey = isStampable(tableMeta, action) ? resolveContextKey(tableMeta.type, rowData, activity) : null;
-  if (isStampable(tableMeta, action) && stampCtxKey) {
-    const entityType = tableMeta.type;
-    const ctxKey = stampCtxKey;
-    seqKey = `s:${entityType}`;
-    seqContextKey = ctxKey;
-    entityStamp = { tableName: getTableName(tableMeta.table), entityId: rowData.id };
-
-    // Parent-context seq delta
-    mergeDelta(deltasByContextKey, ctxKey, { [seqKey]: 1 });
-
-    // Org-level seq signal (skip if ctx === org or no org)
-    if (activity.organizationId && ctxKey !== activity.organizationId) {
-      mergeDelta(deltasByContextKey, activity.organizationId, { [seqKey]: 1 });
-    }
-  }
-
-  // Count deltas (entity counts, membership counts, embedding counts)
-  const countDeltas = getCountDeltas(tableMeta, activity, rowData, oldRowData);
-  for (const { contextKey, deltas } of countDeltas) {
-    mergeDelta(deltasByContextKey, contextKey, deltas);
-  }
-
-  return { seqContextKey, seqKey, entityStamp, deltasByContextKey };
 }
 
 // ── Batch ────────────────────────────────────────────────────────────────────

--- a/cdc/src/utils/context-columns.ts
+++ b/cdc/src/utils/context-columns.ts
@@ -1,0 +1,15 @@
+import { appConfig } from 'shared';
+import type { ContextEntityIdColumns } from 'shared';
+
+/**
+ * ID column keys for every context entity type (e.g. `['organizationId']`),
+ * precomputed once from config.
+ *
+ * The context-column iteration pattern — "for each context entity type, read its
+ * ID column off a row or activity" — recurs in the activity builder, the
+ * transaction buffer, and the delta planner. Sharing the key list keeps those in
+ * lockstep with `appConfig.contextEntityTypes`.
+ */
+export const contextIdColumnKeys = appConfig.contextEntityTypes.map(
+  (type) => appConfig.entityIdColumnKeys[type],
+) as ReadonlyArray<keyof ContextEntityIdColumns>;

--- a/cdc/src/utils/embedding-cleanup.ts
+++ b/cdc/src/utils/embedding-cleanup.ts
@@ -5,6 +5,7 @@ import { getEntityTable } from '#/tables';
 import { cdcDb } from '../lib/db';
 import { log } from '../lib/pino';
 import type { CdcRowData } from '../types';
+import { isSoftDeleteTransition } from './is-soft-delete-transition';
 
 type EmbeddingCleanupAction = Extract<ActivityAction, 'update' | 'delete'>;
 
@@ -50,11 +51,6 @@ function resolveEmbeddings(): ReadonlyMap<ProductEntityType, ResolvedEmbedding[]
 
 /** Pre-resolved embedding lookups, keyed by embedded entity type. */
 const embeddingsByEntity = resolveEmbeddings();
-
-/** True when an update event flips a row from live to soft-deleted (deletedAt newly set). */
-function isSoftDeleteTransition(rowData: CdcRowData, oldRowData: CdcRowData | null | undefined): boolean {
-  return oldRowData != null && oldRowData.deletedAt == null && rowData.deletedAt != null;
-}
 
 /**
  * Strip deleted embedded-entity IDs from host-entity array columns.

--- a/cdc/src/utils/index.ts
+++ b/cdc/src/utils/index.ts
@@ -4,6 +4,6 @@ export { extractRowData } from './extract-row-data';
 export { extractStxData } from './extract-stx-data';
 export { getChangedFields } from './get-changed-fields';
 export { compactRowData, excludedRowDataKeys } from './compact-row-data';
-export { computeUnifiedDeltas, computeBatchUnifiedDeltas } from './compute-unified-deltas';
-export { applyUnifiedDeltas, applyBatchUnifiedDeltas } from './apply-unified-deltas';
+export { computeBatchUnifiedDeltas } from './compute-unified-deltas';
+export { applyBatchUnifiedDeltas } from './apply-unified-deltas';
 export { getCountDeltas } from './update-counts';

--- a/cdc/src/utils/is-soft-delete-transition.ts
+++ b/cdc/src/utils/is-soft-delete-transition.ts
@@ -1,0 +1,12 @@
+import type { RowData } from '../types';
+
+/**
+ * True when an UPDATE flips a row from live to soft-deleted — i.e. `deletedAt`
+ * was null on the old row and is set on the new row.
+ *
+ * Shared by the update handler, count deltas, and embedding cleanup so the
+ * soft-delete definition lives in exactly one place.
+ */
+export function isSoftDeleteTransition(newRow: RowData, oldRow: RowData | null | undefined): boolean {
+  return oldRow != null && oldRow.deletedAt == null && newRow.deletedAt != null;
+}

--- a/cdc/src/utils/update-counts.ts
+++ b/cdc/src/utils/update-counts.ts
@@ -1,10 +1,9 @@
 import { appConfig, hierarchy } from 'shared';
 import type { ActivityAction } from 'shared';
 import type { ActivityWithoutId } from '../pipeline/parse-message';
-import type { InactiveMembershipModel } from '#/modules/memberships/inactive-memberships-db';
-import type { MembershipModel } from '#/modules/memberships/memberships-db';
 import type { TableMeta } from '../types';
 import type { CdcRowData } from '../types';
+import { isSoftDeleteTransition } from './is-soft-delete-transition';
 import { log } from '../lib/pino';
 
 export interface CountDelta {
@@ -42,22 +41,16 @@ export function getCountDeltas(
 ): CountDelta[] {
   const { action, organizationId } = activity;
 
-  // Active memberships: track role counts + total
-  if (tableMeta.kind === 'resource' && tableMeta.type === 'membership') {
-    const delta = getMembershipDelta(action, newRow as MembershipModel, oldRow as MembershipModel | null);
+  // Memberships (active + inactive): counter deltas plus an org-level membership seq signal.
+  if (tableMeta.kind === 'resource' && (tableMeta.type === 'membership' || tableMeta.type === 'inactive_membership')) {
+    const delta =
+      tableMeta.type === 'membership'
+        ? getMembershipDelta(action, newRow, oldRow)
+        : getInactiveMembershipDelta(action, newRow, oldRow);
     const deltas = delta ? [delta] : [];
-    // Bump the org-level membership seq on every membership activity so catchup can detect
-    // membership changes via O(1) counter screening (no activity scan needed).
-    if (organizationId) deltas.push({ contextKey: organizationId, deltas: { 's:membership': 1 } });
-    return deltas;
-  }
-
-  // Inactive memberships: track pending count
-  if (tableMeta.kind === 'resource' && tableMeta.type === 'inactive_membership') {
-    const delta = getInactiveMembershipDelta(action, newRow as InactiveMembershipModel, oldRow as InactiveMembershipModel | null);
-    const deltas = delta ? [delta] : [];
-    // Pending invitations appear in member lists too — bump the membership seq so the client
-    // refreshes them on catchup.
+    // Bump the org-level membership seq on every membership / inactive-membership activity so
+    // catchup can detect membership changes via O(1) counter screening (no activity scan needed).
+    // Pending invitations appear in member lists too, so inactive memberships bump it as well.
     if (organizationId) deltas.push({ contextKey: organizationId, deltas: { 's:membership': 1 } });
     return deltas;
   }
@@ -116,32 +109,35 @@ function getArrayValue(row: CdcRowData | undefined, key: string): string[] {
   return Array.isArray(v) ? v.filter((item): item is string => typeof item === 'string') : [];
 }
 
-function isSoftDeleteTransition(newRow: CdcRowData, oldRow: CdcRowData | null): boolean {
-  return oldRow !== null && oldRow.deletedAt == null && newRow.deletedAt != null;
-}
-
 /**
  * Get membership count delta based on create/update/delete action and role change.
+ * Reads only the fields it needs (contextId, role) off the WAL row — both are
+ * NOT NULL columns, so a missing value means a malformed row and yields no delta.
  */
 function getMembershipDelta(
   action: ActivityAction,
-  newRow: MembershipModel,
-  oldRow: MembershipModel | null,
+  newRow: CdcRowData,
+  oldRow: CdcRowData | null,
 ): CountDelta | null {
-  const { contextId } = newRow;
+  const contextId = getStringValue(newRow, 'contextId');
+  if (!contextId) return null;
 
   if (action === 'create') {
-    return { contextKey: contextId, deltas: { [`m:${newRow.role}`]: 1, 'm:total': 1 } };
+    const role = getStringValue(newRow, 'role');
+    return role ? { contextKey: contextId, deltas: { [`m:${role}`]: 1, 'm:total': 1 } } : null;
   }
 
   if (action === 'delete') {
-    return { contextKey: contextId, deltas: { [`m:${newRow.role}`]: -1, 'm:total': -1 } };
+    const role = getStringValue(newRow, 'role');
+    return role ? { contextKey: contextId, deltas: { [`m:${role}`]: -1, 'm:total': -1 } } : null;
   }
 
   if (action === 'update' && oldRow) {
+    const oldRole = getStringValue(oldRow, 'role');
+    const newRole = getStringValue(newRow, 'role');
     // Only emit delta if role actually changed
-    if (oldRow.role !== newRow.role) {
-      return { contextKey: contextId, deltas: { [`m:${oldRow.role}`]: -1, [`m:${newRow.role}`]: 1 } };
+    if (oldRole && newRole && oldRole !== newRole) {
+      return { contextKey: contextId, deltas: { [`m:${oldRole}`]: -1, [`m:${newRole}`]: 1 } };
     }
   }
 
@@ -152,10 +148,11 @@ function getMembershipDelta(
  */
 function getInactiveMembershipDelta(
   action: ActivityAction,
-  newRow: InactiveMembershipModel,
-  oldRow: InactiveMembershipModel | null,
+  newRow: CdcRowData,
+  oldRow: CdcRowData | null,
 ): CountDelta | null {
-  const { contextId } = newRow;
+  const contextId = getStringValue(newRow, 'contextId');
+  if (!contextId) return null;
 
   if (action === 'create') {
     // Only count pending (not rejected)

--- a/frontend/src/query/realtime/app-stream-handler.ts
+++ b/frontend/src/query/realtime/app-stream-handler.ts
@@ -21,87 +21,81 @@ import type { AppStreamNotification } from './types';
  * to trigger refetch, or use cacheToken for efficient fetches.
  */
 export function handleAppStreamNotification(notification: AppStreamNotification): void {
-  const {
-    subjectId,
-    action,
-    resourceType,
-    entityType,
-    stx,
-    organizationId,
-    tenantId,
-    contextType,
-    seq,
-    cacheToken,
-    _trace,
-  } = notification;
+  const { subjectId, action, stx, organizationId, tenantId, contextType, seq, cacheToken, _trace } = notification;
 
-  withSpanSync(syncSpanNames.messageProcess, { entityType, action, entityId: subjectId, _trace }, () => {
-    // Store cache token if present (for product entities)
-    if (cacheToken && entityType && subjectId) {
-      cacheOps.storeEntityCacheToken(entityType, subjectId, cacheToken);
-    }
-
-    // Store tenantId in sync store whenever we see it in a notification
-    if (organizationId && tenantId) {
-      useSyncStore.getState().setOrgTenantId(organizationId, tenantId);
-    }
-
-    // Membership events (resourceType = 'membership')
-    if (resourceType === 'membership') {
-      handleMembershipNotification(action, organizationId, contextType);
-      return;
-    }
-
-    if (!isProductEntity(entityType))
-      return console.error('Unknown entityType in app stream notification:', entityType);
-
-    // Create/update batch: range fetch also handles soft-delete tombstones.
-    if (notification.batchUntilSeq && seq != null && organizationId && hasEntityQueryKeys(entityType)) {
-      const keys = getEntityQueryKeys(entityType);
-      const seqCursor = `${seq},${notification.batchUntilSeq}`;
-
-      cacheOps
-        .fetchRangeAndPatch(entityType, organizationId, tenantId, seqCursor, keys, cacheToken ?? undefined)
-        .then((success) => {
-          if (success && notification.batchUntilSeq) {
-            // Store project-scoped seq when contextId (projectId) is available, else org-scoped
-            if (notification.contextId) {
-              useSyncStore
-                .getState()
-                .setContextSeq(organizationId, notification.contextId, entityType, notification.batchUntilSeq);
-            } else {
-              useSyncStore.getState().setOrgSeq(organizationId, entityType, notification.batchUntilSeq);
-            }
-          }
-          // Propagate after fresh source data is in cache
-          if (notification.propagation) propagateEmbeddings(notification.propagation);
-        })
-        .catch((err) => console.warn('[AppStream] Batch fetch failed:', err));
-
-      // Unseen count: derive from contiguous seq range (single-context constraint)
-      if (action === 'create') {
-        adjustUnseenCount(entityType, notification.contextId ?? null, notification.batchUntilSeq - seq + 1);
+  withSpanSync(
+    syncSpanNames.messageProcess,
+    { entityType: notification.entityType, action, entityId: subjectId, _trace },
+    () => {
+      // Store cache token if present (for product entities)
+      if (cacheToken && notification.entityType && subjectId) {
+        cacheOps.storeEntityCacheToken(notification.entityType, subjectId, cacheToken);
       }
-      return;
-    }
 
-    const keys = getEntityQueryKeys(entityType);
-    if (!organizationId || !subjectId)
-      return console.error('Missing organizationId/subjectId for product entity event:', entityType, subjectId);
+      // Store tenantId in sync store whenever we see it in a notification
+      if (organizationId && tenantId) {
+        useSyncStore.getState().setOrgTenantId(organizationId, tenantId);
+      }
 
-    handleEntityNotification(
-      entityType,
-      subjectId,
-      action,
-      stx,
-      organizationId,
-      tenantId,
-      seq ?? null,
-      notification.contextId ?? null,
-      keys,
-      notification.propagation,
-    );
-  });
+      // Membership changes use targeted query invalidation, not the seq/cacheToken sync path.
+      if (notification.kind === 'membership') {
+        handleMembershipNotification(action, organizationId, contextType);
+        return;
+      }
+
+      // kind === 'entity' — entityType is narrowed to a product entity type (non-null).
+      const entityType = notification.entityType;
+      if (!isProductEntity(entityType))
+        return console.error('Unknown entityType in app stream notification:', entityType);
+
+      // Create/update batch: range fetch also handles soft-delete tombstones.
+      if (notification.batchUntilSeq && seq != null && organizationId && hasEntityQueryKeys(entityType)) {
+        const keys = getEntityQueryKeys(entityType);
+        const seqCursor = `${seq},${notification.batchUntilSeq}`;
+
+        cacheOps
+          .fetchRangeAndPatch(entityType, organizationId, tenantId, seqCursor, keys, cacheToken ?? undefined)
+          .then((success) => {
+            if (success && notification.batchUntilSeq) {
+              // Store project-scoped seq when contextId (projectId) is available, else org-scoped
+              if (notification.contextId) {
+                useSyncStore
+                  .getState()
+                  .setContextSeq(organizationId, notification.contextId, entityType, notification.batchUntilSeq);
+              } else {
+                useSyncStore.getState().setOrgSeq(organizationId, entityType, notification.batchUntilSeq);
+              }
+            }
+            // Propagate after fresh source data is in cache
+            if (notification.propagation) propagateEmbeddings(notification.propagation);
+          })
+          .catch((err) => console.warn('[AppStream] Batch fetch failed:', err));
+
+        // Unseen count: derive from contiguous seq range (single-context constraint)
+        if (action === 'create') {
+          adjustUnseenCount(entityType, notification.contextId ?? null, notification.batchUntilSeq - seq + 1);
+        }
+        return;
+      }
+
+      const keys = getEntityQueryKeys(entityType);
+      if (!organizationId || !subjectId)
+        return console.error('Missing organizationId/subjectId for product entity event:', entityType, subjectId);
+
+      handleEntityNotification(
+        entityType,
+        subjectId,
+        action,
+        stx,
+        organizationId,
+        tenantId,
+        seq ?? null,
+        notification.contextId ?? null,
+        keys,
+        notification.propagation,
+      );
+    },
+  );
 }
 
 /**

--- a/frontend/src/query/realtime/types.ts
+++ b/frontend/src/query/realtime/types.ts
@@ -1,4 +1,5 @@
 import type { StreamNotification } from 'sdk';
+import type { ProductEntityType } from 'shared';
 
 /** Stream connection state. */
 export type StreamState = 'disconnected' | 'connecting' | 'catching-up' | 'live' | 'error';
@@ -24,8 +25,21 @@ export interface StreamTraceContext {
   lsn?: string;
 }
 
-/** App stream notification with optional trace context for debugging. */
-export type AppStreamNotification = StreamNotification & {
+/**
+ * Product-entity notification — the seq/cacheToken sync path. `entityType` is
+ * guaranteed non-null when `kind === 'entity'`.
+ */
+export type EntityNotification = StreamNotification & { kind: 'entity'; entityType: ProductEntityType };
+
+/** Membership notification — the query-invalidation path. */
+export type MembershipNotification = StreamNotification & { kind: 'membership'; resourceType: 'membership' };
+
+/**
+ * App stream notification with optional trace context for debugging.
+ * Discriminated on `kind` so entity vs membership branches are exhaustive and
+ * the compiler proves which fields are present in each.
+ */
+export type AppStreamNotification = (EntityNotification | MembershipNotification) & {
   _trace?: StreamTraceContext;
 };
 

--- a/sdk/gen/docs.gen/schemas.gen.json
+++ b/sdk/gen/docs.gen/schemas.gen.json
@@ -329,6 +329,12 @@
     "schema": {
       "type": "object",
       "properties": {
+        "kind": {
+          "type": "string",
+          "required": true,
+          "description": "Discriminant for the notification: product-entity sync vs membership change",
+          "enum": ["entity", "membership"]
+        },
         "action": {
           "type": "string",
           "required": true,
@@ -452,6 +458,7 @@
     },
     "description": "Realtime notification delivered via SSE for entity and membership changes.",
     "example": {
+      "kind": "entity",
       "action": "update",
       "entityType": "attachment",
       "resourceType": null,

--- a/sdk/gen/openapi.json
+++ b/sdk/gen/openapi.json
@@ -656,6 +656,11 @@
       "StreamNotification": {
         "type": "object",
         "properties": {
+          "kind": {
+            "type": "string",
+            "enum": ["entity", "membership"],
+            "description": "Discriminant for the notification: product-entity sync vs membership change"
+          },
           "action": {
             "type": "string",
             "enum": ["create", "update", "delete"]
@@ -744,6 +749,7 @@
           }
         },
         "required": [
+          "kind",
           "action",
           "entityType",
           "resourceType",
@@ -760,6 +766,7 @@
         ],
         "description": "Realtime notification delivered via SSE for entity and membership changes.",
         "example": {
+          "kind": "entity",
           "action": "update",
           "entityType": "attachment",
           "resourceType": null,

--- a/sdk/gen/types.gen.ts
+++ b/sdk/gen/types.gen.ts
@@ -107,6 +107,10 @@ export type StxBase = {
  * Realtime notification delivered via SSE for entity and membership changes.
  */
 export type StreamNotification = {
+  /**
+   * Discriminant for the notification: product-entity sync vs membership change
+   */
+  kind: 'entity' | 'membership';
   action: 'create' | 'update' | 'delete';
   entityType: 'attachment' | null;
   resourceType: 'request' | 'membership' | 'inactive_membership' | 'tenant' | null;

--- a/sdk/gen/zod.gen.ts
+++ b/sdk/gen/zod.gen.ts
@@ -88,6 +88,7 @@ export const zStxBase = z.object({
  * Realtime notification delivered via SSE for entity and membership changes.
  */
 export const zStreamNotification = z.object({
+  kind: z.enum(['entity', 'membership']),
   action: z.enum(['create', 'update', 'delete']),
   entityType: z.enum(['attachment']).nullable(),
   resourceType: z.enum(['request', 'membership', 'inactive_membership', 'tenant']).nullable(),


### PR DESCRIPTION
Assessment-driven cleanup of the CDC worker and the app-stream contract it feeds, after the public stream was removed (the app stream is now the only stream). No behaviour change except the additive `kind` discriminant. Verified across `cdc`, `backend`, `frontend` typechecks + unit tests; SDK regenerated.

## 1. CDC quality cleanup
- **Dead code removed** — the single-event delta path (`computeUnifiedDeltas`, `applyUnifiedDeltas`, `applyBatchSeqOnlyDeltas`, `extractContextId`) was fully superseded by the batch path. Membership counter coverage was migrated onto the batch function so nothing is lost.
- **Dedup** — one shared `isSoftDeleteTransition`, precomputed `contextIdColumnKeys`, one record-merge helper; dropped the redundant `stripExcludedColumns` double-strip and the no-op context-id recompute in `buildActivityPayload`.
- **Typing** — replaced `as MembershipModel`/`as InactiveMembershipModel` casts with typed field reads; typed context-column access via `ContextEntityIdColumns`; dropped unnecessary `table-registry` casts.
- **Structure** — extracted `dispatchToApi` from the `processEvents` god-function; moved `create-activity.ts` from `handlers/` to `services/` (it builds the activity model, it is not a WAL handler); refreshed the README file tree.

## 2. Wire-contract drift guard (compile-time)
Named the CDC→backend contract on both ends (`CdcOutboundMessage` producer / `CdcMessage` validator) and added `cdc/src/tests/wire-contract.type-check.ts` — a type-only guard that fails the build if the producer stops satisfying the validated schema. Strict on the hand-written envelope; tolerant on the co-derived `activity` shape (insert-optional vs select-required is a static artifact, not drift). Proven to fire on a renamed field.

## 3. Explicit `kind` discriminant on the app stream
The app stream carries two concerns (product-entity sync vs membership changes) that were told apart by sniffing nullable `entityType`/`resourceType` at ~6 sites. Now:
- `streamNotificationSchema` gains `kind: 'entity' | 'membership'` (SDK regenerated).
- Single source of the discriminant: `appNotificationKind()` + `isMembershipEvent()` type guard.
- Backend dispatch and the frontend handler switch on `kind` exhaustively; the frontend gets a discriminated `EntityNotification | MembershipNotification` union so `entityType` is compiler-narrowed to non-null on the entity path.

Behaviour-preserving: `kind` is additive and each branch derives it identically to the check it replaced.

## Verification
- `cdc`: `pnpm ts` + 114 tests ✅
- `backend`: `pnpm ts` ✅
- `frontend`: `pnpm ts` + realtime tests ✅
- SDK regenerated (DB-free)

## Notes
- `.info/*.md` are the analysis/planning docs behind this work; drop them from the PR if unwanted.
- A runtime Playwright/SSE check was scoped but skipped (change is behaviour-preserving by construction). Ready-to-run plan: two authed sessions in one org — entity CRUD realtime propagation, membership add/role/remove invalidation, echo-prevention, batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
