### PR TITLE
refactor!: large permission refactor

### DIFF
--- a/cella/migrations/2026-07-channel-entity-rename/README.md
+++ b/cella/migrations/2026-07-channel-entity-rename/README.md
@@ -1,0 +1,87 @@
+# ChannelEntity rename migration
+
+Renames the **context entity** concept (membership-scoped entities that host
+products — `organization`, `project`, …) to **channel entity**, unifying
+vocabulary with the sync engine's stream channels (routing keys like `org:abc`
+are already root channel-entity ids). Upstream cella arrives already migrated;
+this runs the same sweep on fork-specific code so a `cella-cli pull` sees
+identical renames on both sides and conflicts stay minimal.
+
+## What it changes
+
+`context-to-channel.ts` rewrites an explicit **allow-list** of identifiers
+(word-boundary matched, case preserving — `ContextEntityType→ChannelEntityType`,
+`contextType→channelType`, `context_counters→channel_counters`, …), the
+`'context'` entity-kind / OpenAPI-tag string literal, the `.context()`
+builder/contract method → `.channel()`, and the kebab stems of renamed files in
+import paths.
+
+It deliberately does **not** touch unrelated "context": `AuthContext`,
+`DbContext`, trace/span context, tenant context, Hono request `Context` /
+`ContextVariableMap`, `ContextMenu`, React `createContext`/`useContext`, canvas
+`getContext`, MCP. (The full allow-list is the `IDENTIFIERS` array in the
+script — add fork-specific channel-entity identifiers there before running.)
+
+## Run it
+
+On fork-specific code after pulling the upstream sweep:
+
+```sh
+# from the repo root
+pnpm exec tsx cella/migrations/2026-07-channel-entity-rename/context-to-channel.ts inventory frontend/src backend/src   # report only
+pnpm exec tsx cella/migrations/2026-07-channel-entity-rename/context-to-channel.ts rewrite  frontend/src backend/src   # apply
+```
+
+Then, by hand:
+
+1. **Rename files** (the codemod already rewrote the import paths that point at
+   them, so do these with `git mv`):
+
+   | old | new |
+   |---|---|
+   | `shared/src/config-builder/resolve-row-context.ts` | `…/resolve-row-channel.ts` |
+   | `shared/src/config-builder/tests/resolve-row-context.test.ts` | `…/resolve-row-channel.test.ts` |
+   | `cdc/src/utils/context-columns.ts` | `…/channel-columns.ts` |
+   | `backend/src/modules/entities/helpers/collect-sub-context-ids.ts` | `…/collect-sub-channel-ids.ts` |
+   | `backend/src/modules/entities/context-counters-db.ts` | `…/channel-counters-db.ts` |
+   | `backend/src/permissions/get-context-entity.ts` | `…/get-channel-entity.ts` |
+   | `backend/src/schemas/context-entity-included.ts` | `…/channel-entity-included.ts` |
+   | `backend/src/mocks/mock-context-entity-id-columns.ts` | `…/mock-channel-entity-id-columns.ts` |
+   | `backend/src/db/utils/context-relation-columns.ts` | `…/channel-relation-columns.ts` |
+   | `backend/src/db/utils/context-relation-schema.ts` | `…/channel-relation-schema.ts` |
+   | `backend/src/db/utils/context-entity-columns.ts` | `…/channel-entity-columns.ts` |
+   | `frontend/src/utils/context-entity-route.ts` | `…/channel-entity-route.ts` |
+   | `frontend/src/modules/navigation/menu-sheet/helpers/collect-context-ids.ts` | `…/collect-channel-ids.ts` |
+
+   Fork-added `*context*` files follow the same pattern.
+
+2. **i18n keys** — the codemod skips JSON: rename `features.context_entities` /
+   `entity_buckets.context_entities` → `channel_entities` in your locales (and
+   any fork keys), updating the display copy too.
+
+3. **Docs / prose** — the codemod only touches identifiers; sweep "context
+   entity" → "channel entity" prose in your own docs.
+
+4. **Regenerate the SDK**: `pnpm sdk`.
+
+5. **DB migration** — the schema *sources* now emit `channel_*` (columns
+   `context_type/context_id → channel_type/channel_id`, table
+   `context_counters → channel_counters`, `context_key → channel_key`, indexes +
+   constraints, plus the RLS / immutability / counter-function / unlogged SQL).
+   Run `pnpm generate` and answer **"rename"** to the drizzle-kit
+   column/table/index prompts (renames, not drop+create — the stored values are
+   entity-type names, so no row rewrite), then apply (`pnpm migrate`, or
+   `pnpm db:reset` for a dev DB). Postgres `RENAME` follows object OIDs, so
+   policies/triggers survive; function bodies that name the tables in text are
+   re-emitted by the same `pnpm generate`.
+
+## Gates
+
+```sh
+pnpm exec biome check --write .
+pnpm ts
+```
+
+Backend integration tests fail until the DB migration is applied (they insert
+`channel_type` into a DB whose schema still has `context_type`). The codemod is
+idempotent: `inventory` on already-migrated code reports zero changes.

--- a/cella/migrations/2026-07-channel-entity-rename/context-to-channel.ts
+++ b/cella/migrations/2026-07-channel-entity-rename/context-to-channel.ts
@@ -14,12 +14,19 @@
  * import paths. It deliberately does NOT touch unrelated "context" (React context,
  * AuthContext, DbContext, TraceContext, ContextMenu, canvas getContext, tenant context, …).
  *
- * DB migration, i18n prose/values and doc prose are handled outside this codemod.
+ * DB migration, i18n prose/values, doc prose and the file renames (see README.md) are
+ * handled outside this codemod.
  *
