### PR TITLE
feat(docs): derive page updatedAt from git (page + imported docs)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -188,6 +188,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          # Full history: the docs-frontmatter Vite plugin derives each page's
+          # updatedAt from git commit dates (frontend/vite/git-updated-at.ts). A
+          # shallow clone would collapse tracked docs onto their checkout mtime.
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5

--- a/frontend/src/content/docs/changelog.mdx
+++ b/frontend/src/content/docs/changelog.mdx
@@ -3,7 +3,6 @@ title: Changelog
 description: Release notes for the Cella template.
 order: -18
 keywords: changelog, releases, versions, release notes
-updatedAt: 2026-07-09T08:13:58.745Z
 ---
 
 

--- a/frontend/src/content/docs/quickstart.mdx
+++ b/frontend/src/content/docs/quickstart.mdx
@@ -3,7 +3,6 @@ title: Getting started
 description: Learn how to get started building your own web app using cella.
 order: -39
 keywords: install, setup, dev, modules, deploy
-updatedAt: 2026-07-09T09:55:08.380Z
 ---
 
 import Content from '../../../../cella/QUICKSTART.md';

--- a/frontend/vite/docs-frontmatter.ts
+++ b/frontend/vite/docs-frontmatter.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import GithubSlugger from 'github-slugger';
 import type { Plugin } from 'vite';
 import { parse } from 'yaml';
