### PR TITLE
test(permissions): make row-predicates parity test config-adaptive

### DIFF
--- a/backend/src/permissions/row-predicates.test.ts
+++ b/backend/src/permissions/row-predicates.test.ts
@@ -1,15 +1,19 @@
 import { sql } from 'drizzle-orm';
-import { pgTable, varchar } from 'drizzle-orm/pg-core';
+import { type PgColumn, pgTable, varchar } from 'drizzle-orm/pg-core';
 import {
   type AccessPolicies,
   appConfig,
+  type ContextEntityType,
   computeCan,
   configureAccessPolicies,
   getAllDecisions,
+  getContextRoles,
+  hierarchy,
   type PermissionValue,
   type RowRestrictions,
   resolvePermission,
   type SubjectForPermission,
+  toColumnName,
 } from 'shared';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { seedDb } from '#/db/db';
@@ -31,51 +35,77 @@ import { buildCollectionReadWhere } from './row-predicates';
  * policy sets (including row-conditional `'own'` grants), memberships and actors, and
  * asserts the three paths agree row-for-row.
  *
- * Runs on the template hierarchy (a single `organization` context). Sub-context scoping
- * (`subContextIds`, explicit sub-context narrowing) needs a nested context between the
- * organization and the product — forks with one (e.g. organization > project) should
- * extend the scenario space with sub-context memberships and a narrowing test.
+ * Config-adaptive: the scenario space is derived from `attachment`'s real ancestor chain, so it
+ * runs on any fork. A fork with a nested context (raak: `project → organization`) exercises the
+ * sub-context narrowing; an org-only fork (cella: `organization`) skips it (`runIf`).
  */
 
+// attachment's ancestor chain, most-specific → root. raak: [project, organization]; cella: [organization].
+const CHAIN = hierarchy.getOrderedAncestors('attachment') as ContextEntityType[];
+const ROOT = CHAIN[CHAIN.length - 1]; // organization (the collection is scoped to one root instance)
+const SUB = CHAIN.length > 1 ? CHAIN[0] : null; // the narrowable sub-context (project) — null on an org-only fork
+const ROOT_ID = 'org1';
+const SUB_INSTANCES = SUB ? ['s1', 's2', 's3'] : []; // sub-context instance ids (empty when there is no sub-context)
+
+// Depth values a row's `visibilityDepth` can take: the sub-context (or root when none), the root,
+// and one context guaranteed to be outside attachment's chain (never qualifies).
+const DEPTH_SUB = SUB ?? ROOT;
+const UNKNOWN_DEPTH = 'nonexistent-context';
+
+// Sub-context id column on the scratch table (raak: `project_id`), derived from config. Null on an
+// org-only fork, where the read is org-wide and no sub-context column is ever referenced.
+const subIdKey = SUB ? appConfig.entityIdColumnKeys[SUB] : null; // 'projectId' | null
+const subColumnName = subIdKey ? toColumnName(subIdKey) : null; // 'project_id' | null
+
 /** Scratch table (real Postgres, admin connection): the minimal shape of a product table. */
-const parityTable = pgTable('test_permission_parity_rows', {
+const baseColumns = {
   id: varchar('id').primaryKey(),
-  organizationId: varchar('organization_id').notNull(),
   createdBy: varchar('created_by'),
   visibilityDepth: varchar('visibility_depth'),
   audienceRoles: varchar('audience_roles').array(),
-});
+};
+const parityTable = pgTable(
+  'test_permission_parity_rows',
+  subIdKey && subColumnName ? { ...baseColumns, [subIdKey]: varchar(subColumnName).notNull() } : baseColumns,
+);
+// The sub-context column passed to `buildCollectionReadWhere`. On an org-only fork the read is
+// org-wide (subContextIds always undefined/[]), so this column is never referenced — `id` stands in.
+const subContextColumn = (
+  subIdKey ? (parityTable as unknown as Record<string, PgColumn>)[subIdKey] : parityTable.id
+) as PgColumn;
 
 const USERS = ['u1', 'u2'] as const;
-const ORG_ID = 'org1';
 
 interface ParityRow {
   id: string;
-  organizationId: string;
+  subContextId: string | null;
   createdBy: string | null;
   visibilityDepth: string | null;
   audienceRoles: string[] | null;
 }
 
