### PR TITLE
perf(backend): source list total from channel counter, skip COUNT(*) on delta sync

### DIFF
--- a/backend/src/modules/attachment/operations/get-attachments.ts
+++ b/backend/src/modules/attachment/operations/get-attachments.ts
@@ -5,6 +5,7 @@ import type { OperationResult } from '#/core/operation-result';
 import { tenantRead, tenantReadIncludingDeleted } from '#/db/tenant-context';
 import { attachmentsTable } from '#/modules/attachment/attachment-db';
 import type { attachmentListQuerySchema } from '#/modules/attachment/attachment-schema';
+import { resolveListTotal } from '#/modules/entities/helpers/list-total';
 import { productCountersTable } from '#/modules/entities/product-counters-db';
 import { auditUserSelect, coalesceAuditUsers, createdByUser, updatedByUser } from '#/modules/user/helpers/audit-user';
 import { actorFrom } from '#/permissions/actor';
@@ -71,29 +72,44 @@ export async function getAttachmentsOp(ctx: AuthContext, input: GetAttachmentsIn
   // Delta sync (seqCursor) must see tombstones so the client can remove soft-deleted attachments
   const read = seqCursor ? tenantReadIncludingDeleted : tenantRead;
 
+  // Where `total` comes from: delta reads discard it; an org-wide read with no search maps
+  // to the pre-computed `e:attachment` channel counter; anything narrower needs COUNT(*).
+  const isDelta = !!seqCursor;
+  const counterEligible = !isDelta && scopeWhere.kind === 'all' && !q?.trim();
+
   const { rawItems, total } = await read(ctx, async (readCtx) => {
     const { db } = readCtx.var;
     const { createdBy: _cb, updatedBy: _mb, ...attachmentCols } = getColumns(attachmentsTable);
 
     const whereClause = and(...filters);
 
-    const [rawItems, [{ total }]] = await Promise.all([
-      db
-        .select({
-          ...attachmentCols,
-          ...auditUserSelect,
-          viewCount: sql<number>`coalesce(${productCountersTable.viewCount}, 0)`.as('view_count'),
-        })
-        .from(attachmentsTable)
-        .leftJoin(productCountersTable, eq(productCountersTable.entityId, attachmentsTable.id))
-        .leftJoin(createdByUser, eq(createdByUser.id, attachmentsTable.createdBy))
-        .leftJoin(updatedByUser, eq(updatedByUser.id, attachmentsTable.updatedBy))
-        .where(whereClause)
-        .orderBy(...orderBy)
-        .limit(limit)
-        .offset(offset),
-      db.select({ total: count() }).from(attachmentsTable).where(whereClause),
-    ]);
+    const itemsQuery = db
+      .select({
+        ...attachmentCols,
+        ...auditUserSelect,
+        viewCount: sql<number>`coalesce(${productCountersTable.viewCount}, 0)`.as('view_count'),
+      })
+      .from(attachmentsTable)
+      .leftJoin(productCountersTable, eq(productCountersTable.entityId, attachmentsTable.id))
+      .leftJoin(createdByUser, eq(createdByUser.id, attachmentsTable.createdBy))
+      .leftJoin(updatedByUser, eq(updatedByUser.id, attachmentsTable.updatedBy))
+      .where(whereClause)
+      .orderBy(...orderBy)
+      .limit(limit)
+      .offset(offset);
+
+    const { items: rawItems, total } = await resolveListTotal({
+      ctx: readCtx,
+      itemsQuery,
+      isDelta,
+      counterEligible,
+      channelKey: organizationId,
+      entityType: 'attachment',
+      exactCount: async () => {
+        const [{ total }] = await db.select({ total: count() }).from(attachmentsTable).where(whereClause);
+        return total;
+      },
+    });
 
     return { rawItems, total };
   });

--- a/backend/src/modules/attachment/operations/get-attachments.ts
+++ b/backend/src/modules/attachment/operations/get-attachments.ts
@@ -5,7 +5,7 @@ import type { OperationResult } from '#/core/operation-result';
 import { tenantRead, tenantReadIncludingDeleted } from '#/db/tenant-context';
 import { attachmentsTable } from '#/modules/attachment/attachment-db';
 import type { attachmentListQuerySchema } from '#/modules/attachment/attachment-schema';
-import { resolveListTotal } from '#/modules/entities/helpers/list-total';
+import { type ListTotalSource, resolveListTotal } from '#/modules/entities/helpers/list-total';
 import { productCountersTable } from '#/modules/entities/product-counters-db';
 import { auditUserSelect, coalesceAuditUsers, createdByUser, updatedByUser } from '#/modules/user/helpers/audit-user';
 import { actorFrom } from '#/permissions/actor';
@@ -98,18 +98,19 @@ export async function getAttachmentsOp(ctx: AuthContext, input: GetAttachmentsIn
       .limit(limit)
       .offset(offset);
 
-    const { items: rawItems, total } = await resolveListTotal({
-      ctx: readCtx,
-      itemsQuery,
-      isDelta,
-      counterEligible,
-      channelKey: organizationId,
-      entityType: 'attachment',
-      exactCount: async () => {
-        const [{ total }] = await db.select({ total: count() }).from(attachmentsTable).where(whereClause);
-        return total;
-      },
-    });
+    const totalSource: ListTotalSource = isDelta
+      ? { kind: 'pageLength' }
+      : counterEligible
+        ? { kind: 'counter', ctx: readCtx, channelKey: organizationId, entityType: 'attachment' }
+        : {
+            kind: 'exact',
+            count: async () => {
+              const [{ total }] = await db.select({ total: count() }).from(attachmentsTable).where(whereClause);
+              return total;
+            },
+          };
+
+    const { items: rawItems, total } = await resolveListTotal(itemsQuery, totalSource);
 
     return { rawItems, total };
   });

