### PR TITLE
refactor(types): tighten entityType: string seams to named entity types

### DIFF
--- a/backend/src/core/schema-evolution/tests/lens-seam.test.ts
+++ b/backend/src/core/schema-evolution/tests/lens-seam.test.ts
@@ -9,15 +9,16 @@
  * shared/src/schema-evolution/tests.
  */
 import { z } from '@hono/zod-openapi';
+import type { LensEntityType } from 'shared/schema-evolution';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('shared/schema-evolution', async (importOriginal) => {
   const actual = await importOriginal<typeof import('shared/schema-evolution')>();
   return {
     ...actual,
-    widenedOpsKeyMap: (entityType: string) => (entityType === 'attachment' ? { name: 'title' } : {}),
+    widenedOpsKeyMap: (entityType: LensEntityType) => (entityType === 'attachment' ? { name: 'title' } : {}),
     normalizeOps: (
-      entityType: string,
+      entityType: LensEntityType,
       ops: Record<string, unknown>,
       stx: { fieldTimestamps?: Record<string, unknown> },
     ) => {

--- a/backend/src/lib/sync-metrics.ts
+++ b/backend/src/lib/sync-metrics.ts
@@ -1,4 +1,5 @@
 import { type Span, SpanStatusCode, trace } from '@opentelemetry/api';
+import type { EntityType } from 'shared';
 import { backendSpanNames, eventAttrs, type TraceContext } from 'shared/tracing';
 import { otel } from '#/lib/tracing';
 
@@ -97,6 +98,6 @@ export function startSyncSpan(
 // Metric recording
 
 /** Record a CDC message received from CDC Worker. */
-export function recordMessageReceived(entityType: string): void {
+export function recordMessageReceived(entityType: EntityType | 'unknown'): void {
   cdcMessagesReceived.add(1, { entityType });
 }

--- a/backend/src/middlewares/entity-cache/app-entity-cache.ts
+++ b/backend/src/middlewares/entity-cache/app-entity-cache.ts
@@ -1,3 +1,4 @@
+import type { EntityType } from 'shared';
 import { TTLCache } from '#/lib/ttl-cache';
 import { log } from '#/utils/logger';
 import { coalesce, isInFlight } from '#/utils/request-coalescing';
@@ -37,7 +38,7 @@ const tokenIndex = new TTLCache<string>({
 });
 
 /** Build entity key. */
-function entityKey(entityType: string, entityId: string): string {
+function entityKey(entityType: EntityType, entityId: string): string {
   return `${entityType}:${entityId}`;
 }
 
@@ -55,7 +56,7 @@ export const entityCache = {
    *
    * @param token - Cache token (nanoid from CDC)
    */
-  reserve(token: string, entityType: string, entityId: string, ttlMs?: number): void {
+  reserve(token: string, entityType: EntityType, entityId: string, ttlMs?: number): void {
     const key = entityKey(entityType, entityId);
     const ttl = ttlMs ?? cacheConfig.defaultTtl;
 
@@ -119,7 +120,7 @@ export const entityCache = {
    * Invalidate cache entry by entity type and ID.
    * Removes entity data from cache. Token index entries expire naturally.
    */
-  invalidateByEntity(entityType: string, entityId: string): boolean {
+  invalidateByEntity(entityType: EntityType, entityId: string): boolean {
     const key = entityKey(entityType, entityId);
     const existed = cache.has(key);
 

--- a/backend/src/modules/entities/entities-queries.ts
+++ b/backend/src/modules/entities/entities-queries.ts
@@ -121,7 +121,7 @@ export const getEntityCounts = async ({ var: { db } }: DbContext, entityType: Ch
  * Reads a single pre-computed entity count from channelCountersTable.
  * Used for quota checks: reads `e:{entityType}` from the org's counter row.
  */
-export const getOrgEntityCount = async ({ var: { db } }: DbContext, orgId: string, entityType: string) => {
+export const getOrgEntityCount = async ({ var: { db } }: DbContext, orgId: string, entityType: EntityType) => {
   const key = `e:${entityType}`;
   const [row] = await db
     .select({ count: sql<number>`coalesce((${channelCountersTable.counts}->>${key})::int, 0)` })

--- a/backend/src/modules/seen/operations/mark-seen.ts
+++ b/backend/src/modules/seen/operations/mark-seen.ts
@@ -1,6 +1,6 @@
 import { and, eq, getColumns, gt, inArray, sql } from 'drizzle-orm';
 import type { AnyPgTable, PgColumn } from 'drizzle-orm/pg-core';
-import type { SeenTrackedEntityType } from 'shared';
+import type { ProductEntityType, SeenTrackedEntityType } from 'shared';
 import { appConfig, hierarchy, possibleHomeChannels } from 'shared';
 import { generateId } from 'shared/utils/entity-id';
 import type { AuthContext } from '#/core/context';
@@ -29,7 +29,7 @@ export function isTrackedEntityType(entityType: string): entityType is SeenTrack
 /** Context types that group unseen counts: every context a tracked row can have as its effective home */
 export const groupingChannelTypes = new Set(trackedEntityTypes.flatMap((t) => possibleHomeChannels(hierarchy, t)));
 
-export async function markSeenOp(ctx: AuthContext, entityIds: string[], entityType: string) {
+export async function markSeenOp(ctx: AuthContext, entityIds: string[], entityType: ProductEntityType) {
   const user = ctx.var.user;
   const organization = ctx.var.organization;
 

--- a/backend/src/modules/seen/seen-queries.ts
+++ b/backend/src/modules/seen/seen-queries.ts
@@ -45,7 +45,7 @@ export const findUnseenCountsByUser = async (
   { userId, channelIds, entityTypes, cutoff, scopeWhereByType }: FindUnseenCountsByUserOpts,
 ) => {
   const { db } = ctx.var;
-  const rows: { channelId: string; entityType: string; unseenCount: number }[] = [];
+  const rows: { channelId: string; entityType: SeenTrackedEntityType; unseenCount: number }[] = [];
 
   for (const entityType of entityTypes) {
     const entityTable = getEntityTable(entityType);
@@ -74,7 +74,7 @@ export const findUnseenCountsByUser = async (
     const entityRows = await db
       .select({
         channelId: channelIdColumn,
-        entityType: sql<string>`${entityType}`,
+        entityType: sql<SeenTrackedEntityType>`${entityType}`,
         unseenCount: count(),
       })
       .from(entityTable)

--- a/backend/src/modules/yjs/helpers/token-signer.ts
+++ b/backend/src/modules/yjs/helpers/token-signer.ts
@@ -1,4 +1,5 @@
 import { createHmac } from 'node:crypto';
+import type { ProductEntityType } from 'shared';
 import { env } from '#/env';
 
 const DELIMITER = '.';
@@ -9,7 +10,7 @@ const TOKEN_TTL_MS = 30 * 60 * 1000;
 
 export interface YjsTokenPayload {
   userId: string;
-  entityType: string;
+  entityType: ProductEntityType;
   tenantId: string;
   organizationId: string | null;
   exp: number;

--- a/backend/src/modules/yjs/operations/get-yjs-token.ts
+++ b/backend/src/modules/yjs/operations/get-yjs-token.ts
@@ -1,4 +1,4 @@
-import type { EntityType } from 'shared';
+import type { ProductEntityType } from 'shared';
 import { AppError } from '#/core/error';
 import type { MembershipBaseModel } from '#/modules/memberships/helpers/select';
 import { signYjsToken } from '../helpers/token-signer';
@@ -6,7 +6,7 @@ import { signYjsToken } from '../helpers/token-signer';
 export function getYjsTokenOp(
   userId: string,
   memberships: MembershipBaseModel[],
-  params: { entityType: string; tenantId: string; organizationId: string },
+  params: { entityType: ProductEntityType; tenantId: string; organizationId: string },
 ) {
   const { entityType, tenantId, organizationId } = params;
 
@@ -14,7 +14,7 @@ export function getYjsTokenOp(
   // Per-entity access (project/task level) is enforced locally by the relay worker,
   // which runs the shared permission engine before allowing any writes.
   const hasOrgMembership = memberships.some((m) => m.organizationId === organizationId);
-  if (!hasOrgMembership) throw new AppError(403, 'forbidden', 'warn', { entityType: entityType as EntityType });
+  if (!hasOrgMembership) throw new AppError(403, 'forbidden', 'warn', { entityType });
 
   const token = signYjsToken({
     userId,

--- a/backend/src/modules/yjs/yjs-handlers.ts
+++ b/backend/src/modules/yjs/yjs-handlers.ts
@@ -6,6 +6,7 @@ import { env } from '#/env';
 import { getYjsTokenOp } from '#/modules/yjs/operations/get-yjs-token';
 import { materializeDescriptionOp } from '#/modules/yjs/operations/materialize-description';
 import { yjsRoutes } from '#/modules/yjs/yjs-routes';
+import { productEntityTypeSchema } from '#/schemas';
 import { defaultHook } from '#/utils/default-hook';
 import { log } from '#/utils/logger';
 
@@ -17,7 +18,7 @@ app.openapi(yjsRoutes.getYjsToken, async (ctx) => {
 });
 
 const materializeBodySchema = z.object({
-  entityType: z.string().max(50),
+  entityType: productEntityTypeSchema,
   entityId: z.uuid(),
   tenantId: z.string().max(50),
   organizationId: z.uuid().nullable(),

--- a/backend/src/modules/yjs/yjs-routes.ts
+++ b/backend/src/modules/yjs/yjs-routes.ts
@@ -2,10 +2,10 @@ import { z } from '@hono/zod-openapi';
 import { createXRoute } from '#/core/x-routes';
 import { authGuard } from '#/middlewares/guard';
 import { singlePointsLimiter } from '#/middlewares/rate-limiter/limiters';
-import { errorResponseRefs, maxLength } from '#/schemas';
+import { errorResponseRefs, maxLength, productEntityTypeSchema } from '#/schemas';
 
 const yjsTokenQuerySchema = z.object({
-  entityType: z.string().max(50),
+  entityType: productEntityTypeSchema,
   tenantId: z.string().max(maxLength.id),
   organizationId: z.string().max(maxLength.id),
 });

--- a/backend/src/permissions/validate-ancestor-scope.test.ts
+++ b/backend/src/permissions/validate-ancestor-scope.test.ts
@@ -16,7 +16,7 @@ const expectAppError = (fn: () => void, type: string) => {
 
 /** Build a raw subject (without validation) for testing validateAncestorScope itself */
 const buildRawSubject = (
-  entityType: string,
+  entityType: SubjectForPermission['entityType'],
   overrides?: Partial<Record<keyof ChannelScope, string | null | undefined>>,
 ): SubjectForPermission => {
   const ancestors = hierarchy.getOrderedAncestors(entityType);
@@ -26,7 +26,7 @@ const buildRawSubject = (
   }
   if (overrides) Object.assign(channelIds, overrides);
   const subject: SubjectForPermission = {
-    entityType: entityType as SubjectForPermission['entityType'],
+    entityType,
     channelIds: channelIds as ChannelScope,
   };
   return subject;

--- a/backend/src/utils/idempotency.ts
+++ b/backend/src/utils/idempotency.ts
@@ -1,3 +1,4 @@
+import type { EntityType } from 'shared';
 import { findActivityByMutationId, findActivityRefByMutationId } from '#/db/prepared';
 
 /**
@@ -22,7 +23,7 @@ export async function checkIdempotency<T>(stxId: string, findExisting: () => Pro
 }
 
 interface EntityReference {
-  entityType: string;
+  entityType: EntityType;
   subjectId: string;
 }
 

--- a/cdc/src/utils/update-counts.ts
+++ b/cdc/src/utils/update-counts.ts
@@ -1,5 +1,5 @@
 import { appConfig, hierarchy, resolveDeepestAncestorId, resolveNonNullAncestors } from 'shared';
-import type { ActivityAction, AncestorSource } from 'shared';
+import type { ActivityAction, AncestorSource, EntityType } from 'shared';
 import type { ActivityWithoutId } from '../pipeline/parse-message';
 import type { TableMeta } from '../types';
 import type { CdcRowData } from '../types';
@@ -217,7 +217,7 @@ function getInactiveMembershipDelta(
 function getEntityDeltas(
   action: ActivityAction,
   organizationId: string,
-  entityType: string,
+  entityType: EntityType,
   newRow: CdcRowData,
   oldRow: CdcRowData | null,
   h: AncestorSource,
@@ -264,7 +264,7 @@ function getEntityDeltas(
 /**
  * Warn for missing ancestor ids, except ancestors declared nullable (variable-depth rows).
  */
-function warnMissingAncestors(h: AncestorSource, entityType: string, row: CdcRowData): void {
+function warnMissingAncestors(h: AncestorSource, entityType: EntityType, row: CdcRowData): void {
   const nullable = h.getNullableAncestors(entityType);
   for (const ancestor of h.getOrderedAncestors(entityType)) {
     if (typeof row[`${ancestor}Id`] === 'string') continue;

--- a/frontend/src/modules/common/blocknote/tests/yjs-connections.test.ts
+++ b/frontend/src/modules/common/blocknote/tests/yjs-connections.test.ts
@@ -52,7 +52,7 @@ const { useUserStore, yjsTokenKey } = await import('~/modules/user/user-store');
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-const TEST_TOKEN_KEY = yjsTokenKey('task', 'tenant-1');
+const TEST_TOKEN_KEY = yjsTokenKey('attachment', 'tenant-1');
 
 /** Create a provider and wire the store→params subscription (mirrors acquireConnection). */
 function createProviderWithTokenSync(token: string) {
@@ -63,7 +63,7 @@ function createProviderWithTokenSync(token: string) {
     'test-session',
     {},
     {
-      params: { token, entityType: 'task', tenantId: 'tenant-1' },
+      params: { token, entityType: 'attachment', tenantId: 'tenant-1' },
     },
   );
 

--- a/frontend/src/modules/seen/helpers.ts
+++ b/frontend/src/modules/seen/helpers.ts
@@ -1,4 +1,4 @@
-import { appConfig, hierarchy } from 'shared';
+import { appConfig, hierarchy, type ProductEntityType } from 'shared';
 
 /** Context types that group seen counts, derived from hierarchy parents of tracked entity types */
 export const seenGroupingChannelTypes = new Set(
@@ -9,7 +9,7 @@ export const seenGroupingChannelTypes = new Set(
  * Derive the channel entity ID for seen-tracking grouping from any entity row.
  * Uses hierarchy to find the parent context type, then reads the matching ID column from the entity.
  */
-export function getSeenChannelId(entityType: string, entity: Record<string, unknown>): string {
+export function getSeenChannelId(entityType: ProductEntityType, entity: Record<string, unknown>): string {
   const parent = hierarchy.getParent(entityType);
   const key = parent ? appConfig.entityIdColumnKeys[parent] : 'organizationId';
   return String(entity[key] ?? entity.organizationId);

--- a/frontend/src/modules/seen/seen-store.ts
+++ b/frontend/src/modules/seen/seen-store.ts
@@ -48,7 +48,7 @@ interface SeenStoreState {
 const FLUSH_INTERVAL_MS = appConfig.mode === 'development' ? 10 * 1000 : 60 * 1000; // 10s in dev, 1min in prod
 
 /** Build a key for the pending map */
-const batchKey = (organizationId: string, entityType: string) => `${organizationId}:${entityType}`;
+const batchKey = (organizationId: string, entityType: ProductEntityType) => `${organizationId}:${entityType}`;
 
 /**
  * Batched unseen-count optimistic update.
@@ -62,7 +62,7 @@ const batchKey = (organizationId: string, entityType: string) => `${organization
  * Decrements are accumulated and applied in a single `setQueryData` call via
  * microtask, so one scroll batch produces at most one cache event.
  */
-const pendingDecrements: { channelId: string; entityType: string }[] = [];
+const pendingDecrements: { channelId: string; entityType: ProductEntityType }[] = [];
 let decrementScheduled = false;
 
 /** Max delay before forcing a flush even if the browser never goes idle */
@@ -73,7 +73,7 @@ const scheduleIdleCallback =
     ? (cb: () => void) => requestIdleCallback(cb, { timeout: UNSEEN_DECREMENT_MAX_DELAY_MS })
     : (cb: () => void) => setTimeout(cb, 1000);
 
-function scheduleUnseenDecrement(channelId: string, entityType: string) {
+function scheduleUnseenDecrement(channelId: string, entityType: ProductEntityType) {
   pendingDecrements.push({ channelId, entityType });
 
   if (!decrementScheduled) {

--- a/frontend/src/modules/user/user-store.ts
+++ b/frontend/src/modules/user/user-store.ts
@@ -1,6 +1,6 @@
 import i18n from 'i18next';
 import type { User } from 'sdk';
-import { appConfig } from 'shared';
+import { appConfig, type ProductEntityType } from 'shared';
 import { create } from 'zustand';
 import { createJSONStorage, devtools, persist } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
@@ -10,7 +10,7 @@ import type { MeUser } from '~/modules/me/types';
 type LastUser = Pick<MeUser, 'id' | 'email'>;
 
 /** Construct the store key for a context-scoped Yjs token. */
-export const yjsTokenKey = (entityType: string, tenantId: string) => `${entityType}:${tenantId}`;
+export const yjsTokenKey = (entityType: ProductEntityType, tenantId: string) => `${entityType}:${tenantId}`;
 
 interface UserStoreState {
   user: MeUser; // Current user data

--- a/frontend/src/query/basic/find-in-list-cache.ts
+++ b/frontend/src/query/basic/find-in-list-cache.ts
@@ -1,4 +1,5 @@
 import type { QueryKey } from '@tanstack/react-query';
+import type { EntityType } from 'shared';
 import { queryClient } from '~/query/query-client';
 import { flattenInfiniteData } from './flatten';
 
@@ -35,6 +36,6 @@ export function findInCache<T extends { id: string }>(
 /**
  * Create a typed cache finder bound to an entity type.
  */
-export function createCacheFinder<T extends { id: string }>(entityType: string) {
+export function createCacheFinder<T extends { id: string }>(entityType: EntityType) {
   return (matcher: string | ((item: T) => boolean)): T | undefined => findInCache<T>(entityType, matcher);
 }

--- a/frontend/src/query/enrichment/helpers.ts
+++ b/frontend/src/query/enrichment/helpers.ts
@@ -41,7 +41,7 @@ export function findMembership(memberships: MembershipBase[], entityId: string):
  * Channel entity types that host this entity as a menu subentity, even if not hierarchy ancestors
  * (e.g. workspace hosts project). From menuStructure config.
  */
-export function getMenuParentTypes(entityType: string): ChannelEntityType[] {
+export function getMenuParentTypes(entityType: ChannelEntityType): ChannelEntityType[] {
   return appConfig.menuStructure.filter((s) => s.subentityType === entityType).map((s) => s.entityType);
 }
 

--- a/frontend/src/query/enrichment/init-enrichment.ts
+++ b/frontend/src/query/enrichment/init-enrichment.ts
@@ -92,7 +92,7 @@ function enrichListData(
 }
 
 /** Build slug index from list queries for a given entity type */
-function buildSlugIndex(entityType: string): Map<string, string> {
+function buildSlugIndex(entityType: ChannelEntityType): Map<string, string> {
   const slugMap = new Map<string, string>();
   for (const query of queryClient.getQueryCache().findAll({ queryKey: [entityType, 'list'] })) {
     const data = query.state.data as InfiniteData | undefined;

--- a/frontend/src/query/offline/failed-sync.ts
+++ b/frontend/src/query/offline/failed-sync.ts
@@ -1,3 +1,4 @@
+import type { ProductEntityType } from 'shared';
 import { reportCriticalError } from '~/lib/tracing';
 import { getAppDb } from '~/query/app-db';
 
@@ -8,7 +9,7 @@ export interface FailedSyncRecord {
   /** Mutation id (stx.mutationId) for idempotent manual replay. */
   mutationId: string;
   /** Product entity type, when known. */
-  entityType?: string;
+  entityType?: ProductEntityType;
   /** Client cache version (appConfig.clientCacheVersion) the client was on when it failed. */
   clientCacheVersion: string;
   /** HTTP status of the failed replay. */

--- a/frontend/src/query/query-client.ts
+++ b/frontend/src/query/query-client.ts
@@ -1,5 +1,5 @@
 import { MutationCache, onlineManager, QueryCache, QueryClient } from '@tanstack/react-query';
-import { appConfig } from 'shared';
+import { appConfig, type ProductEntityType } from 'shared';
 import type { ApiError } from '~/lib/api';
 import { resetConnectivityCache } from '~/query/offline/connectivity';
 import { mutationRetry } from '~/query/offline/network-retry';
@@ -8,9 +8,9 @@ import type { QueryMeta } from '~/query/react-query';
 const productEntitySet = new Set<string>(appConfig.productEntityTypes);
 
 /** Product entity type encoded in a query/mutation key, or undefined. */
-function entityTypeOf(key: unknown): string | undefined {
+function entityTypeOf(key: unknown): ProductEntityType | undefined {
   const head = Array.isArray(key) ? key[0] : undefined;
-  return typeof head === 'string' && productEntitySet.has(head) ? head : undefined;
+  return typeof head === 'string' && productEntitySet.has(head) ? (head as ProductEntityType) : undefined;
 }
 
 // Lazy import to break circular dependency: query-client -> on-error -> flush-stores -> query-client

--- a/frontend/src/query/realtime/app-stream-handler.ts
+++ b/frontend/src/query/realtime/app-stream-handler.ts
@@ -223,7 +223,7 @@ function handleEntityNotification(
 }
 
 /** Refetch the server's predicate-exact unseen counts for a tracked entity type. */
-function invalidateUnseenCounts(entityType: string): void {
+function invalidateUnseenCounts(entityType: ProductEntityType): void {
   const trackedTypes = appConfig.seenTrackedEntityTypes as readonly string[];
   if (!trackedTypes.includes(entityType)) return;
   queryClient.invalidateQueries({ queryKey: seenKeys.unseenCounts });
@@ -233,7 +233,7 @@ function invalidateUnseenCounts(entityType: string): void {
  * Optimistically adjust the unseen count for a tracked entity created/deleted via SSE: patch the
  * cache directly by channelId to avoid a full refetch, falling back to invalidation if none.
  */
-function adjustUnseenCount(entityType: string, channelId: string | null, delta: number): void {
+function adjustUnseenCount(entityType: ProductEntityType, channelId: string | null, delta: number): void {
   const trackedTypes = appConfig.seenTrackedEntityTypes as readonly string[];
   if (!trackedTypes.includes(entityType)) return;
 
@@ -267,7 +267,7 @@ function adjustUnseenCount(entityType: string, channelId: string | null, delta: 
  * pending), the count is unchanged (total−1 and seen−1 cancel); if unseen, decrement. Falls back to
  * invalidation when channelId is unavailable.
  */
-function handleDeleteUnseenCount(entityType: string, entityId: string, channelId: string | null): void {
+function handleDeleteUnseenCount(entityType: ProductEntityType, entityId: string, channelId: string | null): void {
   const trackedTypes = appConfig.seenTrackedEntityTypes as readonly string[];
   if (!trackedTypes.includes(entityType)) return;
 

--- a/frontend/src/query/realtime/cache-ops.ts
+++ b/frontend/src/query/realtime/cache-ops.ts
@@ -106,7 +106,7 @@ function matchesCanonicalScope(queryKey: readonly unknown[], entity: ItemData, s
  * stx is conflict-resolution metadata never rendered in the UI.
  */
 export function patchEntityStxInCache(
-  entityType: string,
+  entityType: ProductEntityType,
   entityId: string,
   stx: { fieldTimestamps?: Record<string, string> },
   organizationId?: string,
@@ -143,7 +143,7 @@ export function patchEntityStxInCache(
 }
 
 /** Store cache token for entity (live notifications only) */
-export function storeEntityCacheToken(entityType: string, entityId: string, token: string): void {
+export function storeEntityCacheToken(entityType: ProductEntityType, entityId: string, token: string): void {
   storeCacheToken(entityType, entityId, token);
 }
 
@@ -231,7 +231,7 @@ export async function fetchEntityAndUpdateList(
   action: 'create' | 'update',
   organizationId?: string,
   tenantId?: string,
-  entityType?: string,
+  entityType?: ProductEntityType,
 ): Promise<void> {
   // Skip remote writes for entities with pending mutations to preserve optimistic state.
   // The mutation's onSuccess will reconcile the cache when it settles.

--- a/sdk/gen/openapi.json
+++ b/sdk/gen/openapi.json
@@ -6879,7 +6879,7 @@
           {
             "schema": {
               "type": "string",
-              "maxLength": 50
+              "enum": ["attachment"]
             },
             "required": true,
             "name": "entityType",

--- a/sdk/gen/sdk.gen.ts
+++ b/sdk/gen/sdk.gen.ts
@@ -2495,7 +2495,7 @@ export const getUser = <ThrowOnError extends boolean = true>(
  * **GET /yjs/token** ·· [getYjsToken](https://www.cellajs.com/docs/operations?operationTag=yjs#tag/yjs/GET/yjs/token) ·· [getYjsToken](https://www.cellajs.com/docs/operations?operationTag=cella#tag/cella/GET/yjs/token) ·· _yjs_cella_
  *
  * @param {getYjsTokenData} options
- * @param {string} options.query.entitytype - `string`
+ * @param {enum} options.query.entitytype - `enum`
  * @param {string} options.query.tenantid - `string`
  * @param {string} options.query.organizationid - `string`
  * @returns Possible status codes: 200, 400, 401, 403, 404, 409, 429

--- a/sdk/gen/types.gen.ts
+++ b/sdk/gen/types.gen.ts
@@ -3416,7 +3416,7 @@ export type GetYjsTokenData = {
   body?: never;
   path?: never;
   query: {
-    entityType: string;
+    entityType: 'attachment';
     tenantId: string;
     organizationId: string;
   };

--- a/sdk/gen/zod.gen.ts
+++ b/sdk/gen/zod.gen.ts
@@ -1183,7 +1183,7 @@ export const zGetUserResponse = zUserBase.and(
 );
 
 export const zGetYjsTokenQuery = z.object({
-  entityType: z.string().max(50),
+  entityType: z.enum(['attachment']),
   tenantId: z.string().max(50),
   organizationId: z.string().max(50),
 });

--- a/shared/src/entity-guards.ts
+++ b/shared/src/entity-guards.ts
@@ -2,7 +2,7 @@ import { hierarchy } from '../config/config.default';
 import type { ChannelEntityType, ProductEntityType } from '../types';
 
 /** Get roles for a channel entity. */
-export function getChannelRoles(channelType: string): readonly string[] {
+export function getChannelRoles(channelType: ChannelEntityType): readonly string[] {
   return hierarchy.getRoles(channelType);
 }
 

--- a/shared/src/permissions/validate-ancestor-scope.test.ts
+++ b/shared/src/permissions/validate-ancestor-scope.test.ts
@@ -4,7 +4,7 @@ import type { ChannelScope, SubjectForPermission } from 'shared';
 
 /** Build a raw subject (without validation) for testing validateAncestorScope itself */
 const buildRawSubject = (
-  entityType: string,
+  entityType: SubjectForPermission['entityType'],
   overrides?: Partial<Record<keyof ChannelScope, string | null | undefined>>,
 ): SubjectForPermission => {
   const ancestors = hierarchy.getOrderedAncestors(entityType);
@@ -14,7 +14,7 @@ const buildRawSubject = (
   }
   if (overrides) Object.assign(channelIds, overrides);
   return {
-    entityType: entityType as SubjectForPermission['entityType'],
+    entityType,
     id: 'test-id',
     channelIds: channelIds as ChannelScope,
   };

--- a/shared/src/tracing/tracing.test.ts
+++ b/shared/src/tracing/tracing.test.ts
@@ -170,11 +170,11 @@ describe('attribute helpers', () => {
       'activity.entityType': null,
     });
 
-    expect(activityAttrs({ type: 'entity', action: 'create', subjectId: 'abc', entityType: 'task' })).toEqual({
+    expect(activityAttrs({ type: 'entity', action: 'create', subjectId: 'abc', entityType: 'attachment' })).toEqual({
       'activity.type': 'entity',
       'activity.action': 'create',
       'activity.subjectId': 'abc',
-      'activity.entityType': 'task',
+      'activity.entityType': 'attachment',
     });
   });
 
@@ -185,10 +185,10 @@ describe('attribute helpers', () => {
       'event.entityType': null,
     });
 
-    expect(eventAttrs({ type: 'update', subjectId: 'x', entityType: 'task' })).toEqual({
+    expect(eventAttrs({ type: 'update', subjectId: 'x', entityType: 'attachment' })).toEqual({
       'event.type': 'update',
       'event.subjectId': 'x',
-      'event.entityType': 'task',
+      'event.entityType': 'attachment',
     });
   });
 });

--- a/shared/src/tracing/tracing.ts
+++ b/shared/src/tracing/tracing.ts
@@ -1,3 +1,5 @@
+import type { EntityType } from '../../types';
+
 export * from './span-names';
 export { createSpanStoreProcessor, type SpanStoreProcessorOptions } from './span-store-processor';
 
@@ -200,7 +202,7 @@ export interface ActivityInput {
   type?: string | null;
   action?: string | null;
   subjectId?: string | null;
-  entityType?: string | null;
+  entityType?: EntityType | null;
 }
 
 /** Build prefixed activity attributes from an activity object. */
@@ -217,7 +219,7 @@ export function activityAttrs(input: ActivityInput): CleanSpanAttributes {
 export interface EventInput {
   type: string;
   subjectId?: string | null;
-  entityType?: string | null;
+  entityType?: EntityType | null;
 }
 
 /** Build prefixed event attributes for ActivityBus spans. */


### PR DESCRIPTION
## What & why

`entityType: string` had proliferated (108 occurrences). Many are genuine seams, but most were **drift** — the caller already held a typed `EntityType` / `ChannelEntityType` / `ProductEntityType` and the callee widened it back to `string`. This tightens those so `string` stays the *exception* (real boundaries), not the rule.

Full audit (verdict + caller evidence per site, and the JUSTIFIED list of what to leave alone) lives in `.todos/ENTITY_TYPE_STRING_AUDIT.md` (gitignored — pasteable on request).

## Changes by priority

- **P0 — the one behavioral change (security-flavoured).** The yjs token route and the internal `/materialize` body validated `entityType` as bare `z.string().max(50)`. They now use `productEntityTypeSchema` (the existing config-derived enum in `common-schemas.ts`). Collaboration only exists for product entities, so this closes a gap where a signed token could be minted for any string. `token-signer` / `get-yjs-token` cascade to `ProductEntityType` (dropped an `as EntityType` cast). **SDK regenerated** → `sdk/gen/*` now reflects the enum.
- **P1** — backend/CDC (`getOrgEntityCount`, `markSeenOp`, `seen-queries`, CDC counter helpers) and frontend app-stream (unseen-count trio, `patchEntityStxInCache`, `fetchEntityAndUpdateList`, `buildSlugIndex`). All callers already pass typed values.
- **P2** — entity-cache trio, `idempotency`, seen-store plumbing, `yjsTokenKey`, `getMenuParentTypes`, `createCacheFinder`, `tracing` inputs, `getChannelRoles`, 3 test helpers.
- **P3** — `recordMessageReceived`, `storeEntityCacheToken`, `getSeenChannelId`, `FailedSyncRecord` (+ `query-client` `entityTypeOf` return).

Everything except P0 is behaviour-preserving type-level tightening.

## Deferred (needs its own PR)

The frontend catchup/sync-store boundary is *correctly* `string` today (it deserializes persisted seq-map keys, some keyed by the non-entity `membership`). Tightening it requires adding **new runtime validation** at a security-relevant sync path — a behavioral change that deserves separate review. Left as-is.

## Findings worth a look (details in the audit md)

- 3 cella tests used `'task'` (a fork entity absent from cella's `productEntityTypes = ['attachment']`) as a placeholder; changed to `'attachment'`. Were these meant to be fork-agnostic?
- `FailedSyncRecord.entityType` → `ProductEntityType` is read back from IndexedDB; a pre-config-change record could hold a stale type (cosmetic — export/repair only). The one item a conservative reviewer might keep as `string`.

## Verification

- `pnpm -r ts` green across all 11 packages (pre-commit hook re-ran it).
- Affected unit tests pass: shared 17, backend 21, frontend 14.
- SDK regen produces only the intended yjs-`entityType` diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