-/** Depth × audience combinations, incl. an unknown depth ('workspace' is not in attachment's chain). */
+/** Depth × audience combinations, incl. an unknown depth outside attachment's chain. */
 const VISIBILITY_COMBOS: Array<{ key: string; visibilityDepth: string | null; audienceRoles: string[] | null }> = [
   { key: 'open', visibilityDepth: null, audienceRoles: null },
-  { key: 'org', visibilityDepth: 'organization', audienceRoles: null },
-  { key: 'org-member', visibilityDepth: 'organization', audienceRoles: ['member'] },
+  { key: 'sub', visibilityDepth: DEPTH_SUB, audienceRoles: null },
+  { key: 'root-member', visibilityDepth: ROOT, audienceRoles: ['member'] },
   { key: 'admin-only', visibilityDepth: null, audienceRoles: ['admin'] },
-  { key: 'unknown-depth', visibilityDepth: 'workspace', audienceRoles: ['admin', 'member'] },
-  { key: 'empty-roles', visibilityDepth: 'organization', audienceRoles: [] },
+  { key: 'unknown-depth', visibilityDepth: UNKNOWN_DEPTH, audienceRoles: ['guest', 'member'] },
+  { key: 'empty-roles', visibilityDepth: DEPTH_SUB, audienceRoles: [] },
 ];
 
