### PR TITLE
fix(backend): key spam limiter per user with IP fallback

### DIFF
--- a/backend/src/middlewares/rate-limiter/core.ts
+++ b/backend/src/middlewares/rate-limiter/core.ts
@@ -6,7 +6,7 @@ import { syncFromDb, tryFastConsume } from '#/middlewares/rate-limiter/points-ca
 import type {
   RateLimiterHandler,
   RateLimiterOpts,
-  RateLimitIdentifier,
+  RateLimitKeyPart,
   RateLimitMode,
 } from '#/middlewares/rate-limiter/types';
 import { toRateLimitIp } from '#/utils/ip-subnet';
@@ -46,7 +46,8 @@ export const slowOptions = {
  *
  * @param mode - Rate limit mode that dictates how rate limiting is applied.
  * @param key - The key to identify the user or entity being rate-limited (e.g., user ID, email).
- * @param identifiers - `("ip" | "email")[]` A list of identifiers to consider when generating rate limit key.
+ * @param identifiers - Key parts concatenated into the rate limit key. Each part is a single
+ *   identifier or a fallback chain (see {@link RateLimitKeyPart}).
  * @param opts - Optional configuration: limits, name, and description.
  * @returns Middleware handler for rate limiting.
  * @link https://github.com/animir/node-rate-limiter-flexible#readme
@@ -54,7 +55,7 @@ export const slowOptions = {
 export const rateLimiter = (
   mode: RateLimitMode,
   key: string,
-  identifiers: RateLimitIdentifier[],
+  identifiers: RateLimitKeyPart[],
   opts?: RateLimiterOpts,
 ): RateLimiterHandler => {
   const { limits, functionName, name, description, onBlock, getConsumePoints, getPointsBudget } = opts ?? {};
@@ -66,45 +67,37 @@ export const rateLimiter = (
   const handler = xMiddleware(
     { functionName: functionName ?? `${key}Limiter`, type: 'x-rate-limiter', name: name ?? key, description },
     async (ctx, next) => {
-      // Extract identifiers from multiple sources
-      const extractedIdentifiers = await extractIdentifiers(ctx, identifiers);
+      // Extract every identifier any key part (or chain member) can use
+      const extractedIdentifiers = await extractIdentifiers(ctx, identifiers.flat());
 
-      // Stop if required identifiers are not available
-      if (identifiers.includes('ip') && !extractedIdentifiers.ip) {
-        throw new AppError(400, 'invalid_request', 'warn');
-      }
-      if (identifiers.includes('email') && !extractedIdentifiers.email) {
-        throw new AppError(400, 'invalid_request', 'warn');
-      }
-
-      // Generate rate limit key with fallback logic
+      // Generate rate limit key. Each part contributes one segment; a chain part
+      // uses its first available identifier (e.g. ['userId', 'ip'] keys signed-in
+      // traffic per user so shared-IP offices are not collectively throttled, and
+      // falls back to IP for anonymous requests).
       let rateLimitKey = '';
 
-      for (const identifier of identifiers) {
-        const value = extractedIdentifiers[identifier];
-        if (!value) continue;
+      for (const part of identifiers) {
+        const chain = Array.isArray(part) ? part : [part];
+        const identifier = chain.find((id) => extractedIdentifiers[id]);
 
-        switch (identifier) {
-          case 'ip': {
-            // Normalize so IPv6 clients cannot rotate addresses within their
-            // allocated /64 to evade auth rate limits.
-            rateLimitKey += `ip:${toRateLimitIp(value)}`;
-            break;
+        if (!identifier) {
+          // Chains and bare ip/email must resolve. Bare userId/tenantId keep their
+          // silent skip: pointsLimiter budgets fall back when tenant context is absent.
+          if (Array.isArray(part) || part === 'ip' || part === 'email') {
+            throw new AppError(400, 'invalid_request', 'warn');
           }
-          case 'email': {
-            rateLimitKey += `email:${value}`;
-            break;
-          }
-          case 'userId': {
-            rateLimitKey += `userId:${value}`;
-            break;
-          }
-          case 'tenantId': {
-            rateLimitKey += `tenantId:${value}`;
-            break;
-          }
+          continue;
         }
+
+        const value = extractedIdentifiers[identifier] as string;
+        // Normalize IPs so IPv6 clients cannot rotate addresses within their
+        // allocated /64 to evade auth rate limits.
+        rateLimitKey += `${identifier}:${identifier === 'ip' ? toRateLimitIp(value) : value}`;
       }
+
+      // An empty key would silently share one bucket across all traffic (e.g. a
+      // userId-keyed limiter on a public route) — treat it as a misconfiguration.
+      if (!rateLimitKey) throw new AppError(400, 'invalid_request', 'warn');
 
       // ── Fast path for `limit` mode (pointsLimiter) ──
       // Uses an in-process LRU counter to skip DB when the key is well under budget.

--- a/backend/src/middlewares/rate-limiter/limiters.ts
+++ b/backend/src/middlewares/rate-limiter/limiters.ts
@@ -5,12 +5,14 @@ import { bulkBodyLength } from '#/middlewares/rate-limiter/helpers';
 import { sendLockoutEmail } from '#/middlewares/rate-limiter/helpers/send-lockout-email';
 import { defaultRestrictions } from '#/modules/tenants/tenant-restrictions';
 
-// TODO [#04] spam limiter might block legitimate users behind a shared IP. Can it use user id and fallback to IP?
 /**
- * Email spam limit for endpoints where emails are sent to others. Identifier: IP. Max 10 requests per hour. For sign up, public requests etc.
+ * Email spam limit for endpoints where emails are sent to others. Max 10 requests per hour.
+ * Keyed per user when authenticated, so invite flows behind a shared office/NAT IP get their
+ * own budget (and rotating IPs does not mint fresh buckets); falls back to IP for anonymous
+ * requests (sign up, public requests etc.).
  */
-export const spamLimiter = rateLimiter('success', 'spam', ['ip'], {
-  description: 'Max 10 requests/hour per IP for email-sending endpoints',
+export const spamLimiter = rateLimiter('success', 'spam', [['userId', 'ip']], {
+  description: 'Max 10 requests/hour per user (per IP when anonymous) for email-sending endpoints',
 });
 
 /**
@@ -34,7 +36,7 @@ export const tokenLimiter = (tokenType: string): MiddlewareHandler<Env> =>
 /**
  * Presigned URL rate limiter to prevent abuse, falls back to IP address for anonymous requests
  */
-export const presignedUrlLimiter = rateLimiter('limit', 'presignedUrl', ['userId'], {
+export const presignedUrlLimiter = rateLimiter('limit', 'presignedUrl', [['userId', 'ip']], {
   limits: { points: 2000, duration: 60 * 60, blockDuration: 60 * 15 },
   description: 'Max 2000 requests/hour per user for presigned URLs',
 });

--- a/backend/src/middlewares/rate-limiter/tests/identifier-validation.test.ts
+++ b/backend/src/middlewares/rate-limiter/tests/identifier-validation.test.ts
@@ -1,19 +1,25 @@
 import { Hono } from 'hono';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '#/core/context';
 import { AppError } from '#/core/error';
 
 // Undo setup.ts mock: this test needs the real rateLimiter to exercise identifier validation.
 vi.unmock('#/middlewares/rate-limiter/core');
+
+// Shared consume spy so tests can observe the generated rate limit key
+const { consumeSpy } = vi.hoisted(() => ({
+  consumeSpy: vi.fn().mockResolvedValue({ consumedPoints: 1, remainingPoints: 9, msBeforeNext: 0 }),
+}));
 
 // Mock the helpers module to isolate identifier extraction from DB/limiter internals
 vi.mock('#/middlewares/rate-limiter/helpers', async (importOriginal) => {
   const original = await importOriginal<typeof import('#/middlewares/rate-limiter/helpers')>();
   return {
     ...original,
-    // Return a no-op limiter that never blocks (we only care about identifier validation)
+    // Return a no-op limiter that never blocks (we only care about key generation/validation)
     getRateLimiterInstance: () => ({
       get: vi.fn().mockResolvedValue(null),
-      consume: vi.fn().mockResolvedValue({ consumedPoints: 1, remainingPoints: 9, msBeforeNext: 0 }),
+      consume: consumeSpy,
       points: 10,
     }),
   };
@@ -35,16 +41,28 @@ function jsonRequest(path: string, body: Record<string, unknown>) {
 /**
  * Creates a minimal Hono test app with error handling that applies
  * the given rate limiter middleware before a simple 200 handler.
+ * Pass `userId` to simulate an authenticated request (authGuard runs before limiters).
  */
-function createTestApp(middleware: ReturnType<typeof rateLimiter>) {
-  const app = new Hono();
+function createTestApp(middleware: ReturnType<typeof rateLimiter>, userId?: string) {
+  const app = new Hono<Env>();
   app.onError((err, c) => {
     if (err instanceof AppError) return c.json({ error: err.type }, err.status as 400);
     return c.json({ error: 'internal' }, 500);
   });
+  if (userId) {
+    app.use(async (c, next) => {
+      // Mirror authGuard, which sets both `user` and `userId`
+      c.set('user', { id: userId } as Env['Variables']['user']);
+      c.set('userId', userId);
+      await next();
+    });
+  }
   app.post('/test', middleware, (c) => c.text('ok'));
   return app;
 }
+
+/** Fake node-server bindings so getIp's socket fallback resolves to null instead of crashing */
+const emptyBindings = { incoming: { socket: {} } } as Env['Bindings'];
 
 describe('rate limiter identifier validation', () => {
   describe('email identifier', () => {
@@ -71,6 +89,64 @@ describe('rate limiter identifier validation', () => {
     it('should reject when email is only in query (not body)', async () => {
       const res = await app.request(new Request('http://localhost/test?email=test@example.com', { method: 'POST' }));
       expect(res.status).toBe(400);
+    });
+  });
+
+  describe('fallback chain identifier', () => {
+    const limiter = () =>
+      rateLimiter('limit', 'chainTest', [['userId', 'ip']], {
+        limits: { points: 10, duration: 60 },
+      });
+
+    beforeEach(() => consumeSpy.mockClear());
+
+    it('should key per user when authenticated, ignoring IP', async () => {
+      const app = createTestApp(limiter(), 'user-1');
+      const req = new Request('http://localhost/test', {
+        method: 'POST',
+        headers: { 'x-forwarded-for': '1.2.3.4' },
+      });
+      const res = await app.request(req, undefined, emptyBindings);
+      expect(res.status).toBe(200);
+      expect(consumeSpy).toHaveBeenCalledWith('userId:user-1', 1);
+    });
+
+    it('should fall back to IP for anonymous requests', async () => {
+      const app = createTestApp(limiter());
+      const req = new Request('http://localhost/test', {
+        method: 'POST',
+        headers: { 'x-forwarded-for': '1.2.3.4' },
+      });
+      const res = await app.request(req, undefined, emptyBindings);
+      expect(res.status).toBe(200);
+      expect(consumeSpy).toHaveBeenCalledWith('ip:1.2.3.4', 1);
+    });
+
+    it('should reject when no identifier in the chain resolves', async () => {
+      const app = createTestApp(limiter());
+      const res = await app.request(new Request('http://localhost/test', { method: 'POST' }), undefined, emptyBindings);
+      expect(res.status).toBe(400);
+      expect(consumeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('empty key guard', () => {
+    it('should reject when the key resolves empty (userId limiter on anonymous request)', async () => {
+      const limiter = rateLimiter('limit', 'emptyKeyTest', ['userId'], {
+        limits: { points: 10, duration: 60 },
+      });
+      const app = createTestApp(limiter);
+      const res = await app.request(new Request('http://localhost/test', { method: 'POST' }), undefined, emptyBindings);
+      expect(res.status).toBe(400);
+    });
+
+    it('should allow when the optional identifier resolves', async () => {
+      const limiter = rateLimiter('limit', 'emptyKeyTest2', ['userId'], {
+        limits: { points: 10, duration: 60 },
+      });
+      const app = createTestApp(limiter, 'user-2');
+      const res = await app.request(new Request('http://localhost/test', { method: 'POST' }), undefined, emptyBindings);
+      expect(res.status).toBe(200);
     });
   });
 });

--- a/backend/src/middlewares/rate-limiter/types.ts
+++ b/backend/src/middlewares/rate-limiter/types.ts
@@ -4,6 +4,13 @@ import type { Env } from '#/core/context';
 
 export type RateLimitMode = 'limit' | 'success' | 'fail' | 'failseries';
 export type RateLimitIdentifier = 'ip' | 'email' | 'userId' | 'tenantId';
+/**
+ * One segment of a rate limit key: a single identifier, or a fallback chain where
+ * the first available identifier wins (e.g. `['userId', 'ip']` keys authenticated
+ * traffic per user and anonymous traffic per IP). A chain must resolve; a request
+ * matching none of its identifiers is rejected.
+ */
+export type RateLimitKeyPart = RateLimitIdentifier | RateLimitIdentifier[];
 export type Identifiers = Record<RateLimitIdentifier, string | null>;
 
 type LimiterStatusLists = {

--- a/sdk/gen/docs.gen/info.gen.json
+++ b/sdk/gen/docs.gen/info.gen.json
@@ -42,7 +42,10 @@
       "required": false,
       "kind": "middleware",
       "values": {
-        "spamLimiter": { "name": "spam", "description": "Max 10 requests/hour per IP for email-sending endpoints" },
+        "spamLimiter": {
+          "name": "spam",
+          "description": "Max 10 requests/hour per user (per IP when anonymous) for email-sending endpoints"
+        },
         "emailEnumLimiter": { "name": "emailEnum", "description": "Blocks IP for 30 min after 5 consecutive failures" },
         "presignedUrlLimiter": {
           "name": "presignedUrl",

--- a/sdk/gen/openapi.json
+++ b/sdk/gen/openapi.json
@@ -55,7 +55,7 @@
         "values": {
           "spamLimiter": {
             "name": "spam",
-            "description": "Max 10 requests/hour per IP for email-sending endpoints"
+            "description": "Max 10 requests/hour per user (per IP when anonymous) for email-sending endpoints"
           },
           "emailEnumLimiter": {
             "name": "emailEnum",


### PR DESCRIPTION
## What

Resolves `TODO [#04]` in `backend/src/middlewares/rate-limiter/limiters.ts`: *"spam limiter might block legitimate users behind a shared IP. Can it use user id and fallback to IP?"*

The `spamLimiter` keyed solely on IP, so several admins inviting members from behind **one office/NAT IP shared a single 10-sends/hour bucket** — one person exhausts it for the whole org. IP-only keying also meant an authenticated abuser could mint fresh buckets by rotating IPs (trivial on mobile). This matches well-documented [industry guidance](https://developers.cloudflare.com/waf/rate-limiting-rules/best-practices/): key by user ID when authenticated, fall back to IP for anonymous traffic.

## How

Add a **fallback-chain key part** to the rate limiter. A key part is now either a single identifier or a chain where the first available identifier wins:

```ts
export const spamLimiter = rateLimiter('success', 'spam', [['userId', 'ip']], { ... });
```

- **Authenticated** invite routes (`membershipInvite`, `systemInvite`) → keyed per **user**: NAT offices get their own budget, *and* IP-rotation no longer helps an attacker.
- **Public** routes (`sendMagicLink`, `resendInvitationWithToken`, `createRequest`) → unchanged, keyed per **IP**.
- No migration: old `ip:*` rows under the `spam_success` prefix age out within the hour.

The chain rule **subsumes** the two ad-hoc `ip`/`email` required-checks (simpler loop), and a new **empty-key guard** turns a misconfigured limiter — e.g. a `userId`-only limiter on a public route, which previously degraded to a single shared empty-string bucket — into a loud `400`.

`presignedUrlLimiter` also moves to `[['userId', 'ip']]`, which makes its existing JSDoc (*"falls back to IP address for anonymous requests"*) actually true.

## Safety

- **Single-identifier limiters are byte-identical** — the new builder produces the same keys as before for `['ip']`, `['email']`, `['userId']`, `['tenantId', 'userId']`, etc. `pointsLimiter`'s reliance on silent `tenantId`/`userId` skipping is preserved.
- New tests cover: per-user keying (IP ignored), IP fallback for anonymous, unresolvable chain → 400, and the empty-key guard.
- Full backend core suite green (1580 passed); workspace-wide typecheck + biome clean via pre-commit.

## Out of scope

The slow-limiter pre-check key mismatch (`core.ts` reads a prefixed key but consumes an unprefixed one) is a separate, pre-existing issue already being handled in another WIP — deliberately left untouched here to keep this reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
