### PR TITLE
fix(auth): preserve /api prefix in token links & add router not-found fallback

### DIFF
--- a/backend/src/modules/auth/general/helpers/send-verification-email.ts
+++ b/backend/src/modules/auth/general/helpers/send-verification-email.ts
@@ -68,9 +68,9 @@ export const sendVerificationEmail = async ({ userId, redirectPath }: Props) => 
   // Send email
   const lng = user.language;
 
-  // Create verification link: go to
-  const verifyPath = `/auth/invoke-token/${tokenRecord.type}/${newToken}`;
-  const verificationURL = new URL(verifyPath, appConfig.backendUrl);
+  // Create verification link. Concatenate onto backendAuthUrl (which already ends in /auth) so the
+  // /api base path is preserved; new URL(absolutePath, backendUrl) would drop it.
+  const verificationURL = new URL(`${appConfig.backendAuthUrl}/invoke-token/${tokenRecord.type}/${newToken}`);
 
   if (redirectPath) verificationURL.searchParams.set('redirect', redirectPath);
 

--- a/backend/src/modules/auth/magic/magic-handlers.ts
+++ b/backend/src/modules/auth/magic/magic-handlers.ts
@@ -75,9 +75,9 @@ app.openapi(authMagicLinkRoutes.sendMagicLink, async (ctx) => {
     })
     .returning();
 
-  // Build magic link URL
-  const verifyPath = `/auth/invoke-token/${tokenRecord.type}/${newToken}`;
-  const magicLinkUrl = new URL(verifyPath, appConfig.backendUrl);
+  // Build magic link URL. Concatenate onto backendAuthUrl (which already ends in /auth) so the
+  // /api base path is preserved; new URL(absolutePath, backendUrl) would drop it.
+  const magicLinkUrl = new URL(`${appConfig.backendAuthUrl}/invoke-token/${tokenRecord.type}/${newToken}`);
 
   // Send email
   const staticProps = { magicLinkUrl: magicLinkUrl.toString(), name: user.name, isNewUser: !existingUser };

--- a/backend/src/modules/auth/oauth/helpers/handle-oauth-verification.ts
+++ b/backend/src/modules/auth/oauth/helpers/handle-oauth-verification.ts
@@ -18,8 +18,9 @@ export const handleOAuthVerification = async (ctx: Context<Env>, token: TokenMod
     .limit(1);
   if (!oauthAccount) throw new AppError(400, 'invalid_request', 'warn');
 
-  const verifyPath = `/auth/${oauthAccount.provider}`;
-  const verificationURL = new URL(verifyPath, appConfig.backendUrl);
+  // Concatenate onto backendAuthUrl (which already ends in /auth) so the /api base path is
+  // preserved; new URL(absolutePath, backendUrl) would drop it.
+  const verificationURL = new URL(`${appConfig.backendAuthUrl}/${oauthAccount.provider}`);
 
   verificationURL.searchParams.set('tokenId', token.id);
   verificationURL.searchParams.set('type', 'verify');

--- a/backend/src/modules/auth/oauth/helpers/send-oauth-verification-email.ts
+++ b/backend/src/modules/auth/oauth/helpers/send-oauth-verification-email.ts
@@ -77,9 +77,9 @@ export const sendOAuthVerificationEmail = async ({ userId, oauthAccountId, redir
   // Send email
   const lng = user.language;
 
-  // Create verification link: go to
-  const verifyPath = `/auth/invoke-token/${tokenRecord.type}/${newToken}`;
-  const verificationURL = new URL(verifyPath, appConfig.backendUrl);
+  // Create verification link. Concatenate onto backendAuthUrl (which already ends in /auth) so the
+  // /api base path is preserved; new URL(absolutePath, backendUrl) would drop it.
+  const verificationURL = new URL(`${appConfig.backendAuthUrl}/invoke-token/${tokenRecord.type}/${newToken}`);
 
   if (redirectPath) verificationURL.searchParams.set('redirectAfter', redirectPath);
 

--- a/frontend/src/routes/router.ts
+++ b/frontend/src/routes/router.ts
@@ -3,6 +3,7 @@ import { useSheeter } from '~/modules/common/sheeter/use-sheeter';
 import { useNavigationStore } from '~/modules/navigation/navigation-store';
 import { useUIStore } from '~/modules/ui/ui-store';
 import { appStreamManager } from '~/query/realtime/stream-store';
+import { createNotFoundComponent } from '~/routes/route-utils';
 import { routeTree } from '~/routes/routeTree.gen';
 import type { BoundaryType } from '~/routes/types';
 import { setSkipPageEnter } from '~/utils/nav-transition';
@@ -20,6 +21,10 @@ const router = createRouter({
   defaultPreload: false,
   context: {},
   defaultPendingMinMs: 0,
+  // Fallback for not-found errors scoped to an intermediate route (e.g. an unmatched path under
+  // /_public/auth). Without this, TanStack renders its generic `<p>Not Found</p>` since the root
+  // route's notFoundComponent only handles not-founds attached to the root match.
+  defaultNotFoundComponent: createNotFoundComponent('public'),
 });
 
 /** Get the deepest boundary from a route match array (e.g. 'app' or 'public') */


### PR DESCRIPTION
## Problem

Clicking a magic-link email (e.g. `http://localhost:3000/auth/invoke-token/magic/<token>`) landed on a **"Not found"** page, and the console logged a TanStack Router warning about a `notFoundError` on route `/_public/auth` with no `notFoundComponent`/`defaultNotFoundComponent` configured.

Two distinct bugs.

### Bug 1 — token links drop the `/api` prefix
The links were built as:
```ts
const verifyPath = `/auth/invoke-token/${type}/${token}`;
new URL(verifyPath, appConfig.backendUrl); // backendUrl = http://localhost:3000/api
```
`verifyPath` is an **absolute** path, so per the URL spec `new URL()` discards the base's `/api` path segment, yielding `http://localhost:3000/auth/invoke-token/magic/<token>`. The Vite dev proxy only forwards `/api` → the request never reaches the backend handler and instead hits the frontend router → 404.

The same anti-pattern affected **4 sites**:
- `magic-handlers.ts` (magic link)
- `send-verification-email.ts` (email verification)
- `send-oauth-verification-email.ts` (oauth verification)
- `handle-oauth-verification.ts` (oauth re-verification redirect to `/auth/{provider}`)

**Fix:** build these off `appConfig.backendAuthUrl` (which already ends in `/auth`) via string concatenation — matching the already-correct invite-link construction — so `/api/auth` is preserved.

### Bug 2 — generic `<p>Not Found</p>` + warning
A not-found scoped to an intermediate route (unmatched path under `/_public/auth`) is resolved **at that match** and does not climb to the root route's `notFoundComponent`. With no router-level `defaultNotFoundComponent`, TanStack fell back to its generic `<p>Not Found</p>` and logged the warning.

**Fix:** add `defaultNotFoundComponent: createNotFoundComponent('public')` to the router config (reuses the existing factory from `route-utils`).

## Testing
- `pnpm --filter backend ts` ✅
- `pnpm --filter frontend ts` ✅
- Biome ✅ / full pre-commit `check` suite ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)