-/** Fixed row set: every creator × visibility combination. */
-const ROWS: ParityRow[] = [...USERS, null].flatMap((createdBy) =>
-  VISIBILITY_COMBOS.map(({ key, visibilityDepth, audienceRoles }) => ({
-    id: `${createdBy ?? 'nobody'}:${key}`,
-    organizationId: ORG_ID,
-    createdBy,
-    visibilityDepth,
-    audienceRoles,
-  })),
+/** Fixed row set: every sub-context (or the single org) × creator × visibility combination. */
+const SUB_SLOTS: (string | null)[] = SUB ? SUB_INSTANCES : [null];
+const ROWS: ParityRow[] = SUB_SLOTS.flatMap((subContextId) =>
+  [...USERS, null].flatMap((createdBy) =>
+    VISIBILITY_COMBOS.map(({ key, visibilityDepth, audienceRoles }) => ({
+      id: `${subContextId ?? 'root'}:${createdBy ?? 'nobody'}:${key}`,
+      subContextId,
+      createdBy,
+      visibilityDepth,
+      audienceRoles,
+    })),
+  ),
 );
 
 /** Deterministic PRNG (mulberry32) so failures reproduce exactly. */
@@ -99,12 +129,16 @@ const pick = <T>(random: () => number, values: readonly T[]): T => {
 /** Random read policy value; other actions stay denied (only `read` matters here). */
 const randomReadValue = (random: () => number): PermissionValue => pick(random, [0, 1, 'own'] as const);
 
-/** Policies for `attachment` with random read cells for every context × role combination. */
+/** Policies for `attachment` with random read cells for every context × role in the real chain. */
 const randomPolicies = (random: () => number): AccessPolicies =>
   configureAccessPolicies(appConfig.entityTypes, ({ subject, contexts }) => {
     if (subject.name !== 'attachment') return;
-    contexts.organization.admin({ read: randomReadValue(random) });
-    contexts.organization.member({ read: randomReadValue(random) });
+    const builders = contexts as unknown as Record<string, Record<string, (perms: { read: PermissionValue }) => void>>;
+    for (const ctx of CHAIN) {
+      for (const role of getContextRoles(ctx)) {
+        builders[ctx][role]({ read: randomReadValue(random) });
+      }
+    }
   });
 
 interface Scenario {
@@ -128,13 +162,13 @@ const randomRestrictions = (random: () => number): RowRestrictions => {
   };
 };
 
-const membership = (contextId: string, role: string): MembershipBaseModel =>
+const membership = (contextType: ContextEntityType, contextId: string, role: string): MembershipBaseModel =>
   ({
-    id: `mem-organization-${contextId}-${role}`,
+    id: `mem-${contextType}-${contextId}-${role}`,
     userId: 'actor',
-    contextType: 'organization',
+    contextType,
     contextId,
-    organizationId: ORG_ID,
+    organizationId: ROOT_ID,
     role,
   }) as unknown as MembershipBaseModel;
 
@@ -150,7 +184,12 @@ const randomScenario = (random: () => number): Scenario => {
   }
 
   const memberships: MembershipBaseModel[] = [];
-  if (random() < 0.7) memberships.push(membership(ORG_ID, pick(random, ['admin', 'member'])));
+  if (random() < 0.4) memberships.push(membership(ROOT, ROOT_ID, pick(random, getContextRoles(ROOT))));
+  if (SUB) {
+    for (const subId of SUB_INSTANCES) {
+      if (random() < 0.4) memberships.push(membership(SUB, subId, pick(random, getContextRoles(SUB))));
+    }
+  }
   return {
     policies: randomPolicies(random),
     memberships,
@@ -163,7 +202,7 @@ const rowSubject = (row: ParityRow): SubjectForPermission => ({
   entityType: 'attachment',
   id: row.id,
   createdBy: row.createdBy,
-  contextIds: { organization: ORG_ID },
+  contextIds: { [ROOT]: ROOT_ID, ...(SUB && row.subContextId !== null ? { [SUB]: row.subContextId } : {}) },
   row: { visibilityDepth: row.visibilityDepth, audienceRoles: row.audienceRoles },
 });
 
@@ -186,11 +225,11 @@ const sqlReadableIds = async (scenario: Scenario): Promise<Set<string>> => {
     scenario.policies,
     scenario.memberships,
     'attachment',
-    ORG_ID,
+    ROOT_ID,
     undefined,
     scenario.restrictions,
   );
-  const where = buildCollectionReadWhere(filter, parityTable, parityTable.organizationId, scenario.userId);
+  const where = buildCollectionReadWhere(filter, parityTable, subContextColumn, scenario.userId);
 
   if (where.kind === 'none') return new Set();
   const query = seedDb.select({ id: parityTable.id }).from(parityTable);
@@ -200,16 +239,24 @@ const sqlReadableIds = async (scenario: Scenario): Promise<Set<string>> => {
 
 beforeAll(async () => {
   await seedDb.execute(sql`drop table if exists test_permission_parity_rows`);
-  await seedDb.execute(sql`
+  await seedDb.execute(
+    sql.raw(`
     create table test_permission_parity_rows (
       id varchar primary key,
-      organization_id varchar not null,
       created_by varchar,
       visibility_depth varchar,
-      audience_roles varchar[]
+      audience_roles varchar[]${subColumnName ? `,\n      ${subColumnName} varchar not null` : ''}
     )
-  `);
-  await seedDb.insert(parityTable).values(ROWS);
+  `),
+  );
+  const values = ROWS.map((r) => ({
+    id: r.id,
+    createdBy: r.createdBy,
+    visibilityDepth: r.visibilityDepth,
+    audienceRoles: r.audienceRoles,
+    ...(subIdKey && r.subContextId !== null ? { [subIdKey]: r.subContextId } : {}),
+  }));
+  await seedDb.insert(parityTable).values(values as (typeof parityTable.$inferInsert)[]);
 });
 
 afterAll(async () => {
@@ -233,15 +280,16 @@ describe('row-condition parity: engine check ⊆⊇ compiled SQL ⊆⊇ compute-
 
       // Engine ⊆⊇ compute-can: per single membership, the frontend-resolved state must
       // match the engine's decision for every row in that membership's scope.
-      // KNOWN LIMITATION: computeCan is restriction-blind (context-level, no row data) —
+      // computeCan is restriction-blind (context-level, no row data).
       // restricted entities must resolve per row via the decision API, so parity with
       // compute-can is only asserted when no restriction is declared.
       if (scenario.restrictions.attachment) continue;
       for (const m of scenario.memberships) {
-        const canMap = computeCan(m.contextType, m, scenario.policies);
+        const canMap = computeCan(m.contextType as ContextEntityType, m, scenario.policies);
         const state = canMap.attachment?.read ?? false;
+        const rowsInScope = m.contextType === ROOT ? ROWS : ROWS.filter((r) => r.subContextId === m.contextId);
 
-        for (const row of ROWS) {
+        for (const row of rowsInScope) {
           const resolved = resolvePermission(state, row.createdBy, scenario.userId);
           const { can } = getAllDecisions(scenario.policies, [m], rowSubject(row), { userId: scenario.userId });
           expect(resolved, `${label}; membership ${m.contextType}:${m.contextId}:${m.role}; row ${row.id}`).toBe(
@@ -250,5 +298,56 @@ describe('row-condition parity: engine check ⊆⊇ compiled SQL ⊆⊇ compute-
         }
       }
     }
+  });
+
+  // Explicit sub-context narrowing needs a nested context (e.g. organization > project). Skips on an
+  // org-only fork, which has no sub-context to narrow into.
+  describe.runIf(SUB !== null)('sub-context narrowing', () => {
+    it('explicitly requested sub-context narrows conditional scopes the same way', async () => {
+      const random = mulberry32(0xbee5);
+
+      for (let i = 0; i < 100; i++) {
+        const scenario = randomScenario(random);
+        const requestedSubContext = pick(random, SUB_INSTANCES);
+
+        let filter: ReturnType<typeof resolveCollectionReadFilterForPolicies>;
+        try {
+          filter = resolveCollectionReadFilterForPolicies(
+            scenario.policies,
+            scenario.memberships,
+            'attachment',
+            ROOT_ID,
+            { subContextId: requestedSubContext },
+            scenario.restrictions,
+          );
+        } catch {
+          // 403: no scope at all for the requested sub-context. The engine must agree that
+          // no row of it is readable.
+          const fromEngine = engineReadableIds(scenario);
+          for (const row of ROWS.filter((r) => r.subContextId === requestedSubContext)) {
+            expect(fromEngine.has(row.id), `seed 0xbee5 scenario ${i} row ${row.id}`).toBe(false);
+          }
+          continue;
+        }
+
+        const where = buildCollectionReadWhere(filter, parityTable, subContextColumn, scenario.userId);
+        const fromSqlAll =
+          where.kind === 'none'
+            ? new Set<string>()
+            : new Set(
+                (where.kind === 'all'
+                  ? await seedDb.select({ id: parityTable.id }).from(parityTable)
+                  : await seedDb.select({ id: parityTable.id }).from(parityTable).where(where.where)
+                ).map((r) => r.id),
+              );
+
+        // Narrowed SQL result == engine-readable rows of the requested sub-context.
+        const fromEngine = engineReadableIds(scenario);
+        const expected = new Set(
+          ROWS.filter((r) => r.subContextId === requestedSubContext && fromEngine.has(r.id)).map((r) => r.id),
+        );
+        expect(fromSqlAll, `seed 0xbee5 scenario ${i} sub-context ${requestedSubContext}`).toEqual(expected);
+      }
+    });
   });
 });


### PR DESCRIPTION
## Why

`row-predicates.test.ts` (the engine⊆⊇SQL⊆⊇compute-can parity property test — a security merge-blocker) was the last hierarchy-bound test still forked per-repo: the template shipped an org-only version while forks (raak) maintained a `project`-shaped one. This makes it **config-adaptive** so one version runs on any fork.

## What

The scratch table, scenario space, memberships and policies now derive from `attachment`'s real ancestor chain:

- `CHAIN = hierarchy.getOrderedAncestors('attachment')` → template `[organization]`, raak `[project, organization]`
- `ROOT = CHAIN.at(-1)`, `SUB = CHAIN.length > 1 ? CHAIN[0] : null`
- the scratch table gets a sub-context column only when `SUB` exists; policies loop `CHAIN × getContextRoles(ctx)`; the primary column passed to `buildCollectionReadWhere` is the sub-context column (or `id` when there's none — never referenced org-wide)
- the explicit sub-context narrowing block is guarded by `describe.runIf(SUB !== null)` — runs where a nested context exists, skips loudly on the org-only template

## Verification (real Postgres)

- **template (org-only)**: parity property test passes, narrowing **skips**
- **fork with `organization > project` (raak)**: 250-iteration parity **and** sub-context narrowing pass

Byte-identical to the version adopted in the raak fork, so it syncs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
