### PR TITLE
refactor(permissions): collapse row conditions to a name union

### DIFF
--- a/backend/src/permissions/collection-scope.ts
+++ b/backend/src/permissions/collection-scope.ts
@@ -14,8 +14,7 @@ import {
   type PermissionTopology,
   type ProductEntityType,
   type PublicReadGrants,
-  publicRow,
-  type RowCondition,
+  type RowConditionName,
 } from 'shared';
 import { AppError } from '#/core/error';
 import type { MembershipBaseModel } from '#/modules/memberships/helpers/select';
@@ -40,7 +39,7 @@ const roleReadValue = (
  * column) — the shape every pre-deep-chain caller produced.
  */
 export interface ConditionalScope {
-  condition: RowCondition;
+  condition: RowConditionName;
   subChannelIds: string[] | undefined;
   channelType?: ChannelEntityType;
   /** Home-scoped grant (elevatedRoles): these levels' columns must be NULL as well. */
@@ -79,11 +78,11 @@ interface ScopeAccumulator {
   ancestorUnconditional: Map<ChannelEntityType, Set<string>>;
   /** HOME-scoped unconditional grants (elevatedRoles), keyed by context type. */
   homeScoped: Map<ChannelEntityType, Set<string>>;
-  /** Keyed by `${condition name}:${level}:${homeOnly}`; conditions sharing a name must be the same rule. */
+  /** Keyed by `${condition name}:${level}:${homeOnly}`; the name uniquely identifies the rule. */
   conditional: Map<
     string,
     {
-      condition: RowCondition;
+      condition: RowConditionName;
       channelType?: ChannelEntityType;
       homeOnly: boolean;
       orgWide: boolean;
@@ -128,12 +127,12 @@ const resolveScopes = (
   };
 
   const addConditional = (
-    condition: RowCondition,
+    condition: RowConditionName,
     channelId: string | null,
     channelType?: ChannelEntityType,
     homeOnly = false,
   ) => {
-    const key = `${condition.name}:${channelType ?? ''}:${homeOnly}`;
+    const key = `${condition}:${channelType ?? ''}:${homeOnly}`;
     const entry = acc.conditional.get(key) ?? {
       condition,
       channelType,
@@ -203,7 +202,7 @@ const resolveScopes = (
   // a caller with no membership scope at all can still read public rows. Modelled as an
   // org-wide conditional slice (`publicAt IS NOT NULL`), which means it rides the exact same
   // compile path as policy row conditions and needs no special case downstream.
-  if (publicGrants?.[entityType]) addConditional(publicRow, null);
+  if (publicGrants?.[entityType]) addConditional('public', null);
 
   return acc;
 };

--- a/backend/src/permissions/row-predicates.ts
+++ b/backend/src/permissions/row-predicates.ts
@@ -1,6 +1,6 @@
 import { and, eq, inArray, isNotNull, isNull, or, type SQL, sql } from 'drizzle-orm';
 import type { AnyPgTable, PgColumn } from 'drizzle-orm/pg-core';
-import { type Actor, appConfig, type ChannelEntityType, type RowCondition, type RowPredicate } from 'shared';
+import { type Actor, appConfig, type ChannelEntityType, type RowConditionName } from 'shared';
 import type { CollectionReadFilter } from './collection-scope';
 
 /**
@@ -26,22 +26,20 @@ const resolveColumn = (table: AnyPgTable, columnName: string, conditionName: str
 };
 
 /**
- * Compile a single row condition to a predicate over `table`'s rows for the acting user.
- * Anonymous actors never match actor-bound forms, mirroring the check-form.
+ * Compile a single row condition (by name) to a predicate over `table`'s rows for the acting
+ * user. The name-keyed switch is the SQL twin of the check-form's `matchesRowCondition`; the two
+ * must agree, asserted by the parity test. Anonymous actors never match actor-bound forms.
  */
-export const compileRowConditionSql = (condition: RowCondition, table: AnyPgTable, actor: Actor): SQL => {
-  const predicate: RowPredicate = condition.predicate;
-  const column = resolveColumn(table, predicate.column, condition.name);
-
-  switch (predicate.kind) {
-    case 'columnEqualsActor': {
+export const compileRowConditionSql = (name: RowConditionName, table: AnyPgTable, actor: Actor): SQL => {
+  switch (name) {
+    case 'own': {
       const userId = 'anonymous' in actor ? undefined : actor.userId;
       if (!userId) return NEVER;
-      return eq(column, userId);
+      return eq(resolveColumn(table, 'createdBy', name), userId);
     }
     // Actor-independent (public read): matches for anonymous actors too.
-    case 'columnIsNotNull':
-      return isNotNull(column);
+    case 'public':
+      return isNotNull(resolveColumn(table, 'publicAt', name));
   }
 };
 

--- a/cella/PERMISSIONS.md
+++ b/cella/PERMISSIONS.md
@@ -19,7 +19,7 @@ Postgres RLS is a **separate, coarser layer**. It enforces tenant isolation and 
 │  │                               │  │                                     │  │
 │  │ createEntityHierarchy(roles)  │  │ configurePermissions(types, cb)     │  │
 │  │   .user()                     │  │   subject × context × role → cell   │  │
-│  │   .channel(name, {parent,     │  │   cell = 0 | 1 | RowCondition       │  │
+│  │   .channel(name, {parent,     │  │   cell = 0 | 1 | 'own'              │  │
 │  │             roles})           │  │   publicRead(mode)                  │  │
 │  │   .product(name, {parent})    │  │   elevatedRoles                     │  │
 │  │                               │  │                                     │  │
@@ -39,7 +39,7 @@ Postgres RLS is a **separate, coarser layer**. It enforces tenant isolation and 
 │      │  2. system admin?    allow every action, short-circuit   │            │
 │      │  3. memberships      policy cell per (channelType, role) │            │
 │      │       1           → grant            grantedBy membership│            │
-│      │       RowCondition→ grant iff matches(row, actor)        │            │
+│      │       condition   → grant iff matches(row, actor)        │            │
 │      │                                      grantedBy relation  │            │
 │      │       0           → nothing                              │            │
 │      │  4. public read      widens `read` only                  │            │
@@ -72,7 +72,7 @@ The engine **never loads rows**. Callers resolve whatever row data a decision ne
 | **User entity** | Carries no policies at all; `configurePermissions` filters it out. |
 | **Membership** | The engine reads only `{ channelType, channelId, role }`. Explicit `user → context` relation. |
 | **Subject** | What is being acted on: entity type, optional id, `channelIds` scope, and optionally `row`. |
-| **Policy cell** | `0` (deny), `1` (allow), or a `RowCondition` (allow on qualifying rows). |
+| **Policy cell** | `0` (deny), `1` (allow), or a row-condition name (`'own'` — allow on qualifying rows). |
 | **Action** | `create`, `read`, `update`, `delete` (`appConfig.entityActions`). |
 | **Grant source** | Why an action was allowed: `membership`, `relation`, `public`, or `systemAdmin`. |
 
@@ -112,7 +112,7 @@ export const { accessPolicies, publicReadGrants } = configurePermissions(
 );
 ```
 
-Any action you omit defaults to `0`. The `'own'` literal is sugar: it is normalized into the built-in `own` row condition at config time, so the engine only ever sees `0 | 1 | RowCondition`.
+Any action you omit defaults to `0`. `'own'` is the built-in owner condition: the engine reads the config cell verbatim (the name *is* the value), so it only ever sees `0 | 1 | 'own'`.
 
 Missing actions and missing role/context rows both deny by default, so policies only need to declare
 grants. Public-read declarations are collected separately because they are membership-independent.
@@ -150,28 +150,22 @@ Boundary code that starts from DB rows, route params, or CDC events uses `buildS
 
 Two mechanisms widen access beyond the policy matrix, and both read the row's own columns. There are exactly two rules — `own` and `public` — and that set is **closed**: it is not a fork extension point. The reasoning is in Constraints; the mechanism is here.
 
-A **row condition** (`shared/src/permissions/row-conditions.ts`) qualifies a grant per row. A cell of `1` grants the action on every row the context scope reaches; a condition cell grants it only on rows the condition matches. A condition is pure data — a name and a `RowPredicate` from a closed vocabulary:
+A **row condition** (`shared/src/permissions/row-conditions.ts`) qualifies a grant per row. A cell of `1` grants the action on every row the context scope reaches; a condition cell grants it only on rows the condition matches. Because the set is closed, a condition is just its **name** — the name determines the rule, so there is no descriptor to carry:
 
 ```ts
-export type RowPredicate =
-  | { kind: 'columnEqualsActor'; column: string }   // row[column] === acting user id (anonymous never matches)
-  | { kind: 'columnIsNotNull'; column: string };    // row[column] is set (actor-independent)
+export type RowConditionName = 'own' | 'public';   // this union IS the contract
 
-export interface RowCondition {
-  name: string;
-  predicate: RowPredicate;
-}
-
-export const own = { name: 'own', predicate: { kind: 'columnEqualsActor', column: 'createdBy' } };
+export const matchesRowCondition = (name: RowConditionName, row, actor): boolean => {
+  switch (name) {
+    case 'own':    return !!actor.userId && row.createdBy === actor.userId; // anonymous never matches
+    case 'public': return !!row.publicAt;                                   // actor-independent
+  }
+};
 ```
 
-The predicate is the single source of truth. Two shared interpreters read it — `rowPredicateMatches` (JS, in `shared/`) and `compileRowConditionSql` (Drizzle, in `backend/`) — so a condition's check-form and SQL-form **cannot drift from each other**: there are no per-condition implementations to keep in sync, only the two interpreters, which the parity property test proves equal. The `shared/`→`backend/` split is why the predicate is a declarative descriptor rather than an inline query builder: `shared/` is ORM-free, so it emits the predicate and the backend compiles it.
+The name is the single source of truth. Three paths map it to behaviour through an exhaustive `switch` — `matchesRowCondition` (JS, in `shared/`), `compileRowConditionSql` (Drizzle, in `backend/`), and the frontend `resolvePermission` (`action-helpers.ts`) — so their forms **cannot drift**: TypeScript's exhaustiveness makes adding a name a compile error in every one of them, and the parity property test proves the paths agree. The `shared/`→`backend/` split is why `shared/` emits only the name and the backend compiles the SQL: `shared/` is ORM-free.
 
-**Public read** (`shared/src/permissions/public-read.ts`) makes rows readable by *any* actor, anonymous included, independent of memberships. One rule: the row's own `publicAt` is set. Declared per subject with `publicRead('publicSelf')`, it widens `read` and nothing else. It is *not* a policy cell — it grants with no membership — but it is the same `RowCondition` shape, so it rides the same interpreters and the same parity test:
-
-```ts
-export const publicRow = { name: 'public', predicate: { kind: 'columnIsNotNull', column: 'publicAt' } };
-```
+**Public read** (`shared/src/permissions/public-read.ts`) makes rows readable by *any* actor, anonymous included, independent of memberships. One rule: the row's own `publicAt` is set. Declared per subject with `publicRead('publicSelf')`, it widens `read` and nothing else. It is *not* a policy cell — it grants with no membership — but it resolves through the same `'public'` row condition, so it rides the same switches and the same parity test.
 
 **Publication does not cascade.** A public parent does not publish its children, and that is a deliberate constraint, not a missing feature. A cross-row rule is unenforceable in the two paths that must agree with the engine: the collection-read SQL compiler would need a join, and CDC stream dispatch only ever ships the row itself. So cascading publication is a **data** concern — propagate `publicAt` down to descendant rows (trigger or app logic), and every path keeps reading one self-describing column.
 
@@ -249,7 +243,7 @@ The rest of the suite covers grant attribution, `'own'` denial when the actor or
 - **No per-row narrowing.** Row conditions and public read only ever widen. Visibility variance belongs at the *type* level — give the entity its own policy matrix — so read visibility stays a function of the context chain, memberships × the static matrix, and the row's own data.
 - **No explicit relation tuples.** Ownership is implicit, derived from `createdBy`. This keeps the model small while leaving a path to real tuples if a fork needs them.
 - **Every rule reads one row: its own.** The engine never loads rows, and no rule may depend on another row. This is the constraint the whole design rests on — it is what lets the check-form, the compiled SQL, and CDC dispatch reach the same verdict from the same data. A rule that needed a *second* row would be evaluable by the engine, need a join in SQL, and be flatly impossible in dispatch (which only ever ships the row itself). Three paths, three answers. So cross-row semantics are pushed into the data instead: denormalize the column, and every path can see it.
-- **Row conditions are a closed set, not an extension point.** There are two — `own` and `public` — and the `RowPredicate` vocabulary has two kinds — `columnEqualsActor` and `columnIsNotNull`. A rule that can't be expressed as a predicate over the row's own columns can't be compiled into a collection read, so it has no place in the model; and the vocabulary is deliberately *not* open, so nothing can express one. Adding a kind is a compile-enforced edit to both interpreters plus a parity scenario — a considered change to the engine, not a fork knob. This is what keeps the reader's model finite: deny / allow / owner-only, plus a public flag.
+- **Row conditions are a closed set, not an extension point.** There are exactly two names — `own` and `public` — and `RowConditionName` is that closed union. A rule that can't be expressed as a check over the row's own columns can't be compiled into a collection read, so it has no place in the model; and the union is deliberately *not* open, so nothing can express one. Adding a name is a compile-enforced edit to all three switches (the JS check, the SQL compiler, the frontend resolver) plus a parity scenario — a considered change to the engine, not a fork knob. This is what keeps the reader's model finite: deny / allow / owner-only, plus a public flag.
 - **Fail-loud config.** A missing policy row throws rather than denying, and a row condition on a `create` cell (which can never match — no row exists yet) throws at boot too. An incomplete or nonsensical matrix fails at startup, never as a silent request-time denial.
 - **System admins get no Yjs bypass.** Collaborative editing is authorized as the acting user. The relay and the backend's materialize endpoint take the same stance, so the WS check and the write it eventually triggers agree.
 
@@ -271,8 +265,8 @@ The rest of the suite covers grant attribution, `'own'` denial when the actor or
 | `shared/src/permissions/check-permission.ts` | `checkPermission` + `Actor` — the entry point every tier calls |
 | `shared/src/permissions/permission-manager/check.ts` | `getAllDecisions` — the engine |
 | `shared/src/permissions/access-policies.ts` | `configurePermissions` + policy lookup helpers |
-| `shared/src/permissions/row-conditions.ts` | `RowPredicate` vocabulary, `rowPredicateMatches`, `own` |
-| `shared/src/permissions/public-read.ts` | `publicRow` — the public read predicate |
+| `shared/src/permissions/row-conditions.ts` | `RowConditionName` union, `matchesRowCondition` (the JS check) |
+| `shared/src/permissions/public-read.ts` | `PublicReadMode` / `PublicReadGrants` — public read grant keying |
 | `shared/src/permissions/build-subject.ts` | Column-shaped input → domain subject (carries the row) |
 | `shared/src/permissions/compute-can.ts` | Frontend three-state `can` map |
 | `backend/src/permissions/actor.ts` | `actorFrom(ctx)` — request context → `Actor` |

--- a/cella/migrations/2026-07-row-condition-names/README.md
+++ b/cella/migrations/2026-07-row-condition-names/README.md
@@ -1,0 +1,96 @@
+# Row conditions collapse to a name union
+
+Upstream simplified the row-condition model. It was built when a row condition was meant to be a
+*dynamic, fork-extensible* rule — a `RowCondition` object carrying a `{ kind, column }`
+`RowPredicate` descriptor, read by two interpreters. In practice the set is closed to exactly two
+rules (`own`, `public`), so the descriptor was redundant: the rule **name** already determines its
+behaviour. The name is now the single source of truth, and each enforcement path maps it through an
+exhaustive `switch`.
+
+**This is a shape-only refactor. It does NOT change permission semantics.** No cell grants anything
+it did not grant before; the `'own'` / `'public'` names are frozen; the config surface
+(`read: 'own'`, `publicRead('publicSelf')`) is untouched. Unlike
+[2026-07-permission-actor](../2026-07-permission-actor/) — which *widened* access and needed a
+pre-pull audit — this one is mechanical and **entirely compiler-enforced**: if it type-checks, it is
+correct. Most forks need to change nothing.
+
+---
+
+## Does my fork need to do anything?
+
+Row conditions have been a **closed set defined only in `shared/`, not a fork extension point**,
+since 2026-07-permission-actor (§5). A well-behaved fork never imported the internals, so:
+
+- **In sync with cella `shared/` (e.g. raak):** you get this by pulling. Zero manual work.
+- **Diverged `shared/permissions` (e.g. projectcampus, still on the older `matches`+`sqlForm`
+  design):** this does not apply cleanly — that module is a separate lineage. Port by hand if you
+  want it, or skip it.
+- **You referenced any removed symbol** (unusual): `pnpm ts` will point at every site. Use the map
+  below. There is no codemod — the surface is a handful of internal symbols and the compiler finds
+  them all.
+
+## What changed in `shared/` (the mapping)
+
+| Removed | Replacement |
+|---|---|
+| `type RowPredicate` (`{ kind: 'columnEqualsActor' \| 'columnIsNotNull'; column }`) | *gone* — the name implies the rule |
+| `interface RowCondition` (`{ name, predicate }`) | `type RowConditionName = 'own' \| 'public'` |
+| `own` (a `RowCondition` object) | the literal `'own'` |
+| `publicRow` (a `RowCondition` object, from `public-read.ts`) | the literal `'public'` |
+| `rowPredicateMatches(predicate, row, actor)` | `matchesRowCondition(name, row, actor)` |
+| `isRowCondition(v)` → `v is RowCondition` | `isRowCondition(v)` → `v is RowConditionName` (now `v === 'own' \|\| v === 'public'`) |
+| `NormalizedPermissionValue = 0 \| 1 \| RowCondition` | `0 \| 1 \| RowConditionName` (a cell is the config literal verbatim — nothing to normalize) |
+
+Backend: `compileRowConditionSql(condition: RowCondition, …)` → `compileRowConditionSql(name:
+RowConditionName, …)`, a name-keyed switch. `ConditionalScope.condition` is now a `RowConditionName`.
+
+`PublicReadMode` / `PublicReadGrants` are unchanged; `public-read.ts` keeps only the grant-keying
+types. Public read still resolves through the `'public'` row condition, so it rides the same
+switches and the same parity test as before.
+
+### One type narrowed: `ActionPermissionState`
+
+`boolean | string` → **`boolean | RowConditionName`**. This is what closes a latent gap: the
+frontend `resolvePermission` used to hard-code `'own'` and silently return `false` for any other
+name (an owner denied in the UI, no compile error). It is now an exhaustive `switch` over the closed
+union, so **adding a condition name is a compile error in all three paths** — the engine
+(`matchesRowCondition`), the SQL compiler (`compileRowConditionSql`), and the frontend
+(`resolvePermission`) — not just the two shared interpreters. If your fork assigned an arbitrary
+string into an `ActionPermissionState`, the compiler will flag it; it should have been a condition
+name or a boolean.
+
+## For forks that referenced the removed symbols
+
+```diff
+- import { own, publicRow, rowPredicateMatches, type RowCondition, type RowPredicate } from 'shared';
++ import { matchesRowCondition, type RowConditionName } from 'shared';
+
+- if (isRowCondition(value)) grant(value.name);          // value was a RowCondition object
++ if (isRowCondition(value)) grant(value);               // value IS the name
+
+- rowPredicateMatches(own.predicate, row, actor)
++ matchesRowCondition('own', row, actor)
+
+- rowPredicateMatches(publicRow.predicate, row, actor)
++ matchesRowCondition('public', row, actor)
+```
+
+If you had built a custom `RowCondition` in fork code (already unsupported since permission-actor),
+it will no longer compile. Fold its logic into the shared engine — a considered edit to
+`RowConditionName` and the three switches — or reconsider whether it belongs in the permission model
+at all. CDC's `permissionRowKeys` is unchanged (`createdBy` + `publicAt`).
+
+## Gates
+
+```sh
+pnpm ts            # compiler finds every affected site; must be clean
+pnpm lint          # biome
+pnpm exec vitest run shared/src/permissions backend/src/permissions   # incl. the parity property test
+```
+
+The parity property test (`backend/src/permissions/row-predicates.test.ts`) is the load-bearing
+check: it proves the engine, the compiled SQL, `computeCan` + `resolvePermission`, and SSE dispatch
+still agree row-for-row. It required **no changes** for this refactor — the collapse is behind the
+same public surface it exercises. To convince yourself the exhaustiveness guarantee is real,
+temporarily add a third name to `RowConditionName` and confirm `pnpm ts` goes red in all three
+switches, then remove it.

--- a/cella/migrations/README.md
+++ b/cella/migrations/README.md
@@ -29,6 +29,12 @@ be a no-op.
   permission check, system-admin + public-read parity in collection reads, and public
   read collapsed to a single row-local `publicAt` mode. **Widens access** — audit
   `'own'` cells on channel-entity and `create` rows *before* pulling.
+- [2026-07-row-condition-names](./2026-07-row-condition-names/): collapses the row-condition
+  model to a `RowConditionName = 'own' | 'public'` union — drops the `RowPredicate`/`RowCondition`
+  descriptor, replaces `rowPredicateMatches`/`own`/`publicRow` with `matchesRowCondition(name, …)`,
+  and narrows `ActionPermissionState` to the closed name union. **Shape-only, no semantic change**
+  and fully compiler-enforced; config surface (`read: 'own'`, `publicRead`) unchanged. In-sync
+  forks get it for free; no script.
 - [2026-07-batch-cache-removal](./2026-07-batch-cache-removal/): removes the unused
   batch cache machinery (`batchCache` middleware, `batchReservations`, batch token
   index); fork-breaking on the frontend `DeltaFetchFn` (drops the 4th `options`/`cacheToken`

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -87,8 +87,8 @@ export type {
   PermissionValue,
   SubjectAccessPolicies,
 } from './src/permissions';
-export { isRowCondition, own, publicRow, rowPredicateMatches } from './src/permissions';
-export type { ConditionActor, PublicReadGrants, PublicReadMode, RowCondition, RowForCondition, RowPredicate } from './src/permissions';
+export { isRowCondition, matchesRowCondition } from './src/permissions';
+export type { ConditionActor, PublicReadGrants, PublicReadMode, RowConditionName, RowForCondition } from './src/permissions';
 export { configurePermissions, getPolicyPermissions, getSubjectPolicies } from './src/permissions';
 export type { PermissionsConfigResult } from './src/permissions';
 export { allActionsAllowed, allActionsDenied, createActionRecord, isUnconditionalPermission, resolvePermission } from './src/permissions';

--- a/shared/src/permissions/access-policies.ts
+++ b/shared/src/permissions/access-policies.ts
@@ -1,6 +1,6 @@
 import type { ChannelEntityType, EntityActionType, EntityType, ProductEntityType } from '../../types';
 import type { PublicReadGrants, PublicReadMode } from './public-read';
-import { isRowCondition, own } from './row-conditions';
+import { isRowCondition } from './row-conditions';
 import type {
   AccessPolicies,
   AccessPolicyCallback,
@@ -8,17 +8,11 @@ import type {
   AccessPolicyEntry,
   ChannelPolicyBuilder,
   EntityActionPermissions,
-  NormalizedPermissionValue,
   PermissionValue,
   SubjectAccessPolicies,
 } from './types';
 import { resolveTopology } from './permission-manager/resolve-topology';
 import type { PermissionTopology } from './permission-manager/topology';
-
-/** Resolves the `'own'` sugar literal to the built-in condition; passes everything else through. */
-const normalizePermissionValue = (value: PermissionValue): NormalizedPermissionValue => {
-  return value === 'own' ? own : value;
-};
 
 /**
  * Creates a context policy builder for fluent role-permission configuration.
@@ -34,19 +28,19 @@ const createChannelPolicyBuilder = (
 
   for (const role of roles) {
     builder[role] = (permissions: Partial<Record<EntityActionType, PermissionValue>>) => {
-      // Normalize to a full record so the engine always reads an explicit value: any action the
-      // policy omits defaults to 0 (denied), and the `'own'` sugar literal resolves to the
-      // built-in row condition.
+      // Expand to a full record so the engine always reads an explicit value: any action the
+      // policy omits defaults to 0 (denied). A cell is the config literal verbatim — the `'own'`
+      // name IS the value the engine reads, so there is nothing to normalize.
       const fullPermissions = {} as EntityActionPermissions;
       for (const action of entityActions) {
-        const value = normalizePermissionValue(permissions[action] ?? 0);
+        const value = permissions[action] ?? 0;
         // Fail loud at boot: a row condition on `create` can never match. The row doesn't exist
         // yet (the subject carries no `row`), so e.g. `create: 'own'` reads a `createdBy` that
         // isn't there and silently denies forever. That's a config mistake, not a runtime state —
         // surface it here rather than as a permanent, invisible denial in production.
         if (action === 'create' && isRowCondition(value)) {
           throw new Error(
-            `[Permission] "${channelType}.${role}" uses a row condition ('${value.name}') on 'create', ` +
+            `[Permission] "${channelType}.${role}" uses a row condition ('${value}') on 'create', ` +
               `which can never match — the row does not exist yet. Use 1 or 0 for create.`,
           );
         }

--- a/shared/src/permissions/action-helpers.ts
+++ b/shared/src/permissions/action-helpers.ts
@@ -22,19 +22,25 @@ export const allActionsAllowed = Object.freeze(createActionRecord(() => true as 
 >;
 
 /**
- * Resolves a three-state permission (`true | false | condition name`) to a boolean. Handles the
- * built-in `'own'` condition (compares the actor's `userId` against `entity.createdBy`). Any other
- * condition name resolves to `false` here (secure default); custom row conditions must be resolved
- * by the call site via the condition's own check-form.
+ * Resolves a three-state permission (`true | false | condition name`) to a boolean. `'own'`
+ * compares the actor's `userId` against `entity.createdBy`. The switch is exhaustive over the
+ * closed {@link ActionPermissionState} name union, so adding a row condition is a compile error
+ * here — the frontend can never silently deny a new condition.
  */
 export const resolvePermission = (
   permission: ActionPermissionState | undefined,
   entityCreatedBy?: string | null,
   userId?: string,
 ): boolean => {
-  if (permission === true) return true;
-  if (permission === 'own') return !!userId && !!entityCreatedBy && entityCreatedBy === userId;
-  return false;
+  if (typeof permission !== 'string') return permission === true;
+  switch (permission) {
+    case 'own':
+      return !!userId && !!entityCreatedBy && entityCreatedBy === userId;
+    case 'public':
+      // Public read is membership-independent and resolved server-side; it never appears in the
+      // frontend can-map. Denied here (secure default) — this arm exists only for exhaustiveness.
+      return false;
+  }
 };
 
 /**

--- a/shared/src/permissions/build-subject.test.ts
+++ b/shared/src/permissions/build-subject.test.ts
@@ -3,10 +3,8 @@ import {
   buildSubject,
   buildSubjectFromEntity,
   hierarchy,
+  matchesRowCondition,
   MissingScopeError,
-  own,
-  publicRow,
-  rowPredicateMatches,
 } from 'shared';
 import { describe, expect, it } from 'vitest';
 
@@ -86,12 +84,12 @@ describe('buildSubjectFromEntity — carries the row', () => {
     const row = { ...subject.row, createdBy: subject.createdBy };
 
     // `own`: the actor created it. Public read: the row carries publicAt.
-    expect(rowPredicateMatches(own.predicate, row, { userId: 'u1' })).toBe(true);
-    expect(rowPredicateMatches(own.predicate, row, { userId: 'u2' })).toBe(false);
-    expect(rowPredicateMatches(publicRow.predicate, row, {})).toBe(true);
+    expect(matchesRowCondition('own', row, { userId: 'u1' })).toBe(true);
+    expect(matchesRowCondition('own', row, { userId: 'u2' })).toBe(false);
+    expect(matchesRowCondition('public', row, {})).toBe(true);
 
     // ...and an unpublished row is not public.
     const unpublished = buildSubjectFromEntity(product, { ...entity, publicAt: null });
-    expect(rowPredicateMatches(publicRow.predicate, { ...unpublished.row }, {})).toBe(false);
+    expect(matchesRowCondition('public', { ...unpublished.row }, {})).toBe(false);
   });
 });

--- a/shared/src/permissions/compute-can.ts
+++ b/shared/src/permissions/compute-can.ts
@@ -36,9 +36,9 @@ function computeEntityPermissions(
   return recordFromKeys(entityActions, (action) => {
     const value = permissions[action];
     if (value === 1) return true;
-    // Row-conditional grant → surface the condition name (e.g. 'own'); the frontend
-    // resolves it per row via resolvePermission / the condition's check-form.
-    if (isRowCondition(value)) return value.name;
+    // Row-conditional grant → surface the condition name (e.g. 'own'); the name IS the cell
+    // value. The frontend resolves it per row via resolvePermission.
+    if (isRowCondition(value)) return value;
     return false;
   }) as ActionStates;
 }

--- a/shared/src/permissions/index.ts
+++ b/shared/src/permissions/index.ts
@@ -10,10 +10,9 @@ export type {
   PermissionValue,
   SubjectAccessPolicies,
 } from './types';
-export { publicRow } from './public-read';
 export type { PublicReadGrants, PublicReadMode } from './public-read';
-export { isRowCondition, own, rowPredicateMatches } from './row-conditions';
-export type { ConditionActor, RowCondition, RowForCondition, RowPredicate } from './row-conditions';
+export { isRowCondition, matchesRowCondition } from './row-conditions';
+export type { ConditionActor, RowConditionName, RowForCondition } from './row-conditions';
 
 // `configureAccessPolicies` is test-only; it lives at `shared/testing/policies`, not on this barrel.
 export { configurePermissions, getPolicyPermissions, getSubjectPolicies } from './access-policies';

--- a/shared/src/permissions/permission-manager/check.ts
+++ b/shared/src/permissions/permission-manager/check.ts
@@ -1,7 +1,7 @@
 import type { ChannelEntityType, EntityActionType, ProductEntityType } from '../../../types';
 import { allActionsAllowed, createActionRecord } from '../action-helpers';
-import { type PublicReadGrants, publicRow } from '../public-read';
-import { type ConditionActor, isRowCondition, rowPredicateMatches, type RowForCondition } from '../row-conditions';
+import type { PublicReadGrants } from '../public-read';
+import { type ConditionActor, isRowCondition, matchesRowCondition, type RowForCondition } from '../row-conditions';
 import type { AccessPolicies, EntityActionPermissions } from '../types';
 import { formatBatchPermissionSummary, formatPermissionDecision } from './format';
 import { resolveTopology } from './resolve-topology';
@@ -84,9 +84,9 @@ const getSubjectChannelId = (
  * Internal function to check permissions for a single subject using pre-built indices.
  * This is the core logic shared by both single and batch permission checks.
  *
- * Supports row-conditional grants: when a policy value is a `RowCondition` (e.g. the
- * built-in `own`, normalized from the `'own'` literal), the engine evaluates its
- * check-form against the subject's row fields to determine the grant.
+ * Supports row-conditional grants: when a policy value is a row-condition name (e.g. the
+ * built-in `'own'`), the engine evaluates that condition's check-form (`matchesRowCondition`)
+ * against the subject's row fields to determine the grant.
  */
 const checkWithIndices = <T extends PermissionMembership>(
   membershipIndex: MembershipIndex<T>,
@@ -204,9 +204,9 @@ const checkWithIndices = <T extends PermissionMembership>(
 
         // Row-conditional grant: allowed only when the row satisfies the condition for this
         // actor (e.g. built-in `own`: actor created the row). Attributed by condition name.
-        if (isRowCondition(policyValue) && rowPredicateMatches(policyValue.predicate, conditionRow, conditionActor)) {
+        if (isRowCondition(policyValue) && matchesRowCondition(policyValue, conditionRow, conditionActor)) {
           actions[action].enabled = true;
-          actions[action].grantedBy.push({ type: 'relation', relation: policyValue.name });
+          actions[action].grantedBy.push({ type: 'relation', relation: policyValue });
         }
       }
     }
@@ -214,9 +214,9 @@ const checkWithIndices = <T extends PermissionMembership>(
 
   // Subject-level public read grant: rows readable by any actor (anonymous included) when
   // the row's own `publicAt` is set. Membership-independent, so it is evaluated outside the
-  // policy walk — but through the same row-predicate the SQL compiler uses (`public-read.ts`).
+  // policy walk — but through the same `'public'` row condition the SQL compiler uses.
   const publicMode = publicGrants?.[subject.entityType];
-  if (publicMode && rowPredicateMatches(publicRow.predicate, conditionRow, conditionActor)) {
+  if (publicMode && matchesRowCondition('public', conditionRow, conditionActor)) {
     actions.read.enabled = true;
     actions.read.grantedBy.push({ type: 'public', mode: publicMode });
   }

--- a/shared/src/permissions/public-read.test.ts
+++ b/shared/src/permissions/public-read.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { configureWidePermissions, widePublicGrants, wideSubject, wideTopology } from '../testing/wide-fixture';
 import { getAllDecisions } from './permission-manager/check';
 import type { SubjectForPermission } from './permission-manager/types';
-import { publicRow } from './public-read';
-import { rowPredicateMatches } from './row-conditions';
+import { matchesRowCondition } from './row-conditions';
 
 /**
  * Public read grants (`publicRead`): subject-level, membership-independent read access derived
@@ -106,17 +105,14 @@ describe('public read grants — anonymous actor', () => {
   });
 });
 
-describe('publicRow — the shared predicate', () => {
-  it('is actor-independent: it matches for anonymous actors', () => {
-    expect(rowPredicateMatches(publicRow.predicate, { publicAt: NOW }, {})).toBe(true);
-    expect(rowPredicateMatches(publicRow.predicate, { publicAt: null }, {})).toBe(false);
-    expect(rowPredicateMatches(publicRow.predicate, {}, {})).toBe(false);
-  });
-
-  it('is a column-is-not-null predicate, so collection SQL can enforce it', () => {
-    // This is what makes public read enforceable in list endpoints. An actor-bound or
-    // cross-row predicate could not be compiled, and public rows would silently vanish from lists.
-    expect(publicRow.predicate).toEqual({ kind: 'columnIsNotNull', column: 'publicAt' });
+describe("the 'public' row condition — the shared rule", () => {
+  it('is actor-independent and reads only the row: it matches for anonymous actors when publicAt is set', () => {
+    // This is what makes public read enforceable in list endpoints too: `'public'` reads only the
+    // row's own `publicAt`, so it compiles identically in the check-form here and in collection SQL.
+    // An actor-bound or cross-row rule could not be compiled, and public rows would vanish from lists.
+    expect(matchesRowCondition('public', { publicAt: NOW }, {})).toBe(true);
+    expect(matchesRowCondition('public', { publicAt: null }, {})).toBe(false);
+    expect(matchesRowCondition('public', {}, {})).toBe(false);
   });
 });
 

--- a/shared/src/permissions/public-read.ts
+++ b/shared/src/permissions/public-read.ts
@@ -1,5 +1,4 @@
 import type { ChannelEntityType, ProductEntityType } from '../../types';
-import type { RowCondition } from './row-conditions';
 
 /**
  * Public read mode: a subject-level grant that makes rows readable by any actor —
@@ -13,25 +12,15 @@ import type { RowCondition } from './row-conditions';
  * concern — a fork that wants it propagates `publicAt` to descendants (trigger or app
  * logic) and every path keeps reading one self-describing column.
  *
+ * A public read grant resolves through the `'public'` row condition (`row-conditions.ts`), so it
+ * rides the exact same name-keyed switches as policy row conditions — the engine's check-form, the
+ * backend's compiled SQL, and stream dispatch all agree, and the parity property test covers it for
+ * free. Unlike a policy row condition it is membership-INDEPENDENT: it is not a policy cell, it
+ * widens `read` on its own, which is why `'public'` is actor-independent (anonymous actors match).
+ *
  * @see cella/PERMISSIONS.md
  */
 export type PublicReadMode = 'publicSelf';
 
 /** Per-subject public read grants, keyed by entity type. */
 export type PublicReadGrants = Partial<Record<ChannelEntityType | ProductEntityType, PublicReadMode>>;
-
-/**
- * The row predicate a public read grant evaluates to.
- *
- * Shares the `RowCondition` shape with policy row conditions so that every enforcement path —
- * the engine's check-form, the backend's compiled SQL, and stream dispatch — evaluates it
- * through the one shared interpreter, and the check/SQL parity property test covers it for free.
- *
- * Unlike a policy row condition, this grant is membership-INDEPENDENT: it is not a policy cell,
- * it widens `read` on its own. Hence the actor-independent `columnIsNotNull` predicate —
- * anonymous actors match.
- */
-export const publicRow: RowCondition = {
-  name: 'public',
-  predicate: { kind: 'columnIsNotNull', column: 'publicAt' },
-};

--- a/shared/src/permissions/row-conditions.ts
+++ b/shared/src/permissions/row-conditions.ts
@@ -1,83 +1,59 @@
 /**
  * Row-local read qualifiers — the closed set of rules the permission system enforces per row.
  *
- * There are exactly two, and this is not a fork extension point: `own` (defined here) and
- * `publicRow` (in `public-read.ts`). Both are a {@link RowPredicate} over the row's OWN columns.
- * A rule that needed a second row, a join, or actor data beyond the user id has no place here —
- * it could not be enforced identically in the three paths that must agree: the engine's JS
- * check, the backend's compiled SQL, and CDC stream dispatch (which only ever ships the row
- * itself).
+ * There are exactly two, and this is not a fork extension point: `own` and `public`. Each is a
+ * pure predicate over the row's OWN columns. A rule that needed a second row, a join, or actor
+ * data beyond the user id has no place here — it could not be enforced identically in the paths
+ * that must agree: the engine's JS check ({@link matchesRowCondition} here), the backend's
+ * compiled SQL (`compileRowConditionSql` in `backend/src/permissions/row-predicates.ts`), and CDC
+ * stream dispatch (which only ever ships the row itself).
+ *
+ * The rule NAME is the single source of truth. It is the value a policy cell normalizes to, the
+ * `grantedBy: { type: 'relation', relation: name }` in decision attribution, and the conditional
+ * state a `can` map surfaces to the frontend — so treat it as part of the public contract. Each
+ * enforcement path maps the name to behaviour through an exhaustive `switch`; the parity property
+ * test (`row-predicates.test.ts`) proves the paths agree.
  *
  * @see cella/PERMISSIONS.md
  */
 
 /**
- * The closed vocabulary of row predicates.
+ * The closed vocabulary of row conditions. This union IS the contract.
  *
- * This union IS the contract. Adding a `kind` is a deliberate edit to the two interpreters that
- * read it — the JS {@link rowPredicateMatches} here and the SQL `compileRowConditionSql` in
- * `backend/src/permissions/row-predicates.ts` — and TypeScript's exhaustiveness makes both a
- * compile error until you do. The parity property test then proves the two agree.
+ * Adding a name is a deliberate edit to the three switches that read it — the JS
+ * {@link matchesRowCondition} here, the SQL `compileRowConditionSql` (backend), and the frontend
+ * `resolvePermission` (`action-helpers.ts`) — and TypeScript's exhaustiveness makes each a compile
+ * error until you do.
  *
- * - `columnEqualsActor`: `row[column] === <acting user id>`. Never matches for an anonymous
- *   actor, so an actor-bound grant fails closed without a user.
- * - `columnIsNotNull`: `row[column]` is set. Actor-independent — anonymous actors match, which
- *   is what public read needs.
+ * - `own`: `row.createdBy === <acting user id>`. Never matches for an anonymous actor, so an
+ *   actor-bound grant fails closed without a user.
+ * - `public`: the row's `publicAt` is set. Actor-independent — anonymous actors match, which is
+ *   what public read needs. Never appears as a policy cell; it backs the subject-level public read
+ *   grant (see `public-read.ts`).
  */
-export type RowPredicate =
-  | { kind: 'columnEqualsActor'; column: string }
-  | { kind: 'columnIsNotNull'; column: string };
+export type RowConditionName = 'own' | 'public';
 
-/** The acting user for predicate evaluation. `userId` is absent for anonymous actors. */
+/** The acting user for condition evaluation. `userId` is absent for anonymous actors. */
 export type ConditionActor = { userId?: string };
 
 /**
- * Row fields available to a predicate. `createdBy` is first-class (carried by
- * `SubjectForPermission`); additional fields come from `SubjectForPermission.row`.
+ * Row fields available to a condition. `createdBy` is first-class (carried by
+ * `SubjectForPermission`); additional fields (e.g. `publicAt`) come from `SubjectForPermission.row`.
  */
 export type RowForCondition = { createdBy?: string | null } & Record<string, unknown>;
 
-/**
- * A named row predicate. Used two ways: as an access-policy cell (`own`, granting an action only
- * on qualifying rows) and as a subject-level public read grant (`publicRow`).
- *
- * It is pure data — a name and a predicate. Both evaluators derive from `predicate`, so a
- * condition's JS and SQL forms cannot drift from each other; the only thing the parity test has
- * to guard is that the two shared INTERPRETERS agree.
- */
-export interface RowCondition {
-  /**
-   * Stable identifier. Surfaces as the conditional state in `can` maps
-   * (`ActionPermissionState`) and as `grantedBy: { type: 'relation', relation: name }` in
-   * decision attribution: treat it as part of the public contract.
-   */
-  name: string;
-  /** What makes a row qualify, over the row's own columns. */
-  predicate: RowPredicate;
-}
-
-/** Type guard: distinguishes a `RowCondition` cell value from `0 | 1`. */
-export const isRowCondition = (value: unknown): value is RowCondition =>
-  typeof value === 'object' && value !== null && 'predicate' in value;
+/** Type guard: distinguishes a row-condition cell value (a name) from `0 | 1`. */
+export const isRowCondition = (value: unknown): value is RowConditionName => value === 'own' || value === 'public';
 
 /**
- * Evaluate a row predicate in JS — the check-form the engine and stream dispatch use. Its SQL
+ * Evaluate a row condition in JS — the check-form the engine and stream dispatch use. Its SQL
  * twin is `compileRowConditionSql` (backend); the two must agree, asserted by the parity test.
  */
-export const rowPredicateMatches = (predicate: RowPredicate, row: RowForCondition, actor: ConditionActor): boolean => {
-  switch (predicate.kind) {
-    case 'columnEqualsActor':
-      return !!actor.userId && !!row[predicate.column] && row[predicate.column] === actor.userId;
-    case 'columnIsNotNull':
-      return !!row[predicate.column];
+export const matchesRowCondition = (name: RowConditionName, row: RowForCondition, actor: ConditionActor): boolean => {
+  switch (name) {
+    case 'own':
+      return !!actor.userId && !!row.createdBy && row.createdBy === actor.userId;
+    case 'public':
+      return !!row.publicAt;
   }
-};
-
-/**
- * Built-in "owner" condition: the actor created the row. In Zanzibar terms, an implicit `owner`
- * relation derived from `createdBy`. The `'own'` policy literal normalizes to this.
- */
-export const own: RowCondition = {
-  name: 'own',
-  predicate: { kind: 'columnEqualsActor', column: 'createdBy' },
 };

--- a/shared/src/permissions/types.ts
+++ b/shared/src/permissions/types.ts
@@ -1,14 +1,13 @@
 import type { ChannelEntityType, EntityActionType, EntityRole, EntityType, ProductEntityType } from '../../types';
 import type { PublicReadMode } from './public-read';
-import type { RowCondition } from './row-conditions';
+import type { RowConditionName } from './row-conditions';
 
 /**
  * Permission value accepted in access policy configuration.
  *
  * - `1` = allowed for all entities of this type (unconditional)
  * - `0` = denied
- * - `'own'` = the built-in owner condition (actor is the entity's creator); normalized to the
- *   `own` `RowCondition` when policies are configured.
+ * - `'own'` = the built-in owner condition (actor is the entity's creator).
  *
  * Row conditions are a closed set (`own`, and the public read grant), not a fork extension
  * point. So a config cell is one of exactly these three literals.
@@ -18,10 +17,12 @@ import type { RowCondition } from './row-conditions';
 export type PermissionValue = 0 | 1 | 'own';
 
 /**
- * Permission value after configuration-time normalization (`'own'` sugar resolved).
- * This is the only vocabulary the engine and downstream consumers see.
+ * Permission value the engine and downstream consumers read. A cell is the config literal
+ * verbatim — there is no object to normalize into, the `'own'` name IS the value. Typed as the
+ * full {@link RowConditionName} union (rather than just `'own'`) because that is the vocabulary
+ * the name-keyed switches close over; `'public'` never actually appears as a cell.
  */
-export type NormalizedPermissionValue = 0 | 1 | RowCondition;
+export type NormalizedPermissionValue = 0 | 1 | RowConditionName;
 
 /**
  * Entity action permission set mapping each action to a normalized permission value.
@@ -84,7 +85,9 @@ export type AccessPolicyCallback = (config: AccessPolicyConfiguration) => void;
  *
  * - `true` = unconditionally allowed
  * - `false` = denied
- * - condition name (e.g. `'own'`) = allowed only for rows satisfying that row condition;
- *   resolve per row via `resolvePermission` (built-in `'own'`) or the condition's `matches`.
+ * - a {@link RowConditionName} (e.g. `'own'`) = allowed only for rows satisfying that row
+ *   condition; resolve per row via `resolvePermission`. Narrowed to the closed name union (not a
+ *   bare `string`) so `resolvePermission`'s switch is exhaustive — a new condition name is a
+ *   compile error there, not a silent frontend denial.
  */
-export type ActionPermissionState = boolean | string;
+export type ActionPermissionState = boolean | RowConditionName;


### PR DESCRIPTION
## What & why

Row conditions were built when a row condition was meant to be a *dynamic, fork-extensible* rule — a `RowCondition` object carrying a `{ kind, column }` `RowPredicate` descriptor, read by two interpreters. In practice the set is **closed to exactly two rules** (`own`, `public`), so the descriptor is redundant: the rule **name** already determines its behaviour. This is "Option B" from the reassessment.

Make the **name the single source of truth**; each enforcement path maps it to behaviour through an exhaustive `switch`.

## Changes

- `RowConditionName = 'own' | 'public'` replaces the `RowPredicate` union and the `RowCondition` object.
- `matchesRowCondition(name, row, actor)` (JS) and `compileRowConditionSql(name, …)` (Drizzle) switch on the name; the `own`/`publicRow` objects and `normalizePermissionValue` are gone (a cell is the config literal verbatim, `0 | 1 | 'own'`).
- **`ActionPermissionState` narrowed** `boolean | string` → `boolean | RowConditionName`, so the frontend `resolvePermission` is exhaustive too. This closes a latent gap: it used to hard-code `'own'` and silently return `false` for any other name (an owner denied in the UI, no compile error).

Net: ~4 types removed, the object hop in the value chain gone, and adding a condition name is now a **compile error in all three paths** (engine, SQL compiler, frontend resolver) — verified by temporarily adding a third name and confirming `pnpm ts` goes red in exactly `matchesRowCondition`, `compileRowConditionSql`, and `resolvePermission`.

## Not changed (by design)

Shape-only refactor — **no permission semantics change**. Config surface (`read: 'own'`, `publicRead('publicSelf')`) untouched; the `'own'`/`'public'` names are frozen; `grantedBy.relation` still carries the name. Public read still resolves through the `'public'` row condition.

## Verification

- `pnpm ts` (full workspace) ✅ · biome ✅ · commitlint ✅ (pre-commit gate)
- `shared/src/permissions` — 80 tests ✅
- `backend/src/permissions` incl. the **parity property test** (engine ≍ compiled SQL ≍ computeCan ≍ SSE dispatch, real Postgres) — 22 passed, 1 skipped (org-only `runIf`) ✅ · required no changes
- Exhaustiveness guarantee verified as above

## Forks

Adds `cella/migrations/2026-07-row-condition-names/` (README) and updates the migrations index + `cella/PERMISSIONS.md`. Row conditions have been a closed set defined only in `shared/` since `2026-07-permission-actor`, so in-sync forks (raak) get this for free; `projectcampus` (older `matches`+`sqlForm` lineage) doesn't apply cleanly and is called out. Mechanical + compiler-enforced — no codemod script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
