### PR TITLE
revert: ignore maintenances change (no-op ignoreChanges)

### DIFF
--- a/infra/resources/database.ts
+++ b/infra/resources/database.ts
@@ -66,12 +66,7 @@ const instance = new scaleway.databases.Instance('main-postgres', {
     sync_replication_slots: 'on',
   },
   loadBalancer: dbPublicEndpoint ? {} : undefined,
-}, {
-  aliases: [{ type: 'scaleway:index/databaseInstance:DatabaseInstance' }],
-  deleteBeforeReplace: true,
-  ignoreChanges: ['maintenances'],
-  protect: isProduction,
-})
+}, { aliases: [{ type: 'scaleway:index/databaseInstance:DatabaseInstance' }], deleteBeforeReplace: true, protect: isProduction })
 
 if (dbPublicEndpoint && dbPublicAcl) {
   new scaleway.databases.Acl('main-postgres-acl', {

--- a/infra/tests/unit/module-invariants.test.ts
+++ b/infra/tests/unit/module-invariants.test.ts
@@ -83,10 +83,6 @@ describe('database resource', () => {
     expect(db).toMatch(/protect:\s*isProduction/)
   })
 
-  it('ignores Scaleway-managed maintenance metadata on the database instance', () => {
-    expect(db).toMatch(/ignoreChanges:\s*\['maintenances'\]/)
-  })
-
   // Known gaps surfaced by the testing plan: these are configuration
   // decisions the operator must make per environment. Listed here so a
   // reviewer sees them in `pnpm test` output.


### PR DESCRIPTION
Reverts commit 2620872ac (`fix: ignore maintenances change`).

## Why

The `ignoreChanges: ['maintenances']` option on `main-postgres` is a no-op: Pulumi's `ignoreChanges` only applies to resource **inputs**, and `maintenances` is an output-only computed attribute on `scaleway:databases:Instance` (present in `InstanceState`/outputs, absent from `InstanceArgs`). The `+maintenances` diff is generated inside the bridged Terraform provider by comparing prior state against the new provider schema, so the engine-level option cannot suppress it — as confirmed by the [production deploy still failing](https://github.com/cellajs/cella/actions/runs/29042920107/job/86205994890) with `[diff: +maintenances]` after the fix shipped.

This also removes the unit test that enforced the misleading line.

## Actual fix for the deploy failure

The `@pulumiverse/scaleway` 1.51.1 → 1.52.0 bump (#867) added the computed `maintenances` attribute; persisting it into stack state requires one update of the RDB instance, which the CI key (`RelationalDatabasesReadOnly`) is correctly forbidden from doing (403). Per the IAM manifest in `infra/lib/scaleway/permissions.ts`, the remedy is a one-shot privileged converge via the infra CLI ("Apply infra change") — after that, CI sees no diff on the database instance and deploys proceed.

## Tests

`pnpm --filter infra test` — 50 files, 419 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
