### PR TITLE
feat(permissions): topology seam + wide-fixture kit for fork-independent engine tests

### DIFF
--- a/backend/src/modules/entities/helpers/recalculate-counters.test.ts
+++ b/backend/src/modules/entities/helpers/recalculate-counters.test.ts
@@ -5,15 +5,24 @@ import { deepestAncestorExpr } from './recalculate-counters';
 /**
  * Recalculation must group seq counters by the same deepest-non-null-ancestor rule CDC
  * stamps them with (`resolveContextKey`), or recovery fights live CDC. The full pipeline
- * runs against real fork tables; the grouping SQL shape is asserted here, including on a
- * synthetic deep hierarchy that raak's own config cannot express.
+ * runs against real fork tables; the grouping SQL shape is asserted here on synthetic
+ * hierarchies built inline (plus one architectural invariant — organization is always the
+ * root context and has no ancestors — true in every fork), so the assertions are fork-independent.
  */
 describe('deepestAncestorExpr', () => {
-  it('app config: attachment groups by its ancestor chain (organization)', () => {
-    expect(deepestAncestorExpr('attachment', 't')).toBe('COALESCE(t.organization_id)');
+  it('two-level hierarchy: product groups by parent context, then organization', () => {
+    const roles = createRoleRegistry(['admin', 'member'] as const);
+    const h = createEntityHierarchy(roles)
+      .user()
+      .context('organization', { parent: null, roles: roles.all })
+      .context('project', { parent: 'organization', roles: roles.all })
+      .product('task', { parent: 'project' })
+      .build();
+
+    expect(deepestAncestorExpr('task', 't', h)).toBe('COALESCE(t.project_id, t.organization_id)');
   });
 
-  it('app config: root context has no grouping expression', () => {
+  it('root context has no grouping expression (organization is guaranteed present in every hierarchy)', () => {
     expect(deepestAncestorExpr('organization', 't')).toBeNull();
   });
 

--- a/backend/tests/attachment-seq-reads.test.ts
+++ b/backend/tests/attachment-seq-reads.test.ts
@@ -20,11 +20,13 @@
 import { inArray } from 'drizzle-orm';
 import { getAttachments } from 'sdk';
 import { generateId } from 'shared/entity-id';
+import { buildTestEntityHierarchyPlan, type TestEntityHierarchyPlan } from 'shared/testing/entity-hierarchy';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { baseDb as db } from '#/db/db';
 import { attachmentsTable } from '#/modules/attachment/attachment-db';
 import { mockStxBase } from '#/schemas/sync-transaction-mocks';
 import { defaultHeaders } from './fixtures';
+import { cleanupEntityHierarchy, seedEntityHierarchy } from './hierarchy-helpers';
 import { clearSecurityTestData, createTestTenant, type TestTenant } from './security/helpers';
 import { createAppClient } from './test-client';
 import { mockFetchRequest, setTestConfig } from './test-utils';
@@ -44,6 +46,9 @@ const daysAgo = (days: number) => new Date(Date.now() - days * 24 * 60 * 60 * 10
 describe('Attachment seq reads', async () => {
   const call = await createAppClient();
   let tenant: TestTenant;
+  // Ancestor context chain for attachment, derived from the app's real hierarchy: a fork with
+  // organization → project → attachment seeds a project; an org-only fork seeds nothing.
+  let plan: TestEntityHierarchyPlan;
 
   const listAttachments = async (query: Record<string, string | number>) => {
     const result = await call(getAttachments, {
@@ -59,11 +64,22 @@ describe('Attachment seq reads', async () => {
     mockFetchRequest();
     tenant = await createTestTenant(call, 'attachment-seq-reads');
 
+    plan = buildTestEntityHierarchyPlan({
+      entityType: 'attachment',
+      rootContextId: tenant.organization.id,
+      makeContextId: () => generateId(),
+    });
+    await seedEntityHierarchy(db, plan, {
+      tenantId: tenant.tenantId,
+      createdBy: tenant.user.id,
+      slugPrefix: 'attachment-seq',
+    });
+
     // Insert order is DESCENDING seq so createdAt order disagrees with seq order —
     // B1 would pass accidentally if the endpoint sorted by createdAt.
     const baseAttachment = {
       tenantId: tenant.tenantId,
-      organizationId: tenant.organization.id,
+      ...plan.contextIdColumns,
       bucketName: 'attachments',
       contentType: 'image/png',
       size: '1000',
@@ -114,12 +130,15 @@ describe('Attachment seq reads', async () => {
       },
     ];
     for (const row of rows) {
-      await db.insert(attachmentsTable).values(row);
+      // Cast: `...plan.contextIdColumns` is a config-derived Record<string,string>, which widens
+      // the row type; the runtime shape matches the attachment insert (organization/project ids).
+      await db.insert(attachmentsTable).values(row as typeof attachmentsTable.$inferInsert);
     }
   });
 
   afterAll(async () => {
     await db.delete(attachmentsTable).where(inArray(attachmentsTable.id, Object.values(attachmentIds)));
+    await cleanupEntityHierarchy(db, plan);
     await clearSecurityTestData();
   });
 

--- a/backend/tests/hierarchy-helpers.ts
+++ b/backend/tests/hierarchy-helpers.ts
@@ -1,0 +1,40 @@
+import { sql } from 'drizzle-orm';
+import type { TestEntityHierarchyPlan } from 'shared/testing/entity-hierarchy';
+
+/**
+ * Config-adaptive seeding for a product entity's ancestor context chain, derived from the app's
+ * real hierarchy via `buildTestEntityHierarchyPlan`. A fork whose attachment lives directly under
+ * organization seeds nothing; a fork with `organization → project → attachment` seeds a project —
+ * from the same test source. Mirrors the inline pattern in `tests/integration/rls-security.test.ts`.
+ */
+
+const quoteIdent = (identifier: string) => `"${identifier.replaceAll('"', '""')}"`;
+
+/** Minimal shape needed to run raw SQL — satisfied by both `baseDb` and the admin connection. */
+type ExecutableDb = { execute: (query: ReturnType<typeof sql>) => Promise<unknown> };
+
+/** Insert every intermediate context row the plan declares (root context is assumed to exist). */
+export async function seedEntityHierarchy(
+  db: ExecutableDb,
+  plan: TestEntityHierarchyPlan,
+  opts: { tenantId: string; createdBy: string; slugPrefix: string },
+): Promise<void> {
+  for (const row of plan.seedContextRows) {
+    await db.execute(sql`
+      INSERT INTO ${sql.raw(quoteIdent(row.tableName))}
+        (id, tenant_id, entity_type, name, slug, created_by, ${sql.raw(quoteIdent(row.parentColumnName))})
+      VALUES (
+        ${row.id}, ${opts.tenantId}, ${row.contextType}, ${`${opts.slugPrefix} ${row.contextType}`},
+        ${`${opts.slugPrefix}-${row.contextType}-${row.id.slice(0, 8)}`}, ${opts.createdBy}, ${row.parentId}
+      )
+      ON CONFLICT (id) DO NOTHING
+    `);
+  }
+}
+
+/** Delete seeded context rows, children before parents. */
+export async function cleanupEntityHierarchy(db: ExecutableDb, ...plans: TestEntityHierarchyPlan[]): Promise<void> {
+  for (const row of plans.flatMap((plan) => plan.seedContextRows).reverse()) {
+    await db.execute(sql`DELETE FROM ${sql.raw(quoteIdent(row.tableName))} WHERE id = ${row.id}`);
+  }
+}

--- a/frontend/src/query/tests/cache-migration.test.ts
+++ b/frontend/src/query/tests/cache-migration.test.ts
@@ -1,3 +1,4 @@
+import { appConfig } from 'shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the lens engine: simulate a single attachment rename name → title.
@@ -30,7 +31,8 @@ describe('entityTypeOf', () => {
 
   it('extracts a context entity type from a query key', () => {
     expect(entityTypeOf(['organization', 'detail'])).toBe('organization');
-    expect(entityTypeOf(['organization'])).toBe('organization');
+    const deepestContext = appConfig.contextEntityTypes[appConfig.contextEntityTypes.length - 1];
+    expect(entityTypeOf([deepestContext])).toBe(deepestContext);
   });
 
   it('returns null for non-entity keys', () => {

--- a/shared/package.json
+++ b/shared/package.json
@@ -21,7 +21,8 @@
     "./module-registry": "./src/module-registry.ts",
     "./version-changes": "./src/version-changes/index.ts",
     "./test-db": "./src/test-db.ts",
-    "./testing/entity-hierarchy": "./src/testing/entity-hierarchy.ts"
+    "./testing/entity-hierarchy": "./src/testing/entity-hierarchy.ts",
+    "./testing/wide-fixture": "./src/testing/wide-fixture.ts"
   },
   "dependencies": {
     "@blocknote/core": "^0.51.4",

--- a/shared/src/permissions/access-policies.ts
+++ b/shared/src/permissions/access-policies.ts
@@ -1,6 +1,5 @@
 import { appConfig } from '../config-builder/app-config';
 import { hierarchy } from '../../config/hierarchy-config';
-import { getContextRoles } from '../entity-guards';
 import type { ContextEntityType, EntityActionType, EntityRole, EntityType, ProductEntityType } from '../../types';
 import type { PublicReadGrants, PublicReadMode } from './public-read';
 import { own } from './row-conditions';
@@ -17,6 +16,7 @@ import type {
   PermissionValue,
   SubjectAccessPolicies,
 } from './types';
+import type { PermissionTopology } from './permission-manager/topology';
 
 /** Resolves the `'own'` sugar literal to the built-in condition; passes everything else through. */
 const normalizePermissionValue = (value: PermissionValue): NormalizedPermissionValue => {
@@ -30,6 +30,7 @@ const createContextPolicyBuilder = (
   contextType: ContextEntityType,
   roles: readonly string[],
   entries: AccessPolicyEntry[],
+  entityActions: readonly EntityActionType[],
 ): ContextPolicyBuilder => {
   const builder = {} as ContextPolicyBuilder;
 
@@ -39,7 +40,7 @@ const createContextPolicyBuilder = (
       // policy omits defaults to 0 (denied), and the `'own'` sugar literal resolves to the
       // built-in row condition. Omitting an action is therefore equivalent to `0`.
       const fullPermissions = {} as EntityActionPermissions;
-      for (const action of appConfig.entityActions as readonly EntityActionType[]) {
+      for (const action of entityActions) {
         fullPermissions[action] = normalizePermissionValue(permissions[action] ?? 0);
       }
       entries.push({ contextType, role: role as EntityRole, permissions: fullPermissions });
@@ -52,12 +53,17 @@ const createContextPolicyBuilder = (
 /**
  * Creates a contexts object with builders for all context types.
  */
-const createContextBuilders = (entries: AccessPolicyEntry[]): Record<ContextEntityType, ContextPolicyBuilder> => {
+const createContextBuilders = (
+  entries: AccessPolicyEntry[],
+  contextEntityTypes: readonly ContextEntityType[],
+  getRoles: (contextType: string) => readonly string[],
+  entityActions: readonly EntityActionType[],
+): Record<ContextEntityType, ContextPolicyBuilder> => {
   const contexts = {} as Record<ContextEntityType, ContextPolicyBuilder>;
 
-  for (const contextType of appConfig.contextEntityTypes) {
-    const roles = getContextRoles(contextType);
-    contexts[contextType] = createContextPolicyBuilder(contextType, roles, entries);
+  for (const contextType of contextEntityTypes) {
+    const roles = getRoles(contextType);
+    contexts[contextType] = createContextPolicyBuilder(contextType, roles, entries, entityActions);
   }
 
   return contexts;
@@ -91,11 +97,24 @@ export interface PermissionsConfigResult {
 export const configurePermissions = (
   entityTypes: readonly EntityType[],
   callback: AccessPolicyCallback,
+  topology?: PermissionTopology,
 ): PermissionsConfigResult => {
   const policies: AccessPolicies = {};
   const publicReadGrants: PublicReadGrants = {};
   const rowRestrictions: RowRestrictions = {};
   const hostDelegation: HostDelegation = {};
+
+  // Topology defaults to the app's real config; tests pass a synthetic one (wide-fixture.ts).
+  // Context set and roles derive from the (possibly synthetic) hierarchy — its own contextTypes,
+  // not appConfig's, so a fork whose real config is narrower than the fixture still builds every
+  // context. Method refs are wrapped in arrows so `this` stays bound to the hierarchy object.
+  const entityActions = (topology?.entityActions ?? appConfig.entityActions) as readonly EntityActionType[];
+  const contextEntityTypes = (
+    topology ? topology.hierarchy.contextTypes : appConfig.contextEntityTypes
+  ) as readonly ContextEntityType[];
+  const getRoles = (type: string): readonly string[] => (topology?.hierarchy ?? hierarchy).getRoles(type);
+  const getHostType = (type: string) => (topology?.hierarchy ?? hierarchy).getHostType(type);
+  const getParent = (type: string) => (topology?.hierarchy ?? hierarchy).getParent(type);
 
   const permissionableTypes = entityTypes.filter(
     (type): type is ContextEntityType | ProductEntityType => type !== 'user',
@@ -103,7 +122,7 @@ export const configurePermissions = (
 
   for (const entityType of permissionableTypes) {
     const entries: AccessPolicyEntry[] = [];
-    const contexts = createContextBuilders(entries);
+    const contexts = createContextBuilders(entries, contextEntityTypes, getRoles, entityActions);
 
     const config: AccessPolicyConfiguration = {
       subject: { name: entityType },
@@ -127,7 +146,7 @@ export const configurePermissions = (
         if (actions.length === 0) {
           throw new Error(`[Permission] delegateToHost() for "${entityType}" needs at least one action`);
         }
-        if (!hierarchy.getHostType(entityType)) {
+        if (!getHostType(entityType)) {
           throw new Error(
             `[Permission] delegateToHost() for "${entityType}" requires a host declared in the hierarchy (host:)`,
           );
@@ -143,7 +162,7 @@ export const configurePermissions = (
     }
   }
 
-  validatePublicReadGrants(publicReadGrants);
+  validatePublicReadGrants(publicReadGrants, getParent);
 
   return { accessPolicies: policies, publicReadGrants, rowRestrictions, hostDelegation };
 };
@@ -153,11 +172,14 @@ export const configurePermissions = (
  * its own grant must include self-publication. Mirrors the validation the entity
  * hierarchy performed when `publicRead` lived there.
  */
-const validatePublicReadGrants = (grants: PublicReadGrants): void => {
+const validatePublicReadGrants = (
+  grants: PublicReadGrants,
+  getParent: (type: string) => string | null,
+): void => {
   for (const [entityType, mode] of Object.entries(grants) as [ContextEntityType | ProductEntityType, PublicReadMode][]) {
     if (mode !== 'publicParent' && mode !== 'publicParentOrSelf') continue;
 
-    const parent = hierarchy.getParent(entityType);
+    const parent = getParent(entityType);
     const parentMode = parent ? grants[parent as ContextEntityType | ProductEntityType] : undefined;
     if (parentMode !== 'publicSelf' && parentMode !== 'publicParentOrSelf') {
       throw new Error(
@@ -175,8 +197,9 @@ const validatePublicReadGrants = (grants: PublicReadGrants): void => {
 export const configureAccessPolicies = (
   entityTypes: readonly EntityType[],
   callback: AccessPolicyCallback,
+  topology?: PermissionTopology,
 ): AccessPolicies => {
-  return configurePermissions(entityTypes, callback).accessPolicies;
+  return configurePermissions(entityTypes, callback, topology).accessPolicies;
 };
 
 /**

--- a/shared/src/permissions/compute-can.test.ts
+++ b/shared/src/permissions/compute-can.test.ts
@@ -1,9 +1,20 @@
-import { appConfig, configureAccessPolicies } from 'shared';
 import { describe, expect, it } from 'vitest';
 import { computeCan } from './compute-can';
+import { computeWideCan, configureWidePermissions, wideMembership, wideTopology } from '../testing/wide-fixture';
 
-// Policies with 'own' permission for attachment update/delete
-const policies = configureAccessPolicies(appConfig.entityTypes, ({ subject, contexts }) => {
+/**
+ * `computeCan` derives an entity-type-keyed `can` map (context entity + descendants) from a
+ * membership + policies over a hierarchy topology, preserving three-state ('own') semantics.
+ *
+ * Runs against the wide fixture (organization → workspace/project → task/label/attachment, with a
+ * guest role on the nested contexts), which every fork can exercise regardless of its own config's
+ * shape. `wideTopology` is threaded through as `computeCan`'s optional 4th argument so the
+ * hierarchy/entityActions used to compute the map match the wide policies driving it.
+ */
+
+// Policies with 'own' permission for attachment update/delete, plus project-scoped grants
+// (attachment guest-read, task member-update) used by the wider coverage below.
+const { accessPolicies: policies } = configureWidePermissions(({ subject, contexts }) => {
   switch (subject.name) {
     case 'organization':
       contexts.organization.admin({ create: 1, read: 1, update: 1, delete: 1 });
@@ -12,6 +23,13 @@ const policies = configureAccessPolicies(appConfig.entityTypes, ({ subject, cont
     case 'attachment':
       contexts.organization.admin({ create: 1, read: 1, update: 1, delete: 1 });
       contexts.organization.member({ create: 1, read: 1, update: 'own', delete: 'own' });
+      contexts.project.admin({ create: 1, read: 1, update: 1, delete: 1 });
+      contexts.project.member({ create: 1, read: 1, update: 'own', delete: 'own' });
+      contexts.project.guest({ create: 0, read: 1, update: 0, delete: 0 });
+      break;
+    case 'task':
+      contexts.organization.member({ create: 0, read: 1, update: 0, delete: 0 });
+      contexts.project.member({ create: 1, read: 1, update: 1, delete: 0 });
       break;
   }
 });
@@ -20,16 +38,16 @@ describe('computeCan with own permissions', () => {
   // --- Pass cases: 'own' state should be preserved ---
 
   it('returns own for member attachment update/delete', () => {
-    const membership = { contextType: 'organization' as const, role: 'member' as const };
-    const can = computeCan('organization', membership, policies);
+    const membership = wideMembership('organization', 'org1', 'member');
+    const can = computeCan('organization', membership, policies, wideTopology);
 
     expect(can.attachment?.update).toBe('own');
     expect(can.attachment?.delete).toBe('own');
   });
 
   it('returns true for member attachment create/read alongside own', () => {
-    const membership = { contextType: 'organization' as const, role: 'member' as const };
-    const can = computeCan('organization', membership, policies);
+    const membership = wideMembership('organization', 'org1', 'member');
+    const can = computeCan('organization', membership, policies, wideTopology);
 
     expect(can.attachment?.create).toBe(true);
     expect(can.attachment?.read).toBe(true);
@@ -38,8 +56,8 @@ describe('computeCan with own permissions', () => {
   // --- Pass cases: admin gets unconditional true ---
 
   it('returns true (not own) for admin on all attachment actions', () => {
-    const membership = { contextType: 'organization' as const, role: 'admin' as const };
-    const can = computeCan('organization', membership, policies);
+    const membership = wideMembership('organization', 'org1', 'admin');
+    const can = computeCan('organization', membership, policies, wideTopology);
 
     expect(can.attachment?.create).toBe(true);
     expect(can.attachment?.read).toBe(true);
@@ -50,8 +68,8 @@ describe('computeCan with own permissions', () => {
   // --- Fail cases: denied actions stay false ---
 
   it('returns false for member organization create/update/delete', () => {
-    const membership = { contextType: 'organization' as const, role: 'member' as const };
-    const can = computeCan('organization', membership, policies);
+    const membership = wideMembership('organization', 'org1', 'member');
+    const can = computeCan('organization', membership, policies, wideTopology);
 
     expect(can.organization?.create).toBe(false);
     expect(can.organization?.update).toBe(false);
@@ -61,19 +79,47 @@ describe('computeCan with own permissions', () => {
   // --- Edge case: no membership ---
 
   it('returns empty map when membership is null', () => {
-    const can = computeCan('organization', null, policies);
+    const can = computeCan('organization', null, policies, wideTopology);
     expect(can).toEqual({});
   });
 
   it('returns empty map when membership is undefined', () => {
-    const can = computeCan('organization', undefined, policies);
+    const can = computeCan('organization', undefined, policies, wideTopology);
     expect(can).toEqual({});
+  });
+
+  // --- Wider coverage: contexts/roles the shallow org/attachment shape couldn't express ---
+
+  it('grants read-only access to a project guest on attachment (guest-only grant)', () => {
+    const membership = wideMembership('project', 'p1', 'guest');
+    const can = computeWideCan('project', membership, policies);
+
+    expect(can.attachment?.read).toBe(true);
+    expect(can.attachment?.create).toBe(false);
+    expect(can.attachment?.update).toBe(false);
+    expect(can.attachment?.delete).toBe(false);
+  });
+
+  it('differs between an organization member and a project member on the same descendant (task)', () => {
+    const orgMembership = wideMembership('organization', 'org1', 'member');
+    const projectMembership = wideMembership('project', 'p1', 'member');
+
+    const orgCan = computeWideCan('organization', orgMembership, policies);
+    const projectCan = computeWideCan('project', projectMembership, policies);
+
+    // Org members can read tasks across the org, but not update them...
+    expect(orgCan.task?.read).toBe(true);
+    expect(orgCan.task?.update).toBe(false);
+
+    // ...while project members additionally get update rights scoped to their project.
+    expect(projectCan.task?.read).toBe(true);
+    expect(projectCan.task?.update).toBe(true);
   });
 });
 
 describe('computeCan three-state semantics', () => {
   // Policies where every action is 'own' for member
-  const allOwnPolicies = configureAccessPolicies(appConfig.entityTypes, ({ subject, contexts }) => {
+  const { accessPolicies: allOwnPolicies } = configureWidePermissions(({ subject, contexts }) => {
     switch (subject.name) {
       case 'attachment':
         contexts.organization.admin({ create: 1, read: 1, update: 1, delete: 1 });
@@ -83,8 +129,8 @@ describe('computeCan three-state semantics', () => {
   });
 
   it('preserves own for every action when all policies are own', () => {
-    const membership = { contextType: 'organization' as const, role: 'member' as const };
-    const can = computeCan('organization', membership, allOwnPolicies);
+    const membership = wideMembership('organization', 'org1', 'member');
+    const can = computeCan('organization', membership, allOwnPolicies, wideTopology);
 
     expect(can.attachment?.create).toBe('own');
     expect(can.attachment?.read).toBe('own');
@@ -93,8 +139,8 @@ describe('computeCan three-state semantics', () => {
   });
 
   it('does not conflate own with true — they are distinct values', () => {
-    const membership = { contextType: 'organization' as const, role: 'member' as const };
-    const can = computeCan('organization', membership, allOwnPolicies);
+    const membership = wideMembership('organization', 'org1', 'member');
+    const can = computeCan('organization', membership, allOwnPolicies, wideTopology);
 
     // 'own' is truthy but !== true
     expect(can.attachment?.update).not.toBe(true);

--- a/shared/src/permissions/compute-can.ts
+++ b/shared/src/permissions/compute-can.ts
@@ -6,6 +6,7 @@ import { getPolicyPermissions, getSubjectPolicies } from './access-policies';
 import { allActionsDenied } from './action-helpers';
 import { isRowCondition } from './row-conditions';
 import type { AccessPolicies, ActionPermissionState } from './types';
+import type { PermissionTopology } from './permission-manager/topology';
 
 /**
  * Per-action permission state for a single entity type.
@@ -33,13 +34,14 @@ function computeEntityPermissions(
   contextType: ContextEntityType,
   role: EntityRole,
   policies: AccessPolicies,
+  entityActions: readonly EntityActionType[],
 ): ActionStates {
   const subjectPolicies = getSubjectPolicies(entityType as ContextEntityType, policies);
   const permissions = getPolicyPermissions(subjectPolicies, contextType, role);
 
   if (!permissions) return allActionsDenied;
 
-  return recordFromKeys(appConfig.entityActions, (action) => {
+  return recordFromKeys(entityActions, (action) => {
     const value = permissions[action];
     if (value === 1) return true;
     // Row-conditional grant → surface the condition name (e.g. 'own'); the frontend
@@ -74,17 +76,21 @@ export const computeCan = (
   contextType: ContextEntityType,
   membership: { contextType: ContextEntityType; role: EntityRole } | undefined | null,
   policies: AccessPolicies,
+  topology?: PermissionTopology,
 ): EntityCanMap => {
   if (!membership) return {};
 
+  // Topology defaults to the app's real config; tests pass a synthetic one (wide-fixture.ts).
+  const h = topology?.hierarchy ?? hierarchy;
+  const entityActions = topology?.entityActions ?? appConfig.entityActions;
   const map: EntityCanMap = {};
 
   // Permissions for the context entity itself
-  map[contextType] = computeEntityPermissions(contextType, membership.contextType, membership.role, policies);
+  map[contextType] = computeEntityPermissions(contextType, membership.contextType, membership.role, policies, entityActions);
 
   // Permissions for all descendant entity types (children + their children)
-  for (const descendant of hierarchy.getOrderedDescendants(contextType)) {
-    map[descendant] = computeEntityPermissions(descendant, membership.contextType, membership.role, policies);
+  for (const descendant of h.getOrderedDescendants(contextType) as EntityType[]) {
+    map[descendant] = computeEntityPermissions(descendant, membership.contextType, membership.role, policies, entityActions);
   }
 
   return map;

--- a/shared/src/permissions/host-delegation.test.ts
+++ b/shared/src/permissions/host-delegation.test.ts
@@ -1,34 +1,188 @@
 import { describe, expect, it } from 'vitest';
-import { appConfig } from '../config-builder/app-config';
-import { configurePermissions } from './access-policies';
+import { getAllDecisions } from './permission-manager/check';
+import type { SubjectForPermission } from './permission-manager/types';
+import {
+  configureWidePermissions,
+  wideHostDelegation,
+  wideMembership,
+  widePublicGrants,
+  wideRestrictions,
+  wideSubject,
+  wideTopology,
+} from '../testing/wide-fixture';
 
 /**
- * Host permission delegation (`delegateToHost`): a hosted row allows a delegated action
- * if the HOST row allows it — including the host's row conditions, public grants and
- * restrictions. Additive with the subject's own grants; fail-closed without a
- * caller-resolved hostRow.
+ * Host permission delegation (`delegateToHost`): a hosted row allows a delegated action if the
+ * host row allows it, including the host's row conditions, public grants and restrictions.
+ * Additive with the subject's own grants; fail-closed without a hostRow.
  *
- * The runtime delegation path in `getAllDecisions` resolves the host type from the app
- * hierarchy (`hierarchy.getHostType`), so it can only be exercised in an app whose
- * hierarchy declares a `host:` relation (e.g. raak's attachment → task). The template
- * hierarchy has none, so this file covers the declaration-time validation; forks with a
- * host relation should extend it with runtime delegation tests.
+ * Runs against the wide fixture (attachment → task host relation), which every fork can exercise
+ * regardless of whether its own config declares a host relation.
  */
+const { accessPolicies: policies } = configureWidePermissions(({ subject, contexts }) => {
+  switch (subject.name) {
+    case 'attachment':
+      // No read cells at all: read must come from the host
+      contexts.project.member({ update: 1 });
+      contexts.organization.admin({});
+      contexts.organization.member({});
+      contexts.project.admin({});
+      contexts.project.guest({});
+      break;
+    case 'task':
+      contexts.organization.admin({ read: 1, update: 1 });
+      contexts.organization.member({ read: 'own' });
+      contexts.project.admin({ read: 1 });
+      contexts.project.member({ read: 1 });
+      contexts.project.guest({});
+      break;
+  }
+});
+
+const delegation = wideHostDelegation({ attachment: ['read'] });
+
+const projectMember = wideMembership('project', 'p1', 'member');
+const projectGuest = wideMembership('project', 'p1', 'guest');
+const orgMember = wideMembership('organization', 'org1', 'member');
+
+const hostedAttachment = (hostRow: Record<string, unknown> | undefined): SubjectForPermission =>
+  wideSubject({
+    entityType: 'attachment',
+    id: 'att1',
+    contextIds: { organization: 'org1', project: 'p1' },
+    ...(hostRow !== undefined && { hostRow }),
+  });
+
+const taskRow = { id: 'task1', createdBy: 'creator-1' };
+
+describe('host delegation', () => {
+  it('grants a delegated action when the host allows it, attributed as host grant', () => {
+    const decision = getAllDecisions(policies, [projectMember], hostedAttachment(taskRow), {
+      userId: 'u1',
+      hostDelegation: delegation,
+      topology: wideTopology,
+    });
+    expect(decision.can.read).toBe(true);
+    expect(decision.actions.read.grantedBy).toContainEqual({ type: 'host', hostType: 'task' });
+  });
+
+  it('denies when the host denies (no own grants to fall back on)', () => {
+    const { can } = getAllDecisions(policies, [projectGuest], hostedAttachment(taskRow), {
+      userId: 'u1',
+      hostDelegation: delegation,
+      topology: wideTopology,
+    });
+    expect(can.read).toBe(false);
+  });
+
+  it("evaluates the host's row conditions: task creator reads the hosted attachment via own-on-host", () => {
+    const asCreator = getAllDecisions(policies, [orgMember], hostedAttachment(taskRow), {
+      userId: 'creator-1',
+      hostDelegation: delegation,
+      topology: wideTopology,
+    });
+    expect(asCreator.can.read).toBe(true);
+
+    const asOther = getAllDecisions(policies, [orgMember], hostedAttachment(taskRow), {
+      userId: 'someone-else',
+      hostDelegation: delegation,
+      topology: wideTopology,
+    });
+    expect(asOther.can.read).toBe(false);
+  });
+
+  it("evaluates the host's public grant: anonymous reads a hosted row of a public host", () => {
+    const publicTask = { ...taskRow, publicAt: '2026-01-01' };
+    const { can } = getAllDecisions(policies, [], hostedAttachment(publicTask), {
+      hostDelegation: delegation,
+      publicGrants: widePublicGrants({ task: 'publicSelf' }),
+      topology: wideTopology,
+    });
+    expect(can.read).toBe(true);
+  });
+
+  it("evaluates the host's restrictions: a restricted host hides its hosted rows", () => {
+    const restrictedTask = { ...taskRow, audienceRoles: ['admin'] };
+    const { can } = getAllDecisions(policies, [projectMember], hostedAttachment(restrictedTask), {
+      userId: 'u1',
+      hostDelegation: delegation,
+      restrictions: wideRestrictions({ task: { rolesColumn: 'audienceRoles', exemptRoles: [] } }),
+      topology: wideTopology,
+    });
+    expect(can.read).toBe(false);
+  });
+
+  it('only delegates the declared actions', () => {
+    // Task update is org-admin-only; attachment update is project-member-owned. Delegation
+    // covers read only: update stays governed by the attachment's own cells.
+    const decision = getAllDecisions(policies, [projectMember], hostedAttachment(taskRow), {
+      userId: 'u1',
+      hostDelegation: delegation,
+      topology: wideTopology,
+    });
+    expect(decision.can.update).toBe(true);
+    expect(decision.actions.update.grantedBy).not.toContainEqual({ type: 'host', hostType: 'task' });
+  });
+
+  it('fail-closed: no hostRow resolved → delegation contributes nothing', () => {
+    const { can } = getAllDecisions(policies, [projectMember], hostedAttachment(undefined), {
+      userId: 'u1',
+      hostDelegation: delegation,
+      topology: wideTopology,
+    });
+    expect(can.read).toBe(false);
+  });
+
+  it('unions with own grants instead of replacing them', () => {
+    const { accessPolicies: withOwnRead } = configureWidePermissions(({ subject, contexts }) => {
+      if (subject.name === 'attachment' || subject.name === 'task') {
+        contexts.project.guest({ read: subject.name === 'attachment' ? 1 : 0 });
+        contexts.project.member({ read: 1 });
+        contexts.project.admin({ read: 1 });
+        contexts.organization.admin({ read: 1 });
+        contexts.organization.member({});
+      }
+    });
+    // Guest has own read on attachments but no task read: own grant must survive delegation
+    const { can } = getAllDecisions(withOwnRead, [projectGuest], hostedAttachment(taskRow), {
+      userId: 'u1',
+      hostDelegation: delegation,
+      topology: wideTopology,
+    });
+    expect(can.read).toBe(true);
+  });
+});
 
 describe('delegateToHost declaration', () => {
+  it('collects delegated actions in the config result', () => {
+    const { hostDelegation } = configureWidePermissions(({ subject, delegateToHost }) => {
+      if (subject.name === 'attachment') delegateToHost(['read']);
+    });
+    expect(hostDelegation).toEqual({ attachment: ['read'] });
+  });
+
   it('throws for subjects without a hierarchy host', () => {
     expect(() =>
-      configurePermissions(appConfig.entityTypes, ({ subject, delegateToHost }) => {
-        if (subject.name === 'attachment') delegateToHost(['read']);
+      configureWidePermissions(({ subject, delegateToHost }) => {
+        if (subject.name === 'task') delegateToHost(['read']);
       }),
     ).toThrow('requires a host declared in the hierarchy');
   });
 
-  it('throws on empty actions', () => {
+  it('throws on empty actions and double declaration', () => {
     expect(() =>
-      configurePermissions(appConfig.entityTypes, ({ subject, delegateToHost }) => {
+      configureWidePermissions(({ subject, delegateToHost }) => {
         if (subject.name === 'attachment') delegateToHost([]);
       }),
     ).toThrow('at least one action');
+
+    expect(() =>
+      configureWidePermissions(({ subject, delegateToHost }) => {
+        if (subject.name === 'attachment') {
+          delegateToHost(['read']);
+          delegateToHost(['update']);
+        }
+      }),
+    ).toThrow('called twice');
   });
 });

--- a/shared/src/permissions/index.ts
+++ b/shared/src/permissions/index.ts
@@ -40,6 +40,7 @@ export type {
   ResolvedContextIds,
   SubjectForPermission,
 } from './permission-manager/types';
+export type { PermissionTopology, TopologyHierarchy } from './permission-manager/topology';
 export { buildSubject, buildSubjectFromEntity } from './build-subject';
 export { validateAncestorScope } from './validate-ancestor-scope';
 export { MissingScopeError } from './missing-scope-error';

--- a/shared/src/permissions/permission-manager/check.ts
+++ b/shared/src/permissions/permission-manager/check.ts
@@ -1,7 +1,6 @@
 import { appConfig } from '../../config-builder/app-config';
 import { hierarchy } from '../../../config/hierarchy-config';
-import type { ContextEntityType, ProductEntityType } from '../../../types';
-import { getContextRoles, isContextEntity } from '../../entity-guards';
+import type { ContextEntityType, EntityActionType, ProductEntityType } from '../../../types';
 import { allActionsAllowed, createActionRecord } from '../action-helpers';
 import { type PublicReadGrants, publicReadMatches } from '../public-read';
 import { type ConditionActor, isRowCondition, type RowForCondition } from '../row-conditions';
@@ -96,6 +95,8 @@ const checkWithIndices = <T extends PermissionMembership>(
   policyIndex: PolicyIndex,
   subject: SubjectForPermission,
   orderedContexts: ContextEntityType[],
+  getRoles: (contextType: ContextEntityType) => readonly string[],
+  entityActions: readonly EntityActionType[],
   isSystemAdmin: boolean,
   userId?: string,
   publicGrants?: PublicReadGrants,
@@ -154,7 +155,7 @@ const checkWithIndices = <T extends PermissionMembership>(
   // Walk through each context level (most specific first, then ancestors)
   for (const contextType of orderedContexts) {
     // Strict: context in hierarchy must have roles defined
-    const contextRoles = getContextRoles(contextType);
+    const contextRoles = getRoles(contextType);
     if (contextRoles.length === 0) {
       throw new Error(
         `[Permission] Context "${contextType}" has no roles defined but is in hierarchy for ${subject.entityType}`,
@@ -194,7 +195,7 @@ const checkWithIndices = <T extends PermissionMembership>(
         !restriction || membershipGrantQualifies(restriction, subject, orderedContexts, contextType, m.role);
 
       // Attribute each granted action to this membership
-      for (const action of appConfig.entityActions) {
+      for (const action of entityActions) {
         const policyValue = permissions[action];
 
         // Unconditional grant
@@ -297,6 +298,12 @@ export function getAllDecisions<T extends PermissionMembership>(
   const restrictions = options?.restrictions;
   const hostDelegation = options?.hostDelegation;
   const debug = options?.debug === true;
+  // Topology defaults to the app's real config; tests override it to drive the engine on a
+  // synthetic hierarchy (see shared/src/testing/wide-fixture.ts). No override → unchanged behavior.
+  const topoHierarchy = options?.topology?.hierarchy ?? hierarchy;
+  const entityActions = options?.topology?.entityActions ?? appConfig.entityActions;
+  // Bind the method to its hierarchy object: it reads `this`, so a bare reference would unbind it.
+  const getRoles = (contextType: ContextEntityType): readonly string[] => topoHierarchy.getRoles(contextType);
 
   const results = new Map<string, PermissionDecision<T>>();
 
@@ -304,8 +311,8 @@ export function getAllDecisions<T extends PermissionMembership>(
     return isSingle ? results.get(subjects.id ?? '_idx:0')! : results;
   }
 
-  // Validate all inputs before processing
-  subjectArray.forEach((subject, i) => validateSubject(subject, i));
+  // Validate all inputs before processing (against the topology hierarchy, which may be synthetic)
+  subjectArray.forEach((subject, i) => validateSubject(subject, i, topoHierarchy));
   memberships.forEach((membership, i) => validateMembership(membership, i));
 
   // Build membership index once for all subjects
@@ -324,8 +331,12 @@ export function getAllDecisions<T extends PermissionMembership>(
   const resolveOrderedContexts = (entityType: ContextEntityType | ProductEntityType): ContextEntityType[] => {
     let orderedContexts = contextCache.get(entityType);
     if (!orderedContexts) {
-      const ancestors = hierarchy.getOrderedAncestors(entityType) as ContextEntityType[];
-      orderedContexts = isContextEntity(entityType) ? [entityType, ...ancestors] : [...ancestors];
+      const ancestors = topoHierarchy.getOrderedAncestors(entityType) as ContextEntityType[];
+      // isContext (unlike the entity-guards type guard) returns plain boolean, so cast the
+      // context-branch result: a true isContext means entityType is a context by construction.
+      orderedContexts = (
+        topoHierarchy.isContext(entityType) ? [entityType, ...ancestors] : [...ancestors]
+      ) as ContextEntityType[];
       contextCache.set(entityType, orderedContexts);
     }
     return orderedContexts;
@@ -342,6 +353,8 @@ export function getAllDecisions<T extends PermissionMembership>(
       policyIndex,
       subject,
       orderedContexts,
+      getRoles,
+      entityActions,
       isSystemAdmin,
       userId,
       publicGrants,
@@ -354,7 +367,7 @@ export function getAllDecisions<T extends PermissionMembership>(
     // unions with the subject's own decision, attributed as {type:'host'}. Requires the
     // caller-resolved subject.hostRow (load-at-check); absent → contributes nothing.
     const delegatedActions = hostDelegation?.[subject.entityType];
-    const hostType = delegatedActions?.length ? hierarchy.getHostType(subject.entityType) : undefined;
+    const hostType = delegatedActions?.length ? topoHierarchy.getHostType(subject.entityType) : undefined;
     if (!isSystemAdmin && delegatedActions && hostType && subject.hostRow) {
       const hostRow = subject.hostRow;
       const hostSubject: SubjectForPermission = {
@@ -372,6 +385,8 @@ export function getAllDecisions<T extends PermissionMembership>(
         getOrBuildPolicyIndex(policies, hostType as ProductEntityType, policyIndexCache),
         hostSubject,
         resolveOrderedContexts(hostType as ProductEntityType),
+        getRoles,
+        entityActions,
         false,
         userId,
         publicGrants,

--- a/shared/src/permissions/permission-manager/index.test.ts
+++ b/shared/src/permissions/permission-manager/index.test.ts
@@ -1,90 +1,58 @@
-import {
-  appConfig,
-  type ContextEntityType,
-  configureAccessPolicies,
-  type EntityRole,
-  getContextRoles,
-  hierarchy,
-  isContextEntity,
-  isProductEntity,
-} from 'shared';
+import { getContextRoles, hierarchy, isContextEntity, isProductEntity } from 'shared';
 import { describe, expect, it } from 'vitest';
+import {
+  configureWidePermissions,
+  wideHierarchy,
+  wideHostDelegation,
+  wideMembership,
+  wideSubject,
+  wideTopology,
+} from '../../testing/wide-fixture';
 import { getAllDecisions } from './check';
 import type { SubjectForPermission } from './types';
 
-/** Minimal test membership matching MembershipBaseModel structure */
-type TestMembership = {
-  id: string;
-  tenantId: string;
-  contextType: ContextEntityType;
-  contextId: string;
-  userId: string;
-  role: EntityRole;
-  displayOrder: number;
-  muted: boolean;
-  archived: boolean;
-  organizationId: string;
-  workspaceId: string | null;
-  projectId: string | null;
-};
+/**
+ * Engine decision tests. The policy-driven cases run against the wide fixture (a synthetic
+ * hierarchy: organization → workspace/project → task/label/attachment, guest role on the nested
+ * contexts, attachment hosted by task) via the `topology` seam — so this suite covers guest roles,
+ * multi-level ancestor resolution and host delegation regardless of a fork's own config.
+ */
 
-/** Creates a test membership with required fields */
-const createTestMembership = (
-  overrides: { contextType: ContextEntityType; role: EntityRole; organizationId: string } & Partial<TestMembership>,
-): TestMembership => ({
-  id: 'mem-test',
-  tenantId: 'test01',
-  contextId: overrides.organizationId,
-  userId: 'user-test',
-  displayOrder: 0,
-  muted: false,
-  archived: false,
-  workspaceId: null,
-  projectId: null,
-  ...overrides,
-});
-
-const organizationSubject = (id: string): SubjectForPermission => ({
-  entityType: 'organization',
-  id,
-  contextIds: {},
-});
+const organizationSubject = (id: string): SubjectForPermission =>
+  wideSubject({ entityType: 'organization', id, contextIds: {} });
 
 const attachmentSubject = (
   id: string,
   organizationId: string,
-  overrides?: Partial<SubjectForPermission>,
-): SubjectForPermission => ({
-  entityType: 'attachment',
-  id,
-  contextIds: { organization: organizationId },
-  ...overrides,
-});
+  overrides: { createdBy?: string | null; project?: string } = {},
+): SubjectForPermission => {
+  const { project, ...rest } = overrides;
+  return wideSubject({
+    entityType: 'attachment',
+    id,
+    contextIds: { organization: organizationId, ...(project !== undefined && { project }) },
+    ...rest,
+  });
+};
 
-/**
- * These tests use appConfig.hierarchy which defines:
- * - organization: context entity with roles ['admin', 'member']
- * - attachment: product entity with parent 'organization'
- * - page: product entity with parent null (global)
- */
-
-describe('hierarchy (from appConfig.hierarchy)', () => {
+// Real-config guard sanity checks. These assertions hold in every fork (organization is always the
+// root context with roles admin/member; a product is never a context), so the block is fork-stable.
+describe('hierarchy guards (real app config)', () => {
   describe('hierarchy.getOrderedAncestors', () => {
     it('returns empty array for root context', () => {
       const ancestors = hierarchy.getOrderedAncestors('organization');
       expect(ancestors).toEqual([]);
     });
 
-    it('returns direct parent for product entity', () => {
+    it('returns organization as an ancestor for a product entity', () => {
       const ancestors = hierarchy.getOrderedAncestors('attachment');
       expect(ancestors).toContain('organization');
     });
   });
 
   describe('getContextRoles', () => {
-    it('returns roles for context entity', () => {
+    it('returns roles for the organization context', () => {
       const roles = getContextRoles('organization');
-      // hierarchy has roles: ['admin', 'member'] for organization
       expect(roles).toEqual(['admin', 'member']);
     });
   });
@@ -104,9 +72,9 @@ describe('hierarchy (from appConfig.hierarchy)', () => {
   });
 });
 
-describe('configureAccessPolicies', () => {
+describe('configureWidePermissions', () => {
   it('configures policies for all entity types', () => {
-    const policies = configureAccessPolicies(appConfig.entityTypes, ({ subject, contexts }) => {
+    const { accessPolicies: policies } = configureWidePermissions(({ subject, contexts }) => {
       switch (subject.name) {
         case 'organization':
           contexts.organization.admin({ create: 1, read: 1, update: 1, delete: 1 });
@@ -126,7 +94,7 @@ describe('configureAccessPolicies', () => {
   });
 
   it('creates empty policies when no config is set', () => {
-    const policies = configureAccessPolicies(appConfig.entityTypes, () => {
+    const { accessPolicies: policies } = configureWidePermissions(() => {
       // No configuration
     });
 
@@ -135,7 +103,7 @@ describe('configureAccessPolicies', () => {
 });
 
 describe('checkPermission', () => {
-  const policies = configureAccessPolicies(appConfig.entityTypes, ({ subject, contexts }) => {
+  const { accessPolicies: policies } = configureWidePermissions(({ subject, contexts }) => {
     switch (subject.name) {
       case 'organization':
         contexts.organization.admin({ create: 1, read: 1, update: 1, delete: 1 });
@@ -149,11 +117,9 @@ describe('checkPermission', () => {
   });
 
   it('grants full permissions for admin on organization', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'admin' }),
-    ];
+    const memberships = [wideMembership('organization', 'org1', 'admin')];
     const subject = organizationSubject('org1');
-    const { can } = getAllDecisions(policies, memberships, subject);
+    const { can } = getAllDecisions(policies, memberships, subject, { topology: wideTopology });
 
     expect(can.create).toBe(true);
     expect(can.read).toBe(true);
@@ -162,11 +128,9 @@ describe('checkPermission', () => {
   });
 
   it('grants limited permissions for member on organization', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member' }),
-    ];
+    const memberships = [wideMembership('organization', 'org1', 'member')];
     const subject = organizationSubject('org1');
-    const { can } = getAllDecisions(policies, memberships, subject);
+    const { can } = getAllDecisions(policies, memberships, subject, { topology: wideTopology });
 
     expect(can.create).toBe(false);
     expect(can.read).toBe(true);
@@ -175,11 +139,9 @@ describe('checkPermission', () => {
   });
 
   it('grants create permission for member on attachment', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member' }),
-    ];
+    const memberships = [wideMembership('organization', 'org1', 'member')];
     const subject = attachmentSubject('att1', 'org1');
-    const { can } = getAllDecisions(policies, memberships, subject);
+    const { can } = getAllDecisions(policies, memberships, subject, { topology: wideTopology });
 
     expect(can.create).toBe(true);
     expect(can.read).toBe(true);
@@ -188,11 +150,9 @@ describe('checkPermission', () => {
   });
 
   it('denies access when no matching membership', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org2', role: 'member' }),
-    ];
+    const memberships = [wideMembership('organization', 'org2', 'member')];
     const subject = attachmentSubject('att1', 'org1');
-    const { can } = getAllDecisions(policies, memberships, subject);
+    const { can } = getAllDecisions(policies, memberships, subject, { topology: wideTopology });
 
     expect(can.create).toBe(false);
     expect(can.read).toBe(false);
@@ -202,7 +162,7 @@ describe('checkPermission', () => {
 });
 
 describe('permission inheritance from organization context', () => {
-  const policies = configureAccessPolicies(appConfig.entityTypes, ({ subject, contexts }) => {
+  const { accessPolicies: policies } = configureWidePermissions(({ subject, contexts }) => {
     switch (subject.name) {
       case 'attachment':
         contexts.organization.admin({ create: 1, read: 1, update: 1, delete: 1 });
@@ -212,28 +172,24 @@ describe('permission inheritance from organization context', () => {
   });
 
   it('admin can delete attachments', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'admin' }),
-    ];
+    const memberships = [wideMembership('organization', 'org1', 'admin')];
     const subject = attachmentSubject('att1', 'org1');
-    const { can } = getAllDecisions(policies, memberships, subject);
+    const { can } = getAllDecisions(policies, memberships, subject, { topology: wideTopology });
 
     expect(can.delete).toBe(true);
   });
 
   it('member cannot delete attachments', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member' }),
-    ];
+    const memberships = [wideMembership('organization', 'org1', 'member')];
     const subject = attachmentSubject('att1', 'org1');
-    const { can } = getAllDecisions(policies, memberships, subject);
+    const { can } = getAllDecisions(policies, memberships, subject, { topology: wideTopology });
 
     expect(can.delete).toBe(false);
   });
 });
 
 describe('PermissionDecision action attribution', () => {
-  const policies = configureAccessPolicies(appConfig.entityTypes, ({ subject, contexts }) => {
+  const { accessPolicies: policies } = configureWidePermissions(({ subject, contexts }) => {
     switch (subject.name) {
       case 'attachment':
         contexts.organization.admin({ create: 1, read: 1, update: 1, delete: 1 });
@@ -243,13 +199,10 @@ describe('PermissionDecision action attribution', () => {
   });
 
   it('returns action attribution with grantedBy details', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member' }),
-    ];
+    const memberships = [wideMembership('organization', 'org1', 'member')];
     const subject = attachmentSubject('att1', 'org1');
-    const decision = getAllDecisions(policies, memberships, subject);
+    const decision = getAllDecisions(policies, memberships, subject, { topology: wideTopology });
 
-    // Check actions structure exists
     expect(decision.actions).toBeDefined();
     expect(decision.actions.create).toBeDefined();
     expect(decision.actions.read).toBeDefined();
@@ -270,11 +223,9 @@ describe('PermissionDecision action attribution', () => {
   });
 
   it('returns subject context IDs for debugging', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member' }),
-    ];
+    const memberships = [wideMembership('organization', 'org1', 'member')];
     const subject = attachmentSubject('att1', 'org1');
-    const decision = getAllDecisions(policies, memberships, subject);
+    const decision = getAllDecisions(policies, memberships, subject, { topology: wideTopology });
 
     expect(decision.subject.entityType).toBe('attachment');
     expect(decision.subject.id).toBe('att1');
@@ -282,27 +233,23 @@ describe('PermissionDecision action attribution', () => {
   });
 
   it('returns orderedContexts and primaryContext', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member' }),
-    ];
+    const memberships = [wideMembership('organization', 'org1', 'member')];
     const subject = attachmentSubject('att1', 'org1');
-    const decision = getAllDecisions(policies, memberships, subject);
+    const decision = getAllDecisions(policies, memberships, subject, { topology: wideTopology });
 
-    // Derive expected contexts from hierarchy rather than hardcoding
-    const ancestors = hierarchy.getOrderedAncestors('attachment') as ContextEntityType[];
-    const expectedContexts = isContextEntity('attachment') ? ['attachment', ...ancestors] : [...ancestors];
-
-    expect(decision.orderedContexts).toEqual(expectedContexts);
-    expect(decision.primaryContext).toBe(expectedContexts[0]);
+    // Derive expected contexts from the wide hierarchy (attachment → project → organization)
+    const ancestors = wideHierarchy.getOrderedAncestors('attachment');
+    expect(decision.orderedContexts).toEqual(ancestors);
+    expect(decision.primaryContext).toBe(ancestors[0]);
   });
 
   it('accumulates multiple grants for same action from different roles', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'admin' }),
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member' }),
+    const memberships = [
+      wideMembership('organization', 'org1', 'admin'),
+      wideMembership('organization', 'org1', 'member'),
     ];
     const subject = attachmentSubject('att1', 'org1');
-    const decision = getAllDecisions(policies, memberships, subject);
+    const decision = getAllDecisions(policies, memberships, subject, { topology: wideTopology });
 
     // Both admin and member grant read permission
     expect(decision.actions.read.enabled).toBe(true);
@@ -330,8 +277,7 @@ describe('PermissionDecision action attribution', () => {
 // ── 'own' permission value tests ─────────────────────────────────────────────
 
 describe('own permission policy — ownership-scoped access', () => {
-  // Policies mirroring the real attachment config: member gets 'own' for update/delete
-  const ownPolicies = configureAccessPolicies(appConfig.entityTypes, ({ subject, contexts }) => {
+  const { accessPolicies: ownPolicies } = configureWidePermissions(({ subject, contexts }) => {
     switch (subject.name) {
       case 'organization':
         contexts.organization.admin({ create: 1, read: 1, update: 1, delete: 1 });
@@ -350,39 +296,27 @@ describe('own permission policy — ownership-scoped access', () => {
   // --- Pass cases: permission IS granted ---
 
   it('grants update/delete when member is the creator (own entity)', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member', userId }),
-    ];
-    const subject = attachmentSubject('att1', 'org1', {
-      createdBy: userId,
-    });
-    const { can } = getAllDecisions(ownPolicies, memberships, subject, { userId });
+    const memberships = [wideMembership('organization', 'org1', 'member')];
+    const subject = attachmentSubject('att1', 'org1', { createdBy: userId });
+    const { can } = getAllDecisions(ownPolicies, memberships, subject, { userId, topology: wideTopology });
 
     expect(can.update).toBe(true);
     expect(can.delete).toBe(true);
   });
 
   it('grants create/read to member regardless of ownership', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member', userId }),
-    ];
-    const subject = attachmentSubject('att1', 'org1', {
-      createdBy: otherUserId, // Not the actor
-    });
-    const { can } = getAllDecisions(ownPolicies, memberships, subject, { userId });
+    const memberships = [wideMembership('organization', 'org1', 'member')];
+    const subject = attachmentSubject('att1', 'org1', { createdBy: otherUserId });
+    const { can } = getAllDecisions(ownPolicies, memberships, subject, { userId, topology: wideTopology });
 
     expect(can.create).toBe(true);
     expect(can.read).toBe(true);
   });
 
   it('admin gets full access regardless of createdBy', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'admin', userId }),
-    ];
-    const subject = attachmentSubject('att1', 'org1', {
-      createdBy: otherUserId, // Created by someone else
-    });
-    const { can } = getAllDecisions(ownPolicies, memberships, subject, { userId });
+    const memberships = [wideMembership('organization', 'org1', 'admin')];
+    const subject = attachmentSubject('att1', 'org1', { createdBy: otherUserId });
+    const { can } = getAllDecisions(ownPolicies, memberships, subject, { userId, topology: wideTopology });
 
     expect(can.create).toBe(true);
     expect(can.read).toBe(true);
@@ -393,66 +327,46 @@ describe('own permission policy — ownership-scoped access', () => {
   // --- Fail cases: permission is NOT granted ---
 
   it('denies update/delete when member is NOT the creator', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member', userId }),
-    ];
-    const subject = attachmentSubject('att1', 'org1', {
-      createdBy: otherUserId, // Someone else created it
-    });
-    const { can } = getAllDecisions(ownPolicies, memberships, subject, { userId });
+    const memberships = [wideMembership('organization', 'org1', 'member')];
+    const subject = attachmentSubject('att1', 'org1', { createdBy: otherUserId });
+    const { can } = getAllDecisions(ownPolicies, memberships, subject, { userId, topology: wideTopology });
 
     expect(can.update).toBe(false);
     expect(can.delete).toBe(false);
   });
 
   it('denies update/delete when userId is not provided in options', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member', userId }),
-    ];
-    const subject = attachmentSubject('att1', 'org1', {
-      createdBy: userId, // Same user, but userId not passed in options
-    });
-    // No userId in options — own check cannot succeed
-    const { can } = getAllDecisions(ownPolicies, memberships, subject);
+    const memberships = [wideMembership('organization', 'org1', 'member')];
+    const subject = attachmentSubject('att1', 'org1', { createdBy: userId });
+    // No userId in options: own check cannot succeed
+    const { can } = getAllDecisions(ownPolicies, memberships, subject, { topology: wideTopology });
 
     expect(can.update).toBe(false);
     expect(can.delete).toBe(false);
   });
 
   it('denies update/delete when createdBy is null', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member', userId }),
-    ];
-    const subject = attachmentSubject('att1', 'org1', {
-      createdBy: null,
-    });
-    const { can } = getAllDecisions(ownPolicies, memberships, subject, { userId });
+    const memberships = [wideMembership('organization', 'org1', 'member')];
+    const subject = attachmentSubject('att1', 'org1', { createdBy: null });
+    const { can } = getAllDecisions(ownPolicies, memberships, subject, { userId, topology: wideTopology });
 
     expect(can.update).toBe(false);
     expect(can.delete).toBe(false);
   });
 
   it('denies update/delete when createdBy is undefined (missing)', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member', userId }),
-    ];
-    const subject = attachmentSubject('att1', 'org1', {
-      // createdBy intentionally omitted
-    });
-    const { can } = getAllDecisions(ownPolicies, memberships, subject, { userId });
+    const memberships = [wideMembership('organization', 'org1', 'member')];
+    const subject = attachmentSubject('att1', 'org1');
+    const { can } = getAllDecisions(ownPolicies, memberships, subject, { userId, topology: wideTopology });
 
     expect(can.update).toBe(false);
     expect(can.delete).toBe(false);
   });
 
   it('denies everything when membership is for wrong org', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org2', role: 'member', userId }),
-    ];
-    const subject = attachmentSubject('att1', 'org1', {
-      createdBy: userId,
-    });
-    const { can } = getAllDecisions(ownPolicies, memberships, subject, { userId });
+    const memberships = [wideMembership('organization', 'org2', 'member')];
+    const subject = attachmentSubject('att1', 'org1', { createdBy: userId });
+    const { can } = getAllDecisions(ownPolicies, memberships, subject, { userId, topology: wideTopology });
 
     expect(can.create).toBe(false);
     expect(can.read).toBe(false);
@@ -462,7 +376,7 @@ describe('own permission policy — ownership-scoped access', () => {
 });
 
 describe('own permission — grant attribution', () => {
-  const ownPolicies = configureAccessPolicies(appConfig.entityTypes, ({ subject, contexts }) => {
+  const { accessPolicies: ownPolicies } = configureWidePermissions(({ subject, contexts }) => {
     switch (subject.name) {
       case 'attachment':
         contexts.organization.admin({ create: 1, read: 1, update: 1, delete: 1 });
@@ -474,13 +388,9 @@ describe('own permission — grant attribution', () => {
   const userId = 'user-actor';
 
   it('attributes own-granted actions to the condition name (relation:own)', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member', userId }),
-    ];
-    const subject = attachmentSubject('att1', 'org1', {
-      createdBy: userId,
-    });
-    const decision = getAllDecisions(ownPolicies, memberships, subject, { userId });
+    const memberships = [wideMembership('organization', 'org1', 'member')];
+    const subject = attachmentSubject('att1', 'org1', { createdBy: userId });
+    const decision = getAllDecisions(ownPolicies, memberships, subject, { userId, topology: wideTopology });
 
     // Update was granted via the built-in `own` condition → attributed by condition name
     expect(decision.actions.update.enabled).toBe(true);
@@ -494,13 +404,9 @@ describe('own permission — grant attribution', () => {
   });
 
   it('attributes unconditional grants to membership (not relation)', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member', userId }),
-    ];
-    const subject = attachmentSubject('att1', 'org1', {
-      createdBy: userId,
-    });
-    const decision = getAllDecisions(ownPolicies, memberships, subject, { userId });
+    const memberships = [wideMembership('organization', 'org1', 'member')];
+    const subject = attachmentSubject('att1', 'org1', { createdBy: userId });
+    const decision = getAllDecisions(ownPolicies, memberships, subject, { userId, topology: wideTopology });
 
     // Create is unconditional 1 → membership grant
     expect(decision.actions.create.grantedBy).toHaveLength(1);
@@ -513,15 +419,11 @@ describe('own permission — grant attribution', () => {
   });
 
   it('does not attribute own grants when ownership check fails', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member', userId }),
-    ];
-    const subject = attachmentSubject('att1', 'org1', {
-      createdBy: 'user-other', // Not the actor
-    });
-    const decision = getAllDecisions(ownPolicies, memberships, subject, { userId });
+    const memberships = [wideMembership('organization', 'org1', 'member')];
+    const subject = attachmentSubject('att1', 'org1', { createdBy: 'user-other' });
+    const decision = getAllDecisions(ownPolicies, memberships, subject, { userId, topology: wideTopology });
 
-    // Update/delete denied — no grants at all
+    // Update/delete denied: no grants at all
     expect(decision.actions.update.enabled).toBe(false);
     expect(decision.actions.update.grantedBy).toHaveLength(0);
     expect(decision.actions.delete.enabled).toBe(false);
@@ -529,13 +431,9 @@ describe('own permission — grant attribution', () => {
   });
 
   it('admin gets membership grant (not relation) even with createdBy set', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'admin', userId }),
-    ];
-    const subject = attachmentSubject('att1', 'org1', {
-      createdBy: 'user-other',
-    });
-    const decision = getAllDecisions(ownPolicies, memberships, subject, { userId });
+    const memberships = [wideMembership('organization', 'org1', 'admin')];
+    const subject = attachmentSubject('att1', 'org1', { createdBy: 'user-other' });
+    const decision = getAllDecisions(ownPolicies, memberships, subject, { userId, topology: wideTopology });
 
     // Admin policy is unconditional 1, so grant is membership-based
     expect(decision.actions.update.enabled).toBe(true);
@@ -549,7 +447,7 @@ describe('own permission — grant attribution', () => {
 });
 
 describe('own permission — batch subjects', () => {
-  const ownPolicies = configureAccessPolicies(appConfig.entityTypes, ({ subject, contexts }) => {
+  const { accessPolicies: ownPolicies } = configureWidePermissions(({ subject, contexts }) => {
     switch (subject.name) {
       case 'attachment':
         contexts.organization.admin({ create: 1, read: 1, update: 1, delete: 1 });
@@ -561,28 +459,26 @@ describe('own permission — batch subjects', () => {
   const userId = 'user-actor';
 
   it('correctly evaluates mixed ownership in batch', () => {
-    const memberships: TestMembership[] = [
-      createTestMembership({ contextType: 'organization', organizationId: 'org1', role: 'member', userId }),
-    ];
+    const memberships = [wideMembership('organization', 'org1', 'member')];
     const subjects: SubjectForPermission[] = [
       attachmentSubject('att-own', 'org1', { createdBy: userId }),
       attachmentSubject('att-other', 'org1', { createdBy: 'user-other' }),
       attachmentSubject('att-null', 'org1', { createdBy: null }),
     ];
 
-    const results = getAllDecisions(ownPolicies, memberships, subjects, { userId });
+    const results = getAllDecisions(ownPolicies, memberships, subjects, { userId, topology: wideTopology });
 
-    // Own entity — full access via ownership
+    // Own entity: full access via ownership
     const ownDecision = results.get('att-own')!;
     expect(ownDecision.can.update).toBe(true);
     expect(ownDecision.can.delete).toBe(true);
 
-    // Other's entity — denied
+    // Other's entity: denied
     const otherDecision = results.get('att-other')!;
     expect(otherDecision.can.update).toBe(false);
     expect(otherDecision.can.delete).toBe(false);
 
-    // Null createdBy — denied
+    // Null createdBy: denied
     const nullDecision = results.get('att-null')!;
     expect(nullDecision.can.update).toBe(false);
     expect(nullDecision.can.delete).toBe(false);
@@ -593,5 +489,75 @@ describe('own permission — batch subjects', () => {
       expect(d.can.create).toBe(true);
       expect(d.can.read).toBe(true);
     }
+  });
+});
+
+// ── Deep-hierarchy coverage the template's org-only config cannot express ─────
+
+describe('wide hierarchy — guest role, multi-level ancestors, host delegation', () => {
+  const { accessPolicies: policies, hostDelegation } = configureWidePermissions(
+    ({ subject, contexts, delegateToHost }) => {
+      switch (subject.name) {
+        case 'attachment':
+          // Read comes only from the host (task); guests can create at project level. Every
+          // context×role cell is declared (deny by default) so the engine's strict policy-coverage
+          // check is satisfied when memberships resolve at either level.
+          contexts.organization.admin({});
+          contexts.organization.member({});
+          contexts.project.admin({ create: 1, update: 1 });
+          contexts.project.member({ create: 1, update: 1 });
+          contexts.project.guest({ create: 1 });
+          delegateToHost(['read']);
+          break;
+        case 'task':
+          contexts.organization.admin({ read: 1 });
+          contexts.organization.member({});
+          contexts.project.admin({ read: 1, update: 1 });
+          contexts.project.member({ read: 1, update: 1 });
+          contexts.project.guest({});
+          break;
+      }
+    },
+  );
+
+  it('grants a project guest their configured project-level cell', () => {
+    const subject = attachmentSubject('att1', 'org1', { project: 'p1' });
+    const { can } = getAllDecisions(policies, [wideMembership('project', 'p1', 'guest')], subject, {
+      topology: wideTopology,
+    });
+    expect(can.create).toBe(true);
+    expect(can.update).toBe(false);
+  });
+
+  it('resolves grants from the correct ancestor level (project vs organization)', () => {
+    const subject = attachmentSubject('att1', 'org1', { project: 'p1' });
+
+    // A project member gets the project-level update grant.
+    const asProjectMember = getAllDecisions(policies, [wideMembership('project', 'p1', 'member')], subject, {
+      topology: wideTopology,
+    });
+    expect(asProjectMember.can.update).toBe(true);
+
+    // An organization member has no attachment cell at the organization level → no grant.
+    const asOrgMember = getAllDecisions(policies, [wideMembership('organization', 'org1', 'member')], subject, {
+      topology: wideTopology,
+    });
+    expect(asOrgMember.can.update).toBe(false);
+  });
+
+  it('delegates read to the host task through getAllDecisions', () => {
+    const subject = attachmentSubject('att1', 'org1', { project: 'p1' });
+    subject.hostRow = { id: 'task1', createdBy: 'someone' };
+
+    // Attachment has no read cell of its own; a project member reads the host task, so read is
+    // delegated and attributed to the host.
+    const decision = getAllDecisions(policies, [wideMembership('project', 'p1', 'member')], subject, {
+      hostDelegation: wideHostDelegation({ attachment: ['read'] }),
+      topology: wideTopology,
+    });
+    expect(decision.can.read).toBe(true);
+    expect(decision.actions.read.grantedBy).toContainEqual({ type: 'host', hostType: 'task' });
+    // Confirm the config actually declared the delegation.
+    expect(hostDelegation).toEqual({ attachment: ['read'] });
   });
 });

--- a/shared/src/permissions/permission-manager/topology.ts
+++ b/shared/src/permissions/permission-manager/topology.ts
@@ -1,0 +1,29 @@
+import type { EntityActionType } from '../../../types';
+
+/**
+ * The testability seam that lets the permission engine run against a hierarchy other than the
+ * app's real `shared/config` — kept out of `types.ts` to keep that core module focused.
+ *
+ * Both are optional overrides: with no `topology` the engine reads the `hierarchy`/`appConfig`
+ * singletons exactly as before. Tests pass a synthetic hierarchy (see
+ * `shared/src/testing/wide-fixture.ts`) to exercise deeper shapes — nested contexts, host
+ * relations, guest roles — than a given fork's config ships, without module-mocking `shared`.
+ */
+
+/** Structural subset of the app's `EntityHierarchy` the engine reads; the real `hierarchy` satisfies it. */
+export interface TopologyHierarchy {
+  readonly contextTypes: readonly string[];
+  getOrderedAncestors(entityType: string): readonly string[];
+  getOrderedDescendants(entityType: string): readonly string[];
+  getHostType(entityType: string): string | null | undefined;
+  getRoles(contextType: string): readonly string[];
+  isContext(entityType: string): boolean;
+  isProduct(entityType: string): boolean;
+  getParent(entityType: string): string | null;
+}
+
+export interface PermissionTopology {
+  hierarchy: TopologyHierarchy;
+  /** Defaults to `appConfig.entityActions` (the action set is hierarchy-independent). */
+  entityActions?: readonly EntityActionType[];
+}

--- a/shared/src/permissions/permission-manager/types.ts
+++ b/shared/src/permissions/permission-manager/types.ts
@@ -2,6 +2,7 @@ import type { ContextEntityType, EntityActionType, EntityIdColumnKeys, EntityRol
 import type { PublicReadGrants, PublicReadMode } from '../public-read';
 import type { RowRestrictions } from '../row-restrictions';
 import type { HostDelegation } from '../types';
+import type { PermissionTopology } from './topology';
 
 export type ContextEntityIdColumns = {
   [K in ContextEntityType as EntityIdColumnKeys[K]]: string | null;
@@ -115,6 +116,11 @@ export interface PermissionCheckOptions {
    * `checkPermission` wrapper like `publicGrants`.
    */
   hostDelegation?: HostDelegation;
+  /**
+   * Override the hierarchy/action topology the engine reads (defaults to the app's config).
+   * Tests use this to exercise a synthetic hierarchy; see `shared/src/testing/wide-fixture.ts`.
+   */
+  topology?: PermissionTopology;
   /** When `true`, emit debug logging of the decision tree. Off by default to keep the engine quiet. */
   debug?: boolean;
 }

--- a/shared/src/permissions/permission-manager/validation.ts
+++ b/shared/src/permissions/permission-manager/validation.ts
@@ -1,15 +1,26 @@
 import { isContextEntity, isProductEntity } from '../../entity-guards';
+import type { TopologyHierarchy } from './topology';
 import type { PermissionMembership, SubjectForPermission } from './types';
 
-/** Validates a subject has required fields for permission checking. */
-export const validateSubject = (subject: SubjectForPermission, index?: number): void => {
+/**
+ * Validates a subject has required fields for permission checking. `topology` defaults to the
+ * real config's entity guards; the engine passes its (possibly synthetic) hierarchy so a subject
+ * whose entity type only exists in a test fixture still validates.
+ */
+export const validateSubject = (
+  subject: SubjectForPermission,
+  index?: number,
+  topology?: Pick<TopologyHierarchy, 'isContext' | 'isProduct'>,
+): void => {
   const prefix = index !== undefined ? `Subject[${index}]` : 'Subject';
 
   if (!subject.entityType) {
     throw new Error(`[Permission] ${prefix} missing entityType`);
   }
 
-  if (!isContextEntity(subject.entityType) && !isProductEntity(subject.entityType)) {
+  const isContext = topology ? topology.isContext(subject.entityType) : isContextEntity(subject.entityType);
+  const isProduct = topology ? topology.isProduct(subject.entityType) : isProductEntity(subject.entityType);
+  if (!isContext && !isProduct) {
     throw new Error(`[Permission] ${prefix} has invalid entityType: ${subject.entityType}`);
   }
 

--- a/shared/src/permissions/public-read.test.ts
+++ b/shared/src/permissions/public-read.test.ts
@@ -1,89 +1,110 @@
 import { describe, expect, it } from 'vitest';
-import { appConfig } from '../config-builder/app-config';
-import { configurePermissions } from './access-policies';
 import { getAllDecisions } from './permission-manager/check';
 import type { SubjectForPermission } from './permission-manager/types';
-import type { PublicReadGrants } from './public-read';
+import { configureWidePermissions, widePublicGrants, wideSubject, wideTopology } from '../testing/wide-fixture';
 
 /**
- * Public read grants: subject-level, membership-independent read access based on row
- * data. Evaluated for anonymous actors (no memberships, no userId) and members alike.
+ * Public read grants (`publicRead`): subject-level, membership-independent read access based on
+ * row data, evaluated for anonymous actors (no memberships, no userId) and members alike.
  *
- * Uses the template hierarchy (organization > attachment): organization publishes
- * itself (publicSelf), attachment derives publicity from its parent (publicParent /
- * publicParentOrSelf).
+ * Runs against the wide fixture (organization → workspace/project, project → task/label/attachment),
+ * not a fork's app config.
  */
-
 const NOW = '2026-07-06T12:00:00Z';
 
-const grants: PublicReadGrants = {
-  organization: 'publicSelf',
-  attachment: 'publicParent',
-};
-
-const orgSubject = (publicAt: string | null): SubjectForPermission => ({
-  entityType: 'organization',
-  id: 'org1',
-  contextIds: {},
-  row: { publicAt },
+const grants = widePublicGrants({
+  project: 'publicSelf',
+  task: 'publicParent',
+  attachment: 'publicParentOrSelf',
 });
 
-const attachmentSubject = (parentPublicAt: string | null): SubjectForPermission => ({
-  entityType: 'attachment',
-  id: 'a1',
-  contextIds: { organization: 'org1' },
-  parentRow: { publicAt: parentPublicAt },
-});
+const projectSubject = (publicAt: string | null): SubjectForPermission =>
+  wideSubject({
+    entityType: 'project',
+    id: 'p1',
+    contextIds: { organization: 'org1' },
+    row: { publicAt },
+  });
+
+const taskSubject = (parentPublicAt: string | null): SubjectForPermission =>
+  wideSubject({
+    entityType: 'task',
+    id: 't1',
+    contextIds: { organization: 'org1', project: 'p1' },
+    parentRow: { publicAt: parentPublicAt },
+  });
 
 // No policies at all: everything below must come from public grants alone.
 const noPolicies = {};
 
 describe('public read grants — anonymous actor', () => {
   it('publicSelf grants read when the row publicAt is set', () => {
-    const { can, actions } = getAllDecisions(noPolicies, [], orgSubject(NOW), { publicGrants: grants });
+    const { can, actions } = getAllDecisions(noPolicies, [], projectSubject(NOW), {
+      publicGrants: grants,
+      topology: wideTopology,
+    });
     expect(can.read).toBe(true);
     expect(actions.read.grantedBy).toEqual([{ type: 'public', mode: 'publicSelf' }]);
   });
 
   it('publicSelf denies when publicAt is null or row data is absent', () => {
-    expect(getAllDecisions(noPolicies, [], orgSubject(null), { publicGrants: grants }).can.read).toBe(false);
+    expect(
+      getAllDecisions(noPolicies, [], projectSubject(null), { publicGrants: grants, topology: wideTopology }).can
+        .read,
+    ).toBe(false);
 
-    const noRow: SubjectForPermission = { entityType: 'organization', id: 'org1', contextIds: {} };
-    expect(getAllDecisions(noPolicies, [], noRow, { publicGrants: grants }).can.read).toBe(false);
+    const noRow = wideSubject({ entityType: 'project', id: 'p1', contextIds: { organization: 'org1' } });
+    expect(
+      getAllDecisions(noPolicies, [], noRow, { publicGrants: grants, topology: wideTopology }).can.read,
+    ).toBe(false);
   });
 
   it('publicParent grants read from the resolved parent row only', () => {
-    expect(getAllDecisions(noPolicies, [], attachmentSubject(NOW), { publicGrants: grants }).can.read).toBe(true);
-    expect(getAllDecisions(noPolicies, [], attachmentSubject(null), { publicGrants: grants }).can.read).toBe(false);
+    expect(
+      getAllDecisions(noPolicies, [], taskSubject(NOW), { publicGrants: grants, topology: wideTopology }).can.read,
+    ).toBe(true);
+    expect(
+      getAllDecisions(noPolicies, [], taskSubject(null), { publicGrants: grants, topology: wideTopology }).can.read,
+    ).toBe(false);
 
     // Own row publicAt must NOT satisfy publicParent
-    const ownPublicOnly: SubjectForPermission = {
-      entityType: 'attachment',
-      id: 'a1',
-      contextIds: { organization: 'org1' },
+    const ownPublicOnly = wideSubject({
+      entityType: 'task',
+      id: 't1',
+      contextIds: { organization: 'org1', project: 'p1' },
       row: { publicAt: NOW },
-    };
-    expect(getAllDecisions(noPolicies, [], ownPublicOnly, { publicGrants: grants }).can.read).toBe(false);
+    });
+    expect(
+      getAllDecisions(noPolicies, [], ownPublicOnly, { publicGrants: grants, topology: wideTopology }).can.read,
+    ).toBe(false);
   });
 
   it('publicParentOrSelf grants from either row', () => {
-    const orSelfGrants: PublicReadGrants = { organization: 'publicSelf', attachment: 'publicParentOrSelf' };
-    const self: SubjectForPermission = {
+    const self = wideSubject({
       entityType: 'attachment',
       id: 'a1',
-      contextIds: { organization: 'org1' },
+      contextIds: { organization: 'org1', project: 'p1' },
       row: { publicAt: NOW },
-    };
+    });
     const parent: SubjectForPermission = { ...self, row: {}, parentRow: { publicAt: NOW } };
     const neither: SubjectForPermission = { ...self, row: {}, parentRow: {} };
 
-    expect(getAllDecisions(noPolicies, [], self, { publicGrants: orSelfGrants }).can.read).toBe(true);
-    expect(getAllDecisions(noPolicies, [], parent, { publicGrants: orSelfGrants }).can.read).toBe(true);
-    expect(getAllDecisions(noPolicies, [], neither, { publicGrants: orSelfGrants }).can.read).toBe(false);
+    expect(
+      getAllDecisions(noPolicies, [], self, { publicGrants: grants, topology: wideTopology }).can.read,
+    ).toBe(true);
+    expect(
+      getAllDecisions(noPolicies, [], parent, { publicGrants: grants, topology: wideTopology }).can.read,
+    ).toBe(true);
+    expect(
+      getAllDecisions(noPolicies, [], neither, { publicGrants: grants, topology: wideTopology }).can.read,
+    ).toBe(false);
   });
 
   it('grants read only — other actions stay denied', () => {
-    const { can } = getAllDecisions(noPolicies, [], orgSubject(NOW), { publicGrants: grants });
+    const { can } = getAllDecisions(noPolicies, [], projectSubject(NOW), {
+      publicGrants: grants,
+      topology: wideTopology,
+    });
     expect(can.read).toBe(true);
     expect(can.create).toBe(false);
     expect(can.update).toBe(false);
@@ -91,35 +112,35 @@ describe('public read grants — anonymous actor', () => {
   });
 
   it('no grant declared for the entity type → no public read', () => {
-    const attachmentOnlyGrants: PublicReadGrants = { organization: 'publicSelf' };
-    const subject: SubjectForPermission = {
-      entityType: 'attachment',
-      id: 'a1',
-      contextIds: { organization: 'org1' },
+    const orgSubject = wideSubject({
+      entityType: 'organization',
+      id: 'org1',
+      contextIds: {},
       row: { publicAt: NOW },
-      parentRow: { publicAt: NOW },
-    };
-    expect(getAllDecisions(noPolicies, [], subject, { publicGrants: attachmentOnlyGrants }).can.read).toBe(false);
+    });
+    expect(
+      getAllDecisions(noPolicies, [], orgSubject, { publicGrants: grants, topology: wideTopology }).can.read,
+    ).toBe(false);
   });
 
   it('no publicGrants passed → engine behaves exactly as before', () => {
-    expect(getAllDecisions(noPolicies, [], orgSubject(NOW)).can.read).toBe(false);
+    expect(getAllDecisions(noPolicies, [], projectSubject(NOW), { topology: wideTopology }).can.read).toBe(false);
   });
 });
 
 describe('configurePermissions — publicRead declaration', () => {
   it('collects grants per subject and returns them alongside policies', () => {
-    const { publicReadGrants } = configurePermissions(appConfig.entityTypes, ({ subject, publicRead }) => {
-      if (subject.name === 'organization') publicRead('publicSelf');
-      if (subject.name === 'attachment') publicRead('publicParent');
+    const { publicReadGrants } = configureWidePermissions(({ subject, publicRead }) => {
+      if (subject.name === 'project') publicRead('publicSelf');
+      if (subject.name === 'task') publicRead('publicParent');
     });
-    expect(publicReadGrants).toEqual({ organization: 'publicSelf', attachment: 'publicParent' });
+    expect(publicReadGrants).toEqual({ project: 'publicSelf', task: 'publicParent' });
   });
 
   it('throws when publicRead is declared twice for a subject', () => {
     expect(() =>
-      configurePermissions(appConfig.entityTypes, ({ subject, publicRead }) => {
-        if (subject.name === 'organization') {
+      configureWidePermissions(({ subject, publicRead }) => {
+        if (subject.name === 'project') {
           publicRead('publicSelf');
           publicRead('publicSelf');
         }
@@ -129,13 +150,13 @@ describe('configurePermissions — publicRead declaration', () => {
 
   it("throws when a parent-dependent grant's parent has no self-publication grant", () => {
     expect(() =>
-      configurePermissions(appConfig.entityTypes, ({ subject, publicRead }) => {
-        if (subject.name === 'attachment') publicRead('publicParent');
+      configureWidePermissions(({ subject, publicRead }) => {
+        if (subject.name === 'task') publicRead('publicParent');
       }),
     ).toThrow('no self-publication grant');
 
     expect(() =>
-      configurePermissions(appConfig.entityTypes, ({ subject, publicRead }) => {
+      configureWidePermissions(({ subject, publicRead }) => {
         if (subject.name === 'attachment') publicRead('publicParentOrSelf');
       }),
     ).toThrow('no self-publication grant');

--- a/shared/src/permissions/row-restrictions.test.ts
+++ b/shared/src/permissions/row-restrictions.test.ts
@@ -1,130 +1,167 @@
 import { describe, expect, it } from 'vitest';
-import { appConfig } from '../config-builder/app-config';
-import { configurePermissions } from './access-policies';
 import { getAllDecisions } from './permission-manager/check';
 import type { PermissionMembership, SubjectForPermission } from './permission-manager/types';
-import type { RowRestrictions } from './row-restrictions';
+import {
+  configureWidePermissions,
+  wideMembership,
+  widePublicGrants,
+  wideRestrictions,
+  wideSubject,
+  wideTopology,
+} from '../testing/wide-fixture';
 
 /**
- * Row restriction semantics at the engine level, on the template hierarchy (a single
- * `organization` context, roles admin/member). Restrictions narrow membership grants
- * per row; row-condition grants ('own'), public grants and `create` are never narrowed;
- * fail-closed without row data; admin exemption is explicit.
+ * Row restrictions (`restrict`): narrow membership grants per row via `visibilityDepth` and
+ * `audienceRoles`, with exempt roles bypassing the restriction and row-condition/public grants
+ * never narrowed. See `row-restrictions.ts` for the full semantics.
  *
- * Multi-level depth ordering ("a grant qualifies only from a context at least as
- * specific as the row's depth") needs a deeper context chain than the template ships —
- * forks with nested contexts (e.g. organization > project) should extend these tests.
+ * Runs against the wide fixture's project → organization chain (roles admin/member/guest),
+ * which exercises multi-level `visibilityDepth` ordering and cross-level `audienceRoles` sets
+ * regardless of how deeply a fork's own config nests contexts.
  */
 
-// Synthetic policies: admins and members can read/create attachments; members can also update.
-const { accessPolicies: policies } = configurePermissions(appConfig.entityTypes, ({ subject, contexts }) => {
-  if (subject.name !== 'attachment') return;
+// Synthetic policies: every role can read tasks unconditionally; project members can
+// also update, and everyone with membership can create.
+const { accessPolicies: policies } = configureWidePermissions(({ subject, contexts }) => {
+  if (subject.name !== 'task') return;
   contexts.organization.admin({ create: 1, read: 1, update: 1, delete: 1 });
-  contexts.organization.member({ create: 1, read: 1, update: 1 });
+  contexts.organization.member({ create: 1, read: 1 });
+  contexts.project.admin({ create: 1, read: 1, update: 1, delete: 1 });
+  contexts.project.member({ create: 1, read: 1, update: 1 });
+  contexts.project.guest({ read: 1 });
 });
 
-const restrictions: RowRestrictions = {
-  attachment: { depthColumn: 'visibilityDepth', rolesColumn: 'audienceRoles', exemptRoles: ['admin'] },
-};
-
-const membership = (contextId: string, role: string): PermissionMembership =>
-  ({ contextType: 'organization', contextId, role }) as PermissionMembership;
-
-const orgMember = membership('org1', 'member');
-const orgAdmin = membership('org1', 'admin');
-
-const attachment = (row: Record<string, unknown> | undefined): SubjectForPermission => ({
-  entityType: 'attachment',
-  id: 'a1',
-  contextIds: { organization: 'org1' },
-  ...(row !== undefined && { row }),
+const restrictions = wideRestrictions({
+  task: { depthColumn: 'visibilityDepth', rolesColumn: 'audienceRoles', exemptRoles: ['admin'] },
 });
+
+const orgMember = wideMembership('organization', 'org1', 'member');
+const orgAdmin = wideMembership('organization', 'org1', 'admin');
+const projectMember = wideMembership('project', 'p1', 'member');
+const projectGuest = wideMembership('project', 'p1', 'guest');
+
+const task = (row: Record<string, unknown> | undefined): SubjectForPermission =>
+  wideSubject({
+    entityType: 'task',
+    id: 't1',
+    contextIds: { organization: 'org1', project: 'p1' },
+    ...(row !== undefined && { row }),
+  });
 
 const readableBy = (m: PermissionMembership, row: Record<string, unknown> | undefined, userId = 'u1') =>
-  getAllDecisions(policies, [m], attachment(row), { userId, restrictions }).can.read;
+  getAllDecisions(policies, [m], task(row), { userId, restrictions, topology: wideTopology }).can.read;
 
+// Multi-level ordering: wide fixture's chain project > organization, roles admin/member/guest.
 describe('visibilityDepth', () => {
   it('null depth: unrestricted — every read grant qualifies', () => {
     expect(readableBy(orgMember, { visibilityDepth: null })).toBe(true);
+    expect(readableBy(projectMember, { visibilityDepth: null })).toBe(true);
   });
 
-  it("depth 'organization': grants from the organization level qualify", () => {
+  it("depth 'project': only grants at least as specific as project qualify", () => {
+    expect(readableBy(projectMember, { visibilityDepth: 'project' })).toBe(true);
+    expect(readableBy(orgMember, { visibilityDepth: 'project' })).toBe(false);
+  });
+
+  it("depth 'organization': grants from both levels qualify (deeper is more specific)", () => {
     expect(readableBy(orgMember, { visibilityDepth: 'organization' })).toBe(true);
+    expect(readableBy(projectMember, { visibilityDepth: 'organization' })).toBe(true);
   });
 
   it('unknown depth value never qualifies (fail closed)', () => {
-    expect(readableBy(orgMember, { visibilityDepth: 'project' })).toBe(false);
+    expect(readableBy(projectMember, { visibilityDepth: 'workspace' })).toBe(false);
     expect(readableBy(orgMember, { visibilityDepth: 'nonsense' })).toBe(false);
   });
 });
 
 describe('audienceRoles', () => {
   it('null or empty audience: unrestricted', () => {
-    expect(readableBy(orgMember, { audienceRoles: null })).toBe(true);
-    expect(readableBy(orgMember, { audienceRoles: [] })).toBe(true);
+    expect(readableBy(projectGuest, { audienceRoles: null })).toBe(true);
+    expect(readableBy(projectGuest, { audienceRoles: [] })).toBe(true);
   });
 
-  it('grant role must be in the audience set', () => {
-    expect(readableBy(orgMember, { audienceRoles: ['member'] })).toBe(true);
-    expect(readableBy(orgMember, { audienceRoles: ['nobody'] })).toBe(false);
+  it('grant role must be in the audience set, qualified per grant', () => {
+    expect(readableBy(projectMember, { audienceRoles: ['member'] })).toBe(true);
+    expect(readableBy(projectGuest, { audienceRoles: ['member'] })).toBe(false);
+    // Set can span levels: org member and project guest both qualify against one set
+    expect(readableBy(orgMember, { audienceRoles: ['member', 'guest'] })).toBe(true);
+    expect(readableBy(projectGuest, { audienceRoles: ['member', 'guest'] })).toBe(true);
   });
 
   it('combines with depth: both must qualify', () => {
-    expect(readableBy(orgMember, { visibilityDepth: 'organization', audienceRoles: ['member'] })).toBe(true);
-    expect(readableBy(orgMember, { visibilityDepth: 'organization', audienceRoles: ['nobody'] })).toBe(false); // role fails
-    expect(readableBy(orgMember, { visibilityDepth: 'nonsense', audienceRoles: ['member'] })).toBe(false); // depth fails
+    const row = { visibilityDepth: 'project', audienceRoles: ['member'] };
+    expect(readableBy(projectMember, row)).toBe(true);
+    expect(readableBy(projectGuest, row)).toBe(false); // role fails
+    expect(readableBy(orgMember, row)).toBe(false); // depth fails
   });
 });
 
 describe('exemption and bypass rules', () => {
   it('exempt roles bypass the restriction entirely', () => {
-    const row = { visibilityDepth: 'nonsense', audienceRoles: ['nobody'] };
+    const row = { visibilityDepth: 'project', audienceRoles: ['member'] };
     expect(readableBy(orgAdmin, row)).toBe(true);
   });
 
   it("row-condition grants ('own') are never narrowed — creator sees own restricted row", () => {
-    const { accessPolicies: ownPolicies } = configurePermissions(appConfig.entityTypes, ({ subject, contexts }) => {
-      if (subject.name !== 'attachment') return;
+    const { accessPolicies: ownPolicies } = configureWidePermissions(({ subject, contexts }) => {
+      if (subject.name !== 'task') return;
       contexts.organization.member({ read: 'own' });
     });
-    const row = { audienceRoles: ['nobody'] };
-    const subject: SubjectForPermission = { ...attachment(row), createdBy: 'u1' };
-    const { can } = getAllDecisions(ownPolicies, [orgMember], subject, { userId: 'u1', restrictions });
+    const row = { visibilityDepth: 'project', audienceRoles: ['nobody'] };
+    const subject: SubjectForPermission = { ...task(row), createdBy: 'u1' };
+    const { can } = getAllDecisions(ownPolicies, [orgMember], subject, {
+      userId: 'u1',
+      restrictions,
+      topology: wideTopology,
+    });
     expect(can.read).toBe(true);
   });
 
   it('public read grants are never narrowed', () => {
-    const row = { audienceRoles: ['nobody'], publicAt: '2026-01-01' };
-    const { can } = getAllDecisions({}, [], attachment(row), {
+    const row = { visibilityDepth: 'project', audienceRoles: ['nobody'], publicAt: '2026-01-01' };
+    const { can } = getAllDecisions({}, [], task(row), {
       restrictions,
-      publicGrants: { attachment: 'publicSelf' },
+      publicGrants: widePublicGrants({ task: 'publicSelf' }),
+      topology: wideTopology,
     });
     expect(can.read).toBe(true);
   });
 
   it('create is never restricted; other actions are', () => {
-    const row = { audienceRoles: ['nobody'] };
-    const { can } = getAllDecisions(policies, [orgMember], attachment(row), { userId: 'u1', restrictions });
+    const row = { visibilityDepth: 'project', audienceRoles: ['guest'] };
+    const { can } = getAllDecisions(policies, [projectMember], task(row), {
+      userId: 'u1',
+      restrictions,
+      topology: wideTopology,
+    });
     expect(can.create).toBe(true);
     expect(can.read).toBe(false);
     expect(can.update).toBe(false);
   });
 
   it('system admin bypasses restrictions like everything else', () => {
-    const row = { audienceRoles: ['nobody'] };
-    const { can } = getAllDecisions(policies, [], attachment(row), { isSystemAdmin: true, restrictions });
+    const row = { visibilityDepth: 'project', audienceRoles: ['nobody'] };
+    const { can } = getAllDecisions(policies, [], task(row), {
+      isSystemAdmin: true,
+      restrictions,
+      topology: wideTopology,
+    });
     expect(can.read).toBe(true);
   });
 });
 
 describe('fail-closed without row data', () => {
   it('restriction declared + no subject row → non-exempt membership grants do not qualify', () => {
-    expect(readableBy(orgMember, undefined)).toBe(false);
+    expect(readableBy(projectMember, undefined)).toBe(false);
     expect(readableBy(orgAdmin, undefined)).toBe(true); // exempt role still qualifies
   });
 
   it('no restriction declared for the entity type → unchanged behavior', () => {
-    const { can } = getAllDecisions(policies, [orgMember], attachment(undefined), { userId: 'u1', restrictions: {} });
+    const { can } = getAllDecisions(policies, [projectMember], task(undefined), {
+      userId: 'u1',
+      restrictions: {},
+      topology: wideTopology,
+    });
     expect(can.read).toBe(true);
   });
 });

--- a/shared/src/testing/wide-fixture.test.ts
+++ b/shared/src/testing/wide-fixture.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { getAllDecisions } from '../permissions';
+import {
+  configureWidePermissions,
+  wideHierarchy,
+  wideMembership,
+  wideSubject,
+  wideTopology,
+} from './wide-fixture';
+
+/**
+ * Smoke test for the wide fixture kit: proves the topology seam drives the engine over the
+ * synthetic hierarchy (nested contexts + guest role) regardless of the app's real config.
+ */
+describe('wide fixture kit', () => {
+  it('exposes a nested hierarchy with a host relation and guest role', () => {
+    expect(wideHierarchy.getOrderedAncestors('attachment')).toEqual(['project', 'organization']);
+    expect(wideHierarchy.getHostType('attachment')).toBe('task');
+    expect([...wideHierarchy.getRoles('project')]).toContain('guest');
+  });
+
+  it('resolves a project-level grant through getAllDecisions on the wide topology', () => {
+    const { accessPolicies } = configureWidePermissions(({ subject, contexts }) => {
+      if (subject.name === 'attachment') {
+        contexts.project.guest({ read: 1 });
+      }
+    });
+
+    const decision = getAllDecisions(
+      accessPolicies,
+      [wideMembership('project', 'p1', 'guest')],
+      wideSubject({ entityType: 'attachment', id: 'a1', contextIds: { organization: 'o1', project: 'p1' } }),
+      { topology: wideTopology },
+    );
+
+    expect(decision.can.read).toBe(true);
+    expect(decision.can.update).toBe(false);
+  });
+});

--- a/shared/src/testing/wide-fixture.ts
+++ b/shared/src/testing/wide-fixture.ts
@@ -1,0 +1,158 @@
+/**
+ * Wide synthetic permission fixture — the canonical "rich hierarchy" that upstream-owned engine
+ * tests run against, instead of a given fork's real `shared/config`.
+ *
+ * The template (cella) ships a deliberately minimal hierarchy (organization → attachment), which
+ * structurally cannot exercise the engine's deeper features: nested + sibling contexts, a host
+ * relation, a guest role, multi-level ancestor resolution, all three public-read modes. This
+ * fixture provides one hierarchy that does, so a single set of tests covers them in every fork.
+ *
+ * It mirrors raak's real hierarchy (documented as the reference example in cella's
+ * `hierarchy-config.ts`). It MUST stay a superset of every feature the hierarchy builder supports;
+ * variable-depth / nullable-ancestor coverage lives separately in
+ * `config-builder/tests/resolve-row-context.test.ts`.
+ *
+ * The engine reads this via the `topology` seam (`PermissionTopology`) — no module mocks. All the
+ * casts needed to name entities the app config doesn't know about are contained here, so the test
+ * files that consume the kit stay cast-free and byte-identical across forks.
+ */
+import { createEntityHierarchy, createRoleRegistry } from '../config-builder/entity-hierarchy';
+import type { EntityActionType, EntityType } from '../../types';
+import {
+  type AccessPolicies,
+  type AccessPolicyCallback,
+  type ActionPermissionState,
+  computeCan,
+  configurePermissions,
+  type HostDelegation,
+  type PermissionMembership,
+  type PermissionsConfigResult,
+  type PermissionTopology,
+  type PermissionValue,
+  type PublicReadGrants,
+  type PublicReadMode,
+  type RowRestriction,
+  type RowRestrictionInput,
+  type RowRestrictions,
+  type SubjectForPermission,
+} from '../permissions';
+
+// Wide entity/role vocabulary — typed independently of any fork's app config so the tests that
+// use these names compile in every fork (a fork whose real config lacks `project` still builds).
+export type WideContextType = 'organization' | 'workspace' | 'project';
+export type WideProductType = 'task' | 'label' | 'attachment';
+export type WideEntityType = 'user' | WideContextType | WideProductType;
+export type WideRole = 'admin' | 'member' | 'guest';
+
+export const wideRoles = createRoleRegistry(['admin', 'member', 'guest'] as const);
+
+/**
+ * The wide hierarchy. Two sibling nested contexts (workspace, project) under organization, three
+ * products under project, `attachment` hosted by `task`, guest role on the nested contexts only.
+ */
+export const wideHierarchy = createEntityHierarchy(wideRoles)
+  .user()
+  .context('organization', { parent: null, roles: ['admin', 'member'] })
+  .context('workspace', { parent: 'organization', roles: wideRoles.all })
+  .context('project', { parent: 'organization', roles: wideRoles.all })
+  .product('task', { parent: 'project' })
+  .product('label', { parent: 'project' })
+  .product('attachment', { parent: 'project', host: 'task' })
+  .build();
+
+export const wideEntityTypes: readonly WideEntityType[] = [
+  'user',
+  'organization',
+  'workspace',
+  'project',
+  'task',
+  'label',
+  'attachment',
+];
+
+/**
+ * Topology bag the engine reads. `entityActions`/`entityIdColumnKeys` are omitted so they default
+ * to the app config — they are hierarchy-independent (the CRUD action set is identical across forks).
+ */
+export const wideTopology: PermissionTopology = { hierarchy: wideHierarchy };
+
+type WidePerms = Partial<Record<EntityActionType, PermissionValue>>;
+type WideContextBuilder = Record<WideRole, (perms: WidePerms) => void>;
+
+/** Callback config surfaced to `configureWidePermissions` — wide-typed mirror of the engine's. */
+export interface WideAccessPolicyConfiguration {
+  subject: { name: WideEntityType };
+  contexts: Record<WideContextType, WideContextBuilder>;
+  publicRead: (mode: PublicReadMode) => void;
+  restrict: (restriction: RowRestrictionInput) => void;
+  delegateToHost: (actions: readonly EntityActionType[]) => void;
+}
+
+export type WideAccessPolicyCallback = (config: WideAccessPolicyConfiguration) => void;
+
+/**
+ * Configure permissions over the wide hierarchy. Same semantics as `configurePermissions`, but the
+ * callback is typed with the wide vocabulary (so `contexts.project.guest(...)` / `case 'project'`
+ * type-check regardless of the fork's real config). The app-config↔wide cast is contained here.
+ */
+export const configureWidePermissions = (callback: WideAccessPolicyCallback): PermissionsConfigResult =>
+  configurePermissions(
+    wideEntityTypes as unknown as readonly EntityType[],
+    callback as unknown as AccessPolicyCallback,
+    wideTopology,
+  );
+
+/** Build a membership over a wide context. */
+export const wideMembership = (
+  contextType: WideContextType,
+  contextId: string,
+  role: WideRole,
+): PermissionMembership => ({ contextType, contextId, role }) as unknown as PermissionMembership;
+
+/** Build a subject over a wide entity. */
+export const wideSubject = (input: {
+  entityType: WideEntityType;
+  id?: string;
+  createdBy?: string | null;
+  contextIds: Partial<Record<WideContextType, string | null>>;
+  row?: Record<string, unknown>;
+  parentRow?: Record<string, unknown>;
+  hostRow?: Record<string, unknown>;
+}): SubjectForPermission => ({ ...input }) as unknown as SubjectForPermission;
+
+/** Wrap a wide-keyed public-read grant map for the engine's `publicGrants` option. */
+export const widePublicGrants = (grants: Partial<Record<WideEntityType, PublicReadMode>>): PublicReadGrants =>
+  grants as PublicReadGrants;
+
+/**
+ * Wrap a wide-keyed row-restriction map for the engine's `restrictions` option. Takes the
+ * engine's normalized `RowRestriction` shape (depthColumn/rolesColumn/exemptRoles), matching what
+ * the `restrictions` option expects — not the `restrict()` callback's `RowRestrictionInput`.
+ */
+export const wideRestrictions = (restrictions: Partial<Record<WideEntityType, RowRestriction>>): RowRestrictions =>
+  restrictions as RowRestrictions;
+
+/** Wrap a wide-keyed host-delegation map for the engine's `hostDelegation` option. */
+export const wideHostDelegation = (
+  delegation: Partial<Record<WideProductType, readonly EntityActionType[]>>,
+): HostDelegation => delegation as HostDelegation;
+
+/** `computeCan`'s result keyed by the wide vocabulary, so tests read `.task` etc. cast-free. */
+export type WideCanMap = Partial<Record<WideEntityType, Record<EntityActionType, ActionPermissionState>>>;
+
+/**
+ * Drive `computeCan` over the wide hierarchy. `computeCan` is typed against the app's real
+ * entities (its `contextType` param and result map), so this wrapper contains the wide↔app casts,
+ * keeping the tests cast-free.
+ */
+export const computeWideCan = (
+  contextType: WideContextType,
+  membership: PermissionMembership | undefined | null,
+  policies: AccessPolicies,
+): WideCanMap =>
+  computeCan(
+    contextType as unknown as Parameters<typeof computeCan>[0],
+    membership as unknown as Parameters<typeof computeCan>[1],
+    policies,
+    wideTopology,
+  ) as unknown as WideCanMap;

--- a/yjs/src/tests/integration/concurrency.test.ts
+++ b/yjs/src/tests/integration/concurrency.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import pg from 'pg';
+import { appConfig } from 'shared';
 import * as Y from 'yjs';
 import { createDoc, loadState, saveState, deleteState } from '../../data/storage';
 import type { DocContext } from '../../constants';
@@ -13,7 +14,8 @@ const testOrgId = '00000000-0000-4000-a000-000000000001';
 
 function ctx(entityId: string): DocContext {
   return {
-    entityType: 'task',
+    // Config-derived: yjs_documents has no FK to the entity table, so any product type works.
+    entityType: appConfig.productEntityTypes[0],
     entityId,
     tenantId: testTenantId,
     userId: testUserId,
@@ -137,7 +139,7 @@ describe('2.3 State consistency under concurrency', () => {
     Y.applyUpdate(docB, stateB!);
     docB.getMap('data').set('fromB', true);
 
-    // Save concurrently — last write wins, one update may be lost
+    // Save concurrently: last write wins, one update may be lost
     await Promise.all([
       saveState(c, Y.encodeStateAsUpdate(docA)),
       saveState(c, Y.encodeStateAsUpdate(docB)),
@@ -153,8 +155,7 @@ describe('2.3 State consistency under concurrency', () => {
     const hasB = map.get('fromB') === true;
     expect(hasA || hasB).toBe(true);
 
-    // Document the race: without merging, one update is typically lost.
-    // The relay's debounce + safeMerge pattern prevents this in practice.
+    // Without merging, one concurrent update is typically lost; the relay's debounce + safeMerge pattern mitigates this in production (untested here).
     if (!hasA || !hasB) {
       console.info('  ℹ Last-write-wins confirmed: one concurrent update was lost (expected without merge)');
     }

--- a/yjs/src/tests/integration/storage-crud.test.ts
+++ b/yjs/src/tests/integration/storage-crud.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import pg from 'pg';
+import { appConfig } from 'shared';
 import * as Y from 'yjs';
 import { createDoc, loadState, saveState, deleteState } from '../../data/storage';
 import type { DocContext } from '../../constants';
@@ -14,7 +15,8 @@ const testOrgId = '00000000-0000-4000-a000-000000000001';
 
 function ctx(entityId: string): DocContext {
   return {
-    entityType: 'task',
+    // Config-derived: yjs_documents has no FK to the entity table, so any product type works.
+    entityType: appConfig.productEntityTypes[0],
     entityId,
     tenantId: testTenantId,
     userId: testUserId,
@@ -76,7 +78,7 @@ describe('6.1 Storage CRUD', () => {
     // Create
     await createDoc(c);
 
-    // Load — row exists with empty state
+    // Load: row exists with empty state
     const empty = await loadState(c);
     expect(empty).not.toBeNull();
     expect(empty!.length).toBe(0);
@@ -87,7 +89,7 @@ describe('6.1 Storage CRUD', () => {
     const update = Y.encodeStateAsUpdate(doc);
     await saveState(c, update);
 
-    // Load — should return saved state
+    // Load: should return saved state
     const loaded = await loadState(c);
     expect(loaded).not.toBeNull();
     expect(loaded!.length).toBeGreaterThan(0);
@@ -100,7 +102,7 @@ describe('6.1 Storage CRUD', () => {
     // Delete
     await deleteState(c);
 
-    // Load — should return null (no row)
+    // Load: should return null (no row)
     const deleted = await loadState(c);
     expect(deleted).toBeNull();
   });


### PR DESCRIPTION
## Why

The permission engine is byte-identical across forks and fully config-driven, but its hierarchy-dependent tests can only exercise whatever the template's config ships (`organization → attachment`). So the template has **no** coverage of runtime host delegation, multi-level ancestor resolution, guest roles, or the three public-read modes on distinct entities — and forks (e.g. raak) re-fork those test files to test their deeper hierarchies. The fixtures were the only thing that differed.

This makes those tests **fork-independent** so the template owns them, and forks stop maintaining divergent copies. Authored in raak and contributed here (raak PR: cellajs/raak#38).

## What

**Topology seam (behavior-preserving).** `getAllDecisions`, `configurePermissions`, `computeCan`, and `validateSubject` take an optional `topology?: PermissionTopology` that defaults to the real `hierarchy`/`appConfig`, so omitting it changes nothing. Tests pass a synthetic hierarchy instead of module-mocking `shared`. New `permission-manager/topology.ts` holds the two small types (kept out of the dense `types.ts`).

**Wide-fixture kit** (`shared/src/testing/wide-fixture.ts`) — one canonical synthetic hierarchy: `organization → workspace/project → task/label/attachment`, `attachment` hosted by `task`, `guest` on the nested contexts. `configureWidePermissions` / `wideMembership` / `wideSubject` / `computeWideCan` / `wide{PublicGrants,Restrictions,HostDelegation}` contain **all** the app-config casts, so consuming tests stay cast-free and identical in every fork.

**Tests migrated onto the kit** — now covered on the template:
| File | Coverage |
|---|---|
| `host-delegation.test.ts` | 11 runtime host-delegation cases (was declaration-only) |
| `public-read.test.ts` | publicSelf / publicParent / publicParentOrSelf on distinct entities |
| `row-restrictions.test.ts` | multi-level depth ordering + cross-level audience |
| `permission-manager/index.test.ts` | guest roles, multi-level ancestors, host delegation through `getAllDecisions` |
| `compute-can.test.ts` | guest + multi-level |

**Config-adaptive DB tests** derive fixtures from the real hierarchy, so they degrade to the template's shape automatically: `attachment-seq-reads` seeds its ancestor chain via a new `buildTestEntityHierarchyPlan`-based helper (`backend/tests/hierarchy-helpers.ts`) — **no intermediate rows on the org-only config**; `recalculate-counters` uses inline synthetic hierarchies; `cache-migration` reads `appConfig.contextEntityTypes`; yjs storage/concurrency use `appConfig.productEntityTypes[0]`.

## Verification (on the template's org-only config)

- Typecheck clean across all packages (enforced by the pre-push hook)
- `shared`: **235 pass** — the wide-fixture tests run against the synthetic hierarchy while the engine reads the template config, proving fork-independence
- `backend` core: **377 pass** (incl. the untouched `row-predicates` parity property test — the seam is behavior-preserving)
- `frontend` cache-migration: **11 pass**

## Notes for reviewers

- `PermissionTopology` is `{ hierarchy, entityActions? }`; the context set is derived from `topology.hierarchy.contextTypes`, so a fork whose real config is narrower than the fixture still builds every context.
- `validateSubject` became topology-aware (added `isProduct` to the structural `TopologyHierarchy`) so a subject whose entity type only exists in a fixture still validates.
- The engine files carry raak's prior comment-sweep wording in a few doc comments; the logic diff is only the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