+import { createUpdatedAtResolver, type UpdatedAtResolver } from './git-updated-at';
 
 /**
  * Virtual module `virtual:docs-frontmatter`: a build-time index of all docs pages
@@ -153,6 +154,19 @@ function parseFrontmatter(source: string): unknown {
   return match ? parse(match[1]) : {};
 }
 
+/**
+ * Attach a build-time `updatedAt` derived from git (the newest committer date across
+ * the page and its imported docs), so the "last edited" line and pages-table column
+ * stay correct without hand-maintained frontmatter. An author-pinned `updatedAt` is
+ * left untouched. See vite/git-updated-at.ts for the full precedence and caveats.
+ */
+function withUpdatedAt(frontmatter: unknown, files: string[], resolver: UpdatedAtResolver): unknown {
+  const record = frontmatter && typeof frontmatter === 'object' ? (frontmatter as Record<string, unknown>) : {};
+  const pinned = typeof record.updatedAt === 'string' ? record.updatedAt : undefined;
+  const updatedAt = resolver.resolve(files, pinned);
+  return updatedAt ? { ...record, updatedAt } : frontmatter;
+}
+
 /** Relative .md import targets of an .mdx wrapper, resolved to absolute paths. */
 function importTargets(file: string, source: string): string[] {
   if (!file.endsWith('.mdx')) return [];
@@ -178,6 +192,7 @@ export function pageStructure(file: string, source: string): { headings: DocHead
 
 export function docsFrontmatter(): Plugin {
   let contentDir: string;
+  let resolver: UpdatedAtResolver | undefined;
 
   const buildIndex = () => {
     const targets = new Set<string>();
@@ -186,10 +201,14 @@ export function docsFrontmatter(): Plugin {
 
     for (const file of collectPages(contentDir)) {
       const source = readFileSync(file, 'utf8');
-      for (const target of importTargets(file, source)) targets.add(target);
+      const imports = importTargets(file, source);
+      for (const target of imports) targets.add(target);
       const relative = path.relative(contentDir, file).replaceAll(path.sep, '/');
       const key = `/src/content/docs/${relative}`;
-      const frontmatter = parseFrontmatter(source);
+      // updatedAt tracks the page plus its imported repo docs (wrapper pages render a
+      // repo doc as their body): a body edit in cella/SYNC_ENGINE.md bumps the page.
+      const parsed = parseFrontmatter(source);
+      const frontmatter = resolver ? withUpdatedAt(parsed, [file, ...imports], resolver) : parsed;
       const { headings, sections } = pageStructure(file, source);
       entries.push([key, { frontmatter, headings }] as const);
 
@@ -211,6 +230,7 @@ export function docsFrontmatter(): Plugin {
     name: 'docs-frontmatter',
     configResolved(config) {
       contentDir = path.resolve(config.root, 'src/content/docs');
+      resolver = createUpdatedAtResolver(contentDir);
     },
     resolveId(id) {
       if (id === VIRTUAL_ID) return RESOLVED_ID;

--- a/frontend/vite/git-updated-at.test.ts
+++ b/frontend/vite/git-updated-at.test.ts
@@ -1,0 +1,54 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { createUpdatedAtResolver } from './git-updated-at';
+
+/**
+ * The resolver derives a page's `updatedAt` from git history at build time. These
+ * tests pin the precedence (author pin > git/mtime) and the newest-wins invariant
+ * without asserting exact dates, so they hold across commits and in git-less CI
+ * (where every path falls back to mtime).
+ */
+describe('createUpdatedAtResolver', () => {
+  const resolver = createUpdatedAtResolver(__dirname);
+  const existing = path.resolve(__dirname, 'docs-frontmatter.ts');
+  const alsoExisting = path.resolve(__dirname, 'git-updated-at.ts');
+  const missing = path.resolve(__dirname, 'does-not-exist.xyz');
+
+  const asMs = (iso: string | undefined) => (iso ? Date.parse(iso) : Number.NaN);
+
+  it('returns an author-pinned date verbatim, ignoring the files', () => {
+    const pin = '2020-01-02T03:04:05.000Z';
+    expect(resolver.resolve([existing, alsoExisting], pin)).toBe(pin);
+    // A pin wins even when no file exists at all.
+    expect(resolver.resolve([missing], pin)).toBe(pin);
+  });
+
+  it('ignores a blank pin and derives from the file instead', () => {
+    const result = resolver.resolve([existing], '   ');
+    expect(result).not.toBe('   ');
+    expect(Number.isNaN(asMs(result))).toBe(false);
+  });
+
+  it('derives a valid ISO date for an existing file (git date, else mtime)', () => {
+    const result = resolver.resolve([existing]);
+    expect(typeof result).toBe('string');
+    expect(Number.isNaN(asMs(result))).toBe(false);
+  });
+
+  it('returns undefined when nothing resolves (no pin, no existing files)', () => {
+    expect(resolver.resolve([missing])).toBeUndefined();
+    expect(resolver.resolve([])).toBeUndefined();
+  });
+
+  it('skips missing files but still resolves from the existing ones', () => {
+    const result = resolver.resolve([missing, existing]);
+    expect(Number.isNaN(asMs(result))).toBe(false);
+  });
+
+  it('takes the newest date across the page and its imports', () => {
+    const combined = asMs(resolver.resolve([existing, alsoExisting]));
+    const a = asMs(resolver.resolve([existing]));
+    const b = asMs(resolver.resolve([alsoExisting]));
+    expect(combined).toBe(Math.max(a, b));
+  });
+});

--- a/frontend/vite/git-updated-at.ts
+++ b/frontend/vite/git-updated-at.ts
@@ -1,0 +1,111 @@
+import { execFileSync } from 'node:child_process';
+import { statSync } from 'node:fs';
+
+/**
+ * Derives a docs page's `updatedAt` from git history at build time, so the value
+ * never has to be hand-maintained in frontmatter and stays correct across the
+ * import-wrapper pages that make up most of the docs: a thin `.mdx` shell rarely
+ * changes, but the repo doc it imports (`cella/SYNC_ENGINE.md`, `cdc/README.md`, …)
+ * changes constantly. The "updated" moment is therefore the most recent change
+ * across the page *and* its imported bodies, not the wrapper file alone.
+ *
+ * Precedence, per page:
+ *  1. an explicit frontmatter `updatedAt` (an author pin — always respected);
+ *  2. else the newest git committer date across the page + its imported docs;
+ *  3. else (untracked file, or no git history at all) the file's mtime.
+ *
+ * Caveats mirror the wider ecosystem (Astro/VitePress/Docusaurus all read git):
+ * the value reflects the last *commit*, so a locally-edited-but-uncommitted page
+ * shows its previous commit date until committed, and CI must fetch full history
+ * (`fetch-depth: 0`) — a shallow clone collapses tracked files onto the mtime path.
+ */
+
+const toIso = (ms: number) => new Date(ms).toISOString();
+
+/** The later of two ISO 8601 dates (either may be undefined). */
+function laterIso(a: string | undefined, b: string | undefined): string | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  return Date.parse(a) >= Date.parse(b) ? a : b;
+}
+
+export type UpdatedAtResolver = {
+  /**
+   * Newest "updated" ISO date across `files` (a page plus its imported docs),
+   * or `pinned` when the page frontmatter sets one explicitly. `undefined` only
+   * when nothing resolves (no pin, no existing files).
+   */
+  resolve(files: string[], pinned?: string): string | undefined;
+  /** Absolute git work-tree root, or null when not inside a repo (probed once). */
+  readonly repoRoot: string | null;
+};
+
+/**
+ * Build a resolver rooted at the git work tree containing `fromDir`. Git lookups
+ * are memoized per file and invalidated on mtime change, so repeated index builds
+ * (and the dev-server rebuilds) don't re-shell `git log` for unchanged files.
+ */
+export function createUpdatedAtResolver(fromDir: string): UpdatedAtResolver {
+  const repoRoot = detectRepoRoot(fromDir);
+  const cache = new Map<string, { mtimeMs: number; iso: string | undefined }>();
+
+  const mtimeMs = (file: string): number | undefined => {
+    try {
+      return statSync(file).mtimeMs;
+    } catch {
+      return undefined; // file was moved/removed between collection and stat
+    }
+  };
+
+  /** Committer date of the last commit touching `file`, or undefined (untracked / no history / no git). */
+  const gitCommittedAt = (file: string, mtime: number): string | undefined => {
+    const cached = cache.get(file);
+    if (cached && cached.mtimeMs === mtime) return cached.iso;
+    let iso: string | undefined;
+    try {
+      // execFile (not a shell) so paths need no quoting; `--` guards paths that look like flags.
+      iso =
+        execFileSync('git', ['log', '-1', '--format=%cI', '--', file], {
+          cwd: repoRoot ?? undefined,
+          stdio: ['ignore', 'pipe', 'ignore'],
+        })
+          .toString()
+          .trim() || undefined;
+    } catch {
+      iso = undefined; // git missing, or file outside the work tree
+    }
+    cache.set(file, { mtimeMs: mtime, iso });
+    return iso;
+  };
+
+  return {
+    repoRoot,
+    resolve(files, pinned) {
+      if (typeof pinned === 'string' && pinned.trim()) return pinned;
+
+      let newest: string | undefined;
+      for (const file of files) {
+        const mtime = mtimeMs(file);
+        if (mtime === undefined) continue;
+        const gitIso = repoRoot ? gitCommittedAt(file, mtime) : undefined;
+        newest = laterIso(newest, gitIso ?? toIso(mtime));
+      }
+      return newest;
+    },
+  };
+}
+
+function detectRepoRoot(fromDir: string): string | null {
+  try {
+    return (
+      execFileSync('git', ['rev-parse', '--show-toplevel'], {
+        cwd: fromDir,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      })
+        .toString()
+        .trim() || null
+    );
+  } catch {
+    return null; // not a git repo, or git unavailable
+  }
+}


### PR DESCRIPTION
## What

Docs pages no longer need a hand-maintained `updatedAt` in frontmatter. The `docs-frontmatter` Vite plugin now **derives it at build time from git**, as the newest committer date across the page **and the repo docs it imports**.

## Why

Most docs under `frontend/src/content/docs/` are thin `.mdx` wrappers that render a repo doc as their body:

```mdx
import Content from '../../../../../cella/SYNC_ENGINE.md';
```

The wrapper rarely changes; the imported `.md` changes constantly. The usual ecosystem pattern (Astro recipe, VitePress, Docusaurus, Nextra) runs `git log -1` on **the file itself only**, which for cella would freeze the timestamp on the near-static wrapper. Taking the **max over the page + its imports** is the fix, and matches the "bump when an import changed" requirement.

Verified on real data — the resolved date tracks the import, not the wrapper:

| page | resolved updatedAt | page commit | import commit |
|---|---|---|---|
| changelog | 2026-07-14 | 2026-07-09 | **2026-07-14** |
| quickstart | 2026-07-15 | 2026-07-14 | **2026-07-15** |
| architecture/sync-engine | 2026-07-15 | 2026-07-14 | **2026-07-15** |

## How

- **`frontend/vite/git-updated-at.ts`** (new): a memoized, `execFile`-based resolver. Precedence per page:
  1. an explicit frontmatter `updatedAt` (author pin) — always respected;
  2. else the newest git committer date (`git log -1 --format=%cI`) across the page + its imported docs;
  3. else the file `mtime` (untracked/new file, or no git history at all).

  Git lookups are cached per file and invalidated on mtime change, so repeated index builds / dev-server rebuilds don't re-shell `git`.
- **`frontend/vite/docs-frontmatter.ts`**: `buildIndex()` injects the derived `updatedAt` into each page's frontmatter entry.
- **Content edits**: dropped the two stale manual `updatedAt` stamps (`quickstart.mdx`, `changelog.mdx`) — now derived automatically.

No consumer changes needed — the chain is already wired: `content.ts` validates `updatedAt`, `view-page.tsx` renders the "last edited" line, and the pages table has an `updatedAt` column.

## Design notes / alternatives considered

This is the "derive at build time from git" approach — the proven ecosystem pattern — rather than a lefthook pre-commit hook that mutates frontmatter. Mutation was rejected because the import-dependency case (the primary case here) would require a fragile reverse index (imported `.md` → pages) resolved at commit time. Deriving at build reuses infrastructure already in place, avoids frontmatter churn / merge conflicts, and self-heals on rebase/squash.

## Caveats

- **CI must fetch full history** (`fetch-depth: 0`); a shallow clone collapses tracked files onto the `mtime` fallback (documented in the module header).
- The value reflects the last **commit**, so a locally-edited-but-uncommitted page shows its previous commit date until committed — standard build-time-git semantics.
- Authors can still pin a date by adding `updatedAt` to a page's frontmatter.

## Testing

- `frontend/vite/git-updated-at.test.ts` (new): precedence (pin wins / blank pin ignored), newest-wins across page+imports, missing-file skip, and undefined-when-nothing-resolves.
- `vitest --project node`: **39 passed** (incl. existing `docs-frontmatter` tests).
- `tsgo -p frontend/tsconfig.json`: **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
