### PR TITLE
refactor(types): tighten role: string seams to EntityRole (+ unbreak main)

### DIFF
--- a/backend/src/modules/entities/helpers/list-total.ts
+++ b/backend/src/modules/entities/helpers/list-total.ts
@@ -1,3 +1,4 @@
+import type { EntityType } from 'shared';
 import type { DbContext } from '#/core/context';
 import { getOrgEntityCount } from '#/modules/entities/entities-queries';
 
@@ -10,7 +11,7 @@ import { getOrgEntityCount } from '#/modules/entities/entities-queries';
  */
 export type ListTotalSource =
   | { kind: 'pageLength' }
-  | { kind: 'counter'; ctx: DbContext; channelKey: string; entityType: string }
+  | { kind: 'counter'; ctx: DbContext; channelKey: string; entityType: EntityType }
   | { kind: 'exact'; count: () => Promise<number> };
 
 /**

--- a/backend/src/modules/entities/stream/dispatch-mirror.test.ts
+++ b/backend/src/modules/entities/stream/dispatch-mirror.test.ts
@@ -1,4 +1,5 @@
 import type { SSEStreamingApi } from 'hono/streaming';
+import type { EntityRole } from 'shared';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { ActivityEvent } from '#/lib/activity-bus';
 import type { AppStreamSubscriber } from '#/modules/entities/helpers/dispatch-to-stream';
@@ -18,7 +19,7 @@ import type { AppStreamEvent } from './types';
 const ORG_A = 'org-dispatch-a';
 const ORG_B = 'org-dispatch-b';
 
-const membership = (organizationId: string, role: string, userId: string): MembershipBaseModel =>
+const membership = (organizationId: string, role: EntityRole, userId: string): MembershipBaseModel =>
   ({
     id: `mem-organization-${organizationId}-${role}-${userId}`,
     userId,

--- a/backend/src/permissions/collection-scope.ts
+++ b/backend/src/permissions/collection-scope.ts
@@ -5,6 +5,7 @@ import {
   type ChannelEntityType,
   elevatedRoles as configuredElevatedRoles,
   publicReadGrants as configuredPublicReadGrants,
+  type EntityRole,
   getPolicyPermissions,
   getSubjectPolicies,
   hierarchy,
@@ -24,7 +25,7 @@ const roleReadValue = (
   policies: AccessPolicies,
   entityType: ProductEntityType,
   channelType: ChannelEntityType,
-  role: string,
+  role: EntityRole,
 ): NormalizedPermissionValue => {
   const subjectPolicies = getSubjectPolicies(entityType, policies);
   const permissions = getPolicyPermissions(subjectPolicies, channelType, role);
@@ -115,7 +116,7 @@ const resolveScopes = (
   // Grant scoping: with elevatedRoles configured, a non-elevated role's grant speaks only
   // for rows HOMED at its level. Grants at the deepest level are home-exact by
   // construction; root/intermediate grants of non-elevated roles become home-scoped.
-  const isHomeScopedGrant = (channelType: ChannelEntityType, role: string): boolean =>
+  const isHomeScopedGrant = (channelType: ChannelEntityType, role: EntityRole): boolean =>
     elevatedRoles !== undefined && !elevatedRoles.includes(role) && channelType !== subChannelType;
 
   const acc: ScopeAccumulator = {
@@ -145,7 +146,7 @@ const resolveScopes = (
     acc.conditional.set(key, entry);
   };
 
-  const addUnconditional = (channelType: ChannelEntityType, role: string, channelId: string | null) => {
+  const addUnconditional = (channelType: ChannelEntityType, role: EntityRole, channelId: string | null) => {
     // Non-elevated roles above the deepest level scope to rows HOMED at their grant level
     if (isHomeScopedGrant(channelType, role)) {
       const ids = acc.homeScoped.get(channelType) ?? new Set<string>();

--- a/frontend/src/modules/common/form-fields/select-role-radio.tsx
+++ b/frontend/src/modules/common/form-fields/select-role-radio.tsx
@@ -4,7 +4,7 @@ import { RadioGroup, RadioGroupItem } from '~/modules/ui/radio-group';
 import { cn } from '~/utils/cn';
 
 interface Props {
-  onValueChange: (value?: string) => void;
+  onValueChange: (value?: EntityRole) => void;
   value?: EntityRole;
   /** Restrict options to this channel entity's role vocabulary (e.g. course → staff/student/guest). */
   entityType?: ChannelEntityType;