- * Usage:  tsx shared/scripts/codemods/context-to-channel.ts [--dry] [root ...]
+ * Modes:
+ *   inventory — report only (no writes)
+ *   rewrite   — apply
+ *
+ * Usage (repo root):
+ *   pnpm exec tsx cella/migrations/2026-07-channel-entity-rename/context-to-channel.ts inventory <srcDir ...>
+ *   pnpm exec tsx cella/migrations/2026-07-channel-entity-rename/context-to-channel.ts rewrite  <srcDir ...>
  */
-import { existsSync, readdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs';
-import { basename, join } from 'node:path';
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 /** Whole-identifier allow-list: every "context"/"Context"/"CONTEXT" in these maps to channel. */
 export const IDENTIFIERS: readonly string[] = [
@@ -285,14 +292,15 @@ function walk(dir: string, files: string[]): void {
 }
 
 function main(): void {
-  const args = process.argv.slice(2);
-  const dry = args.includes('--dry');
-  const roots = args.filter((a) => !a.startsWith('--'));
-  const targets = roots.length ? roots : ['backend', 'cdc', 'frontend', 'shared', 'mcp', 'bench', 'yjs', 'studio'];
+  const mode = process.argv[2];
+  const roots = process.argv.slice(3);
+  if ((mode !== 'inventory' && mode !== 'rewrite') || roots.length === 0) {
+    throw new Error('usage: context-to-channel.ts <inventory|rewrite> <srcDir ...>');
+  }
+  const dry = mode === 'inventory';
 
-  const self = 'shared/scripts/codemods/context-to-channel.ts';
   const files: string[] = [];
-  for (const root of targets) {
+  for (const root of roots) {
     if (!existsSync(root)) continue;
     const st = statSync(root);
     if (st.isDirectory()) walk(root, files);
@@ -301,7 +309,7 @@ function main(): void {
 
   let changed = 0;
   for (const file of files) {
-    if (file.endsWith(self)) continue;
+    if (file.endsWith('context-to-channel.ts')) continue; // never rewrite this codemod
     const src = readFileSync(file, 'utf8');
     const next = transform(src);
     if (next !== src) {
@@ -311,30 +319,6 @@ function main(): void {
     }
   }
   console.info(`\n${changed} file(s) ${dry ? 'would change' : 'changed'} of ${files.length} scanned.`);
-}
-
-// Rename files on disk (import paths are rewritten by transform()).
-export function renameFiles(dryRun: boolean): void {
-  const renames: Array<[string, string]> = [
-    ['shared/src/config-builder/resolve-row-context.ts', 'shared/src/config-builder/resolve-row-channel.ts'],
-    ['shared/src/config-builder/tests/resolve-row-context.test.ts', 'shared/src/config-builder/tests/resolve-row-channel.test.ts'],
-    ['cdc/src/utils/context-columns.ts', 'cdc/src/utils/channel-columns.ts'],
-    ['backend/src/modules/entities/helpers/collect-sub-context-ids.ts', 'backend/src/modules/entities/helpers/collect-sub-channel-ids.ts'],
-    ['backend/src/modules/entities/context-counters-db.ts', 'backend/src/modules/entities/channel-counters-db.ts'],
-    ['backend/src/permissions/get-context-entity.ts', 'backend/src/permissions/get-channel-entity.ts'],
-    ['backend/src/schemas/context-entity-included.ts', 'backend/src/schemas/channel-entity-included.ts'],
-    ['backend/src/mocks/mock-context-entity-id-columns.ts', 'backend/src/mocks/mock-channel-entity-id-columns.ts'],
-    ['backend/src/db/utils/context-relation-columns.ts', 'backend/src/db/utils/channel-relation-columns.ts'],
-    ['backend/src/db/utils/context-relation-schema.ts', 'backend/src/db/utils/channel-relation-schema.ts'],
-    ['backend/src/db/utils/context-entity-columns.ts', 'backend/src/db/utils/channel-entity-columns.ts'],
-    ['frontend/src/utils/context-entity-route.ts', 'frontend/src/utils/channel-entity-route.ts'],
-    ['frontend/src/modules/navigation/menu-sheet/helpers/collect-context-ids.ts', 'frontend/src/modules/navigation/menu-sheet/helpers/collect-channel-ids.ts'],
-  ];
-  for (const [from, to] of renames) {
-    if (basename(from) === basename(to)) continue;
-    console.info(`${dryRun ? '[dry] ' : ''}rename ${from} -> ${to}`);
-    if (!dryRun) renameSync(from, to);
-  }
 }
 
 // Only run when invoked directly (not when imported for its exported helpers/tests).

--- a/cella/migrations/README.md
+++ b/cella/migrations/README.md
@@ -29,3 +29,8 @@ be a no-op.
   permission check, system-admin + public-read parity in collection reads, and public
   read collapsed to a single row-local `publicAt` mode. **Widens access** — audit
   `'own'` cells on channel-entity and `create` rows *before* pulling.
+- [2026-07-channel-entity-rename](./2026-07-channel-entity-rename/): renames the
+  "context entity" concept to "channel entity" (`ContextEntityType→ChannelEntityType`,
+  builder `.context()→.channel()`, `context_type/context_id→channel_type/channel_id`,
+  `context_counters→channel_counters`, …). Allow-list codemod; also needs file renames,
+  i18n keys, SDK regen, and a DB rename migration — see the folder README.


### PR DESCRIPTION
Relocate the ContextEntity→ChannelEntity codemod into the fork-facing migrations convention: cella/migrations/2026-07-channel-entity-rename/. Adapt its CLI to the sibling pattern (`inventory|rewrite <srcDir ...>`), move the 13-file rename map and the i18n/SDK/DB follow-up steps into the folder README, and add the index entry to cella/migrations/README.md.