### PR TITLE
refactor: densify comment blocks, drop decorative banners

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -1,0 +1,160 @@
+# Comment-density cleanup — discussion & decisions
+
+Companion doc for the `chore/comment-density` branch. It records the **non-trivial judgment calls**
+(not the mechanical banner removals) and **flags any new README that overlaps existing docs**, so a
+reviewer can spot-check the risky bits without reading the whole diff.
+
+## Scope & method
+
+- **Goal:** make oversized comment blocks denser *without losing non-obvious information*, and remove
+  pure file-narration / decorative banners. Bias was strongly toward **KEEP** — this codebase
+  documents deliberately, and most long comments are load-bearing ("why", invariants, fork semantics).
+- **Base:** branched off `main` (`cd9968813 refactor: permissions`), so this sits *on top of* the
+  concurrent permissions refactor — no overlap conflicts expected at merge.
+- **Isolation:** all work done in a `git worktree` (`.claude/worktrees/comment-density`); the main
+  working tree was never touched.
+- **Rubric (per block > 3 text lines, and every decorative banner):**
+  - **KEEP** — states a fact a competent dev can't infer from the code (security invariants, "why",
+    cross-file coupling, fork/config semantics, footguns, worked `@example`s). Untouched.
+  - **DENSIFY** — valuable but padded; cut signature-restating `@param`/`@returns` and ceremony,
+    preserve every non-obvious fact.
+  - **DELETE** — file-narration / decorative banners. Relocate any crucial fact before deleting.
+- **All changes are comment-only** — no code, types, imports, or code-line formatting were changed.
+- **Detector caveats surfaced during the run:** the line-count detector (a) over-counts blocks whose
+  length is a valuable `@example` — those were kept; (b) misses short single-title banners — a
+  companion grep for `/*****` and `// ====` boxes covered those.
+
+## ⚠️ README overlap flags (requested)
+
+- **`shared/config/README.md` — NOT created (would duplicate `cella/PERMISSIONS.md`).**
+  The pilot moved the access-policy/hierarchy file-level docs into a new `shared/config/README.md`.
+  On review, `cella/PERMISSIONS.md` §Configuration already documents the same material (hierarchy
+  builder, policy matrix, elevation-vs-self rows, product home rows, public-read, `elevatedRoles`) —
+  and is currently *more* complete (covers `parentRow`/`publicParent`). Rather than create a sizable
+  duplicate, I deleted the README and pointed the source comments in `permissions-config.ts` and
+  `hierarchy-config.ts` at `cella/PERMISSIONS.md`. **No new README was added for shared/config.**
+- _(Other agents' README flags are appended per-area below as they report.)_
+
+## Non-trivial decisions by area
+
+### shared/ (self)
+- **Config section banners → one-line comments.** `config.default.ts` (15) and `config.template.ts`
+  (16) used `/*****/` boxes purely as navigational dividers in a long config literal. Collapsed each
+  title-only box to a `// Title` comment (kept navigation, dropped 2 lines each). Content-bearing
+  banners (e.g. Versioning) were densified to prose, not collapsed. **`config.template.ts` is the
+  fork-facing template** — its change is cosmetic (comments only) and mirrors `config.default.ts`.
+- **KEPT the engine's "why" comments** untouched: `check-permission.ts` `Actor` discriminated-union
+  rationale, `public-read.ts`/`row-conditions.ts` closed-set + parity invariants,
+  `access-policies.ts` fail-loud reasoning, `SubjectForPermission` docs. These are safety-critical.
+- **DENSIFIED** signature-restating JSDoc on `build-subject.ts`, `action-helpers.ts`,
+  `check-permission.ts`, `compute-can.ts`, `permissions/types.ts` (dropped `@param` boilerplate, kept
+  the rationale). De-bannered `config-builder/types.ts`, `shared/types.ts`, `tracing/*`.
+
+### bench/ · sdk/ · mcp/ · cella/migrations · root config (agent)
+- Almost entirely KEEP — deliberate fork/migration semantics and safety invariants. 1 densification
+  (`sdk/src/plugins/tsdoc/plugin.ts` — dropped a `@param` that restated the typed param).
+- KEPT `@param`/`@returns` blocks in `tsdoc/plugin.ts` that end with an in-JSDoc `biome-ignore`
+  directive (didn't disturb directive placement). KEPT the migration codemod file-top explainers
+  (`publicread-codemod.ts`, `context-to-channel.ts`, `icon-codemod.ts`) — they encode lossy-rewrite
+  warnings / footgun allow-lists that must stay at point-of-edit. No READMEs touched.
+
+### frontend/src/modules/common (agent)
+- 15 multi-line `// ====` decorative boxes in long story/devtools files → one-line `// Title`.
+  2 densifications (`use-draft-form.tsx`, `sync-devtools.tsx`). No READMEs touched.
+- **KEPT ~45 single-line `// ─── Title ───` box-drawing dividers** in `resizable-panels.tsx` and
+  others — they're a consistent navigation house-style and several cross-reference invariant IDs
+  (G3/G9/A2/O1/O2) documented in the existing `resizable-panels.md`. Not pure decoration.
+
+### frontend/src/modules (excl. common) (agent)
+- 14 banners collapsed, 16 densified. **Cleaned up stale/inaccurate comments** a reviewer should
+  glance at: `marketing-config.tsx` "suggested categories" list contradicted the `FeatureCategory`
+  type (listed `sync`, omitted `ux`) → dropped; `use-menu.ts` had a stale `@param opts` that isn't a
+  param; `passkey-credentials.ts` kept only the non-obvious `@param email` (discoverable vs not).
+- KEPT `attachment/dexie/attachments-db.ts` enum glossaries — look padded but encode Transloadit
+  step mapping / `source='upload'` restrictions (exported-symbol tooltips). No READMEs.
+
+### frontend/src/query + hooks/utils/lib/routes/stories + vite (agent)
+- 8 banners collapsed, 14 densified. **Stale comment fixed:** `use-lazy-component.tsx` documented
+  params it no longer has → replaced with an accurate one-liner. `locales-hmr.ts` file-top overview
+  duplicated the exported `localesHMR` JSDoc → trimmed, kept its distinct `@example` + a link.
+- KEPT `invalidation-helpers.ts` / `use-breakpoints.tsx` blocks whose `@param`s look like padding but
+  carry `@see` refs + real `@example`s (detector over-counts these). No READMEs.
+
+### backend/src/modules (agent)
+- 3 banners, **30 densified**. **Corrected several factually-wrong comments** (reviewer should
+  confirm — these are the main accuracy risk in the PR; I verified the first one against the code):
+  - `auth/general/helpers/user.ts` — comment claimed `handleCreateUser` "sends verification emails /
+    sets a session"; it does neither → rewritten to actual behavior. **(verified accurate)**
+  - `auth/general/helpers/mfa.ts` — "optionally deleted" token, but the call passes `invokeToken:false`
+    → dropped the inaccurate clause.
+  - `entities/entities-queries.ts` — original had a garbled duplicated sentence → rewrote preserving
+    both facts (CAP+1 overflow, membership exclusion via `s:membership` seq).
+  - `auth/oauth/helpers/callback.ts` — dropped `@param` boilerplate but kept the SameSite=Strict /
+    cross-site CSRF "why" verbatim.
+- Deleted redundant `=== Route handlers ===` banners (redundant with filename). No READMEs.
+
+### backend/src/{middlewares,permissions,core,schemas,db} (agent)
+- 20 banners, 17 densified, 1 deleted. **KEPT the security core fully** — `permissions/collection-scope.ts`
+  and `permissions/row-predicates.ts` (RLS scope resolution + check/SQL parity contract) untouched.
+- Converted `row-predicates.test.ts` `/*****/` star-boxes to plain block comments **keeping every
+  word** (FORK WATCH / deep-chain / `elevatedRoles` invariants). **Corrected stale `@param db` and a
+  "can object"** in `get-channel-entity.ts` / `get-product-entity.ts` that the return type lacks.
+  Deleted a banner labeling an empty section in `common-schemas.ts`. No READMEs.
+
+### backend/{utils,lib,mocks,tests,scripts,emails} + backend/src/*.ts (agent)
+- 11 banners, 27 densified. KEPT `hash-pii.ts` (every line a security invariant). Deliberately
+  **kept a Hyperons attribution `{@link}`** in `emails/renderer/jsx-to-string.ts` — MIT licensing
+  provenance, not padding. Deduped a 3-context prefix list restated 5× in `mocks/mock-nanoid.ts`.
+  No READMEs.
+
+### infra/{resources,config,compose,tests,index} (agent)
+- **43 banners collapsed**, all content preserved. The DNS-before-cert ordering and LB drain-policy
+  footguns lived *inside* dash-banners → kept every content line, removed only the rules. KEPT
+  `runtime-secrets.config.ts` / `managed-keys.config.ts` file-top blocks inline (point-of-edit
+  fork/config contracts, not decoration). No READMEs.
+
+### infra/{tasks,lib,cli} (agent)
+- 17 banners, 1 densified. KEPT the `setup-vm-key.ts` "NO write access / cannot escalate" security
+  invariant verbatim; collapsed decorative section boxes to nav titles. No READMEs.
+
+### cdc/src + yjs/src (agent)
+- 14 banners, 3 densified. **Removed a numbered pipeline-stage file-map** in `pipeline/worker.ts`
+  that duplicated `cdc/README.md`'s "Pipeline stages" section → replaced with a pointer to the README
+  (good overlap hygiene — no new README). KEPT WAL/seq/circuit-breaker state tables. No new READMEs.
+
+### bench / sdk / mcp / cella/migrations / root (agent)
+- Almost entirely KEEP. 1 densification (`sdk/.../tsdoc/plugin.ts`). KEPT `@param` JSDoc that ends
+  with an in-block `biome-ignore` directive (didn't disturb it), and the migration codemod file-top
+  lossy-rewrite warnings. No READMEs.
+
+## Reviewer's attention list (the non-mechanical bits)
+
+Most of the diff is mechanical (decorative banners → one-line nav comments) and safe. The parts worth
+a human eye are the **comment-accuracy rewrites** — where an agent judged a comment factually wrong and
+rewrote it to match the code. If the agent misread, the new comment is wrong (the code is provably
+unchanged either way). They are:
+
+- `backend/src/modules/auth/general/helpers/user.ts` — `handleCreateUser` behavior *(I verified this one)*
+- `backend/src/modules/auth/general/helpers/mfa.ts` — token-deletion clause
+- `backend/src/modules/entities/entities-queries.ts` — CAP+1 / membership-exclusion rewrite
+- `backend/src/permissions/get-channel-entity.ts` / `get-product-entity.ts` — dropped stale `@param db`
+- `frontend/src/modules/navigation/menu-sheet/helpers/use-menu.ts` — dropped stale `@param opts`
+- `frontend/src/hooks/use-lazy-component.tsx` — replaced stale param docs
+
+Also cosmetic-but-fork-facing: `shared/config/config.template.ts` section banners were collapsed to
+one-line comments (the fork template — comments only, mirrors `config.default.ts`).
+
+## Verification
+
+- **Provably comment-only.** For all 141 changed `.ts/.tsx` files, the TypeScript emit with
+  `removeComments:true` is byte-identical between `HEAD` and the branch → **zero code/type/import
+  changes**. (A line-level scan of the diff also found no non-comment changed line.)
+- **Biome-clean.** `biome check` reports no fixes needed across the repo, including every changed file.
+- **No tests run** (comment-only change; nothing to exercise). No new READMEs created.
+
+## Stats
+
+- **141 files changed, +366 / −1487 lines (net −1121 comment lines).**
+- ~190 decorative banners collapsed or removed; ~115 JSDoc/comment blocks densified; the large majority
+  of long comments (security "why", invariants, fork semantics, worked `@example`s) were **kept**.
+- New READMEs: **0** (the pilot's `shared/config/README.md` was intentionally dropped — see flag above).

--- a/backend/emails/renderer/jsx-to-string.ts
+++ b/backend/emails/renderer/jsx-to-string.ts
@@ -25,9 +25,6 @@ const renderSuspense = async (children: ReactNode[]): ReturnType<typeof jsxToStr
  * Convert a JSX element to a string.
  * This is a slightly modified version of Hyperons's
  * [`renderToString`](https://github.com/i-like-robots/hyperons/blob/main/src/render-to-string.js) function.
- *
- * @param element The JSX element to convert to a string
- * @returns The string representation of the JSX element
  */
 export async function jsxToString(element: ReactNode): Promise<string> {
   if (element == null) {

--- a/backend/emails/renderer/stringify-styles.ts
+++ b/backend/emails/renderer/stringify-styles.ts
@@ -44,11 +44,8 @@ function hyphenateString(prop: string) {
 }
 
 /**
- * Converts a React style object to a string.
- * This is based on Hyperon's
- * [`stringifyStyles`](https://github.com/i-like-robots/hyperons/blob/main/src/stringify-styles.js).
- * @param styles The styles to stringify.
- * @returns A string representation of the styles, suitable for use in a `style` attribute.
+ * Converts a React style object to a string suitable for a `style` attribute.
+ * Based on Hyperon's [`stringifyStyles`](https://github.com/i-like-robots/hyperons/blob/main/src/stringify-styles.js).
  */
 export function stringifyStyles(styles: CSSProperties) {
   const parts = [];

--- a/backend/scripts/generate-openapi.ts
+++ b/backend/scripts/generate-openapi.ts
@@ -67,14 +67,10 @@ function canSkipGeneration(): { skip: boolean; reason: string; hash: string | nu
 }
 
 /**
- * Generate OpenAPI documentation and save it to a file.
+ * Generate the OpenAPI document and write it to a JSON file. Sets NODB='true' to avoid
+ * database connections during generation.
  *
- * This script initializes the OpenAPI documentation for the application,
- * registers necessary schemas, and writes the generated OpenAPI document
- * to a JSON file. NODB is set to 'true' to avoid database connections during generation.
- *
- * Supports git-based caching: skips generation if no relevant files changed since last run.
- * Use --force flag to bypass the cache check.
+ * Git-based caching: skips generation if no relevant files changed since last run; --force bypasses it.
  */
 (async () => {
   const startTime = performance.now();

--- a/backend/scripts/migrations/10-counter-functions.migration.ts
+++ b/backend/scripts/migrations/10-counter-functions.migration.ts
@@ -3,17 +3,12 @@ import { logMigrationResult, upsertMigration } from './helpers/drizzle-utils';
 import type { GenerateScript } from '../types';
 
 /**
- * Counter Functions Migration
+ * PL/pgSQL function merging JSONB count deltas into channel_counters rows. Fixed-shape SQL
+ * lets the CDC worker use prepared statements for counter upserts.
  *
- * Creates a PL/pgSQL function for merging JSONB count deltas into
- * channel_counters rows. This enables fixed-shape SQL for counter
- * upserts, which can then use prepared statements in the CDC worker.
- *
- * The function iterates over keys in a deltas JSONB object and applies
- * each increment with a floor of 0 to prevent negative counters.
- * `li:` (last insert) / `lu:` (last update) keys are epoch-ms activity
- * stamps, not deltas: they merge via GREATEST so the signal only moves
- * forward.
+ * Increments apply with a floor of 0 (no negative counters). `li:` (last insert) / `lu:`
+ * (last update) keys are epoch-ms activity stamps, not deltas: they merge via GREATEST so
+ * the signal only moves forward.
  */
 async function run() {
   const migrationSql = `-- Counter Functions Setup

--- a/backend/scripts/migrations/10-immutability.migration.ts
+++ b/backend/scripts/migrations/10-immutability.migration.ts
@@ -10,13 +10,9 @@ import {
 import type { GenerateScript } from '../types';
 
 /**
- * Immutability Triggers Migration
- *
- * Creates database triggers that prevent modification of identity columns
- * (id, tenant_id, organization_id, etc.) after row creation.
- *
- * This provides defense-in-depth protection against accidental or malicious
- * column modifications, even if someone uses admin bypass.
+ * Creates triggers that prevent modification of identity columns (id, tenant_id,
+ * organization_id, etc.) after row creation — defense-in-depth that holds even under
+ * admin bypass.
  */
 async function run() {
   const functionsSql = [

--- a/backend/scripts/migrations/10-partman.migration.ts
+++ b/backend/scripts/migrations/10-partman.migration.ts
@@ -2,9 +2,7 @@ import pc from 'picocolors';
 import { logMigrationResult, upsertMigration } from './helpers/drizzle-utils';
 import type { GenerateScript } from '../types';
 
-// =============================================================================
-// PARTITION CONFIGURATION
-// =============================================================================
+// Partition configuration
 
 interface PartitionConfig {
   name: string;

--- a/backend/scripts/migrations/10-rls.migration.ts
+++ b/backend/scripts/migrations/10-rls.migration.ts
@@ -9,9 +9,7 @@ import { logMigrationResult, upsertMigration } from './helpers/drizzle-utils';
 import type { GenerateScript } from '../types';
 
 async function run() {
-  // ============================================================================
-  // Table Classification
-  // ============================================================================
+  // Table classification
 
   /**
    * Collect all entity tables that need RLS setup (ownership, FORCE RLS, grants).
@@ -67,9 +65,7 @@ async function run() {
   ];
   const readOnlyTables = ['system_roles', 'activities'];
 
-  // ============================================================================
   // Migration SQL
-  // ============================================================================
 
   const migrationSql = `-- RLS (Row-Level Security) Setup
 -- Configures FORCE RLS, table ownership, and grants.
@@ -113,9 +109,7 @@ ${readOnlyTables.map((t) => `    GRANT SELECT ON ${t} TO runtime_role;`).join('\
 END $$;
 `;
 
-  // ============================================================================
-  // Execute Migration
-  // ============================================================================
+  // Execute migration
 
   const result = upsertMigration('rls_setup', migrationSql);
   logMigrationResult(result, 'RLS setup');

--- a/backend/scripts/migrations/10-unlogged.migration.ts
+++ b/backend/scripts/migrations/10-unlogged.migration.ts
@@ -3,10 +3,8 @@ import { logMigrationResult, upsertMigration } from './helpers/drizzle-utils';
 import type { GenerateScript } from '../types';
 
 /**
- * UNLOGGED Tables Setup
- *
- * Converts ephemeral/regenerable tables to UNLOGGED to skip WAL writes.
- * These tables tolerate being truncated on unclean shutdown:
+ * Converts ephemeral/regenerable tables to UNLOGGED to skip WAL writes. These tolerate
+ * truncation on unclean shutdown:
  * - rate_limits: clients get a fresh window
  * - user_counters, channel_counters, product_counters: rebuilt from source data on startup
  *

--- a/backend/scripts/migrations/helpers/drizzle-utils.ts
+++ b/backend/scripts/migrations/helpers/drizzle-utils.ts
@@ -88,7 +88,6 @@ export function resolveSqlContent(sqlOrPath: string): string {
  *
  * @param tag - Unique identifier for the migration (e.g., 'cdc_setup')
  * @param sql - SQL content (not a file path - use resolveSqlContent first if needed)
- * @returns Object containing the folder name, path, tag, and action taken
  */
 export function upsertMigration(tag: string, sql: string): MigrationResult {
   // Normalize tag by removing leading timestamps/underscores if present.

--- a/backend/scripts/seeds/10-organization.seed.ts
+++ b/backend/scripts/seeds/10-organization.seed.ts
@@ -145,16 +145,8 @@ export const organizationsSeed = async () => {
 };
 
 /**
- * Adds an admin membership to `adminMemberships`.
- * Conditions for adding:
- * - The organization must be in an even position.
- * - The number of existing admin memberships must be less than the system-defined limit.
- *
- * The function mutates the `adminMemberships` array by pushing a new, adjusted membership.
- *
- * @param adminUser - The admin user to assign the membership to.
- * @param organization - The organization the admin should be added to.
- * @param adminMemberships - An array tracking admin memberships already created.
+ * Push an admin membership onto `adminMemberships` (mutates it), but only when the organization
+ * is in an even position AND the existing admin-membership count is below the system limit.
  */
 const addAdminMembership = (
   adminUser: UserModel,

--- a/backend/scripts/start-tunnel.ts
+++ b/backend/scripts/start-tunnel.ts
@@ -9,9 +9,7 @@ import { env } from '../src/env';
  * callbacks (`<tunnel>/api/auth/...`) reach the backend through the proxy.
  * Only attempts to start when `TUNNEL_URL` and `TUNNEL_AUTH_TOKEN` are configured.
  *
- * @returns A Promise that resolves to the public URL (string) if the tunnel
- * is successfully established, or `null` if the tunnel is not configured
- * or the connection fails.
+ * @returns The public URL, or `null` if the tunnel is unconfigured or fails to connect.
  */
 const startTunnel = async (): Promise<string | null> => {
   // Check if tunnel is configured via environment variables

--- a/backend/src/core/x-middleware.ts
+++ b/backend/src/core/x-middleware.ts
@@ -28,10 +28,6 @@ export const getExtensionValueMetadata = () => extensionValueMetadata;
 /**
  * Creates a named middleware for Hono with proper function naming and OpenAPI extension type.
  * Sets `.name`, `.__extensionType`, and `.__description` for OpenAPI introspection.
- *
- * @param options - Configuration for the middleware identity and documentation.
- * @param fn - The middleware handler function.
- * @returns A named MiddlewareHandler with extension type and description.
  */
 export const xMiddleware = <E extends Env = Env>(
   options: XMiddlewareOptions,
@@ -55,10 +51,6 @@ export const xMiddleware = <E extends Env = Env>(
 
 /**
  * Sets the extension type on an existing middleware (for composed middlewares like `every()`).
- *
- * @param middleware - The middleware to extend.
- * @param options - Configuration for the middleware identity and documentation.
- * @returns The middleware with extension properties set.
  */
 export const setMiddlewareExtension = <E extends Env = Env>(
   middleware: MiddlewareHandler<E>,

--- a/backend/src/core/x-routes.ts
+++ b/backend/src/core/x-routes.ts
@@ -34,7 +34,6 @@ type Route<P extends string, R extends Omit<RouteOptions, 'path'> & { path: P }>
  * Custom wrapper around hono/zod-openapi createRoute to extend it with extension middleware.
  * Extension middleware (xGuard, xRateLimiter) are documented in OpenAPI via x-* properties.
  *
- * @param config - Route configuration with extension middleware
  * @link https://github.com/honojs/middleware/tree/main/packages/zod-openapi#configure-middleware-for-each-endpoint
  */
 export const createXRoute = <P extends string, R extends Omit<RouteOptions, 'path'> & { path: P }>(

--- a/backend/src/db/immutability-triggers.ts
+++ b/backend/src/db/immutability-triggers.ts
@@ -2,7 +2,7 @@ import { getTableName } from 'drizzle-orm';
 import { appConfig, toColumnName } from 'shared';
 import { entityTables } from '#/tables';
 
-// --- Immutable column sets --------------------------------------------------
+// Immutable column sets
 
 const BASE_ENTITY_COLUMNS = ['id', 'tenant_id', 'entity_type', 'created_at', 'created_by'] as const;
 const MEMBERSHIP_CHANNEL_ID_COLUMNS = appConfig.channelEntityTypes.map((type) =>
@@ -19,7 +19,7 @@ export const membershipImmutableColumns = [...BASE_MEMBERSHIP_COLUMNS, 'user_id'
 /** Inactive memberships allow mutable user_id for re-assignable invitations. */
 export const inactiveMembershipImmutableColumns = BASE_MEMBERSHIP_COLUMNS;
 
-// --- SQL builders -----------------------------------------------------------
+// SQL builders
 
 interface TableImmutabilityConfig {
   tableName: string;
@@ -54,7 +54,7 @@ CREATE TRIGGER ${triggerName}
   FOR EACH ROW EXECUTE FUNCTION ${functionName}();`;
 }
 
-// --- Pre-built trigger functions -------------------------------------------
+// Pre-built trigger functions
 
 /** Shared by channel entities with tenant_id. */
 export const baseEntityImmutabilityFunctionSQL = buildFunctionSQL('base_entity_immutable_keys', BASE_ENTITY_COLUMNS);
@@ -83,7 +83,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;`;
 
-// --- Table to function mapping ---------------------------------------------
+// Table to function mapping
 
 const channelEntityConfigs: TableImmutabilityConfig[] = appConfig.channelEntityTypes.map((t) => ({
   tableName: getTableName(entityTables[t]),
@@ -112,7 +112,7 @@ export const allImmutabilityTables: TableImmutabilityConfig[] = [
   ...appendOnlyConfigs,
 ];
 
-// --- Combined SQL output ----------------------------------------------------
+// Combined SQL output
 
 const baseEntityTables = channelEntityConfigs;
 const names = (configs: TableImmutabilityConfig[]) => configs.map((c) => c.tableName).join(', ');
@@ -142,4 +142,4 @@ ${appendOnlyImmutabilityFunctionSQL}
 ${allImmutabilityTables.map((t) => buildTriggerSQL(t.tableName, t.functionName)).join('\n')}
 `;
 
-// ─── Custom builders (for non-standard tables) ──────────────────────────────
+// Custom builders (for non-standard tables)

--- a/backend/src/db/prepared.ts
+++ b/backend/src/db/prepared.ts
@@ -5,7 +5,7 @@ import { baseDb } from './db';
 
 const hasDb = typeof baseDb.select === 'function';
 
-// --- Tenant guard -----------------------------------------------------------
+// Tenant guard
 
 /** Prepared tenant lookup by tenant id, omitted when baseDb is a stub. */
 export const findTenantById = hasDb
@@ -17,7 +17,7 @@ export const findTenantById = hasDb
       .prepare('find_tenant_by_id')
   : (undefined as never);
 
-// --- Idempotency (sync engine) ---------------------------------------------
+// Idempotency (sync engine)
 
 /** Prepared activity lookup by sync transaction mutation id. */
 export const findActivityByMutationId = hasDb

--- a/backend/src/db/tenant-context.ts
+++ b/backend/src/db/tenant-context.ts
@@ -2,9 +2,7 @@ import { sql } from 'drizzle-orm';
 import type { AuthContext } from '#/core/context';
 import { baseDb } from './db';
 
-// ============================================================================
 // Tenant context helpers, set session vars for RLS policies
-// ============================================================================
 
 /**
  * Apply tenant/session variables for RLS policies within a transaction.

--- a/backend/src/lib/pino.ts
+++ b/backend/src/lib/pino.ts
@@ -27,10 +27,9 @@ const isProduction = appConfig.mode === 'production' || env.NODE_ENV === 'produc
 const isTest = appConfig.mode === 'test';
 
 /**
- * Logger for all requests.
- * This logger is used in logger middleware to log incoming and outgoing requests.
- * In development, pino-pretty handles formatting with the messageFormat template; in production
- * it emits JSON to stdout. When a Maple ingest key is set, request logs are also shipped to Maple.
+ * Logger for incoming/outgoing requests (used by the logger middleware). Dev: pino-pretty formats
+ * via the messageFormat template; production: JSON to stdout. Also ships to Maple when a Maple ingest
+ * key is set.
  */
 export const requestLogger = createLogger({
   level: env.PINO_LOG_LEVEL,

--- a/backend/src/lib/sync-metrics.ts
+++ b/backend/src/lib/sync-metrics.ts
@@ -9,9 +9,7 @@ export type { Span };
 export { backendSpanNames as syncSpanNames, eventAttrs };
 export type SyncTraceContext = TraceContext;
 
-// ================================
-// OTel Metrics
-// ================================
+// OTel metrics
 
 const meter = meterProvider.getMeter('app-sync');
 
@@ -35,15 +33,11 @@ export const pgNotifyFallback = meter.createCounter('sync.pg_notify.fallback', {
   description: 'Times pg_notify was used as fallback (no CDC Worker)',
 });
 
-// ================================
-// OTel Tracer
-// ================================
+// OTel tracer
 
 const tracer = trace.getTracer('app-sync');
 
-// ================================
 // withSpan + startSyncSpan
-// ================================
 
 interface SpanAttrs {
   [key: string]: string | number | boolean | null | undefined;
@@ -100,9 +94,7 @@ export function startSyncSpan(
   return span;
 }
 
-// ================================
-// Metric Recording
-// ================================
+// Metric recording
 
 /** Record a CDC message received from CDC Worker. */
 export function recordMessageReceived(entityType: string): void {

--- a/backend/src/middlewares/entity-cache/app-entity-cache.ts
+++ b/backend/src/middlewares/entity-cache/app-entity-cache.ts
@@ -60,9 +60,6 @@ export const entityCache = {
    * Old tokens for the same entity remain valid (forward-only).
    *
    * @param token - Cache token (nanoid from CDC)
-   * @param entityType - Entity type for key
-   * @param entityId - Entity ID for key
-   * @param ttlMs - Optional TTL in ms (defaults to cacheTtl)
    */
   reserve(token: string, entityType: string, entityId: string, ttlMs?: number): void {
     const key = entityKey(entityType, entityId);
@@ -77,9 +74,7 @@ export const entityCache = {
   /**
    * Resolve a token to its entity key.
    * Works for both current and old tokens (forward-only).
-   *
-   * @param token - Cache token
-   * @returns Entity key or undefined if token unknown/expired
+   * Returns undefined if the token is unknown or expired.
    */
   resolveToken(token: string): string | undefined {
     return tokenIndex.get(token);
@@ -88,10 +83,6 @@ export const entityCache = {
   /**
    * Set enriched entity data in cache.
    * Called by handler after fetching and enriching from DB.
-   *
-   * @param key - Entity key (entityType:entityId)
-   * @param data - Enriched entity data
-   * @param ttlMs - Optional TTL in ms
    */
   set(key: string, data: Record<string, unknown>, ttlMs?: number): void {
     cache.set(key, data, ttlMs ?? cacheConfig.defaultTtl);
@@ -102,9 +93,6 @@ export const entityCache = {
    * Returns undefined if not found.
    * Returns null if reserved but not enriched.
    * Returns data if enriched.
-   *
-   * @param key - Entity key (entityType:entityId)
-   * @returns Entity data, null (reserved), or undefined (not found)
    */
   get(key: string): Record<string, unknown> | null | undefined {
     const data = cache.get(key);
@@ -127,9 +115,6 @@ export const entityCache = {
   /**
    * Check if cache entry is enriched (has actual data, not just reserved).
    * Uses presence of 'id' field as enrichment indicator.
-   *
-   * @param key - Entity key (entityType:entityId)
-   * @returns true if enriched, false if reserved/missing
    */
   isEnriched(key: string): boolean {
     const data = cache.get(key);
@@ -139,10 +124,6 @@ export const entityCache = {
   /**
    * Invalidate cache entry by entity type and ID.
    * Removes entity data from cache. Token index entries expire naturally.
-   *
-   * @param entityType - Entity type
-   * @param entityId - Entity ID
-   * @returns true if entry was found and removed
    */
   invalidateByEntity(entityType: string, entityId: string): boolean {
     const key = entityKey(entityType, entityId);
@@ -186,10 +167,6 @@ export const entityCache = {
    * Fetch with coalescing: prevents thundering herd on cache miss.
    * Coalesces by entity key, so different tokens for the same entity
    * share a single in-flight fetch.
-   *
-   * @param key - Entity key (entityType:entityId)
-   * @param fetcher - Async function to fetch and enrich data
-   * @returns The fetched/cached data or null
    */
   async fetchWithCoalescing(
     key: string,

--- a/backend/src/middlewares/guard/cross-tenant-guard.ts
+++ b/backend/src/middlewares/guard/cross-tenant-guard.ts
@@ -5,10 +5,6 @@ import { baseDb } from '#/db/db';
 /**
  * Guard middleware for authenticated cross-tenant routes.
  * Sets baseDb context for cross-tenant queries; handlers use tenantRead() for RLS when needed.
- *
- * @param ctx - Request/response context
- * @param next - The next middleware or route handler
- * @returns Continues to next handler with user RLS context set
  */
 export const crossTenantGuard = xMiddleware(
   {

--- a/backend/src/middlewares/guard/org-guard.ts
+++ b/backend/src/middlewares/guard/org-guard.ts
@@ -8,10 +8,6 @@ import { getOrgCache, setOrgCache } from './org-cache';
  * Middleware to ensure the user has access to an organization-scoped route.
  * Must run after tenantGuard to use tenant-scoped transaction with RLS.
  * Valid access for users that is a member of the organization or is a system admin.
- *
- * @param ctx - Request/response context with organizationId URL parameter
- * @param next - The next middleware or route handler to call if the check passes
- * @returns Error response or continues to next handler with organization context set
  */
 export const orgGuard = xMiddleware(
   {

--- a/backend/src/middlewares/guard/public-guard.ts
+++ b/backend/src/middlewares/guard/public-guard.ts
@@ -8,9 +8,6 @@ import { baseDb } from '#/db/db';
  * RLS on tenant-scoped tables (organizations, attachments, etc.) will deny access
  * because no session variables are set, which is the correct fail-closed behavior.
  * Non-tenant tables (users, sessions, tokens) remain accessible for auth flows.
- *
- * @param ctx - Request/response context.
- * @param next - The next middleware or route handler.
  */
 export const publicGuard = xMiddleware(
   {

--- a/backend/src/middlewares/guard/tenant-guard.ts
+++ b/backend/src/middlewares/guard/tenant-guard.ts
@@ -9,10 +9,6 @@ import { getTenantCache, setTenantCache } from './tenant-cache';
  * Guard middleware for authenticated tenant-scoped routes.
  * Validates tenant access and sets baseDb + tenant context for downstream handlers.
  * Organization resolution is handled by orgGuard middleware.
- *
- * @param ctx - Request/response context with tenantId URL parameter
- * @param next - The next middleware or route handler
- * @returns Error response or continues to next handler with tenant context set
  */
 export const tenantGuard = xMiddleware(
   {

--- a/backend/src/mocks/faker-seed.ts
+++ b/backend/src/mocks/faker-seed.ts
@@ -15,13 +15,8 @@ const stringToSeed = (key: string): number => {
 };
 
 /**
- * Runs a generator function with a deterministic faker seed.
- * The same key will always produce the same fake data.
- * Useful for OpenAPI examples and reproducible tests.
- *
- * @param key - A unique string key to seed the random generator.
- * @param generator - Function that generates fake data using faker.
- * @returns The result of the generator function.
+ * Runs a generator with a deterministic faker seed: the same `key` always produces the same
+ * fake data. Useful for OpenAPI examples and reproducible tests.
  */
 export const withFakerSeed = <T>(key: string, generator: () => T): T => {
   faker.seed(stringToSeed(key));

--- a/backend/src/mocks/mock-batch-response.ts
+++ b/backend/src/mocks/mock-batch-response.ts
@@ -8,11 +8,8 @@ export interface BatchResponse<T> {
 }
 
 /**
- * Wraps a mock generator to produce a batch response.
- * Matches the batchResponseSchema structure: { data: T[], rejectedIds: string[] }
- *
- * @param mockFn - Mock generator function (takes a seed key)
- * @param count - Number of items to generate (default: 2)
+ * Wraps a mock generator to produce a batch response matching batchResponseSchema
+ * (`{ data: T[], rejectedIds: string[] }`). `count` defaults to 2.
  */
 export const mockBatchResponse = <T>(mockFn: (key: string) => T, count = 2): BatchResponse<T> => ({
   data: Array.from({ length: count }, (_, i) => mockFn(`batch:${i}`)),

--- a/backend/src/mocks/mock-channel-entity-id-columns.ts
+++ b/backend/src/mocks/mock-channel-entity-id-columns.ts
@@ -19,11 +19,9 @@ import { mockUuid } from './mock-nanoid';
 export type MockChannelIdColumns = EntityIdColumns<ChannelEntityType, string>;
 
 /**
- * Generates mock ID columns dynamically based on channel entity types from appConfig.
- *
- * @param mode - 'all' includes all channel entity types, 'relatable' only includes
- *   those in the hierarchy's relatableChannelTypes. Defaults to 'all'.
- * @returns An object with mock ID values for each channel entity ID column.
+ * Generates mock ID columns for channel entity types from appConfig.
+ * @param mode - 'all' (default) covers all channel entity types; 'relatable' only those in the
+ *   hierarchy's relatableChannelTypes.
  */
 export const generateMockChannelIdColumns = (mode: 'all' | 'relatable' = 'all'): MockChannelIdColumns => {
   const entityTypes = mode === 'all' ? appConfig.channelEntityTypes : hierarchy.relatableChannelTypes;

--- a/backend/src/mocks/mock-many.ts
+++ b/backend/src/mocks/mock-many.ts
@@ -1,10 +1,6 @@
 /**
- * Generates an array of mock items using the provided generator.
- * Useful for batch generating test data or seed data.
- *
- * @param generator - A function that generates a single mock item.
- * @param count - The number of items to generate (default: 10).
- * @returns An array of mock items.
+ * Generates an array of `count` (default 10) mock items via `generator`.
+ * Useful for batch test/seed data.
  */
 export const mockMany = <T>(generator: () => T, count = 10): T[] => {
   return Array.from({ length: count }, generator);

--- a/backend/src/mocks/mock-nanoid.ts
+++ b/backend/src/mocks/mock-nanoid.ts
@@ -36,12 +36,7 @@ export const withMockContext = <T>(context: MockContext, fn: () => T): T => {
   }
 };
 
-/**
- * Gets the ID prefix based on current mock context.
- * - 'example': empty string (IDs in OpenAPI docs look like real IDs)
- * - 'script': 'gen-' (CDC worker skips these)
- * - 'loadtest': 'lt-' (for load-test data)
- */
+/** ID prefix for the current mock context (see `setMockContext`). */
 const getIdPrefix = (): string => {
   switch (currentMockContext) {
     case 'script':
@@ -54,14 +49,8 @@ const getIdPrefix = (): string => {
 };
 
 /**
- * Generates a mock nanoid with context-aware prefixing.
- * Total length matches nanoid config (24 chars by default).
- * Uses faker's seeded RNG for deterministic output.
- *
- * Prefix behavior based on context set via setMockContext():
- * - 'example' (default): No prefix - for OpenAPI documentation
- * - 'script': 'gen-' prefix - for DB seeding, CDC filtering
- * - 'loadtest': 'lt-' prefix - for load-test data
+ * Mock nanoid with context-aware prefixing (see `setMockContext`). Total length matches the
+ * nanoid config (24 chars by default). Uses faker's seeded RNG for deterministic output.
  */
 export const mockNanoid = (length = 24) => {
   const prefix = getIdPrefix();
@@ -77,13 +66,8 @@ export const SCRIPT_UUID_PREFIX = '00000000';
 export const LOADTEST_UUID_PREFIX = '00000001';
 
 /**
- * Generates a mock UUID entity ID with context-aware prefixing.
- * Uses faker's seeded RNG for deterministic output.
- *
- * Prefix behavior based on context set via setMockContext():
- * - 'example' (default): Standard faker UUID - for OpenAPI documentation
- * - 'script': UUID starting with '00000000-' - for DB seeding, CDC filtering
- * - 'loadtest': UUID starting with '00000001-' - for load-test data
+ * Mock UUID entity ID with context-aware prefixing (see `setMockContext`): 'script' IDs start
+ * with '00000000', 'loadtest' with '00000001'. Uses faker's seeded RNG for deterministic output.
  */
 export const mockUuid = () => {
   const uuid = faker.string.uuid();

--- a/backend/src/mocks/mock-paginated.ts
+++ b/backend/src/mocks/mock-paginated.ts
@@ -1,9 +1,6 @@
 /**
- * Wraps a mock generator to produce a paginated response.
- * Matches the paginationSchema structure: { items: T[], total: number }
- *
- * @param mockFn - Mock generator function (optionally takes a seed key)
- * @param count - Number of items to generate (default: 2)
+ * Wraps a mock generator to produce a paginated response matching paginationSchema
+ * (`{ items: T[], total: number }`). `count` defaults to 2.
  */
 export const mockPaginated = <T>(mockFn: (key?: string) => T, count = 2): { items: T[]; total: number } => ({
   items: Array.from({ length: count }, (_, i) => mockFn(`item:${i}`)),

--- a/backend/src/mocks/mock-past-iso-date.ts
+++ b/backend/src/mocks/mock-past-iso-date.ts
@@ -5,6 +5,5 @@ import { MOCK_REF_DATE } from './mock-timestamps';
  * Generates a random ISO date in the past, relative to MOCK_REF_DATE so
  * output is deterministic under withFakerSeed() (an unset refDate would
  * fall back to Date.now() and drift on every generation run).
- * @returns An ISO 8601 string representing a past date.
  */
 export const mockPastIsoDate = () => faker.date.past({ refDate: MOCK_REF_DATE }).toISOString();

--- a/backend/src/modules/activities/activities-mocks.ts
+++ b/backend/src/modules/activities/activities-mocks.ts
@@ -12,12 +12,9 @@ import type { ActivityModel } from '#/modules/activities/activities-db';
 import { entityTableNames } from '#/tables';
 
 /**
- * Generates a mock activity with all fields populated. Currently hardcoded
- * with entityType values but true schema also includes resourceType values.
- * It should always be oneOf: entityType or resourceType populated with their respective values.
- * Uses deterministic seeding - same key produces same data.
- * Channel entity ID columns are generated dynamically based on relatable channel entity types.
- * Used for DB seeding, tests, and API response examples.
+ * Mock activity with all fields populated (deterministic per `key`). Channel-entity ID columns are
+ * generated dynamically. Schema is oneOf `entityType`/`resourceType`; this mock hardcodes `entityType`.
+ * Used for DB seeding, tests, and API examples.
  */
 export const mockActivity = (key = 'activity:default', overrides?: Partial<ActivityModel>): ActivityModel =>
   withFakerSeed(key, () => {

--- a/backend/src/modules/attachment/helpers/signed-url.ts
+++ b/backend/src/modules/attachment/helpers/signed-url.ts
@@ -27,17 +27,10 @@ interface GetUrlOptions {
 }
 
 /**
- * Generate a presigned URL for a private object in Scaleway Object Storage.
- * - Blob → return as-is
- * - Public → returns permanent public URL (no signing)
- * - Private → returns presigned URL with optional `expiresIn` (default 24h)
- *
- * @param Key - The object key or blob URL.
- * @param options - Optional settings:
- *   - isPublic: whether the object is public
- *   - bucketName: name of the S3 bucket
- *   - expiresIn: seconds until the presigned URL expires (only used if private, default: 86400)
- * @returns A promise resolving to the URL string.
+ * Resolves an object URL in Scaleway Object Storage:
+ * - blob URL → returned as-is
+ * - public → permanent public URL (no signing)
+ * - private → presigned URL, valid for `expiresIn` seconds (default 24h)
  */
 export async function getSignedUrlFromKey(
   Key: string,

--- a/backend/src/modules/auth/general/helpers/cookie.ts
+++ b/backend/src/modules/auth/general/helpers/cookie.ts
@@ -40,14 +40,7 @@ const isLaxCookie = (name: CookieName) =>
 export const authCookieName = (name: CookieName) =>
   `${prefix === 'host' ? '__Host-' : ''}${appConfig.slug}-${name}-${appConfig.cookieVersion}`;
 
-/**
- * Sets an authentication cookie.
- *
- * @param ctx - Request/response context.
- * @param name - Cookie name.
- * @param content - Content to store in the cookie.
- * @param timeSpan - Duration for which the cookie is valid.
- */
+/** Sets an auth cookie — signed in production, plain otherwise; SameSite per `isLaxCookie`. */
 export const setAuthCookie = async (ctx: Context<Env>, name: CookieName, content: string, timeSpan: TimeSpan) => {
   const versionedName = `${appConfig.slug}-${name}-${appConfig.cookieVersion}`;
   const options = {
@@ -63,13 +56,7 @@ export const setAuthCookie = async (ctx: Context<Env>, name: CookieName, content
     : setCookie(ctx, versionedName, content, options);
 };
 
-/**
- * Retrieves content from an authentication cookie.
- *
- * @param ctx - Request/response context.
- * @param name - Cookie name.
- * @returns The content stored in the cookie.
- */
+/** Reads (and, in production, unsigns) an auth cookie's content. */
 export const getAuthCookie = async (ctx: Context<Env>, name: CookieName) => {
   const versionedName = `${appConfig.slug}-${name}-${appConfig.cookieVersion}`;
 
@@ -79,13 +66,7 @@ export const getAuthCookie = async (ctx: Context<Env>, name: CookieName) => {
   return content;
 };
 
-/**
- * Deletes an authentication cookie.
- *
- * @param ctx - Request/response context.
- * @param name - Cookie name.
- * @returns Deleted value
- */
+/** Deletes an auth cookie. */
 export const deleteAuthCookie = (ctx: Context<Env>, name: CookieName) => {
   const versionedName = `${appConfig.slug}-${name}-${appConfig.cookieVersion}`;
 

--- a/backend/src/modules/auth/general/helpers/mfa.ts
+++ b/backend/src/modules/auth/general/helpers/mfa.ts
@@ -14,13 +14,8 @@ import { encodeLowerCased } from '#/utils/oslo';
 import { createDate, TimeSpan } from '#/utils/time-span';
 
 /**
- * Starts a two-factor authentication challenge for a user.
- * Generates a temporary token, stores it in the database,
- * and sets a confirm MFA auth cookie.
- *
- * @param ctx - Hono context
- * @param user - User to start MFA for
- * @returns Redirect path to MFA confirmation page, or null if MFA is not enabled
+ * Starts an MFA challenge: stores a hashed `confirm-mfa` token and sets its cookie. Returns the
+ * `/auth/mfa` redirect path, or null when the user has no MFA enabled.
  */
 export const initiateMfa = async (ctx: Context<Env>, user: UserModel) => {
   // If the user does not have MFA enabled, do nothing
@@ -52,13 +47,7 @@ export const initiateMfa = async (ctx: Context<Env>, user: UserModel) => {
   return '/auth/mfa';
 };
 
-/**
- * Validates a confirm MFA token from cookie and optionally deletes it.
- *
- * @param ctx - Hono context
- * @returns UserModel
- * @throws AppError if token is missing, not found, or expired
- */
+/** Validates the `confirm-mfa` cookie token and returns its user. Throws if missing, not found, or expired. */
 export const validateConfirmMfaToken = async (ctx: Context<Env>): Promise<UserModel> => {
   const tokenFromCookie = await getAuthCookie(ctx, 'confirm-mfa');
   if (!tokenFromCookie)

--- a/backend/src/modules/auth/general/helpers/user.ts
+++ b/backend/src/modules/auth/general/helpers/user.ts
@@ -19,13 +19,8 @@ interface HandleCreateUserProps {
 }
 
 /**
- * Handles user creation, including OAuth-based sign-up.
- * Inserts the user into the database, processes OAuth accounts, and sends verification emails.
- * Sets a user session upon successful sign-up.
- *
- * @param newUser - New user data for registration(InsertUserModel).
- * @param emailVerified - Optional, new user email verified.
- * @returns Error response or Redirect response or Response
+ * Creates a user (also the OAuth sign-up path): inserts the user, unsubscribe token, and email row,
+ * links any pending invitation tokens to their inactive memberships. Throws 409 if the email exists.
  */
 export const handleCreateUser = async (
   ctx: DbContext,
@@ -94,13 +89,7 @@ export const handleCreateUser = async (
   }
 };
 
-/**
- * Handles updating inactive memberships with the new user ID upon user creation.
- * Deletes associated tokens after updating the memberships.
- *
- * @param userId - The ID of the newly created user.
- * @param inactiveMembershipIds - The IDs of the inactive memberships to update.
- */
+/** Sets the new user's ID on their inactive memberships, then deletes the associated tokens. */
 export const handleSetUserOnInactiveMemberships = async (
   ctx: DbContext,
   { userId, inactiveMembershipIds }: { userId: string; inactiveMembershipIds: string[] },

--- a/backend/src/modules/auth/oauth/helpers/callback.ts
+++ b/backend/src/modules/auth/oauth/helpers/callback.ts
@@ -41,23 +41,14 @@ interface BaseCallbackProps {
 }
 
 /**
- * Handles the OAuth provider callback for authentication, account linking, or invitation flows.
- *
- * This function determines the appropriate flow based on `type` from OAuth payload:
- * - 'connect' → link an existing account with the OAuth provider
- * - 'invite'  → handle invited users completing OAuth signup
+ * Handles the OAuth provider callback, branching on `oauthPayload.type`:
+ * - 'connect' → link the provider to an existing account
+ * - 'invite'  → invited user completing OAuth signup
  * - 'verify'  → verify an existing OAuth account
- * - 'auth'    → standard authentication/signup flow
+ * - 'auth'    → standard authentication/signup
  *
- * It fetches any existing OAuth account, executes corresponding flow handler,
- * and then processes OAuth account to handle session setup, MFA, or verification email,
- * ultimately redirecting user to correct client page.
- *
- * @param ctx - Request context containing request and environment info.
- * @param oauthPayload - Payload from OAuth flow, including type and optional redirect.
- * @param providerUser - Transformed user data returned by OAuth provider.
- * @param provider - OAuth provider identifier (e.g., 'google', 'github').
- * @returns A redirect response to appropriate client page.
+ * Fetches any existing OAuth account, runs the matching flow, then hands off to
+ * `processOAuthAccount` for session setup, MFA, or verification email and the final redirect.
  */
 export const handleOAuthCallback = async (
   ctx: Context<Env>,
@@ -165,17 +156,11 @@ const authCallbackFlow = async ({
 };
 
 /**
- * Handles connecting an OAuth provider to an existing user account.
+ * Connects an OAuth provider to an existing user account.
  *
- * The connecting user comes from the signed oauth-state payload, pinned at
- * initiation where the session was validated — the SameSite=Strict session
- * cookie is not sent on the provider's cross-site callback navigation.
- *
- * @param providerUser - The transformed user data from the OAuth provider.
- * @param provider - The OAuth provider (e.g., 'google', 'github').
- * @param connectUserId - The ID of the user who is attempting to connect an OAuth account.
- * @param oauthAccount - The existing OAuth account, if one exists.
- * @returns A redirect response.
+ * The connecting user comes from the signed oauth-state payload, pinned at initiation where the
+ * session was validated — the SameSite=Strict session cookie is not sent on the provider's
+ * cross-site callback navigation.
  */
 const connectCallbackFlow = async ({
   connectUserId,
@@ -217,15 +202,8 @@ const connectCallbackFlow = async ({
 };
 
 /**
- * Handles user sign-up via invitation flow.
- * Validates the invitation token, checks email matches, and creates an OAuth account.
- *
- * @param ctx - The request context.
- * @param providerUser - The transformed user data from the OAuth provider.
- * @param provider - The OAuth provider (e.g., 'google', 'github').
- * @param oauthAccount - The linked OAuth account, if one exists.
- * @param redirectAfter - OAuth query redirect path, if one exists.
- * @returns A redirect response.
+ * Sign-up via invitation: validates the invitation token, requires its email to match the
+ * provider email, then creates the OAuth account.
  */
 const inviteCallbackFlow = async ({
   ctx,
@@ -314,15 +292,7 @@ const verifyCallbackFlow = async ({
   return { type: 'verified', user, oauthAccount };
 };
 
-/**
- * Inserts a new OAuth account into the database.
- *
- * @param userId - Internal user ID to associate with the OAuth account.
- * @param providerUserId - Unique user ID from the OAuth provider.
- * @param provider - Identifier for the OAuth provider.
- * @param email - Email address associated with the OAuth account.
- * @returns The created OAuth account.
- */
+/** Inserts a new OAuth account row and returns it. */
 const createOAuthAccount = async (
   dbOrTx: DbOrTx,
   userId: OAuthAccountModel['userId'],
@@ -345,14 +315,9 @@ const createOAuthAccount = async (
 };
 
 /**
- * Processes an OAuth account after provider callback.
- *
- * This function handles both verified and unverified OAuth accounts:
- * - Verified, it may initiate MFA and/or set user session, then redirects to appropriate post-login path.
- * - Unverified, it sends a verification email and redirects  user to an email verification page with context.
- *
- * @param info - Contains OAuth flow result, request context, optional redirect path
- * @returns A redirect response to appropriate client page.
+ * Post-callback handling. Verified accounts may start an MFA challenge and/or set the session,
+ * then redirect to the post-login path; unverified accounts get a verification email and are
+ * redirected to the email-verification page.
  */
 const processOAuthAccount = async (info: OAuthFlowResult & { ctx: Context<Env>; redirectAfter?: string }) => {
   const { ctx, type, oauthAccount, redirectAfter } = info;

--- a/backend/src/modules/auth/oauth/helpers/initiation.ts
+++ b/backend/src/modules/auth/oauth/helpers/initiation.ts
@@ -32,19 +32,11 @@ export const parseOAuthCookie = (raw: string | false | null | undefined): OAuthC
 };
 
 /**
- * Creates an OAuth session by setting the necessary cookies and redirecting to the provider.
+ * Creates an OAuth session: sets the flow-context cookies and redirects to the provider.
  *
  * - Stores OAuth flow context (invite, connect, verify, or default)
  * - Associates the context with the OAuth `state` to prevent CSRF
- * - Optionally includes PKCE `codeVerifier`
- *
- * @param ctx - Hono context
- * @param provider - OAuth provider name
- * @param url - Provider’s authorization endpoint
- * @param state - OAuth state param
- * @param codeVerifier - PKCE code verifier (optional)
- * @param nonce - OIDC nonce echoed back in the provider id_token (optional)
- * @returns redirect response
+ * - Optionally includes a PKCE `codeVerifier` and an OIDC `nonce` (echoed back in the id_token)
  */
 export const handleOAuthInitiation = async (
   ctx: Context<Env, string, { out: { query: OAuthQueryParams } }>,

--- a/backend/src/modules/auth/oauth/helpers/transform-user-data.ts
+++ b/backend/src/modules/auth/oauth/helpers/transform-user-data.ts
@@ -18,14 +18,7 @@ export type TransformedUser = {
   lastName: string;
 };
 
-/**
- * Transform social media user data (Google or Microsoft) into a standardized user object.
- * This helper formats the data received from the OAuth provider into a uniform user object.
- *
- * @param user - User data from OAuth provider (Google or Microsoft).
- * @returns  - Formatted user object.
- * @throws - If no email is found in user data.
- */
+/** Normalizes Google/Microsoft OAuth profile data into a `TransformedUser`. Throws if no email. */
 export const transformSocialUserData = (user: GoogleUserProps | MicrosoftUserProps): TransformedUser => {
   if (!user.email) throw new Error('no_email_found');
 
@@ -47,15 +40,7 @@ export const transformSocialUserData = (user: GoogleUserProps | MicrosoftUserPro
   };
 };
 
-/**
- * Transform GitHub user data into a standardized user object.
- * This helper formats the data received from GitHub and fetches the user's primary email.
- *
- * @param user - User data from GitHub.
- * @param emails - List of emails associated with GitHub user.
- * @returns - Formatted user object.
- * @throws - If no email is found in user data.
- */
+/** Normalizes GitHub profile data (and its email list) into a `TransformedUser`. Throws if no primary email. */
 export const transformGithubUserData = (user: GithubUserProps, emails: GithubUserEmailProps[]): TransformedUser => {
   const primaryEmail = emails.find((email) => email.primary);
   if (!primaryEmail) throw new Error('no_email_found');

--- a/backend/src/modules/auth/passkeys/helpers/passkey.ts
+++ b/backend/src/modules/auth/passkeys/helpers/passkey.ts
@@ -26,16 +26,9 @@ import { deleteAuthCookie, getAuthCookie } from '#/modules/auth/general/helpers/
 import { passkeysTable } from '#/modules/auth/passkeys/passkeys-db';
 
 /**
- * Parses and validates passkey attestation data.
- *
- * Verifies attestation statement, relying party ID hash, user presence and verification, credential, algorithm, and challenge.
- * If valid, returns the encoded public key and credential ID.
- *
- * @param clientDataJSON -Client data JSON from the attestation.
- * @param encodedAttestationObject - Base64-encoded attestation object.
- * @param challengeFromCookie - Challenge value from the cookie to validate.
- * @throws Error if some data is invalid.
- * @returns An object with encoded public key and credential ID.
+ * Parses and validates passkey (WebAuthn) attestation: checks the attestation format, relying-party
+ * ID hash, user presence/verification, credential, ES256 algorithm, and challenge. Returns the
+ * encoded public key and credential ID.
  */
 export const parseAndValidatePasskeyAttestation = (
   clientDataJSON: string,
@@ -127,19 +120,7 @@ export const validatePasskey = async (
   if (!isValid) throw new AppError(401, 'invalid_token', 'warn');
 };
 
-/**
- * Verifies a passkey public key signature.
- *
- * Verifies that signature matches public key and client data, ensuring request is valid.
- *
- * @param signature - Base64-encoded signature to verify.
- * @param authenticatorObject - Base64-encoded authenticator object.
- * @param clientDataJSON - Base64-encoded client data JSON.
- * @param publicKey - Base64-encoded public key for verification.
- * @param challengeFromCookie - Challenge value from the cookie to validate.
- * @throws Error if some data is invalid.
- * @returns Boolean indicating whether the signature is valid.
- */
+/** Verifies the passkey assertion signature against the stored public key, challenge, and client data. */
 const verifyPassKeyPublic = async ({
   signature,
   authenticatorObject,

--- a/backend/src/modules/auth/totps/helpers/totps.ts
+++ b/backend/src/modules/auth/totps/helpers/totps.ts
@@ -9,28 +9,14 @@ import { totpsTable } from '#/modules/auth/totps/totps-db';
 
 const { intervalInSeconds, digits, gracePeriodInSeconds } = appConfig.totpConfig;
 
-/**
- * Verifies a Time-based One-Time Password (TOTP) code.
- *
- * Decodes the secret from Base32 format.
- * Checks provided OTP against secret using configured interval, number of digits, and grace period.
- *
- * @param {string} otp - The TOTP code provided by the user.
- * @param {string} secret - The Base32-encoded shared secret.
- * @returns {boolean} - Returns `true` if the OTP is valid within the grace period, otherwise `false`.
- */
+/** Verifies a TOTP `otp` against a Base32 `secret` using the configured interval, digits, and grace period. */
 export const signInWithTotp = (otp: string, secret: string): boolean => {
   const secretBytes = decodeBase32(secret);
 
   return verifyTOTPWithGracePeriod(secretBytes, intervalInSeconds, digits, otp, gracePeriodInSeconds);
 };
 
-/**
- * Verifies a user's TOTP code.
- * - Decodes the Base32 secret.
- * - Checks the OTP against the secret using interval, digits, and grace period.
- * - Throws errors if user credentials are missing or the OTP is invalid.
- */
+/** Loads the user's stored TOTP secret and verifies `code`; throws if no credentials or the code is invalid. */
 export const validateTOTP = async ({ code, userId }: { code: string; userId: string }) => {
   // Get totp credentials
   const [credentials] = await db.select().from(totpsTable).where(eq(totpsTable.userId, userId)).limit(1);

--- a/backend/src/modules/entities/entities-handlers.ts
+++ b/backend/src/modules/entities/entities-handlers.ts
@@ -14,10 +14,6 @@ import { keepAlive, streamSubscriberManager, writeOffset } from './stream';
 
 const app = new OpenAPIHono<Env>({ defaultHook });
 
-// ============================================
-// Route handlers
-// ============================================
-
 app.openapi(entityRoutes.checkSlug, async (ctx) => {
   const { slug, entityType } = ctx.req.valid('json');
   const result = await checkSlugOp(ctx, slug, entityType);

--- a/backend/src/modules/entities/entities-queries.ts
+++ b/backend/src/modules/entities/entities-queries.ts
@@ -141,12 +141,10 @@ export const getOrgEntityCount = async ({ var: { db } }: DbContext, orgId: strin
 export const DELETE_ENUMERATE_CAP = 200;
 
 /**
- * Scan product entity delete activities after a cursor (app stream).
- *
- * Capped at `DELETE_ENUMERATE_CAP + 1` so the caller can detect overflow (more deletes than we
- * enumerate) and fall back to client-side list invalidation. Membership changes are intentionally
- * Memberships are detected via the `s:membership` seq counter, so membership churn can
- * never consume the delete budget.
+ * Scan product entity delete activities after a cursor (app stream), capped at
+ * `DELETE_ENUMERATE_CAP + 1` so the caller can detect overflow and fall back to list invalidation.
+ * Membership changes are excluded here — detected via the `s:membership` seq counter instead, so
+ * membership churn never consumes the delete budget.
  */
 export const findDeleteActivities = async (
   { var: { db } }: DbContext,

--- a/backend/src/modules/entities/helpers/build-zero-counts.ts
+++ b/backend/src/modules/entities/helpers/build-zero-counts.ts
@@ -1,12 +1,8 @@
 import { type ChannelEntityType, hierarchy, recordFromKeys, roles } from 'shared';
 
 /**
- * Build a zero-initialized counts response object for a new channel entity.
- * Used in create responses where the entity has no prior data.
- *
- * @param entityType - The channel entity type (e.g. 'organization')
- * @param creatorRole - The role assigned to the creator (defaults to 'admin')
- * @returns Object matching channelEntityIncludedSchema counts: { membership: {...}, entities: {...}, activity: {...} }
+ * Zero-initialized counts for a newly created channel entity (create responses, no prior data).
+ * Shape matches `channelEntityIncludedSchema`: { membership, entities, activity }.
  */
 export const buildZeroCounts = (entityType: ChannelEntityType, creatorRole = 'admin') => {
   const descendants = hierarchy.getOrderedDescendants(entityType);

--- a/backend/src/modules/me/helpers/get-user-info.ts
+++ b/backend/src/modules/me/helpers/get-user-info.ts
@@ -10,16 +10,8 @@ import { totpsTable } from '#/modules/auth/totps/totps-db';
 import type { sessionSchema } from '#/modules/me/me-schema';
 
 /**
- * Fetches all authentication-related data for a user in parallel.
- *
- * This includes:
- * - Passkeys (excluding sensitive fields like credentialId & publicKey)
- * - TOTP entries
- * - Verified OAuth accounts
- *
- * @param db - Database connection
- * @param userId - ID of the user to fetch auth data for
- * @returns An object containing arrays of passkeys, TOTP entries, and OAuth providers
+ * Fetches a user's auth data in parallel: passkeys (minus the sensitive credentialId/publicKey),
+ * whether TOTP is set, and verified OAuth providers.
  */
 export const getAuthInfo = async (ctx: DbContext, { userId }: { userId: string }) => {
   const { db } = ctx.var;
@@ -38,13 +30,7 @@ export const getAuthInfo = async (ctx: DbContext, { userId }: { userId: string }
   return { passkeys, hasTotp: !!totps.length, oauth };
 };
 
-/**
- * Retrieves all sessions for a specific user, and marks the current session.
- *
- * @param ctx - Request/response context.
- * @param userId - ID of the user whose sessions are requested.
- * @returns A list of sessions, with an additional `isCurrent` flag indicating if the session is the current active session.
- */
+/** Returns a user's sessions (newest first, secret stripped), each flagged with `isCurrent`. */
 export const getUserSessions = async (ctx: Context<Env>, userId: string): Promise<z.infer<typeof sessionSchema>[]> => {
   const db = ctx.var.db;
   const sessions = await db

--- a/backend/src/modules/me/me-handlers.ts
+++ b/backend/src/modules/me/me-handlers.ts
@@ -25,10 +25,6 @@ import { log } from '#/utils/logger';
 
 const app = new OpenAPIHono<Env>({ defaultHook });
 
-// ============================================
-// Route handlers
-// ============================================
-
 app.openapi(meRoutes.getMe, async (ctx) => {
   const data = await getMeOp(ctx);
   return ctx.json(data, 200);

--- a/backend/src/modules/memberships/helpers/membership-helpers.ts
+++ b/backend/src/modules/memberships/helpers/membership-helpers.ts
@@ -52,16 +52,8 @@ interface InsertMultipleProps<T> {
 }
 
 /**
- * Returns an object mapping base membership entity IDs for the given entity.
- *
- * Each mapping corresponds to a channel entity type defined in `appConfig.channelEntityTypes`.
- * The key of each mapping is derived from the values of `appConfig.entityIdColumnKeys`
- * (e.g. `"organizationId"`, `"projectId"`), and the value is the corresponding string ID.
- *
- *
- * @template T - The specific channel entity type.
- * @param entity - The entity object to extract membership ID information from.
- * @returns An object mapping base membership entity IDs for the given entity.
+ * Maps a channel entity to its ancestor channel IDs, keyed by `appConfig.entityIdColumnKeys`
+ * (e.g. `{ organizationId, projectId }`).
  */
 export const getBaseMembershipEntityId = <T extends ChannelEntityType>(entity: EntityModel<T>) => {
   return appConfig.channelEntityTypes.reduce(
@@ -83,18 +75,10 @@ export const getBaseMembershipEntityId = <T extends ChannelEntityType>(entity: E
 };
 
 /**
- * Batch insert direct memberships for existing users. The function assumes that
- *  the data is already deduped, normalized and valid.
- *
- * - Ensures organization membership exists for non-organization entities.
- *   (relies on DB unique constraints + onConflictDoNothing to only insert when missing)
- * - Ensures associated parent membership exists when applicable.
- *   (same: only inserted when missing)
- * - Inserts the target entity memberships.
- * - Computes per-user 'order' in a single grouped query and increments by 10.
- *
- * @param items - membership requests for existing users
- * @returns inserted target memberships (MembershipBaseModel)
+ * Batch-insert direct memberships for existing users. Assumes `items` are already deduped,
+ * normalized, and valid. Root-context and associated parent memberships are upserted (unique
+ * constraint + onConflictDoNothing → inserted only when missing); per-user `displayOrder` is
+ * computed in one grouped query, spaced by `orderGap`. Returns the inserted target memberships.
  */
 export const insertMemberships = async <T extends BaseEntityModel>(
   ctx: DbContext,

--- a/backend/src/modules/memberships/memberships-mocks.ts
+++ b/backend/src/modules/memberships/memberships-mocks.ts
@@ -48,11 +48,8 @@ type ChannelEntity = { id: string; tenantId: string };
 type ChannelEntityIdOverrides = Partial<MockChannelIdColumns>;
 
 /**
- * Generates a mock membership linking a user to a channel entity.
- * Works with any channel entity type (organization, project, etc.).
- * Initializes all channel entity ID columns to null, then sets the specific channel entity ID.
- * Additional ancestor IDs can be provided via overrideIds.
- * Ensures consistent ordering via the `getMembershipOrderOffset` function.
+ * Mock membership linking a user to a channel entity (any type). Nulls all channel-entity ID columns,
+ * then sets the target's (plus any ancestor IDs from `overrideIds`); ordering via `getMembershipOrderOffset`.
  */
 export const mockChannelMembership = <T extends ChannelEntityType>(
   channelType: T,

--- a/backend/src/modules/organization/organization-mocks.ts
+++ b/backend/src/modules/organization/organization-mocks.ts
@@ -30,13 +30,7 @@ export const resetOrganizationMockEnforcers = () => {
   organizationName.reset();
 };
 
-/**
- * Generates base organization fields shared between insert and response mocks.
- * @param id - Organization ID
- * @param tenantId - Tenant ID
- * @param name - Organization name
- * @param createdAt - Creation timestamp
- */
+/** Base organization fields shared between insert and response mocks. */
 const generateOrganizationBase = (id: string, tenantId: string, name: string, createdAt: string) => {
   const slug = slugify(name, { lower: true, strict: true });
 

--- a/backend/src/modules/requests/requests-handlers.ts
+++ b/backend/src/modules/requests/requests-handlers.ts
@@ -11,9 +11,7 @@ import { requestRoutes } from '#/modules/requests/requests-routes';
 import { defaultHook } from '#/utils/default-hook';
 import { log } from '#/utils/logger';
 
-// ============================================
 // ActivityBus: link waitlist requests to invitation tokens
-// ============================================
 activityBus.on('inactive_membership.created', async (event: ActivityEvent) => {
   const membership = getEventData(event, 'inactive_membership');
   if (!membership?.tokenId || !membership.email) return;

--- a/backend/src/modules/tenants/tenants-routes.ts
+++ b/backend/src/modules/tenants/tenants-routes.ts
@@ -1,10 +1,6 @@
 /**
- * Tenant route definitions for system admin operations.
- *
- * Tenants are system-level resources managed exclusively by admins.
- * These routes provide CRUD operations for tenant management.
- *
- * @see cella/ARCHITECTURE.md for architecture documentation
+ * Tenant CRUD routes — system-admin only (see `sysAdminGuard`).
+ * @see cella/ARCHITECTURE.md
  */
 
 import { createXRoute } from '#/core/x-routes';

--- a/backend/src/permissions/get-channel-entity.ts
+++ b/backend/src/permissions/get-channel-entity.ts
@@ -16,23 +16,14 @@ export interface ValidChannelEntityResult<T extends ChannelEntityType> {
 }
 
 /**
- * Checks if current user has permission to perform a given action on a channel entity.
+ * Checks whether the current user may perform `action` on a channel entity, resolving it by ID (or
+ * slug when `bySlug`). Returns the entity plus the user's membership; throws 404 if not found, 403
+ * if not allowed.
  *
- * Resolves channel entity based on provided type and ID/slug, verifies user permissions
- * (including system admin), and retrieves user's membership for entity if applicable.
+ * `membership` may be `null` even when allowed — the user is a system admin, or an admin of a
+ * higher-level entity as defined in `permissions-config`.
  *
- * Returns resolved entity along with user's membership and a `can` object with all action permissions.
- * The membership may be `null` if action is allowed because user is a system admin or an admin
- * of a higher-level entity as defined in `permissions-config`.
- * Throws an error if entity cannot be found or user lacks required permissions.
- *
- *
- * @param ctx - Context with db, memberships, and isSystemAdmin set by guard middleware.
- * @param entityId - Entity's unique ID (or slug when bySlug is true).
- * @param entityType - Type of channel entity (e.g., organization, project).
- * @param action - Action to check (e.g., `"read" | "update" | "delete"`).
- * @param bySlug - If true, resolve by slug instead of ID.
- * @returns An object containing resolved entity, associated membership (or `null`), and can object.
+ * @param ctx - Context with memberships and isSystemAdmin set by the guard chain.
  */
 export const getValidChannelEntity = async <T extends ChannelEntityType>(
   ctx: AuthContext,

--- a/backend/src/permissions/get-product-entity.ts
+++ b/backend/src/permissions/get-product-entity.ts
@@ -16,20 +16,9 @@ export interface ValidProductEntityResult<K extends ProductEntityType> {
 }
 
 /**
- * Checks if current user has permission to perform a given action on a product entity.
- *
- * Resolves product entity based on provided type and ID/slug, and verifies user permissions
- * (including system admin overrides).
- *
- * Returns resolved product entity and a `can` object with all action permissions.
- * Throws an error if entity cannot be found or user lacks required permissions.
- *
- * @param ctx - Hono context (for memberships, user info)
- * @param id - Product's unique ID.
- * @param entityType - Type of product entity.
- * @param action - The action to check (e.g., `"read" | "update" | "delete"`).
- * @param db - Database connection or transaction (e.g., from tenantRead).
- * @returns An object containing resolved entity and can object.
+ * Checks whether the current user may perform `action` on a product entity, resolving it by `id`
+ * (system-admin bypass handled inside `checkPermission`). Returns the resolved entity; throws 404 if
+ * not found, 403 if not allowed.
  */
 export const getValidProductEntity = async <K extends ProductEntityType>(
   ctx: AuthContext,

--- a/backend/src/permissions/row-predicates.test.ts
+++ b/backend/src/permissions/row-predicates.test.ts
@@ -370,7 +370,7 @@ describe('row-condition parity: engine check ⊆⊇ compiled SQL ⊆⊇ compute-
   });
 });
 
-/******************************************************************************
+/*
  * Deep-chain parity: 4-level SYNTHETIC hierarchy (organization > course >
  * courseSection > project, product `item` parented to project with nullable
  * ancestors) — exercises intermediate ancestor-level grants (course /
@@ -379,7 +379,7 @@ describe('row-condition parity: engine check ⊆⊇ compiled SQL ⊆⊇ compute-
  * the scope compiler via `resolveCollectionReadFilterForPolicies(…, topology)`.
  * The casts naming synthetic entities are contained in the fixtures below,
  * mirroring `shared/src/testing/wide-fixture.ts`.
- ******************************************************************************/
+ */
 
 const deepRoles = createRoleRegistry(['admin', 'member', 'staff', 'student', 'owner', 'follower'] as const);
 const deepHierarchy = createEntityHierarchy(deepRoles)
@@ -583,7 +583,7 @@ describe('deep-chain parity: intermediate ancestor grants agree between engine a
   });
 });
 
-/******************************************************************************
+/*
  * elevatedRoles parity (same synthetic topology): with `elevatedRoles` configured,
  * a product grant of a non-listed role speaks only for rows HOMED at its own
  * context level, while listed roles (admin/staff) keep subtree scope. Engine
@@ -595,7 +595,7 @@ describe('deep-chain parity: intermediate ancestor grants agree between engine a
  * organization→course→courseSection→project, with `submission read:'own'` home-scoped) is
  * covered by its own fork parity test. If this synthetic fixture and that real chain ever drift
  * in shape, both suites stay green while the fork breaks — keep them shaped alike.
- ******************************************************************************/
+ */
 
 const SUBTREE_ROLES = ['admin', 'staff'] as const;
 
@@ -657,7 +657,7 @@ describe('elevatedRoles parity: home-scoped grants agree between engine and SQL'
   });
 });
 
-/******************************************************************************
+/*
  * Three-way mirror parity under the REAL app config: collection SQL ≍ single-row
  * engine check ≍ SSE dispatch predicate (`canReceiveEntityEvent`). The dispatch
  * decision doubles as cacheToken issuance (a signed cache token is a read
@@ -677,7 +677,7 @@ describe('elevatedRoles parity: home-scoped grants agree between engine and SQL'
  * collection path used to have no admin flag at all. Public grants ride the real config
  * (which declares none), so their parity is asserted in the synthetic block above, where the
  * grants can actually be injected.
- ******************************************************************************/
+ */
 
 const realMembership = (
   channelType: ChannelEntityType,

--- a/backend/src/permissions/split-by-permission.ts
+++ b/backend/src/permissions/split-by-permission.ts
@@ -9,16 +9,10 @@ import { actorFrom } from '#/permissions/actor';
 import { buildSubjectFromEntity } from '#/permissions/build-subject';
 
 /**
- * Splits entity IDs into allowed and disallowed based on the user's permissions.
+ * Resolves `ids` and splits them into `allowedIds` / `rejectedIds` by whether the user may perform
+ * `action`.
  *
- * Resolves the entities and checks whether the user can perform the specified action.
- * The result is split into `allowedIds` and `rejectedIds`.
- * Throws 403 if none of the requested IDs are allowed.
- *
- * @param action - Action to check `"create" | "read" | "update" | "delete"`.
  * @param entityType - The type of entity (context or product, not user).
- * @param ids - The entity IDs to check.
- * @returns An object with `allowedIds` and `rejectedIds` arrays.
  * @throws {AppError} 403 if no entities are allowed.
  */
 export const splitByPermission = async (

--- a/backend/src/schemas/common-schemas.ts
+++ b/backend/src/schemas/common-schemas.ts
@@ -13,9 +13,7 @@ export const booleanTransformSchema = z
   .transform((v) => v === true || v === 'true')
   .pipe(z.boolean());
 
-/*************************************************************************************************
- * Entity schemas
- ************************************************************************************************/
+// Entity schemas
 
 /** Enum schema for entity types */
 export const entityTypeSchema = z.enum(appConfig.entityTypes);
@@ -26,13 +24,7 @@ export const channelEntityTypeSchema = z.enum(appConfig.channelEntityTypes);
 /** Enum schema for product entity types */
 export const productEntityTypeSchema = z.enum(appConfig.productEntityTypes);
 
-/*************************************************************************************************
- * Common properties schemas
- ************************************************************************************************/
-
-/*************************************************************************************************
- * Common param schemas
- ************************************************************************************************/
+// Common param schemas
 
 /** Schema for an entity ID with max length */
 export const validIdSchema = z.string().max(maxLength.id);
@@ -79,9 +71,7 @@ export const inOrgParamSchema = z.object({ organizationId: validIdSchema });
 /** Schema for entity id within an organization organizationId */
 export const idInOrgParamSchema = z.object({ id: validIdSchema, organizationId: validIdSchema });
 
-/*************************************************************************************************
- * Tenant-scoped param schemas (for RLS-enabled routes)
- ************************************************************************************************/
+// Tenant-scoped param schemas (for RLS-enabled routes)
 
 /** Schema for tenant-scoped routes: tenantId + organizationId */
 export const tenantOrgParamSchema = z.object({
@@ -108,9 +98,7 @@ export const relatableUserIdParamSchema = z.object({
   relatableUserId: validIdSchema,
 });
 
-/*************************************************************************************************
- * Common query schemas
- ************************************************************************************************/
+// Common query schemas
 
 /** Schema for id that must be a specific entity type */
 export const entityWithTypeQuerySchema = z.object({ entityId: validIdSchema, entityType: channelEntityTypeSchema });
@@ -177,9 +165,7 @@ export const emailOrTokenIdQuerySchema = z.union([
   z.object({ email: z.email().optional(), tokenId: z.string() }),
 ]);
 
-/*************************************************************************************************
- * Common body schemas
- ************************************************************************************************/
+// Common body schemas
 
 /** Schema for a request body containing an array of IDs */
 export const idsBodySchema = (maxItems = 50) =>
@@ -205,16 +191,12 @@ export const idsWithStxBodySchema = (maxItems = 50) =>
       .optional(),
   });
 
-/*************************************************************************************************
- * Common headers schemas
- ************************************************************************************************/
+// Common headers schemas
 
 /** Schema for a redirect header */
 export const locationSchema = z.object({ Location: z.string() });
 
-/*************************************************************************************************
- * Validation schemas (for create and update)
- ************************************************************************************************/
+// Validation schemas (for create and update)
 
 /**
  * Creates a superRefine validator that passes a custom error type for i18n translation.

--- a/backend/src/utils/console.ts
+++ b/backend/src/utils/console.ts
@@ -2,9 +2,7 @@ import ora, { type Ora } from 'ora';
 
 export { changeMark, checkMark, crossMark, loadingMark, tildeMark, timestamp, warningMark } from 'shared/utils/console';
 
-// ============================================================================
-// Spinner Utilities
-// ============================================================================
+// Spinner utilities
 
 /** Active spinner reference */
 let activeSpinner: Ora | null = null;

--- a/backend/src/utils/get-valid-single-use-token.ts
+++ b/backend/src/utils/get-valid-single-use-token.ts
@@ -12,11 +12,7 @@ type Props = {
   tokenType: TokenType;
 };
 /**
- * Validates a single use token by its value, ensuring it matches the required type.
- *
- * @param ctx - Hono context
- * @param tokenType (optional) The required type of the token (e.g., 'email-verification').
- * @returns The valid single use token row from the database.
+ * Validates a single-use token from the auth cookie, ensuring it matches the required type.
  * @throws AppError if the token is not found or of an invalid type.
  */
 export const getValidSingleUseToken = async ({ ctx, tokenType }: Props): Promise<TokenModel> => {

--- a/backend/src/utils/get-valid-token.ts
+++ b/backend/src/utils/get-valid-token.ts
@@ -18,14 +18,10 @@ type BaseProps = {
   invokeToken?: boolean;
 };
 /**
- * Validates a token by its value, ensuring it matches the required type and is neither expired nor invoked.
- * By default, it invokes the token upon successful validation.
+ * Validates a token by value, ensuring it matches the required type and is neither expired nor invoked.
+ * Invokes (consumes) the token on success by default.
  *
- * @param ctx - Hono context.
- * @param token The token string to validate.
- * @param invokeToken (optional) Whether to create a single-use token after invoking/consuming the primary `token`.
- * @param tokenType The required type of the token (e.g., 'email-verification').
- * @returns The valid token row from the database.
+ * @param invokeToken When true, mints a fresh single-use token after consuming the primary `token`.
  * @throws AppError if the token is not found, expired, or of an invalid type.
  */
 export const getValidToken = async ({ ctx, token, tokenType, invokeToken = true }: BaseProps): Promise<TokenModel> => {

--- a/backend/src/utils/idempotency.ts
+++ b/backend/src/utils/idempotency.ts
@@ -1,13 +1,10 @@
 import { findActivityByMutationId, findActivityRefByMutationId } from '#/db/prepared';
 
 /**
- * Check if a transaction has already been processed.
- * Idempotency check for replayed mutations.
- *
- * Uses a prepared statement since this runs on every create/update mutation.
+ * Idempotency check for replayed mutations: has this transaction already been processed?
+ * Prepared statement, since it runs on every create/update mutation.
  *
  * @param stxId - The client-generated mutation ID (nanoid)
- * @returns true if transaction exists in activities, false otherwise
  */
 export async function isTransactionProcessed(stxId: string): Promise<boolean> {
   const existing = await findActivityByMutationId.execute({ mutationId: stxId });
@@ -30,13 +27,10 @@ interface EntityReference {
 }
 
 /**
- * Get the entity created/modified by a transaction.
- * Returns the existing entity for idempotent responses.
- *
- * Uses a prepared statement since this runs on every create/update mutation.
+ * Get the entity created/modified by a transaction (the existing entity, for idempotent responses).
+ * Prepared statement, since it runs on every create/update mutation.
  *
  * @param stxId - The client-generated mutation ID (nanoid)
- * @returns Entity reference if found, null otherwise
  */
 export async function getEntityByTransaction(stxId: string): Promise<EntityReference | null> {
   const [activity] = await findActivityRefByMutationId.execute({ mutationId: stxId });

--- a/backend/src/utils/order-column.ts
+++ b/backend/src/utils/order-column.ts
@@ -1,12 +1,8 @@
 import { type AnyColumn, asc, desc, type SQLWrapper } from 'drizzle-orm';
 
 /**
- * Get a Drizzle order column for use in `.orderBy()`.
- * @param sort - The sort key from query params
- * @param def - Default column to sort by if sort is undefined
- * @param order - Sort direction ('asc' or 'desc'), defaults to 'asc'
- * @param sortOptions - Object mapping sort keys to Drizzle columns
- * @returns A Drizzle `asc` or `desc` wrapped column
+ * Get a Drizzle `asc`/`desc` order column for `.orderBy()`, resolving `sort` against
+ * `sortOptions` (a map of query-param sort keys → columns) and falling back to `def`.
  */
 export const getOrderColumn = <T extends Record<string, AnyColumn | SQLWrapper>, U extends keyof T>(
   sort: U | undefined,

--- a/backend/src/utils/time-span.ts
+++ b/backend/src/utils/time-span.ts
@@ -1,9 +1,7 @@
 export type TimeSpanUnit = 'ms' | 's' | 'm' | 'h' | 'd' | 'w';
 
 /**
- * Time span to represent a duration of time.
- * @param value - The value of the time span.
- * @param unit - The unit of the time span. Can be 'ms', 's', 'm', 'h', 'd', or 'w'.
+ * A duration of time, convertible between units.
  * @example
  * const timeSpan = new TimeSpan(1, 'h');
  * console.info(timeSpan.milliseconds()); // 3600000

--- a/backend/src/utils/unsubscribe-token.ts
+++ b/backend/src/utils/unsubscribe-token.ts
@@ -25,12 +25,8 @@ export const generateUnsubscribeToken = (email: string) => {
 };
 
 /**
- * Verifies if a given unsubscribe token matches the generated token for a specific email.
- * Uses timing-safe comparison to prevent timing attacks.
- *
- * @param email - Email address associated with unsubscribe request.
- * @param token - Token to verify against generated token.
- * @returns Boolean(if provided token matches, generated token).
+ * Verifies an unsubscribe token against the one derived from `email`, using a
+ * timing-safe comparison to prevent timing attacks.
  */
 export const verifyUnsubscribeToken = (email: string, token: string) => {
   const expected = new TextEncoder().encode(generateUnsubscribeToken(email));

--- a/backend/src/utils/validate-block-urls.ts
+++ b/backend/src/utils/validate-block-urls.ts
@@ -10,9 +10,6 @@ type ValidationResult = { valid: true } | { valid: false; invalidUrls: string[] 
 
 /**
  * Validates that all media URLs in BlockNote JSON content are from trusted sources.
- * Parses the JSON string and delegates to the shared validation utility.
- *
- * @param blocksJson - Serialized BlockNote JSON string
  * @param extraAllowedDomains - Optional additional trusted domains (e.g., ['mycompany.com'])
  */
 export const validateBlockMediaUrls = (blocksJson: string, extraAllowedDomains?: string[]): ValidationResult => {

--- a/backend/tests/integration/rls-security.test.ts
+++ b/backend/tests/integration/rls-security.test.ts
@@ -406,9 +406,7 @@ async function queryWithoutChannel<T = Record<string, unknown>>(
   });
 }
 
-// ============================================================================
 // Session context tests (run with superuser connection)
-// ============================================================================
 
 describe('RLS Security Tests', () => {
   describe('Tenant Context Helpers', () => {
@@ -514,9 +512,7 @@ describe('RLS Security Tests', () => {
   });
 });
 
-// ============================================================================
 // RLS policy verification (runtime_role connection, genuinely subject to RLS)
-// ============================================================================
 
 /**
  * Whether the environment can run the RLS suite: roles + base tables present.

--- a/cdc/src/lib/tracing.ts
+++ b/cdc/src/lib/tracing.ts
@@ -14,9 +14,7 @@ import { log } from './pino';
 export { activityAttrs, cdcAttrs, cdcSpanNames };
 export type { TraceContext };
 
-// ================================
 // OTel SDK
-// ================================
 
 const debugProcessor = createSpanStoreProcessor({
   onSpanEnd: (span) => {
@@ -37,9 +35,7 @@ export const otel: OtelSDK = createOtelSDK({
   spanProcessors: [debugProcessor],
 });
 
-// ================================
-// OTel Health Metrics
-// ================================
+// OTel health metrics
 
 const meter = otel.meterProvider.getMeter('cdc-health');
 
@@ -74,9 +70,7 @@ meter.createObservableGauge('cdc.replication.status', {
   result.observe(statusMap[replicationState.status]);
 });
 
-// ================================
-// OTel Tracer + withSpan
-// ================================
+// OTel tracer + withSpan
 
 const tracer = trace.getTracer(`${appConfig.name}-cdc`);
 

--- a/cdc/src/pipeline/handle-message.ts
+++ b/cdc/src/pipeline/handle-message.ts
@@ -15,9 +15,7 @@ import { parseMessage } from './parse-message';
 import { processEvents } from './process-events';
 import { runPostCatchupRecovery } from '../services/catchup-recovery';
 
-// ================================
 // Message helpers
-// ================================
 
 /** Narrowed DML message type. */
 type DmlMessage = Pgoutput.MessageInsert | Pgoutput.MessageUpdate | Pgoutput.MessageDelete;
@@ -58,9 +56,7 @@ async function acknowledgeLsn(lsn: string): Promise<void> {
   }
 }
 
-// ================================
 // Buffers
-// ================================
 
 /** Flush buffer: accumulates events across transactions for micro-batching */
 const flushBuffer = new FlushBuffer(processEvents, acknowledgeLsn, RESOURCE_LIMITS.buffers.flushWindowMs);
@@ -68,9 +64,7 @@ const flushBuffer = new FlushBuffer(processEvents, acknowledgeLsn, RESOURCE_LIMI
 /** Transaction buffer: cascade suppression within a single transaction */
 const txBuffer = new TransactionBuffer((events) => flushBuffer.enqueue(events));
 
-// ================================
 // Message handling
-// ================================
 
 /**
  * Handle incoming replication data message.

--- a/cdc/src/pipeline/process-events.ts
+++ b/cdc/src/pipeline/process-events.ts
@@ -26,9 +26,7 @@ interface PreparedEvent {
   rowData: CdcRowData;
 }
 
-// ================================
 // Activity persistence
-// ================================
 
 /**
  * Prepare an activity for persistence: generate ID, extract seq.
@@ -114,9 +112,7 @@ async function persistActivities(
   return true;
 }
 
-// ================================
 // Sync dispatch
-// ================================
 
 /** Forward stamped events to the API server: one batch payload, or a single payload. */
 function dispatchToApi(stamped: PreparedEvent[], traceCtx: TraceContext): void {
@@ -133,9 +129,7 @@ function dispatchToApi(stamped: PreparedEvent[], traceCtx: TraceContext): void {
   }
 }
 
-// ================================
 // Unified event processing
-// ================================
 
 /**
  * Process one or more CDC events through three sequenced concerns:

--- a/cdc/src/pipeline/replication.ts
+++ b/cdc/src/pipeline/replication.ts
@@ -14,9 +14,7 @@ import { handleDataMessage } from './handle-message';
 
 const { reconnection, slotTakeover } = RESOURCE_LIMITS;
 
-// ================================
 // Replication service setup
-// ================================
 
 /**
  * Build the replication connection URL from the CDC database URL.
@@ -72,9 +70,7 @@ export function createReplicationService(): LogicalReplicationService {
   return service;
 }
 
-// ================================
 // Slot management
-// ================================
 
 /**
  * Ensure the replication slot exists, creating it if necessary.
@@ -121,9 +117,7 @@ async function describeSlotHolder(): Promise<Record<string, unknown> | null> {
   }
 }
 
-// ================================
 // Backpressure
-// ================================
 
 /**
  * Wire up WebSocket callbacks for replication backpressure.
@@ -149,9 +143,7 @@ export function setupBackpressure(): void {
   });
 }
 
-// ================================
 // Subscription loop
-// ================================
 
 /**
  * Subscribe to the replication slot with automatic reconnection.

--- a/cdc/src/pipeline/worker.ts
+++ b/cdc/src/pipeline/worker.ts
@@ -12,15 +12,8 @@ import { drainBuffers } from './handle-message';
 import { createReplicationService, ensureReplicationSlot, setupBackpressure, subscribeWithReconnect } from './replication';
 
 /**
- * CDC Worker orchestrator.
- *
- * Pipeline stages (reflected in file structure):
- *   1. table-registry: what tables are tracked
- *   2. parse-message: parse a raw WAL change into activity + row data
- *   3. handle-message: receive, route through tx boundaries, buffer
- *   4. process-events: persist activities, compute deltas, WS dispatch
- *   5. replication: PG logical replication lifecycle
- *   6. worker (this): orchestration, start & stop
+ * CDC Worker orchestrator: start & stop. Pipeline stages and their file layout are
+ * documented in cdc/README.md ("Pipeline stages").
  */
 export async function startCdcWorker(): Promise<void> {
   log.info(`CDC worker starting...`, {

--- a/cdc/src/services/flush-buffer.ts
+++ b/cdc/src/services/flush-buffer.ts
@@ -4,17 +4,11 @@ import { RESOURCE_LIMITS } from '../constants';
 import { cdcMetrics } from './cdc-metrics';
 
 /**
- * Cross-transaction micro-batching buffer.
- *
- * Accumulates surviving events (post-cascade-analysis) from multiple committed
- * transactions, then flushes them as merged groups after a configurable window.
- *
- * When windowMs is 0, events are processed immediately.
- * When windowMs > 0, events accumulate for up to windowMs before flushing,
- * amortizing DB roundtrips across independent single-row commits.
- *
- * Grouping uses tableMeta.type (works for both entities and resources)
- * combined with action.
+ * Cross-transaction micro-batching buffer. Accumulates surviving events
+ * (post-cascade-analysis) from multiple committed transactions and flushes them as merged
+ * groups. windowMs 0 flushes immediately; windowMs > 0 accumulates up to that window,
+ * amortizing DB roundtrips across independent single-row commits. Groups by tableMeta.type
+ * (works for both entities and resources) combined with action.
  */
 export class FlushBuffer {
   private pending: PendingEvent[] = [];

--- a/cdc/src/services/retry.ts
+++ b/cdc/src/services/retry.ts
@@ -50,10 +50,7 @@ type RetryResult<T> =
 
 /**
  * Execute an async function with exponential backoff retry for transient errors.
- *
- * @param fn - The async function to execute
- * @param context - Context string for logging (e.g., "insert activity")
- * @returns RetryResult indicating success or failure with metadata
+ * @param context - label for logging (e.g., "insert activity")
  */
 export async function withRetry<T>(fn: () => Promise<T>, context: string): Promise<RetryResult<T>> {
   let lastError: Error = new Error('No attempts made');

--- a/frontend/src/hooks/use-auto-resize.tsx
+++ b/frontend/src/hooks/use-auto-resize.tsx
@@ -1,15 +1,9 @@
 import * as React from 'react';
 
 /**
- * Custom hook to automatically resize a textarea based on its content.
- *
- * This hook adjusts the height of a `<textarea>` element based on its content. It will resize the textarea as
- * the user types, making it expand or contract according to the `scrollHeight`. The hook exposes the textarea
- * reference to parent components via `useImperativeHandle`.
- *
- * @param autoResize - Boolean flag indicating whether the auto-resizing behavior should be applied.
- *
- * @returns An object containing the `areaRef` to be used in the parent component.
+ * Auto-resizes a `<textarea>` to fit its content on input, matching height to `scrollHeight`.
+ * @param autoResize - Enables the resize behavior when true.
+ * @returns `{ areaRef }` ref to attach to the textarea.
  */
 export const useAutoResize = (autoResize: boolean) => {
   const areaRef = React.useRef<HTMLTextAreaElement>(null);

--- a/frontend/src/hooks/use-before-unload.tsx
+++ b/frontend/src/hooks/use-before-unload.tsx
@@ -2,13 +2,9 @@ import { useEffect } from 'react';
 import { appConfig } from 'shared';
 
 /**
- * Custom hook to show a confirmation dialog when the user tries to leave the page with unsaved changes.
- *
- * This hook listens for the `beforeunload` event and triggers a confirmation dialog if there are unsaved changes.
- * It prevents the page from being unloaded until the user confirms, preventing data loss.
- * In development mode, a log is shown instead of the confirmation dialog.
- *
- * @param isChanged - Boolean flag indicating whether there are unsaved changes.
+ * Warns the user before leaving the page when there are unsaved changes (via `beforeunload`).
+ * In development mode it logs instead of showing the dialog.
+ * @param isChanged - Whether there are unsaved changes.
  */
 export const useBeforeUnload = (isChanged: boolean) => {
   useEffect(() => {

--- a/frontend/src/hooks/use-copy-to-clipboard.tsx
+++ b/frontend/src/hooks/use-copy-to-clipboard.tsx
@@ -1,16 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 
 /**
- * Custom hook to copy text to the clipboard and handle success/error states.
- * After a successful copy, the `copied` state will be set to `true` and reset after a specified timeout duration.
- *
- * @param timeoutDuration - Optional timeout in milliseconds after which the `copied` state will be reset.
- *   Default is `3000` milliseconds (3 seconds).
- *
- * @returns An object containing:
- *   - `copied`: A boolean indicating whether the text has been successfully copied to the clipboard.
- *   - `error`: An error object if the copy operation fails, otherwise `null`.
- *   - `copyToClipboard`: A function to trigger the copy action with the text to be copied as the argument.
+ * Copies text to the clipboard, exposing `copied`/`error` state and a `copyToClipboard(text)` action.
+ * `copied` flips true on success and resets after `timeoutDuration` ms.
+ * @param timeoutDuration - Reset delay in ms (default 3000).
  */
 export const useCopyToClipboard = (timeoutDuration = 3000) => {
   const [copied, setCopied] = useState(false);

--- a/frontend/src/hooks/use-lazy-component.tsx
+++ b/frontend/src/hooks/use-lazy-component.tsx
@@ -1,11 +1,7 @@
 import { type ComponentType, type LazyExoticComponent, lazy, useEffect, useRef, useState } from 'react';
 
 /**
- * Lazily loads a component after a specified delay.
- *
- * @param importFunc - Function returning a promise for the component.
- * @param delay - Delay in milliseconds before loading.
- * @returns Lazily loaded component.
+ * Lazily loads `exportName` from a dynamic import, `delay` ms after mount. Returns null until loaded.
  */
 export function useLazyComponent<
   // biome-ignore lint/suspicious/noExplicitAny: Supports components with any prop shape.

--- a/frontend/src/hooks/use-search-params.tsx
+++ b/frontend/src/hooks/use-search-params.tsx
@@ -12,15 +12,10 @@ type SearchParams<T> = {
 };
 
 /**
- * Hook to manage and synchronize search parameters (query string) with the URL.
- *
- * @template T - The type of search parameters (query string).
- * @param from - The route identifier (optional). If provided, the hook is scoped to that route.
- * @param defaultValues - Default values for search parameters (optional).
- * @param saveDataInSearch - Whether changes should be persisted to URL (default: `true`). Also controls whether existing URL params are read on mount.
- * @returns An object with:
- *   - `search`: The current search parameters (query string).
- *   - `setSearch`: A function to update the search parameters and sync with the URL.
+ * Manages search parameters (query string) and optionally syncs them to the URL.
+ * @param from - Route id to scope the hook to (optional).
+ * @param saveDataInSearch - Persist changes to the URL; also gates whether existing URL params are read on mount (default: `true`).
+ * @returns `{ search, setSearch }`.
  */
 export function useSearchParams<T extends Record<string, string | string[] | undefined>>(
   searchParams?: SearchParams<T>,

--- a/frontend/src/lib/export.ts
+++ b/frontend/src/lib/export.ts
@@ -10,18 +10,7 @@ dayjs.extend(localizedFormat);
 type Row = Record<string, any>;
 type Column = ColumnOrColumnGroup<Row>;
 
-/**
- * Exports table data to a CSV file.
- *
- * Filters columns, formats rows, serializes cell values, and creates a CSV file.CSV content is then
- * downloaded with provided file name.
- *
- * @param columns - Column definitions (key and name) for table.
- * @param rows - Data rows to be displayed in table.
- * @param fileName - Name of generated CSV file.
- *
- * @returns A promise that resolves when CSV is downloaded.
- */
+/** Exports visible table columns/rows to a downloadable CSV file. */
 export async function exportToCsv<R extends Row>(
   columns: { key: string; name: ReactElement | string }[],
   rows: R[],
@@ -38,19 +27,8 @@ export async function exportToCsv<R extends Row>(
 }
 
 /**
- * Generates and exports tabular data to a PDF file, applying styling based on dark or light mode.
- *
- * Filters the columns, formats the rows into a table, and dynamically imports `jsPDF` and `jspdf-autotable`
- * to create and style PDF. Export includes metadata like the page name and export date. PDF is
- * saved with the provided filename.
- *
- * @param columns - Column definitions (key and name) for table.
- * @param rows - Data rows to be displayed in table.
- * @param fileName - Name of generated PDF file.
- * @param pageName - Name of page from which data is exported.
- * @param mode - Mode `"dark" | "light"` to determine color scheme.
- *
- * @returns A promise that resolves when PDF is saved.
+ * Exports table data to a PDF, styled for dark/light `mode`, with a page-name + export-date header.
+ * Lazy-imports `jsPDF`/`jspdf-autotable` to keep them out of the main bundle.
  */
 export async function exportToPdf<R extends Row>(
   columns: { key: string; name: ReactElement | string }[],

--- a/frontend/src/lib/tracing.ts
+++ b/frontend/src/lib/tracing.ts
@@ -12,9 +12,7 @@ import { spanStore, tracer } from './otel';
 export type { SpanData };
 export { frontendSpanNames as syncSpanNames };
 
-// ================================
 // Public API for devtools
-// ================================
 
 export function getSpans(): SpanData[] {
   return spanStore.getSpans();
@@ -36,9 +34,7 @@ export function getSpanStats(): SpanStats {
   return spanStore.getStats();
 }
 
-// ================================
 // Span attribute helpers
-// ================================
 
 interface SpanAttrs {
   [key: string]: string | number | boolean | null | undefined | IncomingTraceContext;
@@ -58,9 +54,7 @@ function applyAttrs(span: Span, attrs: SpanAttrs): void {
   }
 }
 
-// ================================
 // withSpan helpers
-// ================================
 
 export async function withSpan<T>(name: string, attrs: SpanAttrs, fn: (ctx: TraceContext) => Promise<T>): Promise<T> {
   return tracer.startActiveSpan(name, async (span) => {

--- a/frontend/src/modules/attachment/upload-service.ts
+++ b/frontend/src/modules/attachment/upload-service.ts
@@ -9,12 +9,8 @@ import { attachmentStorage } from '~/modules/attachment/dexie/storage-service';
 import { getAppDb } from '~/query/app-db';
 
 /**
- * Upload Service
- *
- * Background service that syncs pending local uploads to cloud storage.
- * Runs periodically and when coming back online.
- *
- * Uses headless Uppy with @uppy/transloadit for reliable uploads with:
+ * Background service that syncs pending local uploads to cloud storage. Runs periodically and when
+ * coming back online. Uses headless Uppy with @uppy/transloadit:
  * - Tus resumable upload protocol
  * - Built-in exponential backoff for rate limiting
  * - Lazy token fetching per upload (never expires mid-upload)

--- a/frontend/src/modules/auth/passkey-credentials.ts
+++ b/frontend/src/modules/auth/passkey-credentials.ts
@@ -19,13 +19,11 @@ export const isConditionalMediationAvailable = async (): Promise<boolean> => {
 };
 
 /**
- * Starts a conditional mediation (passkey autofill) flow.
- * Returns an AbortController so the caller can cancel it (e.g. on unmount or navigation).
- * When a user selects a passkey from autofill, `onCredential` is called with the assertion data.
+ * Starts a conditional mediation (passkey autofill) flow. Returns an AbortController so the caller
+ * can cancel it (e.g. on unmount or navigation); `onCredential` fires with the assertion data when a
+ * user picks a passkey from autofill.
  *
- * @param onCredential - Callback when user selects a passkey
- * @param signal - AbortSignal to cancel the mediation
- * @param email - Optional email to get specific credential IDs (non-discoverable). If omitted, uses discoverable credentials only.
+ * @param email - Optional. Fetches specific credential IDs (non-discoverable); omit to use discoverable credentials only.
  */
 export const startConditionalMediation = async (
   onCredential: (data: ConditionalMediationResult) => void,

--- a/frontend/src/modules/auth/steps/waitlist.tsx
+++ b/frontend/src/modules/auth/steps/waitlist.tsx
@@ -5,12 +5,7 @@ import { useAuthStore } from '~/modules/auth/auth-store';
 import { LegalNotice } from '~/modules/auth/legal-notice';
 import { WaitlistForm } from '~/modules/requests/waitlist-form';
 
-/**
- * Renders the waitlist request step, including:
- * - Greeting with the user's email and a reset button
- * - Legal notice specific to the waitlist
- * - Waitlist form with a request access button
- */
+/** Waitlist request step: email greeting with reset, waitlist-specific legal notice, and the request form. */
 export function WaitlistStep() {
   const { t } = useTranslation();
 

--- a/frontend/src/modules/auth/use-get-token-data.tsx
+++ b/frontend/src/modules/auth/use-get-token-data.tsx
@@ -4,13 +4,7 @@ import type { TokenType } from 'shared';
 import type { ApiError } from '~/lib/api';
 import type { TokenData } from '~/modules/auth/types';
 
-/**
- *  Get token data by ID.
- *
- * @param type Type of the token
- * @param tokenId Token ID to check
- * @param enabled (Default true) Enable the query
- */
+/** Query token data by ID. */
 export const useGetTokenData = (
   type: TokenType,
   tokenId?: string,

--- a/frontend/src/modules/common/data-grid/cell-renderers/render-expand-toggle.tsx
+++ b/frontend/src/modules/common/data-grid/cell-renderers/render-expand-toggle.tsx
@@ -27,8 +27,7 @@ export interface RenderExpandToggleProps {
   onToggle: () => void;
 }
 
-// ─── Connector geometry ──────────────────────────────────────────────────────
-// All values are in SVG user units == cell pixels (the SVG has no scaling).
+// Connector geometry. All values are in SVG user units == cell pixels (the SVG has no scaling).
 
 /** Column width in px. Must match the column factory's `width`. */
 const COL = 36;

--- a/frontend/src/modules/common/devtools/sync-devtools.tsx
+++ b/frontend/src/modules/common/devtools/sync-devtools.tsx
@@ -1,19 +1,13 @@
 /**
- * Sync Devtools Panel
- *
- * A floating panel for debugging the sync flow in development.
- * Shows real-time spans, latencies, and connection state.
- *
- * Only renders when VITE_DEBUG_MODE=true.
+ * Floating dev-only panel for debugging the sync flow: real-time spans, latencies, and
+ * connection state. Renders only when `VITE_DEBUG_MODE=true`.
  */
 
 import { useEffect, useState } from 'react';
 import { isDebugMode } from '~/env';
 import { clearSpans, getSpanStats, type SpanData, subscribeToSpans } from '~/lib/tracing';
 
-// ================================
 // Types
-// ================================
 
 interface SyncDevtoolsState {
   isOpen: boolean;
@@ -21,9 +15,7 @@ interface SyncDevtoolsState {
   filter: string;
 }
 
-// ================================
 // Helpers
-// ================================
 
 /** Format duration in ms. */
 function formatDuration(ms: number | null): string {
@@ -63,9 +55,7 @@ function getCategoryColor(name: string): string {
   return '#6b7280';
 }
 
-// ================================
 // Styles (inline for zero deps)
-// ================================
 
 const styles = {
   container: {
@@ -220,9 +210,7 @@ const styles = {
   },
 };
 
-// ================================
 // Components
-// ================================
 
 /** Span list view. */
 function SpanList({ spans, filter }: { spans: SpanData[]; filter: string }) {
@@ -402,9 +390,7 @@ function TimelineView({ spans }: { spans: SpanData[] }) {
   );
 }
 
-// ================================
-// Main Component
-// ================================
+// Main component
 
 interface SyncDevtoolsProps {
   isOpen: boolean;

--- a/frontend/src/modules/common/form-draft/use-draft-form.tsx
+++ b/frontend/src/modules/common/form-draft/use-draft-form.tsx
@@ -11,21 +11,14 @@ import { useDraftStore } from '~/modules/common/form-draft/draft-store';
 import { defaultOnInvalid } from '~/utils/form-on-invalid';
 
 /**
- * This hook manages form state with draft-saving support. It automatically
- * restores saved drafts on mount and tracks unsaved changes.
+ * Form state with draft-saving: restores saved drafts on mount, tracks unsaved changes.
+ * Drafts persist via a debounced `form.watch` subscription (not per keystroke) and flush on
+ * unmount to prevent data loss.
  *
- * Drafts are persisted via a debounced subscription (not on every keystroke)
- * and flushed on unmount to prevent data loss.
- *
- * @param formId - A unique identifier for the form draft storage.
- * @param opt - Optional configuration:
- *   - `formOptions`: Props passed to `useForm()` from react-hook-form.
- *   - `formContainerId`: element id to target and toggle .unsaved-changes class with.
- *
- * @returns - Returns form methods along with:
- *  - `isDirty`: `true` if the form has unsaved changes.
- *  - `unsavedChanges`: `true` if the form has unsaved changes (alias for isDirty).
- *  - `loading`: `true` while restoring draft data.
+ * @param formId - Unique key for the draft storage.
+ * @param opt.formOptions - Passed through to react-hook-form's `useForm()`.
+ * @param opt.formContainerId - Element id whose `.unsaved-changes` class is toggled.
+ * @returns Form methods plus `isDirty`/`unsavedChanges` (aliases) and `loading` (true while restoring).
  */
 // biome-ignore lint/suspicious/noExplicitAny: Can be any form context
 export function useFormWithDraft<TFieldValues extends FieldValues = FieldValues, TContext = any>(

--- a/frontend/src/modules/common/json-viewer/json-viewer.stories.tsx
+++ b/frontend/src/modules/common/json-viewer/json-viewer.stories.tsx
@@ -447,9 +447,7 @@ export const AllFeatures: Story = {
   },
 };
 
-// ============================================================================
-// Interaction Tests
-// ============================================================================
+// Interaction tests
 
 /**
  * Tests that clicking a collapsed node expands it to show children.

--- a/frontend/src/modules/common/stories/data-grid.stories.tsx
+++ b/frontend/src/modules/common/stories/data-grid.stories.tsx
@@ -246,9 +246,7 @@ export default meta;
 
 type Story = StoryObj<DataGridProps<Person>>;
 
-// ============================================================================
 // Core stories
-// ============================================================================
 
 /** Default data grid with basic columns. */
 export const Default: Story = {};
@@ -444,9 +442,7 @@ export const CopyCell: Story = {
   },
 };
 
-// ============================================================================
 // Interaction tests (hidden from sidebar)
-// ============================================================================
 
 export const ShouldSelectCellOnClick: Story = {
   name: 'when cell is clicked, should select it',
@@ -679,9 +675,7 @@ export const ShouldFreezeFrozenColumns: Story = {
   },
 };
 
-// ============================================================================
 // Column drag-and-drop stories
-// ============================================================================
 
 const draggableHeaderColumns: Column<Person>[] = [
   { key: 'firstName', name: 'First Name', width: 120, draggable: true },
@@ -789,9 +783,7 @@ export const ShouldReorderColumnOnDragDrop: Story = {
   },
 };
 
-// ============================================================================
 // Row drag-and-drop stories
-// ============================================================================
 
 interface DraggablePerson extends Person {
   displayOrder: number;

--- a/frontend/src/modules/common/stories/focus-trap.stories.tsx
+++ b/frontend/src/modules/common/stories/focus-trap.stories.tsx
@@ -3,9 +3,7 @@ import { useState } from 'react';
 import { expect, userEvent, waitFor } from 'storybook/test';
 import { FocusTrap } from '../focus-trap';
 
-// ============================================================================
 // Helpers
-// ============================================================================
 
 function TrapWithButtons({
   label = 'Trap',
@@ -153,9 +151,7 @@ function DisableInactiveTrap() {
   );
 }
 
-// ============================================================================
 // Meta
-// ============================================================================
 
 const meta = {
   title: 'common/FocusTrap',
@@ -169,9 +165,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-// ============================================================================
 // Visual stories
-// ============================================================================
 
 /**
  * Basic active focus trap. Tab cycles through the buttons and wraps around
@@ -228,9 +222,7 @@ export const DisableInactive: Story = {
   render: () => <DisableInactiveTrap />,
 };
 
-// ============================================================================
 // Interaction tests (hidden from sidebar)
-// ============================================================================
 
 export const ShouldCycleForwardOnTab: Story = {
   name: 'when Tab on last element, should wrap to first',

--- a/frontend/src/modules/marketing/marketing-config.tsx
+++ b/frontend/src/modules/marketing/marketing-config.tsx
@@ -23,9 +23,7 @@ import type { InfoCard } from '~/modules/marketing/about/info-cards';
 import type { PricingPlan } from '~/modules/marketing/about/pricing';
 import type { ShowcaseItem } from '~/modules/marketing/about/showcase';
 
-/*************************************************************************************************
- * Nav
- ************************************************************************************************/
+// Nav
 
 export const marketingNavConfig = [
   { id: 'features', url: '/features', hash: '' },
@@ -34,9 +32,7 @@ export const marketingNavConfig = [
   { id: 'docs', url: '/docs', hash: '' },
 ];
 
-/*************************************************************************************************
- * Footer
- ************************************************************************************************/
+// Footer
 
 export const socials = [
   { title: 'Social', href: appConfig.company.socialUrl, icon: CloudIcon },
@@ -66,18 +62,14 @@ export const footerSections = [
   },
 ];
 
-/*************************************************************************************************
- * Legal
- ************************************************************************************************/
+// Legal
 
 export const legalLinks = [
   { title: 'c:legal', href: '/legal' },
   { title: 'c:accessibility', href: '/accessibility' },
 ];
 
-/*************************************************************************************************
- * About - Stack (tech-stack tile grid on /about)
- ************************************************************************************************/
+// About - Stack (tech-stack tile grid on /about)
 
 export const stackItems = [
   { id: 'hono' },
@@ -91,22 +83,8 @@ export const stackItems = [
   { id: 'artillery' },
 ];
 
-/*************************************************************************************************
- * Features page — categorised capability list (/features)
- *
- * Categories (suggested):
- *   sync        Sync, realtime & offline
- *   security    Security & multi-tenancy
- *   auth        Authentication
- *   dx          Developer experience
- *   deploy      Deployment & infrastructure
- *   performance Performance & observability
- *   data        Data modelling
- *
- * Each item maps to translation keys:
- *   about:features.<id>
- *   about:features.<id>.text
- ************************************************************************************************/
+// Features page — categorised capability list (/features).
+// Each item maps to translation keys `about:features.<id>` and `about:features.<id>.text`.
 
 export type FeatureCategory = 'security' | 'auth' | 'ux' | 'dx' | 'deploy' | 'performance' | 'data';
 
@@ -187,22 +165,10 @@ export const featuresPageItems: FeaturesPageItem[] = [
   { id: 'load_testing', category: 'performance' },
 ];
 
-/*************************************************************************************************
- * Sync engine — categorised capability list (/sync-engine)
- *
- * Kept separate from featuresPageItems so the sync engine page can group its
- * many capabilities into readable sub-categories.
- *
- * Each item maps to translation keys:
- *   about:features.<id>
- *   about:features.<id>.text
- * Each category maps to:
- *   about:features.category_<category>
- *
- * `layers` tags which part of the stack a capability lives in (client, api,
- * cdc, yjs), rendered as badges after the title so it's clear where each
- * feature runs. Multiple layers means the capability spans them.
- ************************************************************************************************/
+// Sync engine — categorised capability list (/sync-engine). Kept separate from featuresPageItems so
+// this page can group its many capabilities into sub-categories.
+// Translation keys: item → `about:features.<id>` / `.text`; category → `about:features.category_<category>`.
+// `layers` tags which part of the stack a capability runs in; rendered as badges, multiple means it spans them.
 
 export type SyncCategory = 'realtime' | 'offline' | 'consistency' | 'resilience';
 
@@ -258,9 +224,7 @@ export const syncPageItems: SyncPageItem[] = [
   { id: 'catchup_recovery', category: 'resilience', layers: ['cdc', 'api'] },
 ];
 
-/*************************************************************************************************
- * About - Cards
- ************************************************************************************************/
+// About - Cards
 
 export const cards: InfoCard[] = [
   { name: 'Transloadit', country: 'DE', url: 'transloadit.com', id: 'transloadit' },
@@ -272,9 +236,7 @@ export const cards: InfoCard[] = [
   { name: 'Gleap', country: 'AT', url: 'gleap.io', id: 'gleap' },
 ];
 
-/*************************************************************************************************
- * About - Pricing plan
- ************************************************************************************************/
+// About - Pricing plan
 
 export const pricingPlans: PricingPlan[] = [
   { id: 'donate', action: 'contact_us', priceId: null, featureCount: 5, borderColor: '' },
@@ -289,9 +251,7 @@ export const pricingPlans: PricingPlan[] = [
   { id: 'partner', action: 'contact_us', priceId: null, featureCount: 3, borderColor: '' },
 ];
 
-/*************************************************************************************************
- * About - FAQ
- ************************************************************************************************/
+// About - FAQ
 
 export const faqsData = [
   { id: 'production-ready', link: appConfig.company.githubUrl },
@@ -300,18 +260,14 @@ export const faqsData = [
   { id: 'cella-made-in-europe' },
 ];
 
-/*************************************************************************************************
- * About - Counters
- ************************************************************************************************/
+// About - Counters
 
 export const counts = [
   { id: 'user', title: 'c:users', icon: UsersIcon },
   { id: 'organization', title: 'c:organization_other', icon: Building2Icon },
 ] as const satisfies readonly { id: EntityType; title: string; icon: IconComponent }[];
 
-/*************************************************************************************************
- * About - Why
- ************************************************************************************************/
+// About - Why
 
 export const whyItems = [{ id: 'implementation-ready' }, { id: 'prebuilt-endpoints' }, { id: 'dedicated-community' }];
 
@@ -362,9 +318,7 @@ export const whyDarkSlides = [
   },
 ];
 
-/*************************************************************************************************
- * About - Showcase
- ************************************************************************************************/
+// About - Showcase
 
 export const showcaseItems: ShowcaseItem[] = [
   {

--- a/frontend/src/modules/memberships/query.ts
+++ b/frontend/src/modules/memberships/query.ts
@@ -29,22 +29,7 @@ const keys = {
 
 export const memberQueryKeys = keys;
 
-/**
- * Infinite query options to fetch a paginated list of members.
- *
- * This function returns the configuration needed to query a list of members from target entity with pagination.
- *
- * @param param.entityId - ID or slug of entity.
- * @param param.entityType - Type of entity.
- * @param param.tenantId - Tenant ID.
- * @param param.organizationId - ID or slug of organization.
- * @param param.q - Optional search query to filter members by (default is an empty string).
- * @param param.role - Role of the members to filter by.
- * @param param.sort - Field to sort by (default is 'createdAt').
- * @param param.order - Order of sorting (default is 'desc').
- * @param param.limit - Number of items per page (default is configured in `appConfig.requestLimits.members`).
- * @returns Infinite query options.
- */
+/** Infinite query options for a paginated list of members of the target entity. */
 export const membersListQueryOptions = ({
   entityId,
   tenantId,
@@ -77,21 +62,7 @@ export const membersListQueryOptions = ({
   });
 };
 
-/**
- * Infinite query options to fetch a paginated list of invited members.
- *
- * This function returns the configuration needed to query a list of members from target entity with pagination.
- *
- * @param param.entityId - ID or slug of entity.
- * @param param.entityType - Type of entity.
- * @param param.tenantId - Tenant ID.
- * @param param.organizationId - ID or slug of organization.
- * @param param.q - Optional search query to filter invited members by (default is an empty string).
- * @param param.sort - Field to sort by (default is 'createdAt').
- * @param param.order - Order of sorting (default is 'desc').
- * @param param.limit - Number of items per page (default is configured in `appConfig.requestLimits.pendingMemberships`).
- * @returns Infinite query options.
- */
+/** Infinite query options for a paginated list of invited (pending) members of the target entity. */
 export const pendingMembershipsQueryOptions = ({
   entityId,
   tenantId,

--- a/frontend/src/modules/navigation/app-nav-loader.tsx
+++ b/frontend/src/modules/navigation/app-nav-loader.tsx
@@ -9,11 +9,9 @@ import { useNavigationStore } from '~/modules/navigation/navigation-store';
 import { cn } from '~/utils/cn';
 
 /**
- * Navigation loader component.
- * Shows logo for 3 seconds on startup (scales up and fades in), then transitions out
- * before the home icon appears. During subsequent loading states, shows a spinner.
- * Skips the initial logo animation if the menu sheet is already open.
- * Uses debounced loading state to avoid flickering for quick loads.
+ * Shows the logo for 3s on startup (scale-up + fade), transitioning out before the home icon; a
+ * spinner for subsequent loading states. Skips the intro animation if the menu sheet is already
+ * open. Loading state is debounced to avoid flicker on quick loads.
  */
 export function AppNavLoader({ className }: { className?: string }) {
   const [hasLoaded, setHasLoaded] = useState(false);

--- a/frontend/src/modules/navigation/app-nav.tsx
+++ b/frontend/src/modules/navigation/app-nav.tsx
@@ -11,10 +11,9 @@ import { SidebarNav } from '~/modules/navigation/sidebar-nav';
 import type { NavItem, TriggerNavItemFn } from '~/modules/navigation/types';
 import { navItems } from '~/nav-config';
 
-/** Application navigation component.
- * - Renders floating, sidebar, or bottom bar nav.
- * - Manages navigation item triggering, including routing and sheet handling.
- * - Sets up hotkeys for quick navigation access.
+/**
+ * Renders the nav as a floating, sidebar, or bottom bar. Handles nav-item triggering (routing +
+ * sheet) and sets up quick-navigation hotkeys.
  */
 export function AppNav() {
   const navigate = useNavigate();

--- a/frontend/src/modules/navigation/menu-sheet/helpers/build-menu.ts
+++ b/frontend/src/modules/navigation/menu-sheet/helpers/build-menu.ts
@@ -14,14 +14,7 @@ function buildInitialMenu<const T extends readonly { entityType: ChannelEntityTy
 // Base menu
 const baseMenu = buildInitialMenu(appConfig.menuStructure);
 
-/**
- * Builds a user menu from a mapping of channel entity types to their corresponding items.
- *
- * @param byType - A map of entity types to their menu items
- * @param menuStructure - The menu structure configuration
- * @param opts - Optional configuration for building detailed menu with submenus
- * @returns The constructed user menu with items grouped by entity type
- */
+/** Builds a user menu from a map of channel entity types to their items; `opts` enables detailed submenus. */
 export function buildMenu(
   byType: Map<MenuSection['entityType'] | MenuSection['subentityType'], UserMenuItem[]>,
   menuStructure: MenuSection[],

--- a/frontend/src/modules/navigation/menu-sheet/helpers/get-menu-data.ts
+++ b/frontend/src/modules/navigation/menu-sheet/helpers/get-menu-data.ts
@@ -8,11 +8,9 @@ import { queryClient } from '~/query/query-client';
 import { buildMenuFromCache } from './build-menu-from-cache';
 
 /**
- * Ensures entity data is in the cache and returns the user menu.
- * Fetches memberships first so the cache subscriber (initChannelEntityEnrichment)
- * can enrich entity lists automatically, then delegates to buildMenuFromCache.
- *
- * @returns The menu data.
+ * Ensures entity data is in the cache and returns the user menu. Fetches memberships first so the
+ * cache subscriber (initChannelEntityEnrichment) can enrich entity lists, then delegates to
+ * buildMenuFromCache.
  */
 export async function getMenuData() {
   const userId = useUserStore.getState().user.id;

--- a/frontend/src/modules/navigation/menu-sheet/helpers/get-relative-item-order.ts
+++ b/frontend/src/modules/navigation/menu-sheet/helpers/get-relative-item-order.ts
@@ -4,17 +4,7 @@ import { getRelativeOrder } from 'shared/utils/display-order';
 import type { UserMenu } from '~/modules/me/types';
 import { sortAndFilterMenu } from './sort-and-filter-menu';
 
-/**
- * Calculates the relative order position for a dragged item based on its drop location.
- *
- * @param data - The user menu data containing all menu items and submenus
- * @param entityType - The type of channel entity (organization, workspace, etc.)
- * @param archived - Whether to filter for archived items
- * @param itemId - The ID of the item being dragged
- * @param targetOrder - The displayOrder of the drop target
- * @param edge - The drop edge ('top' or 'bottom'), or null
- * @returns The new order value for the item
- */
+/** Computes the new displayOrder for a dragged item from its drop target and edge. */
 export const getRelativeItemOrder = (
   data: UserMenu,
   entityType: ChannelEntityType,

--- a/frontend/src/modules/navigation/menu-sheet/helpers/sort-and-filter-menu.ts
+++ b/frontend/src/modules/navigation/menu-sheet/helpers/sort-and-filter-menu.ts
@@ -1,15 +1,7 @@
 import type { ChannelEntityType } from 'shared';
 import type { UserMenuItem } from '~/modules/me/types';
 
-/**
- * Filters and sorts menu items by entity type and archive state.
- *
- * @param data - The array of menu items to filter and sort
- * @param entityType - The type of channel entity to filter by
- * @param archived - Whether to filter for archived or non-archived items
- * @param reverse - Whether to reverse the sort order (default: false)
- * @returns The filtered and sorted array of menu items
- */
+/** Filters menu items by entity type and archive state, then sorts them (`reverse` flips the order). */
 export const sortAndFilterMenu = (
   data: UserMenuItem[],
   entityType: ChannelEntityType,

--- a/frontend/src/modules/navigation/menu-sheet/helpers/use-menu.ts
+++ b/frontend/src/modules/navigation/menu-sheet/helpers/use-menu.ts
@@ -4,13 +4,9 @@ import { channelEntityListQueriesByType } from '~/list-queries-config';
 import { buildMenuFromCache, menuEntityTypes } from './build-menu-from-cache';
 
 /**
- * React hook that fetches and builds the user menu based on their memberships.
- * Subscribes to entity list queries for granular reactivity. When the cache
- * subscriber enriches data, useQueries detects the update and re-builds the menu.
- *
- * @param userId - The ID of the user to fetch menu data for (optional - queries disabled when undefined)
- * @param opts - Optional configuration for building detailed menu with submenus
- * @returns An object containing the menu, loading state, and any errors
+ * React hook that fetches and builds the user menu from the user's memberships. Subscribes to entity
+ * list queries for granular reactivity: when the cache subscriber enriches data, useQueries detects
+ * the update and re-builds the menu. Queries are disabled when `userId` is undefined.
  */
 export function useMenu(userId: string | undefined) {
   // Subscribe to each entity list query for granular reactivity

--- a/frontend/src/modules/requests/query.ts
+++ b/frontend/src/modules/requests/query.ts
@@ -32,17 +32,7 @@ export const requestsKeys = {
   delete: () => ['requests', 'delete'],
 };
 
-/**
- * Query options to get a paginated list of requests.
- *
- * This function returns infinite query options to fetch a list of requests with support for pagination.
- *
- * @param param.q - Search query for filtering requests(default is an empty string).
- * @param param.sort - Field to sort by (default is 'createdAt').
- * @param param.order - Order of sorting (default is 'desc').
- * @param param.limit - Number of items per page (default: `appConfig.requestLimits.requests`).
- * @returns Infinite query options.
- */
+/** Infinite query options for a paginated list of requests. */
 export const requestsListQueryOptions = ({
   q = '',
   sort = 'createdAt',

--- a/frontend/src/modules/ui/combobox.tsx
+++ b/frontend/src/modules/ui/combobox.tsx
@@ -10,9 +10,7 @@ import { Button } from '~/modules/ui/button';
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from '~/modules/ui/input-group';
 import { cn } from '~/utils/cn';
 
-// ============================================================================
 // Styled base-ui Combobox primitives
-// ============================================================================
 
 const Combobox = ComboboxPrimitive.Root;
 
@@ -335,9 +333,7 @@ function ComboboxSearchInput({
   );
 }
 
-// ============================================================================
 // High-level ComboboxSelect: drop-in for form fields
-// ============================================================================
 
 interface ComboBoxOption {
   value: string;

--- a/frontend/src/modules/ui/field.tsx
+++ b/frontend/src/modules/ui/field.tsx
@@ -18,9 +18,7 @@ import { Label } from '~/modules/ui/label';
 import { Separator } from '~/modules/ui/separator';
 import { cn } from '~/utils/cn';
 
-// ============================================================================
 // Layout primitives (no RHF dependency)
-// ============================================================================
 
 export function FieldSet({ className, ...props }: React.ComponentProps<'fieldset'>) {
   return (
@@ -234,9 +232,7 @@ export function FieldError({
   );
 }
 
-// ============================================================================
 // RHF + base-ui Field integration
-// ============================================================================
 
 export type LabelDirectionType = 'top' | 'left';
 const LabelDirectionContext = React.createContext<LabelDirectionType>('top');

--- a/frontend/src/query/basic/infinite-query-options.ts
+++ b/frontend/src/query/basic/infinite-query-options.ts
@@ -2,19 +2,9 @@ import type { GetNextPageParamFunction } from '@tanstack/react-query';
 import type { PageParams, QueryData } from '~/query/types';
 
 /**
- *  A reusable base options for `infiniteQueryOptions`.
- *
- *  Includes:
- *  - `initialPageParam`: default page parameters `{ page: 0, offset: 0 }`.
- *  - `getNextPageParam`: generic pagination logic that works with
- *    API responses shaped like `{ items: T[]; total: number }`.
- *
- *  Pagination logic:
- *  - Counts how many items are fetched across all pages.
- *  - If fetched count >= `total` -> returns `undefined` (no more pages).
- *  - Otherwise -> returns next page params `{ page, offset }`.
- *
- *  staleTime uses global default from query-client.ts (1 min online, infinite offline).
+ * Reusable base for `infiniteQueryOptions`: `initialPageParam` plus a `getNextPageParam` that pages
+ * any `{ items: T[]; total: number }` response until all items are fetched.
+ * staleTime is intentionally omitted so it inherits the global default from query-client.ts (1 min online, infinite offline).
  */
 export const baseInfiniteQueryOptions = {
   initialPageParam: { page: 0, offset: 0 },

--- a/frontend/src/query/persister.ts
+++ b/frontend/src/query/persister.ts
@@ -13,7 +13,7 @@ const SESSION_KEY_PREFIX = 's-';
 const SESSION_ID_STORAGE_KEY = `${appConfig.slug}-tab-session-id`;
 const ORPHAN_MAX_AGE_MS = 2 * 60 * 60 * 1000; // 2 hours
 
-// -- Query classification ----------------------------------------------------
+// Query classification
 
 const productEntitySet = new Set<string>(appConfig.productEntityTypes);
 
@@ -23,7 +23,7 @@ function isProductQuery(queryKey: unknown): boolean {
   return typeof entity === 'string' && productEntitySet.has(entity);
 }
 
-// -- Session ID management ---------------------------------------------------
+// Session ID management
 
 function getTabSessionId(): string {
   let id = sessionStorage.getItem(SESSION_ID_STORAGE_KEY);
@@ -34,7 +34,7 @@ function getTabSessionId(): string {
   return id;
 }
 
-// -- Persister factory -------------------------------------------------------
+// Persister factory
 
 /**
  * Throttle interval for IDB writes. PersistQueryClientProvider fires on every

--- a/frontend/src/query/tests/persister.test.ts
+++ b/frontend/src/query/tests/persister.test.ts
@@ -30,7 +30,7 @@ const { persister, sessionPersister, cleanupOrphanedSessions } = await import('~
 // The persister reads/writes the live per-user appdb; bind one (owner `u1`) per test.
 const { bindAppDb, deleteAppDb, getAppDb } = await import('~/query/app-db');
 
-// -- Helpers ------------------------------------------------------------------
+// Helpers
 
 function makeQuery(hash: string, entityType: string, dataUpdatedAt: number, data: unknown = null) {
   return {
@@ -69,7 +69,7 @@ async function deleteDb() {
   await deleteAppDb();
 }
 
-// -- Tests --------------------------------------------------------------------
+// Tests
 
 describe('per-query IDB persister', () => {
   beforeEach(async () => {

--- a/frontend/src/utils/date-mini.ts
+++ b/frontend/src/utils/date-mini.ts
@@ -10,19 +10,8 @@ const day = 864e5;
 const year = 31536e6;
 
 /**
- * Converts a date into a minimal format, based on the difference between the current date and the provided start date.
- *
- * If the difference is less than:
- * - a second, returns "now".
- * - a minute, returns the number of seconds.
- * - an hour, returns the number of minutes.
- * - a day, returns the number of hours.
- * - a year, returns the full date in "MMM D" format.
- *
- * @param startDate - The start date to compare against the current date.
- * @param passedLoc - Key for the locale to use for formatting the output.
- * @param addStr - Optional, additional string to append to the result.
- * @returns A string representing the formatted date difference or the full date.
+ * Formats the distance from now as a minimal relative string: "now" (<1s), seconds (<1m),
+ * minutes (<1h), hours (<1d), "MMM D" (<1y), else "MMM D, YYYY". `addStr` is appended to the result.
  */
 export const dateMini = (startDate: string, passedLoc: keyof typeof locale, addStr?: string) => {
   const start = dayjs.utc(startDate).local();

--- a/frontend/src/utils/date-short.ts
+++ b/frontend/src/utils/date-short.ts
@@ -1,17 +1,8 @@
 import dayjs from 'dayjs';
 
 /**
- * Formats a date into a relative time format.
- *
- * The formatting depends on the difference between the given date and the current date:
- * - Today, "Today, H:mm".
- * - Yesterday, "Yesterday, H:mm".
- * - Previous week, the day of the week and time, e.g. "Monday, H:mm".
- * - Last 3 months, the date in the format "MMM D, H:mm".
- * - Otherwise, the full date in the format "MMM D, YYYY".
- *
- * @param date - The date to format. Can be a string, Date object, or null.
- * @returns A formatted string representing the relative time or the full date.
+ * Formats a date as a short relative string: "Today, H:mm", "Yesterday, H:mm", weekday within the
+ * last week, "MMM D, H:mm" within ~3 months, else "MMM D, YYYY". Returns null for a nullish date.
  */
 export const dateShort = (date?: string | null | Date) => {
   if (!date) return null;

--- a/frontend/src/utils/get-draggable-item-data.ts
+++ b/frontend/src/utils/get-draggable-item-data.ts
@@ -9,20 +9,7 @@ export type DraggableItemData<T, D extends string> = {
   displayOrder: number;
 };
 
-/**
- * Creates data for draggable items to be used in a drag-and-drop interface.
- *
- * The function returns an object that contains information necessary for identifying
- * and managing the draggable item in a DnD scenario, including the item
- * itself, its order, and its type.
- *
- * @param item - Item to be dragged.
- * @param itemOrder - Order of item in list or collection.
- * @param type - Type of the draggable item.
- * @param itemType - Entity type of the item.
- *
- * @returns An object containing the item data for DnD functionality.
- */
+/** Builds the drag payload for a draggable item, tagged with its order, type, and entity type. */
 export const getDraggableItemData = <T, D extends string>(
   item: T,
   itemOrder: number,

--- a/frontend/src/utils/truncate-middle.ts
+++ b/frontend/src/utils/truncate-middle.ts
@@ -1,11 +1,4 @@
-/**
- * Truncates a string in the middle if it exceeds the specified maximum length.
- * The truncated string will have an ellipsis ("…") in the middle to indicate that it has been shortened.
- *
- * @param text - The string to be truncated.
- * @param maxLength - The maximum allowed length of the string including the ellipsis.
- * @returns The truncated string if it exceeds the maximum length, otherwise returns the original string.
- */
+/** Truncates `text` to `maxLength` chars by dropping the middle and inserting an ellipsis (…). */
 export const truncateMiddle = (text: string, maxLength: number) => {
   if (text.length <= maxLength) return text;
   const edgeLen = Math.floor((maxLength - 1) / 2);

--- a/frontend/vite/locales-hmr.ts
+++ b/frontend/vite/locales-hmr.ts
@@ -3,12 +3,9 @@ import path from 'node:path';
 import type { HmrContext, ModuleNode, Plugin } from 'vite';
 
 /**
- * Vite plugin for i18next locale file Hot Module Replacement (HMR).
- *
- * This plugin watches locale files (JSON/YAML) in the source directory and:
- * 1. Syncs them to a cache directory for faster access
- * 2. Merges specified namespaces into a target namespace (e.g., 'app' -> 'common')
- * 3. Sends custom HMR events to trigger i18next reloads without full page refresh
+ * Vite plugin for i18next locale-file HMR: watches JSON/YAML locales, syncs them to a cache dir while
+ * merging configured namespaces (e.g. `app` -> `common`), and emits a custom HMR event so i18next
+ * reloads translations without a full page refresh. See {@link localesHMR} for client wire-up.
  *
  * @example
  * ```ts
@@ -106,15 +103,8 @@ async function readJsonIfExists(file: string): Promise<Record<string, unknown>> 
 }
 
 /**
- * Sync a single language directory to the cache.
- *
- * This function:
- * 1. Reads all JSON namespace files from the source language directory
- * 2. Merges configured source namespaces into the target namespace
- * 3. Copies non-merged namespaces as-is to the output directory
- *
- * @param lang - Language code (e.g., 'en', 'nl')
- * @param options - Resolved plugin options
+ * Sync one language directory to the cache: merge configured source namespaces into the target
+ * namespace, and copy the remaining namespaces as-is.
  */
 async function syncLanguage(lang: string, options: Required<LocalesHMROptions>): Promise<void> {
   const { srcDir, outDir, merge, verbose } = options;

--- a/infra/cli/actions/setup.ts
+++ b/infra/cli/actions/setup.ts
@@ -433,7 +433,7 @@ export async function runSetup(context: InfraContext, mode: Extract<CliMode, 're
     must,
   }
 
-  // -- State backend + stack --------------------------------------------------
+  // State backend + stack
   await must('Ensure Pulumi state bucket', 'pnpm', ['ensure-state-bucket'], spawnSync, { retry: true, env: stateBucketEnv })
   await must('Pulumi login (S3 backend)', 'pulumi', ['login', pulumiLoginUrl(appConfig)], spawnSync, { retry: true })
   const selected = spawnSync('pulumi', ['stack', 'select', stackName], { cwd: infraDir, env: childEnv, stdio: 'ignore' })
@@ -450,7 +450,7 @@ export async function runSetup(context: InfraContext, mode: Extract<CliMode, 're
   // is read-only, so it is safe to run before `up`.
   if (!inputs.operatorSecrets.adminEmail) await warnOnMissingOperatorSecrets(ctx)
 
-  // -- Identities: CI deploy key, VM reader key, operator app ------------------
+  // Identities: CI deploy key, VM reader key, operator app
   let ciKey: CiKeyResult = { accessKey: '', secretKey: '', organizationId: '' }
   if (needsCiKey) {
     ciKey = await mintCiKey(ctx)
@@ -488,7 +488,7 @@ export async function runSetup(context: InfraContext, mode: Extract<CliMode, 're
 
   printSummary({ needsCiKey, ciAccessKey: ciKey.accessKey, vmAccessKey, operatorAppId, mode })
 
-  // -- Base infrastructure provisioning ----------------------------------------
+  // Base infrastructure provisioning
   const canDeploy = context.hasCiKey || !!ciKey.accessKey
   if (canDeploy) {
     console.info(`\n${pc.bold('Next: provision base infrastructure')} (registry, DB, network — no compute yet)`)

--- a/infra/compose/infrastructure.ts
+++ b/infra/compose/infrastructure.ts
@@ -116,10 +116,8 @@ function migrateBlock(slug: string, cfg: AppServiceConfig): ComposeService {
   }
 }
 
-// ---------------------------------------------------------------------------
 // Machinery: hand-authored, cella-owned. The one-shot migrate companion and
 // the compose assembly. Not fork data; driven by the fork's service registry.
-// ---------------------------------------------------------------------------
 
 /**
  * Env injected into a `runMigrate` service's app block: its one-shot `migrate`

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -5,9 +5,7 @@ console.info(`Slug: ${naming.slug}`)
 console.info(`Region: ${region}`)
 console.info(`Prefix: ${naming.prefix}`)
 
-// ---------------------------------------------------------------------------
 // Static site (Object Storage)
-// ---------------------------------------------------------------------------
 
 import * as storage from './resources/storage'
 
@@ -15,15 +13,11 @@ export const frontendBucketName = storage.frontendBucketName
 export const frontendBucketEndpoint = storage.frontendBucketEndpoint
 export const frontendWebsiteEndpoint = storage.frontendWebsiteEndpoint
 
-// ---------------------------------------------------------------------------
 // DNS (CAA records)
-// ---------------------------------------------------------------------------
 
 import './resources/dns'
 
-// ---------------------------------------------------------------------------
 // Network + Registry + Upload Buckets
-// ---------------------------------------------------------------------------
 
 import * as network from './resources/network'
 import * as registry from './resources/registry'
@@ -40,9 +34,7 @@ export const privateUploadsBucketEndpoint = storage.privateUploadsBucketEndpoint
 export const bootDiagBucketName = storage.bootDiagBucketName
 export const bootDiagBucketEndpoint = storage.bootDiagBucketEndpoint
 
-// ---------------------------------------------------------------------------
 // Database (Managed PostgreSQL)
-// ---------------------------------------------------------------------------
 
 import * as database from './resources/database'
 
@@ -54,9 +46,7 @@ export const dbConnectionStringRuntime = database.connectionStringRuntime
 export const dbConnectionStringCdc = database.connectionStringCdc
 export const dbConnectionStringAdminPublic = database.connectionStringAdminPublic
 
-// ---------------------------------------------------------------------------
 // Secrets + Compute (Docker Compose VMs)
-// ---------------------------------------------------------------------------
 
 import * as compute from './resources/compute'
 import './resources/secrets'
@@ -65,9 +55,7 @@ import './resources/vm-iam'
 export const computeInstances = compute.computeInstances.map((i) => i.name)
 export const computeGenerationMetadata = compute.computeGenerationMetadata
 
-// ---------------------------------------------------------------------------
 // Load Balancer + API/Yjs/AI DNS
-// ---------------------------------------------------------------------------
 
 import * as lb from './resources/loadbalancer'
 

--- a/infra/lib/scaleway/permissions.ts
+++ b/infra/lib/scaleway/permissions.ts
@@ -1,6 +1,4 @@
-// ───────────────────────────────────────────────────────────────────────────
 // CI deploy key (`<slug>-ci-deploy`): project scope
-// ───────────────────────────────────────────────────────────────────────────
 
 /**
  * Permission sets granted to the CI deploy key at project scope. The `…ReadOnly`
@@ -23,9 +21,7 @@ export const PROJECT_PERMISSION_SETS = [
   'RelationalDatabasesReadOnly',
 ] as const
 
-// ───────────────────────────────────────────────────────────────────────────
 // CI deploy key: organization scope
-// ───────────────────────────────────────────────────────────────────────────
 
 // Org-level grants are split by Scaleway *scope type*: a single IAM policy rule
 // may only hold permission sets of ONE scope type, so these become two separate
@@ -44,9 +40,7 @@ export const ORG_SCOPED_PERMISSION_SETS = ['IAMReadOnly'] as const
 /** Union of all org-level grants, for audit/drift checks only (rule-agnostic). */
 export const ORG_PERMISSION_SETS = [...ORG_WIDE_PROJECT_PERMISSION_SETS, ...ORG_SCOPED_PERMISSION_SETS] as const
 
-// ───────────────────────────────────────────────────────────────────────────
 // VM reader key (`<slug>-vm-reader`): project scope
-// ───────────────────────────────────────────────────────────────────────────
 
 /**
  * Permission sets granted to the VM reader key at project scope. Deliberately
@@ -60,9 +54,7 @@ export const VM_PROJECT_PERMISSION_SETS = [
   'SecretManagerSecretAccess',
 ] as const
 
-// ───────────────────────────────────────────────────────────────────────────
 // Bootstrap-owned boundary
-// ───────────────────────────────────────────────────────────────────────────
 
 /**
  * Resource-token fragments that are bootstrap-owned: NOT write-granted to the CI

--- a/infra/lib/stack/control-store.ts
+++ b/infra/lib/stack/control-store.ts
@@ -196,11 +196,9 @@ export function serializeControlState(state: ControlState): string {
   return `${JSON.stringify(state, null, 2)}\n`
 }
 
-// ---------------------------------------------------------------------------
 // Pure ledger transitions: every rollout state change is a total function over
 // the previous rollout, so the orchestrator never hand-mutates pointer fields
 // and the transitions are unit-tested in isolation.
-// ---------------------------------------------------------------------------
 
 /** A service with no rollout history yet. */
 export function emptyRollout(): ServiceRollout {
@@ -242,10 +240,8 @@ export async function writeControlState(
   return putJsonObject(s3, bucket, key, serializeControlState(state), opts)
 }
 
-// ---------------------------------------------------------------------------
 // Orchestrator helpers (used by the deploy tasks; read process.env / build a
 // client, so not part of the pure unit-tested core above).
-// ---------------------------------------------------------------------------
 
 /** Build an S3 client for the state bucket with explicit credentials. */
 export async function makeControlClient(region: string, accessKey: string, secretKey: string): Promise<S3Like> {
@@ -313,12 +309,10 @@ export async function updateServiceRollout(
   await writeControlState(s3, bucket, key, state, etag ? { ifMatch: etag } : {})
 }
 
-// ---------------------------------------------------------------------------
 // Distributed lock: prevents concurrent mutating ops (two operators, or an
 // operator and CI) from racing on the same stack. Built on Scaleway's
 // conditional writes: atomic create-if-absent via `If-None-Match: *`, stale
 // break via `If-Match: <etag>`.
-// ---------------------------------------------------------------------------
 
 export interface LockInfo {
   owner: string

--- a/infra/lib/stack/pulumi-passphrase.ts
+++ b/infra/lib/stack/pulumi-passphrase.ts
@@ -91,7 +91,5 @@ function decryptStackSecretsFromText(text: string, passphrase: string, keys: str
   return out
 }
 
-// ---------------------------------------------------------------------------
 // Internals exposed for testing (do not import from production code).
-// ---------------------------------------------------------------------------
 export const __testing = { decryptV1, deriveKey, verify, decryptStackSecretsFromText, PBKDF2_ITERATIONS, KEY_LEN, GCM_TAG_LEN }

--- a/infra/resources/compose-env.ts
+++ b/infra/resources/compose-env.ts
@@ -39,14 +39,12 @@ function composePlaceholders(slug: string): string[] {
   return [...vars]
 }
 
-// ---------------------------------------------------------------------------
 // Registry bindings: resolve `@{<slug>.<prop>}` templates from the registry's
 // `bindings` field. Supported properties:
 //   @{<slug>.url}: the service's public URL from the endpoint registry
 //   @{<slug>.privateIp}: the service's current-generation private-network IP
 //   @{<slug>.port}: the service's health/app port
 //   @{self.<prop>}: the consuming service's own values
-// ---------------------------------------------------------------------------
 
 const BINDING_RE = /@\{([a-z]+)\.([a-zA-Z]+)\}/g
 const endpointBySlug = new Map(endpoints.map((e) => [e.slug, e]))

--- a/infra/resources/compute.ts
+++ b/infra/resources/compute.ts
@@ -16,11 +16,9 @@ import { secretIds } from './secrets'
 import { bootDiagBucketName } from './storage'
 import { vmReaderPolicy } from './vm-iam'
 
-// ---------------------------------------------------------------------------
 // Security Group: fully closed inbound; LB reaches VMs via private network.
 // Break-glass access is via Scaleway's serial console (no SSH on the public
 // internet). See infra/README.md, "Emergency access".
-// ---------------------------------------------------------------------------
 
 const securityGroup = new scaleway.instance.SecurityGroup('compute-sg', {
   name: naming.resource('compute-sg'),
@@ -31,13 +29,11 @@ const securityGroup = new scaleway.instance.SecurityGroup('compute-sg', {
   tags,
 })
 
-// ---------------------------------------------------------------------------
 // Runtime secret manifest: metadata only (secret IDs + env var names, never
 // values). Baked directly into the new generation's cloud-init: under immutable
 // releases every change replaces the VM anyway, so there is no reason to deliver
 // it out-of-band. The on-VM boot agent reads it to hydrate /opt/app/.env.runtime
 // from Secret Manager before the app boots.
-// ---------------------------------------------------------------------------
 
 function buildRuntimeSecretsManifest(consumers: RuntimeSecretConsumer[]): pulumi.Output<string> {
   const definitions = unionRuntimeSecrets(consumers)
@@ -60,18 +56,14 @@ function buildRuntimeSecretsManifest(consumers: RuntimeSecretConsumer[]): pulumi
   )
 }
 
-// ---------------------------------------------------------------------------
 // Compose file content (the generated deploy artifact, read at deploy time)
-// ---------------------------------------------------------------------------
 
 const composeContent = fs.readFileSync(
   path.resolve(import.meta.dirname, '../compose.gen.yml'),
   'utf-8',
 )
 
-// ---------------------------------------------------------------------------
 // Cloud-init template
-// ---------------------------------------------------------------------------
 
 interface ServiceConfig {
   name: string
@@ -126,20 +118,16 @@ function buildCloudInit(service: ServiceConfig, releaseSha: string): pulumi.Outp
   )
 }
 
-// ---------------------------------------------------------------------------
 // Compose env: the `${VAR}` placeholder scan + `@{slug.prop}` binding DSL live
 // in resources/compose-env.ts; the per-generation private-IP supplier is the
 // only piece compute owns (it depends on VM planning state below).
-// ---------------------------------------------------------------------------
 
 const buildComposeEnv = createComposeEnvBuilder(currentGenBindingIp, { hostSlug, coHosted })
 
-// ---------------------------------------------------------------------------
 // Create VMs: the service set (`enabled`, `coHosted`, `hostSlug`) and the
 // content-addressed generation plan come from resources/generations.ts; the
 // program derives the content-addressed id for a pending SHA there and
 // materialises each generation here.
-// ---------------------------------------------------------------------------
 
 
 export interface GenerationInstance {
@@ -287,9 +275,7 @@ if (infra.computeEnabled) {
   }
 }
 
-// ---------------------------------------------------------------------------
 // Exports
-// ---------------------------------------------------------------------------
 
 /** All generation VM instances (one per active generation per enabled service). */
 export const computeInstances = instances

--- a/infra/resources/database.ts
+++ b/infra/resources/database.ts
@@ -10,9 +10,7 @@ const dbVolumeSize = infra.dbVolumeSize
 /** Database name derived from slug (e.g. 'cella') */
 const dbSlug = naming.slug.replace(/-/g, '_') // PostgreSQL identifiers can't have hyphens
 
-// ---------------------------------------------------------------------------
 // Passwords: one per role, each from stack config secret or generated.
-// ---------------------------------------------------------------------------
 
 // Resource names (`<role>-password`) are load-bearing: they are the shipped
 // Pulumi identities of the live credentials.
@@ -38,9 +36,7 @@ if (dbPublicEndpoint && !dbPublicAcl) {
   )
 }
 
-// ---------------------------------------------------------------------------
 // PostgreSQL Instance
-// ---------------------------------------------------------------------------
 
 const instance = new scaleway.databases.Instance('main-postgres', {
   name: naming.resource('postgres'),
@@ -79,9 +75,7 @@ if (dbPublicEndpoint && dbPublicAcl) {
   })
 }
 
-// ---------------------------------------------------------------------------
 // Database
-// ---------------------------------------------------------------------------
 
 const database = new scaleway.databases.Database('main-database', {
   instanceId: instance.id,
@@ -89,11 +83,9 @@ const database = new scaleway.databases.Database('main-database', {
   region,
 }, { aliases: [{ type: 'scaleway:index/database:Database' }] })
 
-// ---------------------------------------------------------------------------
 // Users: one per role, matching the PostgreSQL roles used by the application.
 // admin_role: migrations, seeds, system jobs, CDC worker (isAdmin gives BYPASSRLS + REPLICATION)
 // runtime_role: authenticated app requests, subject to RLS
-// ---------------------------------------------------------------------------
 
 const adminUser = new scaleway.databases.User('admin-user', {
   instanceId: instance.id,
@@ -111,10 +103,8 @@ const runtimeUser = new scaleway.databases.User('runtime-user', {
   region,
 })
 
-// ---------------------------------------------------------------------------
 // Privileges: each role gets 'all' on the database (fine-grained table
 // permissions are enforced by the RLS migration, not Scaleway-level grants)
-// ---------------------------------------------------------------------------
 
 new scaleway.databases.Privilege('admin-privilege', {
   instanceId: instance.id,
@@ -132,9 +122,7 @@ new scaleway.databases.Privilege('runtime-privilege', {
   region,
 })
 
-// ---------------------------------------------------------------------------
 // Exports
-// ---------------------------------------------------------------------------
 
 /** Database instance ID */
 export const instanceId = instance.id

--- a/infra/resources/loadbalancer.ts
+++ b/infra/resources/loadbalancer.ts
@@ -37,7 +37,6 @@ function provisionLoadBalancer(): LoadBalancerOutputs {
   const appHost = serviceHost('frontend')
   const appIsAtApex = appHost === dnsZone
 
-  // ---------------------------------------------------------------------------
   // Public hosts: one DNS record + cert per unique HOSTNAME, not per service.
   // Under the same-origin model every path-routed service shares the app host,
   // and decommissioned service hosts (appConfig.legacyUrls) stay alive so their
@@ -46,7 +45,6 @@ function provisionLoadBalancer(): LoadBalancerOutputs {
   // service claims its host first (www stays `app-*`), and a host that moved
   // from endpoint to legacyUrls keeps its service's base name (api.example.com
   // stays `api-*`), so no DNS record or cert is replaced by the migration.
-  // ---------------------------------------------------------------------------
 
   interface PublicHost {
     host: string
@@ -75,17 +73,13 @@ function provisionLoadBalancer(): LoadBalancerOutputs {
   }
   const publicHosts = [...hostEntries.values()]
 
-  // -------------------------------------------------------------------------
   // LB IP (static public IPv4)
-  // -------------------------------------------------------------------------
 
   const lbIp = new scaleway.loadbalancers.Ip('lb-ip', {
     zone,
   })
 
-  // -------------------------------------------------------------------------
   // Load Balancer
-  // -------------------------------------------------------------------------
 
   const lb = new scaleway.loadbalancers.LoadBalancer('main-lb', {
     name: naming.resource('lb'),
@@ -98,11 +92,9 @@ function provisionLoadBalancer(): LoadBalancerOutputs {
     }],
   })
 
-  // -------------------------------------------------------------------------
   // DNS A Records: all point to the LB public IP.
   // Must exist BEFORE Let's Encrypt certificates, since Scaleway validates
   // the cert by resolving the FQDN to the LB IP at creation time.
-  // -------------------------------------------------------------------------
 
   const lbPublicIp = lb.ipAddress
 
@@ -146,12 +138,10 @@ function provisionLoadBalancer(): LoadBalancerOutputs {
     }, { dependsOn: [apexDns] })
   }
 
-  // -------------------------------------------------------------------------
   // Let's Encrypt certificates: gated on the DNS record being publicly
   // resolvable (not merely created) before Scaleway runs the ACME validation,
   // and gated after on `ready` status so an issuance failure surfaces AT the
   // cert with its ACME detail instead of at the frontend attach.
-  // -------------------------------------------------------------------------
 
   const certs = new Map<string, scaleway.loadbalancers.Certificate>()
   const certGates: CertReadyGate[] = []
@@ -181,7 +171,6 @@ function provisionLoadBalancer(): LoadBalancerOutputs {
     certGates.push(new CertReadyGate('apex-cert-ready', { certificateId: apexCert.id }, { dependsOn: [apexCert] }))
   }
 
-  // -------------------------------------------------------------------------
   // LB Backends: each targets the private IPs of its service's active VM
   // generation(s). Pulumi sets the initial list, then ignores live changes so
   // tasks/cutover.ts can perform explicit expand→health→contract handoff via
@@ -191,7 +180,6 @@ function provisionLoadBalancer(): LoadBalancerOutputs {
   // `onMarkedDownAction` follows the service's drainPolicy: HTTP services let
   // in-flight requests finish ('none'); WebSocket services shed sessions so
   // clients reconnect to the new generation ('shutdown_sessions').
-  // -------------------------------------------------------------------------
 
   const backends = new Map<ServiceName, scaleway.loadbalancers.Backend>()
   for (const service of lbServices) {
@@ -217,9 +205,7 @@ function provisionLoadBalancer(): LoadBalancerOutputs {
 
   const defaultBackend = backends.get(defaultService.slug)!
 
-  // -------------------------------------------------------------------------
   // HTTPS Frontend (port 443): TLS termination + host-header routes
-  // -------------------------------------------------------------------------
 
   const allCertIds: pulumi.Input<string>[] = [...certs.values()].map((cert) => cert.id)
   if (apexCert) allCertIds.push(apexCert.id)
@@ -318,9 +304,7 @@ function provisionLoadBalancer(): LoadBalancerOutputs {
     })
   }
 
-  // -------------------------------------------------------------------------
   // HTTP Frontend (port 80): redirect all to HTTPS
-  // -------------------------------------------------------------------------
 
   const httpFrontend = new scaleway.loadbalancers.Frontend('http-frontend', {
     lbId: lb.id,
@@ -347,9 +331,7 @@ function provisionLoadBalancer(): LoadBalancerOutputs {
     },
   })
 
-  // -------------------------------------------------------------------------
   // Outputs: public URL per LB-exposed service (scheme from appConfig)
-  // -------------------------------------------------------------------------
 
   const serviceUrls: Record<string, pulumi.Output<string>> = {}
   for (const service of lbServices) {

--- a/infra/resources/network.ts
+++ b/infra/resources/network.ts
@@ -1,9 +1,7 @@
 import * as scaleway from '@pulumiverse/scaleway'
 import { naming, region, tags } from '../pulumi-context'
 
-// ---------------------------------------------------------------------------
 // VPC
-// ---------------------------------------------------------------------------
 
 const vpc = new scaleway.network.Vpc('main-vpc', {
   name: naming.resource('vpc'),
@@ -11,9 +9,7 @@ const vpc = new scaleway.network.Vpc('main-vpc', {
   tags,
 }, { aliases: [{ type: 'scaleway:index/vpc:Vpc' }] })
 
-// ---------------------------------------------------------------------------
 // Private Network
-// ---------------------------------------------------------------------------
 
 const privateNetwork = new scaleway.network.PrivateNetwork('main-private-network', {
   name: naming.resource('private-network'),
@@ -25,9 +21,7 @@ const privateNetwork = new scaleway.network.PrivateNetwork('main-private-network
   },
 }, { aliases: [{ type: 'scaleway:index/vpcPrivateNetwork:VpcPrivateNetwork' }] })
 
-// ---------------------------------------------------------------------------
 // Exports
-// ---------------------------------------------------------------------------
 
 /** VPC ID */
 export const vpcId = vpc.id

--- a/infra/resources/registry.ts
+++ b/infra/resources/registry.ts
@@ -1,9 +1,7 @@
 import * as scaleway from '@pulumiverse/scaleway'
 import { naming, region } from '../pulumi-context'
 
-// ---------------------------------------------------------------------------
 // Container Registry Namespace
-// ---------------------------------------------------------------------------
 
 const registry = new scaleway.registry.Namespace('main-registry', {
   name: naming.registryNamespace,
@@ -12,9 +10,7 @@ const registry = new scaleway.registry.Namespace('main-registry', {
   isPublic: false,
 }, { aliases: [{ type: 'scaleway:index/registryNamespace:RegistryNamespace' }] })
 
-// ---------------------------------------------------------------------------
 // Exports
-// ---------------------------------------------------------------------------
 
 /** Registry namespace ID */
 export const registryId = registry.id

--- a/infra/resources/secrets.ts
+++ b/infra/resources/secrets.ts
@@ -44,9 +44,7 @@ function parseOperatorSecretImports(raw: string | undefined): Record<string, str
 
 const operatorSecretImports = parseOperatorSecretImports(process.env.OPERATOR_SECRET_IMPORTS)
 
-// ---------------------------------------------------------------------------
 // Helper: create a Secret container, optionally with a Version
-// ---------------------------------------------------------------------------
 
 function createSecretContainer(
   name: string,
@@ -110,9 +108,7 @@ function pulumiRuntimeSecretData(definition: RuntimeSecretDefinition): pulumi.In
   )
 }
 
-// ---------------------------------------------------------------------------
 // Registry-driven secret containers
-// ---------------------------------------------------------------------------
 
 const secretResources = Object.fromEntries(runtimeSecrets.map((definition) => {
   const isOperator = definition.valueSource === 'operator'
@@ -131,9 +127,7 @@ const secretResources = Object.fromEntries(runtimeSecrets.map((definition) => {
   return [definition.id, secret]
 }))
 
-// ---------------------------------------------------------------------------
 // Exports: secret IDs for container references
-// ---------------------------------------------------------------------------
 
 /** Map of runtime secret IDs to their Scaleway Secret IDs. The key type is the
  *  literal id union, so a typo'd lookup is a compile error rather than an

--- a/infra/resources/storage.ts
+++ b/infra/resources/storage.ts
@@ -36,9 +36,7 @@ const deployAccess = (bucketName: pulumi.Input<string>) => ({
 // outside this prefix, so they are not touched by this rule.
 const assetRetentionDays = infra.assetRetentionDays
 
-// ---------------------------------------------------------------------------
 // Frontend static files bucket (website hosting)
-// ---------------------------------------------------------------------------
 
 const frontendBucket = new scaleway.object.Bucket('frontend-bucket', {
   name: naming.frontendBucket,
@@ -103,9 +101,7 @@ new scaleway.object.BucketPolicy('frontend-policy', {
   }),
 }, { aliases: [{ type: 'scaleway:index/objectBucketPolicy:ObjectBucketPolicy' }], dependsOn: [frontendWebsite] })
 
-// ---------------------------------------------------------------------------
 // Public uploads bucket (user-uploaded public assets)
-// ---------------------------------------------------------------------------
 
 const publicUploadsBucket = new scaleway.object.Bucket('public-uploads-bucket', {
   name: naming.publicBucket,
@@ -143,9 +139,7 @@ new scaleway.object.BucketPolicy('public-uploads-policy', {
   }),
 }, { aliases: [{ type: 'scaleway:index/objectBucketPolicy:ObjectBucketPolicy' }] })
 
-// ---------------------------------------------------------------------------
 // Private uploads bucket (user-uploaded private assets, signed URL access)
-// ---------------------------------------------------------------------------
 
 const privateUploadsBucket = new scaleway.object.Bucket('private-uploads-bucket', {
   name: naming.privateBucket,
@@ -165,9 +159,7 @@ const privateUploadsBucket = new scaleway.object.Bucket('private-uploads-bucket'
 
 // No public policy: access via signed URLs only.
 
-// ---------------------------------------------------------------------------
 // Boot diagnostics bucket (VM write-only diagnostics channel)
-// ---------------------------------------------------------------------------
 
 const bootDiagBucket = new scaleway.object.Bucket('boot-diag-bucket', {
   name: naming.bootDiagBucket,
@@ -204,9 +196,7 @@ new scaleway.object.BucketPolicy('boot-diag-policy', {
   }),
 })
 
-// ---------------------------------------------------------------------------
 // Exports
-// ---------------------------------------------------------------------------
 
 /** Frontend bucket name */
 export const frontendBucketName = frontendBucket.name

--- a/infra/tasks/cutover.ts
+++ b/infra/tasks/cutover.ts
@@ -19,19 +19,15 @@ export type GetServersFn = () => Promise<string[]>
 /** Resolve true once the new generation is serving the expected release (app /health gate). */
 export type HealthGateFn = () => Promise<boolean>
 
-// ---------------------------------------------------------------------------
 // Pure LB operations: one atomic `SetBackendServers` call each.
-// ---------------------------------------------------------------------------
 
 /** Contract the backend to serve ONLY the new generation (old removed, drains). */
 export async function contractBackend(setServers: SetServersFn, newIps: string[]): Promise<void> {
   await setServers(newIps)
 }
 
-// ---------------------------------------------------------------------------
 // The sequencer: orders the rollout steps over injected effects. Never touches
 // the network or a subprocess itself; that is the entrypoint's job.
-// ---------------------------------------------------------------------------
 
 export interface CutoverPlan {
   service: string
@@ -45,7 +41,7 @@ export interface CutoverPlan {
   /** Seconds to let the old generation drain after it is de-registered. */
   drainSeconds: number
 
-  // --- injected effects ---
+  // Injected effects
   /** Gate: resolves true once the new generation serves the expected SHA. Required. */
   healthGate: HealthGateFn
   /** lb-overlap: replace the LB backend server list atomically. Required for lb-overlap. */
@@ -151,14 +147,11 @@ export async function sequenceCutover(plan: CutoverPlan): Promise<CutoverResult>
   return { ok: true, steps }
 }
 
-// ---------------------------------------------------------------------------
 // Impure edge: the real Scaleway `SetBackendServers` REST call.
-//
 // PUT /lb/v1/zones/{zone}/backends/{backendId}/servers   body: { server_ip: [...] }
 // replaces the whole server list in one atomic server-side operation (Scaleway
 // Load Balancer zoned API v1). Preview-gated: exercised only in a live deploy,
 // never by the unit tests (which inject `setServers`).
-// ---------------------------------------------------------------------------
 
 const LB_BASE = 'https://api.scaleway.com/lb/v1'
 
@@ -233,11 +226,9 @@ export function createLbGetServers(opts: LbSetServersOptions): GetServersFn {
   }
 }
 
-// ---------------------------------------------------------------------------
 // Standalone entry point: wires the live effects and runs the cutover. The
 // `pulumi up` create/destroy bookends are CI-orchestrated around this call
 // (see .github/workflows/deploy.yml), keeping subprocess calls out of the core.
-// ---------------------------------------------------------------------------
 
 function parseIps(raw: string | undefined): string[] {
   return (raw ?? '')

--- a/infra/tasks/deploy-service.ts
+++ b/infra/tasks/deploy-service.ts
@@ -18,10 +18,8 @@ import { getFlag, sleep } from './args'
 import { createLbGetServers, createLbSetServers, sequenceCutover } from './cutover'
 import { createFetchProbe, pollForVersion } from './wait-for-version'
 
-// ---------------------------------------------------------------------------
 // Control object (S3): the source of truth for rollout state. Lazily resolved;
 // null when no S3 credentials are present (the deploy then cannot record state).
-// ---------------------------------------------------------------------------
 let controlCtxPromise: Promise<ControlContext | null> | undefined
 
 function controlCtx(stack: string): Promise<ControlContext | null> {

--- a/infra/tasks/setup-vm-key.ts
+++ b/infra/tasks/setup-vm-key.ts
@@ -1,26 +1,19 @@
 /**
- * Create (or reuse) a scoped IAM application `<slug>-vm-reader` and mint a fresh
+ * Create (or reuse) the scoped IAM application `<slug>-vm-reader` and mint a fresh
  * API key (deleting any orphans). The application's IAM **policy** is NOT created
- * here: it is declared as a Pulumi-managed `iam.Policy` resource
- * (`infra/resources/vm-iam.ts`) so `pulumi up` reconciles the permission sets on
- * every deploy and the VM's grant can never silently drift.
+ * here: it is a Pulumi-managed `iam.Policy` (`infra/resources/vm-iam.ts`) so
+ * `pulumi up` reconciles the permission sets (VM_PROJECT_PERMISSION_SETS in
+ * lib/scaleway/permissions.ts, the canonical manifest) on every deploy and the
+ * VM's grant can never silently drift.
  *
- * The VM reader identity is granted exactly these capabilities (by Pulumi):
- *   - ContainerRegistryReadOnly: docker pull from the project registry
- *   - SecretManagerReadOnly: list/describe runtime secrets by ID
- *   - SecretManagerSecretAccess: decrypt + read the runtime secret VALUES
+ * The VM reader is intentionally read-only (registry pull + Secret Manager
+ * read/decrypt) with NO write access to instances, the LB, or IAM: a compromised
+ * container can exfiltrate its own secrets but cannot provision infrastructure or
+ * escalate privileges.
  *
- * It intentionally has NO write access to anything: not instances, not the LB,
- * not IAM. A compromised container can exfiltrate its own secrets but cannot
- * provision infrastructure or escalate privileges.
- *
- * Used by the bootstrap command inside the "Rotate keys" path so both the CI key
- * and the VM key are provisioned atomically with a single IAM bootstrap credential.
- * Standalone usage: SCW_SECRET_KEY + SCW_DEFAULT_PROJECT_ID required.
- *
- * The shared provisioning flow lives in `lib/scaleway-iam.ts`; the VM-specific
- * permission sets live in `lib/permissions.ts` (the canonical IAM manifest),
- * which Pulumi consumes via `VM_PROJECT_PERMISSION_SETS`.
+ * Used by bootstrap's "Rotate keys" path so the CI key and VM key are provisioned
+ * atomically from one IAM bootstrap credential. Standalone: SCW_SECRET_KEY +
+ * SCW_DEFAULT_PROJECT_ID required.
  */
 
 import { pc } from 'shared/cli-utils/colors';

--- a/sdk/src/plugins/tsdoc/plugin.ts
+++ b/sdk/src/plugins/tsdoc/plugin.ts
@@ -23,8 +23,6 @@ export function buildOperationDocsUrl(method: string, path: string, tag: string)
  * Enriches each generated operation's description with a TSDoc-style summary: a
  * method/path heading, links to the hosted docs, and `@param`/`@returns` tags derived
  * from the operation's path, query, and body parameters and its response codes.
- *
- * @param plugin - The TSDoc Plugin instance
  */
 export const handler: TsdocPlugin['Handler'] = ({ plugin }) => {
   plugin.forEach('operation', (op) => {

--- a/shared/config/config.default.ts
+++ b/shared/config/config.default.ts
@@ -9,9 +9,7 @@ const productEntityTypes = ['attachment'] as const;
 
 export const config = {
 
-  /******************************************************************************
-   * ENTITY DATA MODEL
-   ******************************************************************************/
+  // Entity data model
 
   /** All entity types in the app - must match hierarchy.allTypes. */
   entityTypes,
@@ -71,15 +69,11 @@ export const config = {
     },
   } as const,
 
-  /******************************************************************************
-   * SYSTEM ROLES
-   ******************************************************************************/
+  // System roles
 
   systemRoles: ['admin'] as const,
 
-  /******************************************************************************
-   * APP IDENTITY
-   ******************************************************************************/
+  // App identity
 
   name: 'Cella',
   slug: 'cella',
@@ -88,9 +82,7 @@ export const config = {
   keywords:
     'starter kit, fullstack, monorepo, typescript, hono, honojs, drizzle, baseui, react, postgres, pwa, offline, instant updates, realtime data, sync engine',
 
-  /******************************************************************************
-   * URLS & ENDPOINTS
-   ******************************************************************************/
+  // URLs & endpoints
 
   // Same-origin: every service is a path under the app origin, so cookies stay
   // first-party (`__Host-`, SameSite=Strict), CORS disappears and CSP collapses
@@ -124,17 +116,13 @@ export const config = {
   defaultRedirectPath: '/home',
   welcomeRedirectPath: '/welcome',
 
-  /******************************************************************************
-   * EMAIL
-   ******************************************************************************/
+  // Email
 
   senderEmail: 'notifications@shareworks.nl',
   supportEmail: 'info@cellajs.com',
   securityEmail: 'security@cellajs.com',
 
-  /******************************************************************************
-   * MODE & FLAGS
-   ******************************************************************************/
+  // Mode & flags
 
   mode: 'development' as ConfigMode,
   maintenance: false,
@@ -147,18 +135,12 @@ export const config = {
     chatSupport: false as boolean,
   },
 
-  /******************************************************************************
-   * VERSIONING
-   *
-   * Three independent tokens. Bump the relevant one in the SAME PR as the change
-   * it guards:
-   * - apiVersion: API contract / frozen-envelope version (wire structure).
-   * - cookieVersion: session cookie name; bump to invalidate all sessions.
-   * - clientCacheVersion: persisted client query-cache shape; bump on a breaking
-   *   change to a cached entity so clients wipe stale cache (queued mutations are
-   *   preserved). CI's schema-bust gate enforces this. Temporary escape hatch
-   *   until the lens system lands.
-   ******************************************************************************/
+  // Three independent version tokens. Bump the relevant one in the SAME PR as the change it guards:
+  // - apiVersion: API contract / frozen-envelope version (wire structure).
+  // - cookieVersion: session cookie name; bump to invalidate all sessions.
+  // - clientCacheVersion: persisted client query-cache shape; bump on a breaking change to a cached
+  //   entity so clients wipe stale cache (queued mutations survive). Enforced by CI's schema-bust
+  //   gate; a temporary escape hatch until the lens system lands.
 
   apiVersion: 'v1',
   // v2: same-origin migration — clean break from the Domain-scoped v1 cookies
@@ -166,9 +148,7 @@ export const config = {
   cookieVersion: 'v2',
   clientCacheVersion: 'v1',
 
-  /******************************************************************************
-   * AUTHENTICATION
-   ******************************************************************************/
+  // Authentication
 
   enabledAuthStrategies: ['passkey', 'oauth', 'totp', 'magic'] as const,
   enabledOAuthProviders: ['github'] as const,
@@ -180,16 +160,12 @@ export const config = {
     digits: 6,
   },
 
-  /******************************************************************************
-   * API CONFIGURATION
-   ******************************************************************************/
+  // API configuration
 
   apiDescription: `⚠️ ATTENTION: PRERELEASE!
                   This API is organized into modules based on logical domains.`,
 
-  /******************************************************************************
-   * REQUEST LIMITS
-   ******************************************************************************/
+  // Request limits
 
   requestLimits: {
     default: 40,
@@ -205,9 +181,7 @@ export const config = {
   fileUploadLimit: 20 * 1024 * 1024,
   defaultBodyLimit: 1 * 1024 * 1024,
 
-  /******************************************************************************
-   * STORAGE & UPLOADS (S3)
-   ******************************************************************************/
+  // Storage & uploads (S3)
 
   s3: {
     region: 'nl-ams',
@@ -239,18 +213,14 @@ export const config = {
     uploadRetryDelays: [60000, 300000, 900000] as const,
   },
 
-  /******************************************************************************
-   * THIRD-PARTY SERVICES
-   ******************************************************************************/
+  // Third-party services
 
   gleapToken: '1ZoAxCRA83h5pj7qtRSvuz7rNNN9iXDd',
   googleMapsKey: 'AIzaSyBc1KkCJr6TNMeAw9XK4OunGVWDSXJAKEM',
   matrixURL: 'https://matrix-client.matrix.org',
   maplePublicIngestKey: 'maple_pk_LnUSK6-_5j3orVrlZ1Hv6I1pxzDh3SJ5',
 
-  /******************************************************************************
-   * THEMING & UI
-   ******************************************************************************/
+  // Theming & UI
 
   themeColor: '#26262b',
   theme: {
@@ -285,9 +255,7 @@ export const config = {
     'bg-red-300',
   ],
 
-  /******************************************************************************
-   * LOCALIZATION
-   ******************************************************************************/
+  // Localization
 
   defaultLanguage: 'en' as const,
   languages: ['en', 'nl'] as const,
@@ -296,9 +264,7 @@ export const config = {
     timezones: [],
   },
 
-  /******************************************************************************
-   * COMPANY DETAILS
-   ******************************************************************************/
+  // Company details
 
   company: {
     name: 'CellaJS',
@@ -325,9 +291,7 @@ export const config = {
     },
   },
 
-  /******************************************************************************
-   * USER DEFAULTS
-   ******************************************************************************/
+  // User defaults
 
   defaultUserFlags: {
     finishedOnboarding: false,

--- a/shared/config/config.template.ts
+++ b/shared/config/config.template.ts
@@ -9,9 +9,7 @@ const productEntityTypes = ['attachment'] as const;
 
 export const config = {
 
-  /******************************************************************************
-   * ENTITY DATA MODEL
-   ******************************************************************************/
+  // Entity data model
 
   /** All entity types in the app - must match hierarchy.allTypes. */
   entityTypes,
@@ -71,15 +69,11 @@ export const config = {
     },
   } as const,
 
-  /******************************************************************************
-   * SYSTEM ROLES
-   ******************************************************************************/
+  // System roles
 
   systemRoles: ['admin'] as const,
 
-  /******************************************************************************
-   * APP IDENTITY
-   ******************************************************************************/
+  // App identity
 
   /** App display name shown in UI and emails */
   name: '__project_name__',
@@ -93,9 +87,7 @@ export const config = {
   keywords:
     'starter kit, fullstack, monorepo, typescript, hono, honojs, drizzle, baseui, react, postgres, pwa, offline, instant updates, realtime data, sync engine',
 
-  /******************************************************************************
-   * URLS & ENDPOINTS
-   ******************************************************************************/
+  // URLs & endpoints
 
   /** Frontend SPA base URL (the app origin — every service is a path under it) */
   frontendUrl: 'https://__project_slug__.example.com',
@@ -141,9 +133,7 @@ export const config = {
   /** Redirect path for first-time users */
   welcomeRedirectPath: '/welcome',
 
-  /******************************************************************************
-   * EMAIL
-   ******************************************************************************/
+  // Email
 
   /** From address for system notifications */
   senderEmail: 'notifications@__project_slug__.example.com',
@@ -152,9 +142,7 @@ export const config = {
   /** Receive security warnings */
   securityEmail: 'security@__project_slug__.example.com',
 
-  /******************************************************************************
-   * MODE & FLAGS
-   ******************************************************************************/
+  // Mode & flags
 
   /** Runtime mode - overridden per environment file */
   mode: 'development' as ConfigMode,
@@ -165,9 +153,7 @@ export const config = {
   /** Persisted client query-cache shape - bump on a breaking change to a cached entity so clients wipe stale cache */
   clientCacheVersion: 'v1',
 
-  /******************************************************************************
-   * FEATURE FLAGS
-   ******************************************************************************/
+  // Feature flags
 
   /**
    * Feature toggles for app capabilities.
@@ -186,9 +172,7 @@ export const config = {
     chatSupport: false as boolean,
   },
 
-  /******************************************************************************
-   * AUTHENTICATION
-   ******************************************************************************/
+  // Authentication
 
   /**
    * Enabled authentication strategies.
@@ -209,9 +193,7 @@ export const config = {
     digits: 6,
   },
 
-  /******************************************************************************
-   * API CONFIGURATION
-   ******************************************************************************/
+  // API configuration
 
   /** API version prefix for endpoints */
   apiVersion: 'v1',
@@ -219,9 +201,7 @@ export const config = {
   apiDescription: `⚠️ ATTENTION: PRERELEASE!
                   This API is organized into modules based on logical domains.`,
 
-  /******************************************************************************
-   * REQUEST LIMITS
-   ******************************************************************************/
+  // Request limits
 
   /**
    * Default page sizes for list endpoints. Backend enforces max 1000.
@@ -244,9 +224,7 @@ export const config = {
   /** Default body size limit in bytes */
   defaultBodyLimit: 1 * 1024 * 1024,
 
-  /******************************************************************************
-   * STORAGE & UPLOADS (S3)
-   ******************************************************************************/
+  // Storage & uploads (S3)
 
   /** S3-compatible storage configuration. Only region and host are required; the rest is derived from the slug. */
   s3: {
@@ -285,9 +263,7 @@ export const config = {
     uploadRetryDelays: [60000, 300000, 900000] as const,
   },
 
-  /******************************************************************************
-   * THIRD-PARTY SERVICES
-   ******************************************************************************/
+  // Third-party services
 
   /** Gleap token for customer support widget */
   gleapToken: '',
@@ -298,9 +274,7 @@ export const config = {
   /** Maple.dev public ingest key, safe to embed in the frontend bundle (empty disables frontend export) */
   maplePublicIngestKey: '',
 
-  /******************************************************************************
-   * THEMING & UI
-   ******************************************************************************/
+  // Theming & UI
 
   /** Primary theme color for PWA manifest and browser chrome */
   themeColor: '#26262b',
@@ -337,9 +311,7 @@ export const config = {
     'bg-red-300',
   ],
 
-  /******************************************************************************
-   * LOCALIZATION
-   ******************************************************************************/
+  // Localization
 
   /** Default language code */
   defaultLanguage: 'en' as const,
@@ -351,9 +323,7 @@ export const config = {
     timezones: [],
   },
 
-  /******************************************************************************
-   * COMPANY DETAILS
-   ******************************************************************************/
+  // Company details
 
   /** Company/organization details for footer, legal pages, and contact info */
   company: {
@@ -381,9 +351,7 @@ export const config = {
     },
   },
 
-  /******************************************************************************
-   * USER DEFAULTS
-   ******************************************************************************/
+  // User defaults
 
   /** Default user flags applied to new users */
   defaultUserFlags: {

--- a/shared/config/hierarchy-config.ts
+++ b/shared/config/hierarchy-config.ts
@@ -1,50 +1,16 @@
-/**
- * Entity hierarchy and role registry definitions.
- * Separated from default-config.ts to enable type inference before config object creation.
- */
+// Split from config.default.ts so its types can be inferred before the config object is built.
 import { createEntityHierarchy, createRoleRegistry } from '../src/config-builder/entity-hierarchy';
 
-/******************************************************************************
- * ROLE REGISTRY
- ******************************************************************************/
-
-/**
- * Single source of truth for all entity roles used in memberships and permissions.
- */
+/** Single source of truth for all entity roles used in memberships and permissions. */
 export const roles = createRoleRegistry(['admin', 'member'] as const);
 
-/******************************************************************************
- * ENTITY HIERARCHY
- ******************************************************************************/
-
 /**
- * Entity relationships with single-parent inheritance.
- * Parents are defined before children. Order determines ancestor chain.
- *
- * Optional `relatedChannels` on products declare non-ancestor context references (nullable id columns).
- *
- * Public readability is NOT declared here — it is a permission concern, declared per
- * subject via `publicRead(mode)` in `permissions-config.ts`.
+ * Entity relationships, single-parent inheritance. Parents before children; order sets the ancestor
+ * chain. Products may add `relatedChannels` (non-ancestor context refs, nullable id columns). Public
+ * readability is a permission concern, not declared here — see cella/PERMISSIONS.md for the model.
  */
 export const hierarchy = createEntityHierarchy(roles)
   .user()
   .channel('organization', { parent: null, roles: roles.all })
   .product('attachment', { parent: 'organization' })
   .build();
-
-/**
- * Example hierarchy from raak.dev (roles registry: ['admin', 'member', 'guest']):
- *
- * createEntityHierarchy(roles)
- *   .user()
- *   .channel('organization', { parent: null, roles: ['admin', 'member'] })
- *   .channel('workspace', { parent: 'organization', roles: roles.all })
- *   .channel('project', { parent: 'organization', roles: roles.all })
- *   .product('task', { parent: 'project' })
- *   .product('label', { parent: 'project' })
- *   .product('attachment', { parent: 'project' })
- *   .build();
- *
- * Public read grants for these entities (e.g. project 'publicSelf', task 'publicParent')
- * are declared in `permissions-config.ts` via `publicRead(mode)`.
- */

--- a/shared/config/permissions-config.ts
+++ b/shared/config/permissions-config.ts
@@ -1,56 +1,13 @@
 import { appConfig } from '../src/config-builder/app-config';
 import { configurePermissions } from '../src/permissions/access-policies';
 
+// Access policies per entity type: `1` = allowed, `0`/omitted = denied. Elevation vs. self rows,
+// product home rows, publicRead and row conditions are all explained in cella/PERMISSIONS.md.
+
 /**
- * Access policies for each entity type.
- *
- * Policies define CRUD permissions per role within each context.
- * Values: `1` = allowed, `0` = denied. Any action you omit defaults to `0` (denied), so a row
- * only needs to list the actions it grants.
- *
- * ## Elevation vs. self rows (channel entities)
- *
- * For a channel entity (organization, workspace, project), its policy has two kinds of rows:
- * - **elevation** rows on an *ancestor* context (e.g. `organization.*` under `project`): what a
- *   member of the parent can do to children. `create` lives here — it grants making the child.
- * - **self** rows on the *same* context (e.g. `project.*` under `project`): what a member of the
- *   entity can do to that entity. `create` is omitted on self rows because you can't create an
- *   entity from inside itself.
- *
- * Product entities have no self rows: their context rows are *home* rows, where `create` is
- * meaningful (it grants creating the product inside that context).
- *
- * Beyond plain cells, the builder callback also exposes:
- * - `publicRead(mode)` — declare how the subject becomes publicly readable. Public readability is
- *   purely a permission concern; it is NOT declared in the hierarchy config. A `publicParent` mode
- *   does require the parent subject to be publicly readable itself (validated at boot).
- * - row conditions like `read: 'own'` — grant an action only on rows the user created
- *
- * ## Adding new entities
- *
- * Defining access policies (a `case` in the switch below) is only one step of adding an entity.
- * For the full end-to-end recipe — hierarchy declaration, config arrays, DB table + RLS, module
- * wiring, sync engine, and frontend registration — see `cella/ADD_ENTITY.md`.
- */
-/**
- * Grant scoping for PRODUCT entities (optional). When a role list is configured, a
- * product membership grant of a role NOT in the list speaks only for rows HOMED at its
- * own context level — e.g. in a fork with `organization > course > project` chains, a
- * course `student` grant covers course-homed rows but not rows in the projects below,
- * while listed roles (typically staff/admin) keep full subtree scope (moderation
- * cascade, admin oversight). Context-entity subjects are exempt, so discovery of child
- * contexts is unaffected. Applies to every action, including `create` and `'own'`
- * conditions.
- *
- * This is a static, type-level visibility knob — one role set instead of per-row
- * audience data — evaluated identically by the engine check
- * (`getAllDecisions`) and the collection-scope SQL compiler
- * (`resolveCollectionReadFilter`), so both stay mirror-consistent.
- *
- * `undefined` (the template default) keeps every grant subtree-scoped — the current
- * behavior. A fork with nested contexts and elevated roles enables it like:
- *
- *   export const elevatedRoles = ['admin', 'staff'] as const;
+ * Optional product grant scoping: roles NOT in this list see only rows homed at their own context
+ * level; listed roles keep full subtree scope. `undefined` keeps every grant subtree-scoped.
+ * Read by the engine and the collection-scope SQL compiler alike — see cella/PERMISSIONS.md.
  */
 export const elevatedRoles: readonly string[] | undefined = undefined;
 

--- a/shared/src/config-builder/types.ts
+++ b/shared/src/config-builder/types.ts
@@ -1,30 +1,12 @@
-/******************************************************************************
- * CONFIG BUILDER TYPES
- * Types for building and validating configuration.
- * Includes both external config interface and hierarchy-derived types.
- ******************************************************************************/
-
-/******************************************************************************
- * DEEP PARTIAL UTILITY
- ******************************************************************************/
-
 export type DeepPartial<T> = T extends object
   ? {
       [P in keyof T]?: DeepPartial<T[P]>;
     }
   : T;
 
-/******************************************************************************
- * CONFIG MODE & BASE TYPES
- ******************************************************************************/
-
 export type ConfigMode = 'development' | 'tunnel' | 'staging' | 'production' | 'test';
 export type BaseAuthStrategies = 'passkey' | 'oauth' | 'totp' | 'magic';
 export type BaseOAuthProviders = 'github' | 'google' | 'microsoft';
-
-/******************************************************************************
- * CONFIG SUB-TYPES
- ******************************************************************************/
 
 /** Input S3 config: only host and region are required, rest derived from slug in app-config */
 export interface S3ConfigInput {
@@ -132,12 +114,7 @@ export interface MenuStructureItem {
   carryRole?: boolean;
 }
 
-/******************************************************************************
- * CONFIG STRING ARRAYS
- * Type for all readonly string array properties in config.
- * Used as a single generic parameter to preserve literal types.
- ******************************************************************************/
-
+/** All readonly string-array config properties, grouped as one generic parameter so literal types survive. */
 export interface ConfigStringArrays {
   entityTypes: readonly string[];
   channelEntityTypes: readonly string[];
@@ -151,16 +128,10 @@ export interface ConfigStringArrays {
   uploadTemplateIds: readonly string[];
 }
 
-/******************************************************************************
- * REQUIRED CONFIG
- * Complete config type that forks must satisfy.
- * Use `satisfies RequiredConfig` in fork's default.ts for type enforcement.
- *
- * Generic parameter preserves literal types for Drizzle v1 strict enum typing.
- * When accessed via appConfig, arrays remain as literal tuples like ['organization']
- * instead of being widened to readonly string[].
- ******************************************************************************/
-
+/**
+ * The config a fork must satisfy (`satisfies RequiredConfig` in its default.ts). The generic keeps
+ * arrays as literal tuples (`['organization']`, not `readonly string[]`) so Drizzle v1 gets strict enums.
+ */
 export interface RequiredConfig<T extends ConfigStringArrays = ConfigStringArrays> {
   // Entity data model - use T['key'] to preserve literal types
   entityTypes: T['entityTypes'];

--- a/shared/src/permissions/action-helpers.ts
+++ b/shared/src/permissions/action-helpers.ts
@@ -22,17 +22,10 @@ export const allActionsAllowed = Object.freeze(createActionRecord(() => true as 
 >;
 
 /**
- * Resolves a three-state permission (`true | false | condition name`) to a boolean.
- *
- * Handles the built-in `'own'` condition (actor created the entity, derived from
- * `entity.createdBy`). Any other condition name resolves to `false` here (a secure
- * default); call sites using a custom row condition must resolve it via the
- * condition's own check-form.
- *
- * @param permission - The permission state from `EntityCanMap` (`true`, `false`, or a condition name)
- * @param entityCreatedBy - The `createdBy` field of the entity being checked
- * @param userId - The current user's ID (the actor)
- * @returns `true` if action is allowed, `false` otherwise. Defaults to `false` for safety.
+ * Resolves a three-state permission (`true | false | condition name`) to a boolean. Handles the
+ * built-in `'own'` condition (compares the actor's `userId` against `entity.createdBy`). Any other
+ * condition name resolves to `false` here (secure default); custom row conditions must be resolved
+ * by the call site via the condition's own check-form.
  */
 export const resolvePermission = (
   permission: ActionPermissionState | undefined,

--- a/shared/src/permissions/build-subject.ts
+++ b/shared/src/permissions/build-subject.ts
@@ -6,22 +6,15 @@ import type { ChannelEntityIdColumns, ChannelScope, SubjectForPermission } from 
 import { validateAncestorScope } from './validate-ancestor-scope';
 
 /**
- * Build a permission subject from an entity type and ancestor context ID columns.
- *
- * Extracts the relevant ancestor ID columns (e.g., `organizationId`, `projectId`) from the input
- * based on the entity hierarchy, validates that all required ancestors are present, and returns
- * a ready-to-use `SubjectForPermission` with domain-shaped `channelIds`. Extra properties on the
- * input are ignored.
+ * Build a permission subject from an entity type and ancestor context ID columns. Extracts the
+ * relevant ancestor ID columns (e.g. `organizationId`, `projectId`) per the hierarchy, validates all
+ * required ancestors are present, and returns a `SubjectForPermission` with domain-shaped
+ * `channelIds`. Extra input properties are ignored.
  *
  * The `undefined` vs `null` distinction is preserved:
- * - `undefined` on the input -> omitted from the subject -> `validateAncestorScope` throws
- * - `null` on the input -> set on the subject -> means "intentionally not scoped to this context"
+ * - `undefined` on the input → omitted → `validateAncestorScope` throws
+ * - `null` on the input → set on the subject → "intentionally not scoped to this context"
  *
- * @param entityType - The entity type to build a subject for
- * @param ancestorChannelIds - Object containing ancestor ID values (e.g., route params, event data)
- * @param options.id - Entity ID (defaults to a generated ID for collection-level checks)
- * @param options.createdBy - Creator for ownership checks
- * @param options.row - Row fields for row-condition / public read evaluation
  * @throws MissingScopeError if any required ancestor context ID is missing (undefined)
  */
 export const buildSubject = (

--- a/shared/src/permissions/check-permission.ts
+++ b/shared/src/permissions/check-permission.ts
@@ -45,21 +45,12 @@ export interface BatchPermissionResult<T extends PermissionMembership = Permissi
 }
 
 /**
- * Checks if a permission is allowed for the given memberships and action.
- * Accepts a single entity or array of entities.
+ * The one authorization entry point shared by every tier (backend handlers, yjs relay), so the
+ * decision is computed by a single engine. Public read grants and `elevatedRoles` are injected
+ * here; callers only supply the {@link Actor}. Allowed if the entity OR an ancestor matches a grant.
  *
- * This is the shared entry point used by every tier (backend handlers, yjs relay) so the
- * authorization decision is computed by exactly one engine. The configured public read
- * grants and `elevatedRoles` are injected here, so callers only supply the actor.
- *
- * @param memberships - User's memberships to check against
- * @param action - The action to check (create, read, update, delete)
- * @param entityOrEntities - Single entity or array of entities to check
- * @param actor - Who is acting. Required: see {@link Actor}
- * @returns Single entity: `PermissionResult` with `{ isAllowed, membership }`
- * @returns Array: `BatchPermissionResult` with `{ results: Map<id, PermissionResult>, decisions }`
- *
- * Permission is allowed if the entity OR an ancestor matches a membership grant.
+ * Overloaded on the entity arg: a single entity returns `PermissionResult`; an array returns
+ * `BatchPermissionResult` (`{ results: Map<id, …>, decisions }`).
  */
 export function checkPermission<T extends PermissionMembership>(
   memberships: T[],

--- a/shared/src/permissions/compute-can.ts
+++ b/shared/src/permissions/compute-can.ts
@@ -8,16 +8,9 @@ import { resolveTopology } from './permission-manager/resolve-topology';
 import type { PermissionTopology } from './permission-manager/topology';
 
 /**
- * Per-action permission state for a single entity type.
- *
- * - `true` = unconditionally allowed (policy value `1`)
- * - `false` = denied (policy value `0`)
- * - condition name (e.g. `'own'`) = allowed only for rows satisfying that row condition.
- *   The frontend resolves it per row: `resolvePermission` handles the built-in `'own'`
- *   (compare `entity.createdBy` against the current user ID); custom conditions resolve
- *   via their check-form.
- *
- * Keeping the state three-valued preserves row-condition semantics at the UI layer.
+ * Per-action permission state for one entity type. Three-valued to carry row conditions to the UI:
+ * `true` = allowed (`1`), `false` = denied (`0`), condition name (e.g. `'own'`) = allowed only on
+ * matching rows, resolved per row on the frontend by `resolvePermission` / the condition's check-form.
  */
 type ActionStates = Record<EntityActionType, ActionPermissionState>;
 
@@ -51,24 +44,15 @@ function computeEntityPermissions(
 }
 
 /**
- * Computes a permission map keyed by entity type for a channel entity and its descendants.
- * Used on the frontend to derive `can` from the membership baked onto a channel entity.
- *
- * The map includes permissions for:
- * - The channel entity itself (e.g., `organization`)
- * - All descendant entity types per the hierarchy (e.g., `attachment`)
- *
- * Actions with `'own'` permission are preserved as `'own'` in the map.
- * The frontend resolves these per-entity by checking `entity.createdBy === userId`.
- *
- * Returns empty map if no membership is provided.
+ * Frontend `can` map for a channel entity and all its hierarchy descendants, derived from the
+ * membership baked onto the channel entity. `'own'` grants are preserved (see {@link ActionStates}).
+ * Returns `{}` when no membership is given.
  *
  * @example
  * ```ts
  * const can = computeCan('organization', membership, policies);
  * // can.organization.update → true
  * // can.attachment.update → 'own' (member can only update own attachments)
- * // can.attachment.create → true
  * ```
  */
 export const computeCan = (

--- a/shared/src/permissions/types.ts
+++ b/shared/src/permissions/types.ts
@@ -50,12 +50,9 @@ export type SubjectAccessPolicies = AccessPolicyEntry[];
 export type AccessPolicies = Partial<Record<ChannelEntityType | ProductEntityType, SubjectAccessPolicies>>;
 
 /**
- * Context builder for fluent access policy configuration.
- * Maps entity roles to their permission setters.
- *
- * Permissions are partial: any action you omit defaults to `0` (denied). This lets a policy list
- * only the actions it grants (e.g. a channel entity's own ("self") rows can omit `create`, since
- * an entity can never be created from inside itself: creation is granted on ancestor rows).
+ * Fluent per-role permission setters for a context. Permissions are partial: any omitted action
+ * defaults to `0` (denied), so a policy lists only what it grants (e.g. a channel entity's own
+ * "self" rows omit `create` — creation is granted on ancestor rows, not from inside the entity).
  */
 export type ChannelPolicyBuilder = {
   [R in EntityRole]: (permissions: Partial<Record<EntityActionType, PermissionValue>>) => void;

--- a/shared/src/testing/wide-fixture.ts
+++ b/shared/src/testing/wide-fixture.ts
@@ -1,20 +1,15 @@
 /**
- * Wide synthetic permission fixture — the canonical "rich hierarchy" that upstream-owned engine
- * tests run against, instead of a given fork's real `shared/config`.
+ * Wide synthetic permission fixture — the canonical "rich hierarchy" upstream engine tests run
+ * against instead of a fork's real `shared/config`. The template ships a minimal hierarchy
+ * (organization → attachment) that structurally can't exercise the engine's deeper features (nested +
+ * sibling contexts, guest role, multi-level ancestors, all three public-read modes); this one can, so
+ * one test set covers them in every fork. It mirrors raak's real hierarchy (the reference example in
+ * `hierarchy-config.ts`) and MUST stay a superset of every builder feature — variable-depth /
+ * nullable-ancestor coverage lives in `config-builder/tests/resolve-row-channel.test.ts`.
  *
- * The template (cella) ships a deliberately minimal hierarchy (organization → attachment), which
- * structurally cannot exercise the engine's deeper features: nested + sibling contexts, a guest
- * role, multi-level ancestor resolution, all three public-read modes. This fixture provides one
- * hierarchy that does, so a single set of tests covers them in every fork.
- *
- * It mirrors raak's real hierarchy (documented as the reference example in cella's
- * `hierarchy-config.ts`). It MUST stay a superset of every feature the hierarchy builder supports;
- * variable-depth / nullable-ancestor coverage lives separately in
- * `config-builder/tests/resolve-row-channel.test.ts`.
- *
- * The engine reads this via the `topology` seam (`PermissionTopology`) — no module mocks. All the
- * casts needed to name entities the app config doesn't know about are contained here, so the test
- * files that consume the kit stay cast-free and byte-identical across forks.
+ * The engine reads it via the `topology` seam (`PermissionTopology`) — no module mocks. All casts for
+ * entities the app config doesn't know about are contained here, so consumer test files stay
+ * cast-free and byte-identical across forks.
  */
 import { createEntityHierarchy, createRoleRegistry } from '../config-builder/entity-hierarchy';
 import type { EntityActionType, EntityType } from '../../types';

--- a/shared/src/tracing/span-names.ts
+++ b/shared/src/tracing/span-names.ts
@@ -1,7 +1,4 @@
-// ================================
-// CDC Span Names
-// ================================
-
+// CDC span names
 export const cdcSpanNames = {
   processWal: 'cdc.wal.process',
   createActivity: 'cdc.activity.create',
@@ -12,10 +9,7 @@ export const cdcSpanNames = {
 
 export type CdcSpanName = (typeof cdcSpanNames)[keyof typeof cdcSpanNames];
 
-// ================================
-// Backend Span Names
-// ================================
-
+// Backend span names
 export const backendSpanNames = {
   // ActivityBus
   activityBusReceive: 'sync.activitybus.receive',
@@ -31,10 +25,7 @@ export const backendSpanNames = {
 
 export type BackendSpanName = (typeof backendSpanNames)[keyof typeof backendSpanNames];
 
-// ================================
-// Frontend Span Names
-// ================================
-
+// Frontend span names
 export const frontendSpanNames = {
   // SSE connection
   sseConnect: 'sync.sse.connect',
@@ -59,10 +50,7 @@ export const frontendSpanNames = {
 
 export type FrontendSpanName = (typeof frontendSpanNames)[keyof typeof frontendSpanNames];
 
-// ================================
-// Combined Span Names
-// ================================
-
+// Combined span names
 /** All span names organized by layer; each name follows the convention `layer.domain.action`. */
 export const spanNames = {
   cdc: cdcSpanNames,

--- a/shared/src/tracing/tracing.ts
+++ b/shared/src/tracing/tracing.ts
@@ -1,10 +1,7 @@
 export * from './span-names';
 export { createSpanStoreProcessor, type SpanStoreProcessorOptions } from './span-store-processor';
 
-// ================================
 // Types
-// ================================
-
 /** Span status aligned with OTel conventions. */
 export type SpanStatus = 'ok' | 'error' | 'unset';
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,9 +1,7 @@
 import { hierarchy, roles } from './config/config.default';
 import { appConfig } from './src/config-builder/app-config';
 
-/******************************************************************************
- * ENTITY TYPES
- ******************************************************************************/
+// Entity types
 
 /** All entities in this app */
 export type EntityType = (typeof appConfig.entityTypes)[number];
@@ -23,9 +21,7 @@ export type ResourceType = (typeof appConfig.resourceTypes)[number];
 /** Product entity types tracked for seen/unseen counts */
 export type SeenTrackedEntityType = (typeof appConfig.seenTrackedEntityTypes)[number];
 
-/******************************************************************************
- * APP CONFIGURATION TYPES
- ******************************************************************************/
+// App configuration types
 
 /** Menu sections in the menu structure */
 export type MenuSection = {
@@ -93,9 +89,7 @@ export type TokenType = (typeof appConfig.tokenTypes)[number];
 /** System roles available in the app */
 export type SystemRole = (typeof appConfig.systemRoles)[number] | null;
 
-/******************************************************************************
- * ENTITY HIERARCHY HELPERS
- ******************************************************************************/
+// Entity hierarchy helpers
 
 /** Entity roles type - union of all roles from the role registry. */
 export type EntityRole = (typeof roles.all)[number];
@@ -117,11 +111,8 @@ export type EntityIdColumnKey<T extends EntityType> = EntityIdColumnKeys[T];
  */
 export type EntityIdColumns<TS extends EntityType, V> = { [T in TS as EntityIdColumnKey<T>]: V };
 
-/******************************************************************************
- * CONTEXT RELATION TYPES
- * Derived from the hierarchy's phantom parent/related maps. Used to generate
- * context-entity id columns on product/context tables in a fork-agnostic way.
- ******************************************************************************/
+// Context relation types, derived from the hierarchy's phantom parent/related maps — used to
+// generate context-entity id columns on product/context tables in a fork-agnostic way.
 
 /** Type-level map of each entity to its strict parent (null = root). */
 type HierarchyParentMap = typeof hierarchy._parentMap;
@@ -172,9 +163,7 @@ export type NullableAncestorType<E extends string> = E extends keyof HierarchyNu
 /** Entity actions that can be performed (CRUD + search) */
 export type EntityActionType = (typeof appConfig.entityActions)[number];
 
-/******************************************************************************
- * EMBEDDING PROPAGATION TYPES
- ******************************************************************************/
+// Embedding propagation types
 
 /** Single entity embedding relationship derived from config */
 type EntityEmbedding = (typeof appConfig.entityEmbeddings)[number];

--- a/yjs/src/lib/tracing.ts
+++ b/yjs/src/lib/tracing.ts
@@ -9,9 +9,7 @@ export const otel: OtelSDK = createOtelSDK({
   autoInstrumentations: false,
 });
 
-// ================================
-// OTel Health Metrics
-// ================================
+// OTel health metrics
 
 const meter = otel.meterProvider.getMeter('yjs-health');
 


### PR DESCRIPTION
## What

A repo-wide **comment-only** cleanup: denser comment blocks, decorative banners removed, a few factually-wrong comments corrected — **no code, types, imports, or code formatting changed.**

- Collapse decorative `/*****/` and `// ====` section banners → one-line nav comments (~190).
- Densify padded JSDoc (~115): drop signature-restating `@param`/`@returns`, keep the "why".
- Correct a handful of comments that contradicted the code (see reviewer list in `DISCUSSION.md`).
- **Keep** load-bearing rationale, invariants, fork/config semantics, and worked `@example`s — the bias was strongly toward keeping.

**141 files changed, +366 / −1487 (net −1121 comment lines).**

## How it was verified

- **Provably comment-only:** for all 141 changed `.ts/.tsx` files, the TypeScript emit with `removeComments:true` is byte-identical between `main` and this branch → zero code/type/import changes.
- **Biome-clean:** `biome check` reports no fixes needed.
- Built on top of `main` (post `refactor: permissions`), in an isolated git worktree, as delegated per-directory passes under one shared rubric.

## Please skim `DISCUSSION.md`

It records the **non-mechanical judgment calls** and a **"reviewer attention list"** — the comment-*accuracy* rewrites (mostly in `backend/src/modules/auth/*`) are the only real risk, since a misread would leave a wrong comment (the code is provably unchanged regardless).

### README-overlap flags (as requested)

- **`shared/config/README.md` was intentionally NOT created** — it would have duplicated `cella/PERMISSIONS.md` §Configuration. Source comments now point there instead.
- `cdc/src/pipeline/worker.ts` dropped a pipeline-stage map that duplicated `cdc/README.md` and points there instead. No new READMEs were added anywhere.

> Note: `DISCUSSION.md` is a review aid — happy to drop it from the branch before merge if you would prefer it not land in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
