### PR TITLE
feat(cdc): identify the slot holder in slot-contention retry warnings

### DIFF
--- a/cdc/src/pipeline/replication.ts
+++ b/cdc/src/pipeline/replication.ts
@@ -94,6 +94,33 @@ export async function ensureReplicationSlot(): Promise<void> {
   }
 }
 
+/** Postgres `object_in_use`: subscribe() lost the race for an actively held slot. */
+const PG_OBJECT_IN_USE = '55006';
+
+/**
+ * Best-effort lookup of the connection currently holding the replication slot.
+ *
+ * "replication slot is active for PID N" alone is hard to act on: the PID is a
+ * Postgres walsender, not a host process. The holder's application_name and
+ * backend_start usually identify the competing worker at a glance — the old
+ * worker of a rolling deploy, or a stray local process that never shut down.
+ * Returns null when the slot is free or the lookup fails; diagnostics must
+ * never break the retry loop.
+ */
+async function describeSlotHolder(): Promise<Record<string, unknown> | null> {
+  try {
+    const result = await cdcDb.execute(sql`
+      SELECT a.pid, a.application_name, a.client_addr::text AS client_addr, a.backend_start::text AS backend_start
+      FROM pg_replication_slots s
+      JOIN pg_stat_activity a ON a.pid = s.active_pid
+      WHERE s.slot_name = ${CDC_SLOT_NAME}
+    `);
+    return result.rows[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
 // ================================
 // Backpressure
 // ================================
@@ -148,7 +175,11 @@ export async function subscribeWithReconnect(service: LogicalReplicationService,
       const inHandoffWindow = attempt <= slotTakeover.maxAttempts;
       const retryDelayMs = inHandoffWindow ? slotTakeover.retryDelayMs : reconnection.retryDelayMs;
       const takeover = inHandoffWindow ? ` (slot-takeover ${attempt}/${slotTakeover.maxAttempts})` : '';
-      log.warn(`Subscription error, retrying in ${retryDelayMs / 1000}s${takeover}...`, { err: error });
+      const slotHolder = (error as { code?: string } | null)?.code === PG_OBJECT_IN_USE ? await describeSlotHolder() : null;
+      log.warn(`Subscription error, retrying in ${retryDelayMs / 1000}s${takeover}...`, {
+        err: error,
+        ...(slotHolder && { slotHolder }),
+      });
       replicationState.markStopped();
       await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
     }


### PR DESCRIPTION
## Problem

When the CDC worker's `subscribe()` loses the race for the replication slot, Postgres rejects it with `55006`: *replication slot "cdc_slot" is active for PID N*. That PID is a **walsender inside Postgres**, not a host process, so the retry warning gives no clue *which* worker is holding the slot. In practice a stuck slot-takeover can be caused by the old worker of a rolling deploy, or by an orphaned local process that never shut down — and today diagnosing that requires manually joining `pg_replication_slots` against `pg_stat_activity` mid-incident.

## Change

On a `55006` subscription failure, `subscribeWithReconnect` now does a best-effort lookup of the slot holder and enriches the existing retry warning with a `slotHolder` field: the holder's `pid`, `application_name`, `client_addr` and `backend_start`. Since workers set a distinctive `application_name` (`<slug>-cdc-worker`), the competing process is identifiable from a single log line.

The lookup runs on the regular `cdcDb` connection (not the replication connection), only fires on slot contention, and never breaks the retry loop — any lookup failure degrades to the previous log output.

## Testing

- `pnpm ts` (cdc + full repo via pre-commit): clean
- `pnpm test` in `cdc/`: 137/137 passing
- Motivating case was a real one: an orphaned `dist/main.js` backend kept re-acquiring `cdc_slot` against a dev stack; with this change the very first retry warning names it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)