@@ -22,7 +22,7 @@ export function SelectRoleRadio({ onValueChange, value, entityType, className }:
   return (
     <RadioGroup
       value={value}
-      onValueChange={(v) => onValueChange(v as string)}
+      onValueChange={(v) => onValueChange(v as EntityRole)}
       className={cn('inline-flex items-center gap-4', className)}
     >
       {roleOptions.map((role) => (

--- a/frontend/src/modules/common/form-fields/select-roles.tsx
+++ b/frontend/src/modules/common/form-fields/select-roles.tsx
@@ -1,15 +1,15 @@
 import { useTranslation } from 'react-i18next';
-import { roles } from 'shared';
+import { type EntityRole, roles } from 'shared';
 import { Checkbox } from '~/modules/ui/checkbox';
 import { cn } from '~/utils/cn';
 
 interface SelectRoleProps {
-  onValueChange: (value: string[]) => void;
-  value?: string[];
+  onValueChange: (value: EntityRole[]) => void;
+  value?: EntityRole[];
   className?: string;
 }
 
-const EMPTY_ROLES: string[] = [];
+const EMPTY_ROLES: EntityRole[] = [];
 
 /**
  * Checkbox group for selecting multiple entity roles.
@@ -17,7 +17,7 @@ const EMPTY_ROLES: string[] = [];
 export function SelectRoles({ onValueChange, value = EMPTY_ROLES, className }: SelectRoleProps) {
   const { t } = useTranslation();
 
-  const handleCheckboxChange = (role: string) => {
+  const handleCheckboxChange = (role: EntityRole) => {
     const newValue = value.includes(role)
       ? value.filter((selectedRole) => selectedRole !== role) // Remove role if it already exists
       : [...value, role];

--- a/frontend/src/modules/common/stories/select-role-radio.stories.tsx
+++ b/frontend/src/modules/common/stories/select-role-radio.stories.tsx
@@ -22,7 +22,7 @@ export const Empty: Story = {
   render: function Render() {
     const [value, setValue] = useState<EntityRole | undefined>(undefined);
 
-    return <SelectRoleRadio value={value} onValueChange={(next) => setValue(next as EntityRole | undefined)} />;
+    return <SelectRoleRadio value={value} onValueChange={setValue} />;
   },
 };
 
@@ -34,7 +34,7 @@ export const Selected: Story = {
   render: function Render() {
     const [value, setValue] = useState<EntityRole | undefined>('admin');
 
-    return <SelectRoleRadio value={value} onValueChange={(next) => setValue(next as EntityRole | undefined)} />;
+    return <SelectRoleRadio value={value} onValueChange={setValue} />;
   },
 };
 
@@ -49,11 +49,7 @@ export const WrappedLayout: Story = {
 
     return (
       <div className="w-72 rounded-lg border p-4">
-        <SelectRoleRadio
-          value={value}
-          onValueChange={(next) => setValue(next as EntityRole | undefined)}
-          className="flex-wrap items-start gap-3"
-        />
+        <SelectRoleRadio value={value} onValueChange={setValue} className="flex-wrap items-start gap-3" />
       </div>
     );
   },
@@ -69,7 +65,7 @@ export const ShouldSelectRole: Story = {
   render: function Render() {
     const [value, setValue] = useState<EntityRole | undefined>(undefined);
 
-    return <SelectRoleRadio value={value} onValueChange={(next) => setValue(next as EntityRole | undefined)} />;
+    return <SelectRoleRadio value={value} onValueChange={setValue} />;
   },
   play: async ({ canvas, step }) => {
     const radios = await canvas.findAllByRole('radio');

--- a/frontend/src/modules/common/stories/select-roles.stories.tsx
+++ b/frontend/src/modules/common/stories/select-roles.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
+import type { EntityRole } from 'shared';
 import { SelectRoles } from '~/modules/common/form-fields/select-roles';
 
 const meta = {
@@ -18,7 +19,7 @@ export const Empty: Story = {
     onValueChange: () => {},
   },
   render: function Render() {
-    const [value, setValue] = useState<string[]>([]);
+    const [value, setValue] = useState<EntityRole[]>([]);
 
     return <SelectRoles value={value} onValueChange={setValue} />;
   },
@@ -26,11 +27,11 @@ export const Empty: Story = {
 
 export const Preselected: Story = {
   args: {
-    value: ['owner'],
+    value: ['member'],
     onValueChange: () => {},
   },
   render: function Render() {
-    const [value, setValue] = useState<string[]>(['owner']);
+    const [value, setValue] = useState<EntityRole[]>(['member']);
 
     return <SelectRoles value={value} onValueChange={setValue} />;
   },
@@ -38,11 +39,11 @@ export const Preselected: Story = {
 
 export const MultipleSelected: Story = {
   args: {
-    value: ['owner', 'admin'],
+    value: ['member', 'admin'],
     onValueChange: () => {},
   },
   render: function Render() {
-    const [value, setValue] = useState<string[]>(['owner', 'admin']);
+    const [value, setValue] = useState<EntityRole[]>(['member', 'admin']);
 
     return <SelectRoles value={value} onValueChange={setValue} />;
   },
@@ -54,7 +55,7 @@ export const WrappedLayout: Story = {
     onValueChange: () => {},
   },
   render: function Render() {
-    const [value, setValue] = useState<string[]>(['member']);
+    const [value, setValue] = useState<EntityRole[]>(['member']);
 
     return (
       <div className="w-64 rounded-lg border p-4">

--- a/shared/src/entity-guards.ts
+++ b/shared/src/entity-guards.ts
@@ -1,8 +1,8 @@
 import { hierarchy } from '../config/config.default';
-import type { ChannelEntityType, ProductEntityType } from '../types';
+import type { ChannelEntityType, EntityRole, ProductEntityType } from '../types';
 
 /** Get roles for a channel entity. */
-export function getChannelRoles(channelType: ChannelEntityType): readonly string[] {
+export function getChannelRoles(channelType: ChannelEntityType): readonly EntityRole[] {
   return hierarchy.getRoles(channelType);
 }
 

--- a/shared/src/permissions/permission-manager/types.ts
+++ b/shared/src/permissions/permission-manager/types.ts
@@ -55,7 +55,7 @@ export type SubjectForPermission = {
  * grants every action regardless of membership).
  */
 export type GrantSource =
-  | { type: 'membership'; channelType: ChannelEntityType; channelId: string; role: string }
+  | { type: 'membership'; channelType: ChannelEntityType; channelId: string; role: EntityRole }
   | { type: 'relation'; relation: string }
   | { type: 'public'; mode: PublicReadMode }
   | { type: 'systemAdmin' };


### PR DESCRIPTION
## What & why

Follow-up to #897, same principle for `role`. Role has far fewer real offenders than `entityType` — most of the permission layer is one deliberate seam. This tightens only the places that carry a **membership's role** but were typed `string`.

Full audit (per-site verdicts + the JUSTIFIED list) in `.todos/ROLE_STRING_AUDIT.md` (gitignored — pasteable on request).

## ⚠️ Also unbreaks `main`

`main` is currently **red** on `backend ts`, independent of this work. #896 added `ListTotalSource.entityType: string` calling `getOrgEntityCount`; #897 concurrently tightened `getOrgEntityCount` to `EntityType`. The two landed together, so #897's CI never saw #896's new caller. This PR tightens `ListTotalSource.entityType` → `EntityType` (its only constructor passes the literal `'attachment'`), which makes `pnpm -r ts` green again. If you want that fix faster, it's a one-liner you can cherry-pick from this branch.

## Role changes

- **Permissions:** `GrantSource.role` → `EntityRole` (it was `string` right beside its sibling `PermissionMembership.role: EntityRole`); the three `collection-scope` helpers (`roleReadValue`, `isHomeScopedGrant`, `addUnconditional`), all fed by `membership.role`.
- **shared:** `getChannelRoles` now returns `readonly EntityRole[]` (it already did at runtime via `hierarchy.getRoles`).
- **frontend:** `SelectRoleRadio.onValueChange` → `EntityRole`; `SelectRoles` value/handlers → `EntityRole[]`. Removes the `as string` / `as EntityRole` casts in the components and their stories.
- **test:** `dispatch-mirror` membership helper → `EntityRole`.

## Left as JUSTIFIED `string` (see audit)

- **The permission-engine synthetic-hierarchy seam** — the direct analogue of #897's `TopologyHierarchy`/`AncestorSource`: `AccessPolicyEntry.role`, `getRoles`/topology, `createChannelPolicyBuilder`, `elevatedRoles`, `validateRoles`. Roles out of a *possibly-synthetic* hierarchy aren't the fork's `EntityRole`.
- **`SelectRole` + the three table bars.** The report initially listed the bars as FIXes, but their `onRoleChange` is passed straight into `SelectRole`'s `(value?: string)` prop; under `strictFunctionTypes` (contravariant params) they can't tighten unless `SelectRole` is made generic. `SelectRole` is genuinely polymorphic (`entity ? roles.all : appConfig.systemRoles`) with an `'all'` sentinel, and the report recommended keeping it `string`. The bars' **stored** role types are already typed via their route zod schemas, so nothing is lost. Making `SelectRole` generic (to type the bar handlers) is a reasonable follow-up if wanted.

## Findings

- `select-roles.stories.tsx` used `'owner'` (a fork role absent from cella's `roles.all = ['admin','member']`) — same fork-literal pattern as #897's `'task'`. Changed to `'member'`.

## Verification

- `pnpm -r ts` green across all 11 packages (pre-commit hook re-ran it — this is what confirms `main` is unbroken).
- Shared permission tests (34) and role-selector storybook tests (8) pass.
- No zod/runtime changes (role schemas already use `z.enum(roles.all)` / `z.enum(appConfig.systemRoles)`); no SDK diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
