### PR TITLE
refactor: densify self-evident comments in emails/bench/tests/scripts/mocks

### DIFF
--- a/backend/emails/components/safe-html.tsx
+++ b/backend/emails/components/safe-html.tsx
@@ -86,11 +86,9 @@ interface SafeHtmlProps {
 }
 
 /**
- * Renders sanitized HTML using a strict allowlist policy.
- *
- * This is the only place in the email pipeline that is allowed to use
- * `dangerouslySetInnerHTML`. All input is run through `sanitize-html` against
- * one of the named policies above, so call sites stay safe by construction.
+ * The only place in the email pipeline allowed to use `dangerouslySetInnerHTML`:
+ * input is sanitized against one of the named allowlist policies above, so call
+ * sites stay safe by construction.
  */
 export const SafeHtml = ({ html, policy, as: Tag = 'span', className }: SafeHtmlProps) => {
   const clean = sanitizeHtml(html, policies[policy]);

--- a/backend/emails/preview-fixtures.ts
+++ b/backend/emails/preview-fixtures.ts
@@ -15,14 +15,10 @@ import {
 import type { EmailTemplateDef } from './types';
 
 /**
- * A single email preview fixture: enough sample data to render one template.
- *
- * - `statics` are the props shared across all recipients (passed to `translate`).
- * - `recipient` are the per-recipient display props the component reads (the
- *   values the mailer turns into Brevo `{{params.x}}` placeholders at send time).
- *
- * Sample data lives on each template's `preview` field (type-checked against
- * the template's own props). This registry maps the preview slug to its template.
+ * `statics` are props shared across all recipients (passed to `translate`);
+ * `recipient` are per-recipient display props — the values the mailer turns into
+ * Brevo `{{params.x}}` placeholders at send time. Sample data lives on each
+ * template's `preview` field, type-checked against the template's own props.
  */
 export interface EmailPreviewFixture {
   // Template defs are heterogeneous (each binds its own statics/recipient shape).

--- a/backend/emails/render-preview.ts
+++ b/backend/emails/render-preview.ts
@@ -12,10 +12,8 @@ export interface RenderEmailPreviewOptions {
 }
 
 /**
- * Render a single email template to HTML using its preview fixture.
- *
- * Goes through the real render pipeline (`emails/jsx-email`), so the output
- * matches what the mailer sends. Shared by the dev preview route and tests.
+ * Goes through the real render pipeline (`emails/jsx-email`), so preview output
+ * matches what the mailer actually sends. Shared by the dev preview route and tests.
  */
 export async function renderEmailPreview(
   name: EmailPreviewName,

--- a/backend/emails/renderer/conditional.ts
+++ b/backend/emails/renderer/conditional.ts
@@ -19,11 +19,9 @@ interface ParentWithRaw {
 }
 
 /**
- * Returns a rehype plugin that replaces `<jsx-email-cond>` elements (from
- * the Conditional component) with conditional comment wrappers, based on the
+ * Returns a rehype plugin that replaces `<jsx-email-cond>` elements (from the
+ * Conditional component) with conditional comment wrappers, based on the
  * `data-mso` and `data-expression` attributes.
- *
- * Mirrors the async factory pattern used by `getRawPlugin()`.
  */
 export const getConditionalPlugin = async () => {
   return function conditionalPlugin() {
@@ -61,10 +59,8 @@ export const getConditionalPlugin = async () => {
           const expression = exprAttr || (msoAttr === true ? 'mso' : void 0);
           if (expression) {
             openRaw = `<!--[if ${expression}]>`;
-            // Older Outlook/Word HTML parsers prefer the self-closing
-            // conditional terminator variant to avoid comment spillover
-            // when adjacent comments appear. Use the `<![endif]/-->` form
-            // for maximum compatibility.
+            // Older Outlook/Word parsers prefer the self-closing `<![endif]/-->`
+            // terminator, which avoids comment spillover when comments are adjacent.
             closeRaw = '<![endif]/-->';
           }
         }

--- a/backend/emails/renderer/escape-string.ts
+++ b/backend/emails/renderer/escape-string.ts
@@ -14,12 +14,8 @@ enum ASCII {
 }
 
 /**
- * Escapes special characters and HTML entities in a given html string.
- *
- * This is a slightly modified version of React's
- * [`escapeHtml`](https://github.com/facebook/react/blob/dddfe688206dafa5646550d351eb9a8e9c53654a/packages/react-dom-bindings/src/server/escapeTextForBrowser.js#L53)
- *
- * @param string HTML string to escape for later insertion
+ * Slightly modified version of React's
+ * [`escapeHtml`](https://github.com/facebook/react/blob/dddfe688206dafa5646550d351eb9a8e9c53654a/packages/react-dom-bindings/src/server/escapeTextForBrowser.js#L53).
  */
 export function escapeString(string: string) {
   const str = String(string);

--- a/backend/emails/renderer/jsx-to-string.ts
+++ b/backend/emails/renderer/jsx-to-string.ts
@@ -22,9 +22,8 @@ const renderSuspense = async (children: ReactNode[]): ReturnType<typeof jsxToStr
 };
 
 /**
- * Convert a JSX element to a string.
- * This is a slightly modified version of Hyperons's
- * [`renderToString`](https://github.com/i-like-robots/hyperons/blob/main/src/render-to-string.js) function.
+ * Slightly modified version of Hyperons's
+ * [`renderToString`](https://github.com/i-like-robots/hyperons/blob/main/src/render-to-string.js).
  */
 export async function jsxToString(element: ReactNode): Promise<string> {
   if (element == null) {

--- a/backend/emails/renderer/raw.ts
+++ b/backend/emails/renderer/raw.ts
@@ -32,8 +32,6 @@ export function unescapeForRawComponent(input: string): string {
 /**
  * Returns a rehype plugin that replaces `<jsx-email-raw><!--...--></jsx-email-raw>`
  * elements with a raw HTML node using the original, unescaped content.
- *
- * Mirrors the async factory pattern used by `getMovePlugin()`.
  */
 export const getRawPlugin = async () => {
   return function rawPlugin() {

--- a/backend/emails/renderer/visit.ts
+++ b/backend/emails/renderer/visit.ts
@@ -3,12 +3,11 @@ import type { Element, Parents, Root } from 'hast';
 type ElementVisitor = (node: Element, index: number | undefined, parent: Parents | undefined) => void;
 
 /**
- * Minimal, dependency-free replacement for `unist-util-visit`, scoped to the
- * only thing the email render pipeline needs: a depth-first, pre-order walk that
- * calls `visitor` for every `element` node with its index and parent.
+ * Dependency-free replacement for `unist-util-visit`: a depth-first, pre-order
+ * walk calling `visitor` for every `element` node with its index and parent.
  *
- * Visitors must not mutate the tree during the walk. Plugins collect
- * matches first and mutate afterwards, so this stays safe and simple.
+ * Visitors must not mutate the tree mid-walk — plugins collect matches first,
+ * then mutate afterwards.
  */
 export const visitElements = (tree: Root, visitor: ElementVisitor): void => {
   const walk = (node: Root | Element, index: number | undefined, parent: Parents | undefined): void => {

--- a/backend/emails/templates/welcome.tsx
+++ b/backend/emails/templates/welcome.tsx
@@ -16,11 +16,9 @@ const withAppName = (text: string) => text.replaceAll('{{appName}}', appName);
 const { welcomeEmail } = welcomeConfig;
 
 /**
- * Founder-style welcome email sent to new users.
- *
- * The marketing copy (intro, getting-started steps, P.S., founder details) is
- * fork-customizable in `json/text-blocks.json` under `welcomeEmail`, so forks can
- * tailor the message without touching code or translations.
+ * Founder-style welcome email. The marketing copy (intro, getting-started steps,
+ * P.S., founder details) is fork-customizable in `json/text-blocks.json` under
+ * `welcomeEmail`, so forks can tailor it without touching code or translations.
  */
 export const welcomeEmailTemplate = defineEmailTemplate<Record<string, never>, WelcomeRecipient>()({
   translate(lng) {

--- a/backend/emails/types.ts
+++ b/backend/emails/types.ts
@@ -2,9 +2,8 @@
 export type EmailRecipient = { email: string; lng: string };
 
 /**
- * Per-recipient display props a component reads (the values the mailer turns
- * into Brevo `{{params.x}}` placeholders at send time). Derived from the
- * recipient type minus the always-present `EmailRecipient` base fields.
+ * Per-recipient display props a component reads — the values the mailer turns
+ * into Brevo `{{params.x}}` placeholders at send time.
  */
 export type RecipientProps<TRecipient extends EmailRecipient> = {
   [K in Exclude<keyof TRecipient, keyof EmailRecipient>]: string;
@@ -22,10 +21,9 @@ export interface EmailPreviewData<TStatic, TRecipient extends EmailRecipient = E
 }
 
 /**
- * Email template definition (runtime contract used by the mailer).
- *
- * @template TStatic     - Props shared across all recipients (e.g. senderName, entityName)
- * @template TRecipient  - Per-recipient props (must extend EmailRecipient)
+ * Email template definition — the runtime contract the mailer consumes.
+ * `TStatic`: props shared across recipients (e.g. senderName, entityName);
+ * `TRecipient` extends `EmailRecipient` with per-recipient props.
  */
 export interface EmailTemplateDef<TStatic = Record<string, never>, TRecipient extends EmailRecipient = EmailRecipient> {
   /** Pre-compute all translated strings (+ pass-through statics the component needs). Must include `subject`. */
@@ -39,16 +37,14 @@ export interface EmailTemplateDef<TStatic = Record<string, never>, TRecipient ex
 }
 
 /**
- * Type-safe factory for email templates.
+ * Type-safe factory for email templates: infers the shape returned by
+ * `translate()` and enforces that `component()` receives exactly those props
+ * (plus per-recipient placeholder strings), catching props a component
+ * destructures that `translate()` never returns.
  *
- * Infers the shape returned by `translate()` and enforces that `component()`
- * receives exactly those props (plus any per-recipient placeholder strings).
- * This prevents mismatches where a component destructures a prop that
- * `translate()` never returns.
- *
- * Uses a curried call because TypeScript cannot partially infer type params:
- * the first call binds TStatic / TRecipient (caller-specified), while the
- * second call lets TS infer TTranslated from the `translate` return type.
+ * Curried because TypeScript cannot partially infer type params: the first call
+ * binds TStatic / TRecipient (caller-specified), the second infers TTranslated
+ * from `translate`'s return type.
  *
  * @example
  * ```ts

--- a/backend/scripts/generate-openapi.ts
+++ b/backend/scripts/generate-openapi.ts
@@ -67,10 +67,8 @@ function canSkipGeneration(): { skip: boolean; reason: string; hash: string | nu
 }
 
 /**
- * Generate the OpenAPI document and write it to a JSON file. Sets NODB='true' to avoid
- * database connections during generation.
- *
- * Git-based caching: skips generation if no relevant files changed since last run; --force bypasses it.
+ * Sets NODB='true' to avoid database connections during generation.
+ * Git-based caching: skips if no relevant files changed since last run; --force bypasses it.
  */
 (async () => {
   const startTime = performance.now();

--- a/backend/scripts/migrations/10-cdc.migration.ts
+++ b/backend/scripts/migrations/10-cdc.migration.ts
@@ -11,8 +11,6 @@ interface TableSpec {
 }
 
 /**
- * Build per-table publication specs.
- *
  * Publication column lists are incompatible with REPLICA IDENTITY FULL (PG error 42P10).
  * Since the CDC worker needs REPLICA IDENTITY FULL for old-row diffs, we publish all columns.
  * Large columns are still stripped from WS payloads via cdcExcludeColumnLengthThreshold in the activity service.

--- a/backend/scripts/migrations/10-partman.migration.ts
+++ b/backend/scripts/migrations/10-partman.migration.ts
@@ -115,13 +115,10 @@ const partitionConfigs: PartitionConfig[] = [
 ];
 
 /**
- * Generate SQL for a single table partition setup using dynamic SQL.
- * Uses EXECUTE to avoid parser errors in environments that don't support PARTITION BY.
- *
- * Each table conversion is idempotent: checks if already partitioned before converting.
- *
- * For tables with createTableSql = null (like activities), uses PostgreSQL's LIKE clause
- * to clone the existing table structure. This makes it robust to dynamic columns.
+ * Uses EXECUTE (dynamic SQL) to avoid parser errors in environments that don't support PARTITION BY.
+ * Idempotent: checks if already partitioned before converting.
+ * For tables with createTableSql = null (like activities), uses PostgreSQL's LIKE clause to clone
+ * the existing table structure, making it robust to dynamic columns.
  */
 function generateTablePartitionSql(config: PartitionConfig): string {
   // Shared idempotency guard: skip if table is already partitioned.

--- a/backend/scripts/migrations/helpers/drizzle-utils.ts
+++ b/backend/scripts/migrations/helpers/drizzle-utils.ts
@@ -43,9 +43,8 @@ export function getMigrationFolders(): string[] {
 }
 
 /**
- * Find the latest migration folder by tag suffix.
- * Since migrations can evolve (multiple folders with the same tag), returns the most recent one.
- * @param tagSuffix - The tag suffix to search for (e.g., 'cdc_setup')
+ * Find the latest migration folder by tag suffix. Migrations can evolve (multiple folders
+ * share a tag), so this returns the most recent match.
  */
 export function findMigrationByTag(tagSuffix: string): string | undefined {
   const matches = getMigrationFolders().filter((folder) => folder.endsWith(`_${tagSuffix}`));
@@ -81,13 +80,11 @@ export function resolveSqlContent(sqlOrPath: string): string {
 /**
  * Add or update a SQL migration in the Drizzle migrations folder (v1 format).
  *
- * When a migration with the given tag already exists:
- * - If the SQL content is identical, the action is 'unchanged'.
- * - If the SQL content changed, the action is 'evolved' and the old folder stays
- *   untouched while a fresh timestamped folder receives the new SQL.
+ * When a migration with the tag already exists: identical SQL → action 'unchanged'; changed
+ * SQL → action 'evolved', leaving the old folder untouched and writing a fresh timestamped
+ * folder with the new SQL.
  *
- * @param tag - Unique identifier for the migration (e.g., 'cdc_setup')
- * @param sql - SQL content (not a file path - use resolveSqlContent first if needed)
+ * @param sql - SQL content, not a file path (use resolveSqlContent first if needed)
  */
 export function upsertMigration(tag: string, sql: string): MigrationResult {
   // Normalize tag by removing leading timestamps/underscores if present.

--- a/backend/scripts/migrations/helpers/run-generate-scripts.ts
+++ b/backend/scripts/migrations/helpers/run-generate-scripts.ts
@@ -12,12 +12,8 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Run all generation scripts.
- *
- * Scripts are executed in filename order (drizzle first via 00- prefix,
- * then migration scripts via 10- prefix).
- *
- * A 1-second delay is added between migration scripts to ensure unique timestamps.
+ * Scripts run in filename order (drizzle first via 00- prefix, then migration scripts via 10-).
+ * A 1-second delay between migration scripts ensures unique timestamps.
  */
 export async function runGenerateScripts(scripts: GenerateScript[]): Promise<void> {
   console.info('');

--- a/backend/scripts/seeds/00-init.seed.ts
+++ b/backend/scripts/seeds/00-init.seed.ts
@@ -30,10 +30,8 @@ const isUserSeeded = async () => {
 };
 
 /**
- * Seed an admin user to access app first time.
- * Works in all environments:
- * - ADMIN_EMAIL env var takes precedence when set; otherwise falls back to the fixture default (admin-test@cellajs.com)
- * - Production: ADMIN_EMAIL is required
+ * Seed an admin user for first-time app access. ADMIN_EMAIL takes precedence when set, otherwise
+ * falls back to the fixture default (admin-test@cellajs.com); ADMIN_EMAIL is required in production.
  */
 export const initSeed = async () => {
   // Determine admin email: env var takes precedence, then fixture default

--- a/backend/scripts/seeds/50-counters.seed.ts
+++ b/backend/scripts/seeds/50-counters.seed.ts
@@ -7,11 +7,9 @@ import { startSpinner, succeedSpinner } from '#/utils/console';
 const db = seedDb;
 
 /**
- * Recalculate channel_counters and product_counters from current database state.
- *
- * Delegates to recalculateCounters() which uses ON CONFLICT with || merge,
- * so it's safe to run even when rows already exist (e.g. pre-populated by triggers).
- * Runs on every seed invocation.
+ * Recalculate channel_counters and product_counters from current DB state. Delegates to
+ * recalculateCounters(), which uses ON CONFLICT with || merge, so it's safe to re-run even
+ * when rows already exist (e.g. pre-populated by triggers).
  */
 export const countersSeed = async () => {
   startSpinner('Recalculating counters...');

--- a/backend/scripts/types.ts
+++ b/backend/scripts/types.ts
@@ -1,7 +1,6 @@
 /**
- * Type of generation script.
- * - 'drizzle': Schema-to-SQL generation (drizzle-kit generate)
- * - 'migration': Custom migration script that upserts to drizzle folder
+ * - 'drizzle': schema-to-SQL generation (drizzle-kit generate)
+ * - 'migration': custom migration script that upserts to the drizzle folder
  */
 export type GenerateScriptType = 'drizzle' | 'migration';
 

--- a/backend/src/mocks/mock-activity-stamps.ts
+++ b/backend/src/mocks/mock-activity-stamps.ts
@@ -4,10 +4,9 @@ import { withFakerSeed } from './faker-seed';
 import { MOCK_REF_DATE } from './mock-timestamps';
 
 /**
- * Type for dynamically generated per-stream activity stamps in mocks.
- * Epoch-ms timestamps per product entity type: latest post (created, null when never
- * posted) and latest content update (updated, null when never updated), matching the
- * `activity` object in channelEntityIncludedSchema counts.
+ * Epoch-ms timestamps per product entity type: `created` = latest post (null when
+ * never posted), `updated` = latest content update (null when never updated),
+ * matching the `activity` object in channelEntityIncludedSchema counts.
  */
 export type MockActivityStamps = {
   [K in ProductEntityType]: { created: number | null; updated: number | null };

--- a/backend/src/mocks/mock-channel-entity-id-columns.ts
+++ b/backend/src/mocks/mock-channel-entity-id-columns.ts
@@ -19,9 +19,8 @@ import { mockUuid } from './mock-nanoid';
 export type MockChannelIdColumns = EntityIdColumns<ChannelEntityType, string>;
 
 /**
- * Generates mock ID columns for channel entity types from appConfig.
- * @param mode - 'all' (default) covers all channel entity types; 'relatable' only those in the
- *   hierarchy's relatableChannelTypes.
+ * @param mode - 'all' (default) covers all channel entity types; 'relatable' only
+ *   those in the hierarchy's relatableChannelTypes.
  */
 export const generateMockChannelIdColumns = (mode: 'all' | 'relatable' = 'all'): MockChannelIdColumns => {
   const entityTypes = mode === 'all' ? appConfig.channelEntityTypes : hierarchy.relatableChannelTypes;

--- a/backend/src/mocks/mock-entity-counts.ts
+++ b/backend/src/mocks/mock-entity-counts.ts
@@ -18,9 +18,8 @@ export type MockEntityCounts = {
 };
 
 /**
- * Generates mock entity counts dynamically based on appConfig.entityTypes.
- * Excludes 'user' and 'organization' to match fullCountsSchema pattern.
- * @param key - Key for deterministic generation.
+ * Excludes 'user' and 'organization' to match the fullCountsSchema pattern.
+ * @param key - seeds deterministic generation.
  */
 export const generateMockEntityCounts = (key: string): MockEntityCounts => {
   const generator = (): MockEntityCounts =>

--- a/backend/src/mocks/mock-full-counts.ts
+++ b/backend/src/mocks/mock-full-counts.ts
@@ -3,9 +3,8 @@ import { generateMockEntityCounts, type MockEntityCounts } from './mock-entity-c
 import { generateMockMembershipCounts, type MockMembershipCounts } from './mock-membership-counts';
 
 /**
- * Generates full counts structure for organization responses.
- * Combines membership counts, entity counts and activity stamps dynamically.
- * @param key - Key for deterministic generation.
+ * Full counts (membership + entities + activity) for organization responses.
+ * @param key - seeds deterministic generation.
  */
 export const generateMockFullCounts = (
   key: string,

--- a/backend/src/mocks/mock-membership-counts.ts
+++ b/backend/src/mocks/mock-membership-counts.ts
@@ -14,9 +14,7 @@ export type MockMembershipCounts = {
 };
 
 /**
- * Generates mock membership counts for an organization.
- * Dynamically generates counts for each entity role defined in config.
- * @param key - Key for deterministic generation.
+ * @param key - seeds deterministic generation.
  */
 export const generateMockMembershipCounts = (key: string): MockMembershipCounts => {
   const generator = (): MockMembershipCounts => {

--- a/backend/src/mocks/mock-nanoid.ts
+++ b/backend/src/mocks/mock-nanoid.ts
@@ -13,10 +13,10 @@ export const LOADTEST_ID_PREFIX = 'lt-';
 let currentMockContext: MockContext = 'example';
 
 /**
- * Sets the mock context for ID generation.
- * - 'example': No prefix (for OpenAPI examples)
- * - 'script': 'gen-' prefix (for seed scripts, CDC filtering)
- * - 'loadtest': 'lt-' prefix (for load-test data, never collides with real/seed data)
+ * ID prefix per context:
+ * - 'example': none (OpenAPI examples)
+ * - 'script': 'gen-' (seed scripts, CDC filtering)
+ * - 'loadtest': 'lt-' (load-test data, never collides with real/seed data)
  */
 export const setMockContext = (context: MockContext) => {
   currentMockContext = context;

--- a/backend/src/mocks/mock-past-iso-date.ts
+++ b/backend/src/mocks/mock-past-iso-date.ts
@@ -2,8 +2,7 @@ import { faker } from '@faker-js/faker';
 import { MOCK_REF_DATE } from './mock-timestamps';
 
 /**
- * Generates a random ISO date in the past, relative to MOCK_REF_DATE so
- * output is deterministic under withFakerSeed() (an unset refDate would
- * fall back to Date.now() and drift on every generation run).
+ * Past ISO date relative to MOCK_REF_DATE for determinism under withFakerSeed()
+ * — an unset refDate would fall back to Date.now() and drift on every run.
  */
 export const mockPastIsoDate = () => faker.date.past({ refDate: MOCK_REF_DATE }).toISOString();

--- a/backend/src/mocks/mock-timestamps.ts
+++ b/backend/src/mocks/mock-timestamps.ts
@@ -4,9 +4,8 @@ import { faker } from '@faker-js/faker';
 export const MOCK_REF_DATE = new Date('2025-01-01T00:00:00.000Z');
 
 /**
- * Generates deterministic created/modified timestamps.
- * createdAt is in the past, updatedAt is between createdAt and refDate.
- * Must be called within withFakerSeed() for deterministic output.
+ * created/modified timestamps: createdAt in the past, updatedAt between createdAt
+ * and refDate. Must run inside withFakerSeed() for deterministic output.
  */
 export const mockTimestamps = (refDate = MOCK_REF_DATE) => {
   const createdAt = faker.date.past({ refDate });

--- a/backend/tests/helpers.ts
+++ b/backend/tests/helpers.ts
@@ -118,11 +118,6 @@ export async function createTestUser(email: string, verified = true) {
   return user;
 }
 
-/**
- * Helper function to retrieve a user by email from the database.
- * @param email - The email of the user to retrieve.
- * @returns
- */
 export async function getUserByEmail(email: string): Promise<UserModel[]> {
   return await db.select().from(usersTable).where(eq(usersTable.email, email));
 }

--- a/backend/tests/integration/cdc-event-bus.test.ts
+++ b/backend/tests/integration/cdc-event-bus.test.ts
@@ -78,8 +78,7 @@ describe.skipIf(process.env.TEST_MODE !== 'full')('CDC Setup Verification', () =
 });
 
 /**
- * Full CDC flow tests.
- * These start the CDC worker pipeline in-process so the suite runs in `pnpm test`
+ * Starts the CDC worker pipeline in-process so the suite runs in `pnpm test`
  * without depending on a separately running worker.
  */
 describe.skipIf(process.env.TEST_MODE !== 'full')('Full CDC Flow', () => {

--- a/backend/tests/integration/schema-verification.test.ts
+++ b/backend/tests/integration/schema-verification.test.ts
@@ -76,7 +76,6 @@ describe('Schema verification', () => {
     });
   });
 
-  // ── RLS setup: FORCE RLS + policies + ownership ─────────────────────────
   // These require the RLS migration to have been run. The beforeAll ensures
   // admin_role/runtime_role exist and FORCE RLS is set (mirrors 10-rls.migration.ts).
 

--- a/backend/tests/integration/test-utils.ts
+++ b/backend/tests/integration/test-utils.ts
@@ -49,11 +49,6 @@ interface CdcTestHarness {
   stop(): Promise<void>;
 }
 
-/**
- * Helper to wait for an event with timeout.
- * @param eventType - The event type to wait for
- * @param timeoutMs - Maximum time to wait (default 10s)
- */
 export function waitForEvent(
   eventType: Parameters<typeof activityBus.once>[0],
   timeoutMs = 10000,
@@ -87,7 +82,6 @@ export async function waitFor(
 /**
  * Host the backend's real `/internal/cdc` WebSocket endpoint on an ephemeral
  * local port, standing in for the deployed backend the CDC worker would dial.
- * Returns the dial URL and a closer.
  */
 async function startInternalCdcWsServer(): Promise<{ url: string; close(): Promise<void> }> {
   const server = createServer((_req, res) => {

--- a/backend/tests/test-client.ts
+++ b/backend/tests/test-client.ts
@@ -24,9 +24,8 @@ export function createTestClient(app: AppLike): Client {
 }
 
 /**
- * Calls an SDK function in test mode, returning { data, error, response }.
- * Injects the test client, disables throwOnError, and sets responseStyle to 'fields'.
- * Input options are type-checked against the SDK function's signature.
+ * Injects the test client, disables throwOnError, and sets responseStyle to 'fields'; input
+ * options are type-checked against the SDK function's signature.
  */
 export function sdk(client: Client) {
   return async <F extends (opts: any) => Promise<any>>(

--- a/backend/tests/test-utils.ts
+++ b/backend/tests/test-utils.ts
@@ -54,9 +54,8 @@ export function mockFetchRequest() {
 }
 
 /**
- * Clear the database by truncating all test-related tables.
- * Uses TRUNCATE CASCADE which is much faster than individual DELETEs.
- * Also resets mock enforcers to prevent conflicts with unique values.
+ * Clear the database with TRUNCATE CASCADE (much faster than per-table DELETEs). Also resets
+ * mock enforcers so unique values don't conflict across tests.
  */
 export async function clearDatabase() {
   // Reset mock enforcers so unique values don't conflict across tests
@@ -69,7 +68,6 @@ export async function clearDatabase() {
 }
 
 /**
- * Mock factory for rate limiter core module.
  * vi.mock() calls must be at the top level of each test file because Vitest hoists them.
  * Use at top level: vi.mock('#/middlewares/rate-limiter/core', rateLimiterCoreMock)
  */
@@ -148,8 +146,7 @@ export function setTestConfig(overrides: ConfigOverride) {
 }
 
 /**
- * Mock factory for cookie helpers (used in OAuth tests).
- * Returns an in-memory cookie store with set/get/delete.
+ * In-memory cookie store standing in for the real cookie helpers (OAuth tests).
  * Use at top level: vi.mock('#/modules/auth/general/helpers/cookie', async () => (await import('../test-utils')).cookieMock())
  * Call clearCookieStore() in afterEach to reset between tests.
  * Access mockCookieStore directly to pre-populate cookies in tests.

--- a/bench/src/bench-cli.ts
+++ b/bench/src/bench-cli.ts
@@ -54,11 +54,7 @@ function discoverScenarios(): string[] {
     .sort();
 }
 
-/**
- * Short description for a scenario, read from the first comment line of its YAML.
- * Keeps the picker in sync with whatever scenarios exist, no hardcoded map to
- * edit when a fork adds a scenario.
- */
+/** Scenario description from the first `#` comment line of its YAML — keeps the picker in sync as forks add scenarios, no hardcoded map. */
 function scenarioDescription(name: string): string {
   try {
     const content = readFileSync(resolve(BENCH_ROOT, 'scenarios', `${name}.yaml`), 'utf-8');
@@ -91,11 +87,10 @@ const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 // ── Preflight ──────────────────────────────────────────────────────────────
 
 /**
- * Fail-fast preflight. Bench expects Postgres seeded with app data and the
- * backend/cdc/yjs/mcp services already running via `pnpm dev`; it does not
- * start them. Services are polled briefly to tolerate `dev` still compiling,
- * then bench exits with an actionable message rather than hanging or
- * producing empty runs.
+ * Fail-fast preflight — bench does NOT start services; it expects Postgres seeded
+ * and backend/cdc/yjs/mcp already up via `pnpm dev`. Services are polled briefly to
+ * tolerate `dev` still compiling, then it exits with an actionable message rather
+ * than hanging on empty runs.
  */
 async function assertInfrastructureReady(): Promise<void> {
   const spinner = ora('checking infrastructure...').start();
@@ -161,10 +156,9 @@ function seedDatabase(): Promise<{ output: string }> {
 // ── Artillery ──────────────────────────────────────────────────────────────
 
 /**
- * Artillery `--overrides` payload for `--short`: collapse every phase into a
- * single 1s / 1-VU arrival and drop the ensure thresholds, so a run becomes a
- * fast "does it still work" smoke check rather than a load test. Loop `count`s
- * inside scenario flows stay as-is but execute once (single VU).
+ * Artillery `--overrides` for `--short`: collapse every phase to a single 1s/1-VU
+ * arrival and drop ensure thresholds — a fast "does it still work" smoke check, not
+ * a load test. Loop `count`s in scenario flows stay but execute once (single VU).
  */
 const SHORT_OVERRIDES = JSON.stringify({
   config: {
@@ -213,14 +207,10 @@ function runArtillery(
 }
 
 /**
- * Background CDC health poller. Runs automatically for every scenario, with
- * no flag or developer awareness needed. Collects throughput/latency samples
- * silently and only emits a summary if CDC actually processed events, so
- * read-only scenarios stay clean. Runs as a separate process because
+ * Background CDC health poller, started automatically for every scenario. Collects
+ * throughput/latency samples silently, emitting a summary only if CDC actually
+ * processed events (read-only scenarios stay clean). A separate process because
  * `runArtillery` blocks the event loop via synchronous `execFileSync`.
- *
- * Returns the process and a promise resolving to the collected summary output
- * once the poller has flushed and exited.
  */
 function startCdcPoller(): { proc: ChildProcess; summary: Promise<string> } {
   const proc = spawn('tsx', ['src/cdc-poller.ts', '--quiet'], {
@@ -386,11 +376,7 @@ function printComparison(current: BaselineMetrics, baseline: BaselineMetrics | n
   console.info();
 }
 
-/**
- * One combined table for a `--all` run: a row per scenario with its key metrics
- * and the p95 delta vs the previous baseline. Printed once at the end so the run
- * stays quiet until every scenario is done.
- */
+/** Combined `--all` table: one row per scenario with key metrics and p95 delta vs baseline. Printed once at the end so the run stays quiet. */
 function printAllSummary(results: { name: string; result: ScenarioResult }[]): void {
   console.info(`\n${pc.bold('Summary')} ${pc.dim('— all scenarios')}\n`);
 
@@ -443,13 +429,10 @@ interface ScenarioResult {
 }
 
 /**
- * Run one scenario end to end: start the silent CDC poller, run Artillery, then
- * (for full runs) compare against and save the baseline. Short runs are smoke
- * checks, so their metrics are not comparable and never touch baselines.
- *
- * In `quiet` mode (used by `--all`) Artillery output is hidden behind a spinner
- * and the per-scenario comparison table is skipped. The caller prints one
- * combined summary at the end. Returns the run's exit code and metrics.
+ * Run one scenario end to end (CDC poller + Artillery + baseline compare/save).
+ * Short runs are smoke checks: metrics aren't comparable and never touch baselines.
+ * `quiet` (used by `--all`) hides Artillery output and the per-scenario table — the
+ * caller prints one combined summary instead.
  */
 async function runScenario(
   name: string,

--- a/bench/src/cdc-poller.ts
+++ b/bench/src/cdc-poller.ts
@@ -89,11 +89,9 @@ function printSummary(samples: PollState['samples']) {
 }
 
 /**
- * Polls the CDC worker's /health endpoint during a bench run to capture
- * throughput (ops/s), p95 latency, WAL lag, and event counts.
- *
- * Bench starts this automatically in the background for every run (`--quiet`),
- * so it stays silent unless CDC actually processed events. Run standalone for
+ * Polls the CDC worker's /health endpoint during a run to capture throughput
+ * (ops/s), p95 latency, WAL lag, and event counts. Bench starts it automatically
+ * in the background (`--quiet`), silent unless CDC processed events. Standalone for
  * live per-interval logging:
  *
  *   tsx src/cdc-poller.ts [--interval 3] [--duration 120] [--quiet]

--- a/bench/src/config.ts
+++ b/bench/src/config.ts
@@ -7,9 +7,8 @@ try {
 } catch {}
 
 /**
- * Shared configuration for Artillery load tests, derived from the fork's own
- * config (`appConfig`, `backend/.env`) so bench follows a fork's port offset
- * automatically. Dev-only, tied to the local stack.
+ * Load-test config derived from the fork's own config (`appConfig`, `backend/.env`)
+ * so bench follows a fork's port offset automatically. Dev-only, local stack.
  */
 export const BASE_URL = appConfig.backendUrl;
 

--- a/bench/src/data-setup.ts
+++ b/bench/src/data-setup.ts
@@ -17,9 +17,9 @@ const __dirname = import.meta.dirname ?? dirname(fileURLToPath(import.meta.url))
 const SEEDS_DIR = resolve(__dirname, 'seeds');
 
 /**
- * Auto-import every `*.bench.ts` module under seeds/ so each self-registers
- * its seed target (core data + any fork-defined entities/resources). No barrel
- * or data-setup edit is needed to add a new load-test table.
+ * Auto-import every `*.bench.ts` under seeds/ so each self-registers its seed
+ * target — a fork adds a load-test table by dropping in one file, no barrel or
+ * data-setup edit.
  */
 async function loadBenchEntities(): Promise<void> {
   for (const file of readdirSync(SEEDS_DIR)
@@ -109,9 +109,8 @@ async function cleanLoadtestData(pool: pg.Pool) {
 // ── Seed ───────────────────────────────────────────────────────────────────
 
 /**
- * Seeds deterministic bench data into the dev database using mock generators
- * from backend/mocks for type-safe, schema-aligned rows. Idempotent: cleans
- * existing bench data before re-seeding. Run with `pnpm db:seed`.
+ * Seeds deterministic bench data via backend/mocks generators (type-safe rows).
+ * Idempotent: cleans existing bench data before re-seeding. Run with `pnpm db:seed`.
  */
 async function seed() {
   const pool = new Pool({ connectionString: DB_URL, statement_timeout: QUERY_TIMEOUT_MS });

--- a/bench/src/preflight.ts
+++ b/bench/src/preflight.ts
@@ -33,10 +33,9 @@ export async function isServiceHealthy(url: string): Promise<boolean> {
 }
 
 /**
- * One-shot readiness probe: Postgres reachable and every enabled service
- * healthy. Shared between the bench CLI and the Vitest smoke test. Unlike the
- * CLI's `assertInfrastructureReady`, this does not poll or exit: it returns
- * `false` immediately so callers can skip gracefully.
+ * One-shot readiness probe (Postgres + every enabled service), shared by the bench
+ * CLI and the Vitest smoke test. Unlike `assertInfrastructureReady`, it never polls
+ * or exits — returns `false` immediately so callers can skip gracefully.
  */
 export async function isInfrastructureReady(): Promise<boolean> {
   if (!(await isPostgresReady())) return false;

--- a/bench/src/processors/auth.ts
+++ b/bench/src/processors/auth.ts
@@ -22,11 +22,10 @@ function buildCookie(userIndex: number): string {
 // ── Authenticate ───────────────────────────────────────────────────────────
 
 /**
- * Builds the session cookie for a virtual user from pre-seeded, deterministic
- * session tokens (used as `beforeScenario` in every scenario), skipping the
- * HTTP sign-in call for an instant VU start. Cookie format:
- * `{hashedToken}.{sessionId}.` where hashedToken is the SHA-256 hex of the
- * deterministic token (matches what data-setup inserts).
+ * Builds a VU's session cookie from pre-seeded deterministic tokens (`beforeScenario`
+ * hook), skipping the HTTP sign-in for an instant VU start. Format
+ * `{hashedToken}.{sessionId}.` where hashedToken is the SHA-256 hex of the token —
+ * must match what data-setup inserts.
  */
 export async function authenticate(context: { vars: Record<string, unknown> }, _events: unknown) {
   const userIndex = userCounter++ % TOTAL_USERS;

--- a/bench/src/registry.ts
+++ b/bench/src/registry.ts
@@ -34,9 +34,9 @@ export interface TableBenchSeed {
    */
   cleanupWhere?: string;
   /**
-   * Produce rows to insert. `now` is an ISO timestamp shared across the seed run.
-   * INSERT columns are derived from each row's keys (camelCase → snake_case), so
-   * generators should return typed insert rows whose keys are real columns.
+   * Produce rows to insert; `now` is one ISO timestamp shared across the seed run.
+   * INSERT columns derive from each row's keys (camelCase → snake_case), so keys
+   * must be real columns.
    */
   rows: (ctx: BenchSeedContext) => Record<string, unknown>[];
 }
@@ -70,11 +70,9 @@ export const getBenchSeedCleanupWhere = (seed: TableBenchSeed): string => {
 };
 
 /**
- * Registers a bench seed target as an import side effect (mirrors the cella
- * module/tag registry pattern in `shared/src/module-registry.ts`); `data-setup.ts`
- * auto-imports every `*.bench.ts` file under seeds/, so a fork adds a load-test
- * table by dropping in one file. Idempotent by name; rejects malformed or
- * duplicate id variants.
+ * Registers a bench seed as an import side effect (mirrors the module/tag registry
+ * in `shared/src/module-registry.ts`) — a fork adds a load-test table by dropping in
+ * one `*.bench.ts` file. Idempotent by name; rejects malformed or duplicate id variants.
  *
  * @see seeds/README.md
  */

--- a/bench/src/seed-utils.ts
+++ b/bench/src/seed-utils.ts
@@ -4,19 +4,14 @@ import { type BenchSeed, getBenchSeedCleanupWhere, type TableBenchSeed } from '.
 
 const BATCH_SIZE = 200;
 
-/**
- * Convert a camelCase record key to its snake_case Postgres column name.
- * Inverse of the transform in `recordToRow`. Relies on the DB using snake_case
- * columns (all bench tables do).
- */
+/** snake_case column name for a camelCase key; inverse of `recordToRow`. Assumes snake_case DB columns (all bench tables). */
 function camelToSnake(key: string): string {
   return key.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
 }
 
 /**
- * Convert a camelCase record to a snake_case value array for SQL insertion.
- * Columns listed in `pgArrayColumns` are kept as native JS arrays (pg driver converts them).
- * All other arrays/objects are JSON-stringified for json/jsonb columns.
+ * Value array for SQL insertion. Columns in `pgArrayColumns` stay native JS arrays
+ * (pg driver converts them); other arrays/objects are JSON-stringified for json/jsonb.
  */
 function recordToRow(record: Record<string, unknown>, columns: string[], pgArrayColumns?: Set<string>): unknown[] {
   return columns.map((col) => {

--- a/bench/src/seeds/attachment.bench.ts
+++ b/bench/src/seeds/attachment.bench.ts
@@ -6,8 +6,7 @@ import { attachmentId, CORE_ID_VARIANTS, ORG_ID, TENANT_ID, userId } from './ids
 export const TOTAL_ATTACHMENTS = 500;
 
 /**
- * Generate a load-test attachment row by index. Reference implementation
- * for the fork seed pattern.
+ * Reference implementation for the fork seed pattern.
  *
  * @see seeds/README.md
  */

--- a/bench/src/seeds/membership.ts
+++ b/bench/src/seeds/membership.ts
@@ -2,11 +2,6 @@ import type { InsertMembershipModel } from '#/modules/memberships/memberships-db
 import { mockChannelMembership } from '#/modules/memberships/memberships-mocks';
 import { ORG_ID, TENANT_ID, userId } from './ids';
 
-/**
- * Generate organization-level membership for a load-test user, using backend
- * mocks for a type-safe entity. Runs in Node.js (data-setup), not in Artillery
- * scenarios.
- */
 export const loadtestOrgMembership = (userIndex: number): InsertMembershipModel => {
   const membership = mockChannelMembership(
     'organization',

--- a/bench/src/seeds/organization.ts
+++ b/bench/src/seeds/organization.ts
@@ -2,11 +2,6 @@ import type { InsertOrganizationModel } from '#/modules/organization/organizatio
 import { mockOrganization } from '#/modules/organization/organization-mocks';
 import { ORG_ID, TENANT_ID } from './ids';
 
-/**
- * Generate the load-test organization row, using backend mocks for a
- * type-safe entity. Overrides id, tenantId, slug, and name for a deterministic
- * row. Runs in Node.js (data-setup), not in Artillery scenarios.
- */
 export const loadtestOrganization = (): InsertOrganizationModel => {
   const record = mockOrganization();
   return {

--- a/bench/src/seeds/user.ts
+++ b/bench/src/seeds/user.ts
@@ -33,9 +33,8 @@ export function loadtestEmail(index: number) {
 }
 
 /**
- * Generate a session row + cookie string for a load-test user.
- * Token is deterministic per index so the Artillery processor can reconstruct
- * the cookie without querying the DB.
+ * Token is deterministic per index so the Artillery processor can reconstruct the
+ * cookie without querying the DB.
  */
 export function loadtestSession(index: number, hashedToken: string, expiresAt: string) {
   return {

--- a/bench/src/tests/all-scenarios.test.ts
+++ b/bench/src/tests/all-scenarios.test.ts
@@ -1,10 +1,10 @@
 /**
  * Bench smoke test: runs every scenario through the real CLI in `--short` mode
- * (1s / 1 VU, no thresholds, no baselines) to catch scenarios that break, e.g.
- * after a route/schema change. It is a smoke check, not a performance gate.
+ * (1s/1 VU, no thresholds/baselines) to catch scenarios that break after a
+ * route/schema change. A smoke check, not a performance gate.
  *
- * Skips itself when the local stack is not reachable so the monorepo `vitest`
- * run does not require `pnpm dev` to be running.
+ * Skips itself when the local stack is unreachable, so the monorepo `vitest` run
+ * doesn't require `pnpm dev`.
  */
 
 import { execFileSync } from 'node:child_process';


### PR DESCRIPTION
## What

Tier‑1 of the "self‑evident code" cleanup, following the frontend pass (#891): an **aggressive, comment‑only** sweep of the presentational/scripting code — email components, benchmarks/seeds, tests, tooling scripts, and mocks — where the code reads clearly on its own.

Reviewed **all 98 blocks with ≥3 text lines** in these areas → **4 removed · 56 densified · 38 kept**, across **45 files** (**+130 / −242, net −112 lines**).

| Slice | blocks | removed | densified | kept |
|---|--:|--:|--:|--:|
| `backend/emails` + `backend/src/mocks` | 28 | 0 | 21 | 7 |
| `bench/**` | 24 | 2 | 19 | 3 |
| `backend/tests` + `backend/scripts` | 46 | 2 | 16 | 28 |

The keep‑rate tracks how much real "why" lives in each area: `bench` densified hard (mostly narration), while `tests`/`scripts` kept more (security/RLS rationale, regression guards, migration safety).

## Removed / densified vs kept

**Removed / densified:** signature‑restating JSDoc, narration of self‑evident seed/render/test code, redundant section labels.

**Kept (protected categories):**
- **Email‑client quirks** — Outlook/MSO `<![endif]/-->` self‑closing hack; the `safe-html` `dangerouslySetInnerHTML` security invariant.
- **Vendored‑code attribution** — jsx‑email / Hyperons / React source links (licensing provenance, not padding).
- **Mock/fixture determinism** — nanoid prefix conventions (CDC filtering, collision avoidance), timestamp ordering + `withFakerSeed` preconditions.
- **Test rationale** — the RLS/security integration header, CDC‑under‑FORCE‑RLS regression (silent 0‑row UPDATE breaks sync), B1–B4 regression enumerations, first‑run CI setup‑ordering.
- **Script gotchas** — migration idempotency, `UNLOGGED` data‑loss‑tolerance rationale, prod‑vs‑dev role provisioning + `DATABASE_ADMIN_URL` precondition.
- Directives (`biome-ignore`, `v8 ignore`), `TODO`/`FIXME`, and worked `@example`s — untouched.

## Verified

- **Provably comment‑only:** TypeScript emit with `removeComments` is byte‑identical to `main` for all 45 files; a diff line‑scan shows only comment lines changed.
- **Biome‑clean:** no fixes needed.
- Ran as three delegated per‑area passes in an isolated worktree off `main`.

> This is the last of the high‑confidence "easy wins." Remaining areas (`shared/src`, `cdc`, `yjs`, `infra/*`, backend permissions/middlewares) are deliberately documented — not recommended for an aggressive pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