--- a/backend/src/modules/entities/helpers/list-total.test.ts
+++ b/backend/src/modules/entities/helpers/list-total.test.ts
@@ -16,57 +16,34 @@ describe('resolveListTotal', () => {
     getOrgEntityCount.mockReset();
   });
 
-  it('delta reads report the page length and run neither count', async () => {
-    const exactCount = vi.fn();
-    const result = await resolveListTotal({
-      ctx,
-      itemsQuery: Promise.resolve(items),
-      isDelta: true,
-      counterEligible: false,
-      channelKey: 'org-1',
-      entityType: 'attachment',
-      exactCount,
-    });
+  it('pageLength reads report the page length and query no count', async () => {
+    const result = await resolveListTotal(Promise.resolve(items), { kind: 'pageLength' });
 
     expect(result).toEqual({ items, total: items.length });
-    expect(exactCount).not.toHaveBeenCalled();
     expect(getOrgEntityCount).not.toHaveBeenCalled();
   });
 
-  it('org-wide unfiltered reads use the channel counter, not COUNT(*)', async () => {
+  it('counter reads use the channel counter, not COUNT(*)', async () => {
     getOrgEntityCount.mockResolvedValue(42);
-    const exactCount = vi.fn();
 
-    const result = await resolveListTotal({
+    const result = await resolveListTotal(Promise.resolve(items), {
+      kind: 'counter',
       ctx,
-      itemsQuery: Promise.resolve(items),
-      isDelta: false,
-      counterEligible: true,
       channelKey: 'org-1',
       entityType: 'attachment',
-      exactCount,
     });
 
     expect(result).toEqual({ items, total: 42 });
     expect(getOrgEntityCount).toHaveBeenCalledWith(ctx, 'org-1', 'attachment');
-    expect(exactCount).not.toHaveBeenCalled();
   });
 
-  it('filtered/scoped reads fall back to the exact COUNT(*)', async () => {
-    const exactCount = vi.fn().mockResolvedValue(7);
+  it('exact reads run the provided COUNT(*) thunk', async () => {
+    const count = vi.fn().mockResolvedValue(7);
 
-    const result = await resolveListTotal({
-      ctx,
-      itemsQuery: Promise.resolve(items),
-      isDelta: false,
-      counterEligible: false,
-      channelKey: 'org-1',
-      entityType: 'attachment',
-      exactCount,
-    });
+    const result = await resolveListTotal(Promise.resolve(items), { kind: 'exact', count });
 
     expect(result).toEqual({ items, total: 7 });
-    expect(exactCount).toHaveBeenCalledOnce();
+    expect(count).toHaveBeenCalledOnce();
     expect(getOrgEntityCount).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/entities/helpers/list-total.test.ts
+++ b/backend/src/modules/entities/helpers/list-total.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DbContext } from '#/core/context';
+import { resolveListTotal } from './list-total';
+
+// The counter branch delegates to getOrgEntityCount; stub it so the test needs no DB.
+const getOrgEntityCount = vi.fn();
+vi.mock('#/modules/entities/entities-queries', () => ({
+  getOrgEntityCount: (...args: unknown[]) => getOrgEntityCount(...args),
+}));
+
+const ctx = { var: { db: {} } } as unknown as DbContext;
+const items = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+
+describe('resolveListTotal', () => {
+  beforeEach(() => {
+    getOrgEntityCount.mockReset();
+  });
+
+  it('delta reads report the page length and run neither count', async () => {
+    const exactCount = vi.fn();
+    const result = await resolveListTotal({
+      ctx,
+      itemsQuery: Promise.resolve(items),
+      isDelta: true,
+      counterEligible: false,
+      channelKey: 'org-1',
+      entityType: 'attachment',
+      exactCount,
+    });
+
+    expect(result).toEqual({ items, total: items.length });
+    expect(exactCount).not.toHaveBeenCalled();
+    expect(getOrgEntityCount).not.toHaveBeenCalled();
+  });
+
+  it('org-wide unfiltered reads use the channel counter, not COUNT(*)', async () => {
+    getOrgEntityCount.mockResolvedValue(42);
+    const exactCount = vi.fn();
+
+    const result = await resolveListTotal({
+      ctx,
+      itemsQuery: Promise.resolve(items),
+      isDelta: false,
+      counterEligible: true,
+      channelKey: 'org-1',
+      entityType: 'attachment',
+      exactCount,
+    });
+
+    expect(result).toEqual({ items, total: 42 });
+    expect(getOrgEntityCount).toHaveBeenCalledWith(ctx, 'org-1', 'attachment');
+    expect(exactCount).not.toHaveBeenCalled();
+  });
+
+  it('filtered/scoped reads fall back to the exact COUNT(*)', async () => {
+    const exactCount = vi.fn().mockResolvedValue(7);
+
+    const result = await resolveListTotal({
+      ctx,
+      itemsQuery: Promise.resolve(items),
+      isDelta: false,
+      counterEligible: false,
+      channelKey: 'org-1',
+      entityType: 'attachment',
+      exactCount,
+    });
+
+    expect(result).toEqual({ items, total: 7 });
+    expect(exactCount).toHaveBeenCalledOnce();
+    expect(getOrgEntityCount).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/entities/helpers/list-total.ts
+++ b/backend/src/modules/entities/helpers/list-total.ts
@@ -2,48 +2,32 @@ import type { DbContext } from '#/core/context';
 import { getOrgEntityCount } from '#/modules/entities/entities-queries';
 
 /**
- * Source a product list's `total` the cheapest correct way: delta reads discard it (page
- * length, no query); an org-wide unfiltered read maps to the O(1) `e:{entityType}` channel
- * counter (CDC-maintained → eventually consistent, fine for a list total); anything narrower
- * needs the exact `COUNT(*)`. `counterEligible` is the caller's — true only when the WHERE
- * is exactly the channel scope + live rows (`scopeWhere.kind === 'all'`, no `q`, not delta).
+ * Where a product list's `total` comes from — the caller picks one:
+ * - `pageLength`: delta reads discard `total` → report the page, no second query.
+ * - `counter`: org-wide unfiltered read (`kind:'all'`, no `q`, not delta) → the O(1)
+ *   `e:{entityType}` channel counter (CDC-maintained, eventually consistent; fine here).
+ * - `exact`: anything narrower (search / row-scoped) → the exact `COUNT(*)`.
  */
-export interface ResolveListTotalArgs<TItem> {
-  ctx: DbContext;
-  /** The paginated items query (a lazy Drizzle builder or a Promise). Always executed. */
-  itemsQuery: PromiseLike<TItem[]>;
-  /** Delta/sync read (`seqCursor` present): the client discards `total`. */
-  isDelta: boolean;
-  /**
-   * The WHERE clause reduces to exactly "this channel's live rows" (org-wide read, no
-   * search/filter), so the pre-computed `e:{entityType}` channel counter equals the total.
-   */
-  counterEligible: boolean;
-  /** Channel key whose `e:{entityType}` counter holds the total (org id for org-homed entities). */
-  channelKey: string;
-  entityType: string;
-  /** Exact `COUNT(*)` over the same WHERE, invoked only when neither shortcut applies. */
-  exactCount: () => Promise<number>;
-}
+export type ListTotalSource =
+  | { kind: 'pageLength' }
+  | { kind: 'counter'; ctx: DbContext; channelKey: string; entityType: string }
+  | { kind: 'exact'; count: () => Promise<number> };
 
-export async function resolveListTotal<TItem>({
-  ctx,
-  itemsQuery,
-  isDelta,
-  counterEligible,
-  channelKey,
-  entityType,
-  exactCount,
-}: ResolveListTotalArgs<TItem>): Promise<{ items: TItem[]; total: number }> {
-  // Delta/sync reads discard `total`, so skip the second query and report the page length.
-  if (isDelta) {
+/**
+ * Run `itemsQuery` and resolve `total` from `source`, keeping the count (when any) in
+ * parallel with the items query — the delta path skips the second query entirely.
+ */
+export async function resolveListTotal<TItem>(
+  itemsQuery: PromiseLike<TItem[]>,
+  source: ListTotalSource,
+): Promise<{ items: TItem[]; total: number }> {
+  if (source.kind === 'pageLength') {
     const items = await itemsQuery;
     return { items, total: items.length };
   }
 
-  // Default org-wide list → O(1) channel-counter lookup; otherwise the exact COUNT(*).
-  // Either way it runs in parallel with the items query, preserving the original concurrency.
-  const totalSource = counterEligible ? getOrgEntityCount(ctx, channelKey, entityType) : exactCount();
-  const [items, total] = await Promise.all([itemsQuery, totalSource]);
+  const totalQuery =
+    source.kind === 'counter' ? getOrgEntityCount(source.ctx, source.channelKey, source.entityType) : source.count();
+  const [items, total] = await Promise.all([itemsQuery, totalQuery]);
   return { items, total };
 }

--- a/backend/src/modules/entities/helpers/list-total.ts
+++ b/backend/src/modules/entities/helpers/list-total.ts
@@ -1,0 +1,63 @@
+import type { DbContext } from '#/core/context';
+import { getOrgEntityCount } from '#/modules/entities/entities-queries';
+
+/**
+ * Decide where a product-entity list op's `total` comes from, and run the items query
+ * alongside it. Every product list faces the same three cases:
+ *
+ * 1. **Delta/sync read** (`seqCursor` present) — the client discards `total` entirely
+ *    (`cache-ops.ts` reads only `items`), so we skip the second query and report the
+ *    page length. This removes the `COUNT(*)` that the SSE fan-out stampede pays for on
+ *    every subscriber (see `.todos/SYNC_FANOUT_OPTIMIZATION.md`).
+ * 2. **Default org-wide list** (`counterEligible`) — the WHERE clause reduces to exactly
+ *    "this channel's live rows", so the pre-computed `e:{entityType}` channel counter
+ *    equals the total. An O(1) primary-key lookup on `channel_counters` replaces an O(n)
+ *    `COUNT(*)` scan. Trade-off: the counter is CDC-maintained, so the total is
+ *    eventually consistent (bounded by CDC lag) rather than read-time exact — acceptable
+ *    for a list total, and delta reads (which need exactness) never take this path.
+ * 3. **Filtered / scoped list** — a search (`q`) or a row-conditional read (`read:'own'`)
+ *    narrows the set below the counter, so the exact `COUNT(*)` is still required.
+ *
+ * `counterEligible` must be `true` only when the WHERE clause is exactly the channel scope
+ * plus the live-row filter — i.e. `scopeWhere.kind === 'all'`, no search token, and not a
+ * delta read. The caller owns that decision because only it knows its filter set.
+ */
+export interface ResolveListTotalArgs<TItem> {
+  ctx: DbContext;
+  /** The paginated items query (a lazy Drizzle builder or a Promise). Always executed. */
+  itemsQuery: PromiseLike<TItem[]>;
+  /** Delta/sync read (`seqCursor` present): the client discards `total`. */
+  isDelta: boolean;
+  /**
+   * The WHERE clause reduces to exactly "this channel's live rows" (org-wide read, no
+   * search/filter), so the pre-computed `e:{entityType}` channel counter equals the total.
+   */
+  counterEligible: boolean;
+  /** Channel key whose `e:{entityType}` counter holds the total (org id for org-homed entities). */
+  channelKey: string;
+  entityType: string;
+  /** Exact `COUNT(*)` over the same WHERE, invoked only when neither shortcut applies. */
+  exactCount: () => Promise<number>;
+}
+
+export async function resolveListTotal<TItem>({
+  ctx,
+  itemsQuery,
+  isDelta,
+  counterEligible,
+  channelKey,
+  entityType,
+  exactCount,
+}: ResolveListTotalArgs<TItem>): Promise<{ items: TItem[]; total: number }> {
+  // Delta/sync reads discard `total`, so skip the second query and report the page length.
+  if (isDelta) {
+    const items = await itemsQuery;
+    return { items, total: items.length };
+  }
+
+  // Default org-wide list → O(1) channel-counter lookup; otherwise the exact COUNT(*).
+  // Either way it runs in parallel with the items query, preserving the original concurrency.
+  const totalSource = counterEligible ? getOrgEntityCount(ctx, channelKey, entityType) : exactCount();
+  const [items, total] = await Promise.all([itemsQuery, totalSource]);
+  return { items, total };
+}

--- a/backend/src/modules/entities/helpers/list-total.ts
+++ b/backend/src/modules/entities/helpers/list-total.ts
@@ -2,25 +2,11 @@ import type { DbContext } from '#/core/context';
 import { getOrgEntityCount } from '#/modules/entities/entities-queries';
 
 /**
- * Decide where a product-entity list op's `total` comes from, and run the items query
- * alongside it. Every product list faces the same three cases:
- *
- * 1. **Delta/sync read** (`seqCursor` present) — the client discards `total` entirely
- *    (`cache-ops.ts` reads only `items`), so we skip the second query and report the
- *    page length. This removes the `COUNT(*)` that the SSE fan-out stampede pays for on
- *    every subscriber (see `.todos/SYNC_FANOUT_OPTIMIZATION.md`).
- * 2. **Default org-wide list** (`counterEligible`) — the WHERE clause reduces to exactly
- *    "this channel's live rows", so the pre-computed `e:{entityType}` channel counter
- *    equals the total. An O(1) primary-key lookup on `channel_counters` replaces an O(n)
- *    `COUNT(*)` scan. Trade-off: the counter is CDC-maintained, so the total is
- *    eventually consistent (bounded by CDC lag) rather than read-time exact — acceptable
- *    for a list total, and delta reads (which need exactness) never take this path.
- * 3. **Filtered / scoped list** — a search (`q`) or a row-conditional read (`read:'own'`)
- *    narrows the set below the counter, so the exact `COUNT(*)` is still required.
- *
- * `counterEligible` must be `true` only when the WHERE clause is exactly the channel scope
- * plus the live-row filter — i.e. `scopeWhere.kind === 'all'`, no search token, and not a
- * delta read. The caller owns that decision because only it knows its filter set.
+ * Source a product list's `total` the cheapest correct way: delta reads discard it (page
+ * length, no query); an org-wide unfiltered read maps to the O(1) `e:{entityType}` channel
+ * counter (CDC-maintained → eventually consistent, fine for a list total); anything narrower
+ * needs the exact `COUNT(*)`. `counterEligible` is the caller's — true only when the WHERE
+ * is exactly the channel scope + live rows (`scopeWhere.kind === 'all'`, no `q`, not delta).
  */
 export interface ResolveListTotalArgs<TItem> {
   ctx: DbContext;


### PR DESCRIPTION
## What

Adds a shared `resolveListTotal` helper that routes a product-entity list op's `total` through **one decision point** instead of always issuing a `COUNT(*)`, and wires `getAttachments` through it. Combines two efforts from `.todos/SYNC_FANOUT_OPTIMIZATION.md` (option 2 + the channel-counter fast path).

## The three cases

| Request shape | `total` source | Cost |
|---|---|---|
| Delta / sync read (`seqCursor`) | `rawItems.length` — no 2nd query | zero (client discards `total`) |
| Default org-wide list (`scopeWhere.kind === 'all'`, no `q`) | `e:{entityType}` channel counter via `getOrgEntityCount` | O(1) PK lookup |
| Filtered (`q`) / row-scoped (`read:'own'` → `kind:'where'`) | exact `COUNT(*)` | O(n) |

The counter and exact paths still run in parallel with the items query, preserving the original concurrency; the delta path skips the second query entirely.

## Why

- **Removes the discarded `COUNT(*)` from the SSE fan-out stampede.** On a batch notification ~N subscribers fire the same `?seqCursor=X,Y` delta read, each paying for a `COUNT(*)` the client never reads (constraint B in the todo doc). Now they don't.
- **Turns the common list total into a PK lookup.** The default list view reads the pre-computed channel counter instead of scanning the table.

## Trade-off

The counter is CDC-maintained, so for the default-list case `total` becomes **eventually consistent** (bounded by CDC lag) rather than read-time exact. That's acceptable for a UI list total, and the exactness-sensitive delta path never takes this branch. Filtered/scoped reads keep the exact count.

## Eligibility gate

`counterEligible` is true only when the WHERE clause reduces to exactly "this channel's live rows" — `scopeWhere.kind === 'all'`, no search token, not a delta read. A row-conditional read (`read:'own'`) resolves to `kind:'where'` and correctly falls through to `COUNT(*)`, so the counter never over-counts rows the caller can't see.

## Forks

The helper takes a `channelKey` argument so forks can extend it to their product list ops (raak 3, projectcampus 6), passing the deepest-ancestor context key for sub-context-homed entities rather than the org id.

## Tests

- New `list-total.test.ts` covers all three strategies (delta → page length, eligible → counter, else → exact), asserting the other two count paths are not invoked.
- Backend typecheck, biome, and the full-workspace pre-commit hook all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
