### PR TITLE
refactor: replace ambiguous jargon in comments with plain naming

### DIFF
--- a/backend/src/db/utils/channel-entity-columns.ts
+++ b/backend/src/db/utils/channel-entity-columns.ts
@@ -18,7 +18,7 @@ export const channelEntityColumns = <T extends ChannelEntityType>(entityType: T)
    * When the context went live for its members: null = draft (invites against it are
    * deferred, see membership dispatch). Defaults to creation time, so forks without
    * draft flows never see null and the mechanism stays dormant. Distinct from
-   * `publicAt` below: `publishedAt` gates MEMBERS, `publicAt` grants NON-members.
+   * `publicAt` below: `publishedAt` controls MEMBER visibility, `publicAt` grants NON-members.
    * The PRODUCT-entity sibling (`published-column.ts`, nullable, no default) carries
    * different semantics: null = author-only draft, enforced across dispatch, reads,
    * counters and cache (see `shared/src/published-rows.ts`).

--- a/backend/src/middlewares/rate-limiter/limiters.ts
+++ b/backend/src/middlewares/rate-limiter/limiters.ts
@@ -8,7 +8,7 @@ import { defaultRestrictions } from '#/modules/tenants/tenant-restrictions';
 /**
  * Email spam limit for endpoints where emails are sent to others. Max 10 requests per hour.
  * Keyed per user when authenticated, so invite flows behind a shared office/NAT IP get their
- * own budget (and rotating IPs does not mint fresh buckets); falls back to IP for anonymous
+ * own budget (and rotating IPs does not create fresh buckets); falls back to IP for anonymous
  * requests (sign up, public requests etc.).
  */
 export const spamLimiter = rateLimiter('success', 'spam', [['userId', 'ip']], {

--- a/backend/src/mocks/mock-entity-counts.ts
+++ b/backend/src/mocks/mock-entity-counts.ts
@@ -19,7 +19,7 @@ export type MockEntityCounts = {
 
 /**
  * Excludes 'user' and 'organization' to match the fullCountsSchema pattern.
- * @param key - seeds deterministic generation.
+ * @param key - keys the deterministic RNG.
  */
 export const generateMockEntityCounts = (key: string): MockEntityCounts => {
   const generator = (): MockEntityCounts =>

--- a/backend/src/modules/attachment/operations/create-attachments.ts
+++ b/backend/src/modules/attachment/operations/create-attachments.ts
@@ -13,7 +13,7 @@ import { log } from '#/utils/logger';
 
 type CreateAttachmentsInput = z.infer<typeof attachmentCreateManyStxBodySchema>;
 export async function createAttachmentsOp(ctx: AuthContext, rawInput: CreateAttachmentsInput) {
-  // Lens seam: canonicalize old-shape field names before any body access
+  // Lens seam: normalize old-shape field names to their current names before any body access
   const input = rawInput.map((item) => attachmentContract.normalizeCreateItem(item));
   const { organization, tenant } = ctx.var;
   const attachmentRestrictions = tenant.restrictions.quotas.attachment;

--- a/backend/src/modules/organization/operations/create-organizations.ts
+++ b/backend/src/modules/organization/operations/create-organizations.ts
@@ -16,7 +16,7 @@ import { defaultWelcomeText } from '#json/text-blocks.json';
 type CreateOrganizationItem = { id: string; name: string; slug: string };
 
 export async function createOrganizationsOp(ctx: AuthContext, rawItems: CreateOrganizationItem[], tenantId: string) {
-  // Lens seam: canonicalize old-shape field names before any body access
+  // Lens seam: normalize old-shape field names to their current names before any body access
   const items = rawItems.map((item) => organizationContract.normalizeBody(item));
   const user = ctx.var.user;
   const isSystemAdmin = ctx.var.isSystemAdmin;

--- a/backend/src/modules/organization/operations/update-organization.ts
+++ b/backend/src/modules/organization/operations/update-organization.ts
@@ -18,7 +18,7 @@ export async function updateOrganizationOp(
   tenantId: string,
   rawInput: Record<string, unknown>,
 ) {
-  // Lens seam: canonicalize old-shape field names before any body access
+  // Lens seam: normalize old-shape field names to their current names before any body access
   const input = organizationContract.normalizeBody(rawInput);
   const user = ctx.var.user;
 

--- a/backend/src/modules/seen/seen-queries.ts
+++ b/backend/src/modules/seen/seen-queries.ts
@@ -18,7 +18,7 @@ interface FindUnseenCountsByUserOpts {
   entityTypes: readonly SeenTrackedEntityType[];
   cutoff: string;
   /**
-   * Per-type collection read predicate (same compiler as list endpoints), so badges
+   * Per-type collection read filter (same SQL compiler as list endpoints), so badges
    * only count rows the user can actually fetch. `undefined` value = unrestricted
    * scope for that type; a type absent from the record is counted unrestricted too
    * (callers should pre-drop types whose scope resolved to `none`).

--- a/bench/src/registry.ts
+++ b/bench/src/registry.ts
@@ -29,7 +29,7 @@ export interface TableBenchSeed {
    */
   idVariant?: string;
   /**
-   * Explicit cleanup predicate: use only when rows aren't identified by an id
+   * Explicit cleanup WHERE clause: use only when rows aren't identified by an id
    * variant (e.g. `"tenant_id = '...'"`). Prefer `idVariant` for id-based rows.
    */
   cleanupWhere?: string;
@@ -62,7 +62,7 @@ const VARIANT_PATTERN = /^[89ab][0-9a-f]{3}$/;
 
 export const getBenchSeedName = (seed: BenchSeed): string => (seed.kind === 'custom' ? seed.name : seed.table);
 
-/** Derive the cleanup WHERE predicate for a table seed from its `idVariant`, or fall back to an explicit `cleanupWhere`. */
+/** Derive the cleanup WHERE clause for a table seed from its `idVariant`, or fall back to an explicit `cleanupWhere`. */
 export const getBenchSeedCleanupWhere = (seed: TableBenchSeed): string => {
   if (seed.idVariant) return `id::text LIKE '${BENCH_UUID_PREFIX}${seed.idVariant}%'`;
   if (seed.cleanupWhere) return seed.cleanupWhere;

--- a/bench/src/seeds/ids.ts
+++ b/bench/src/seeds/ids.ts
@@ -11,7 +11,7 @@ const benchUuid = (variant: string, i: number) => `${BENCH_UUID_PREFIX}${variant
 /**
  * Variant byte (UUID group-4) claimed per core entity: the single source shared
  * by the id helpers below and each seed's `idVariant` (which derives its cleanup
- * predicate), so an id and the rows it cleans up can never drift apart.
+ * WHERE clause), so an id and the rows it cleans up can never drift apart.
  *
  * cella core owns the `a*` band; forks must claim the `b*` band so new core and
  * fork entities never collide across upstream syncs.

--- a/frontend/src/modules/attachment/query.ts
+++ b/frontend/src/modules/attachment/query.ts
@@ -30,7 +30,7 @@ import { baseInfiniteQueryOptions } from '~/query/basic/infinite-query-options';
 import { invalidateIfLastMutation, removePendingMutations } from '~/query/basic/invalidation-helpers';
 import { syncStaleTime } from '~/query/basic/sync-stale-config';
 import { addMutationRegistrar } from '~/query/mutation-registry';
-import { coalescePendingCreate, squashPendingMutation } from '~/query/offline/squash-utils';
+import { squashIntoPendingCreate, squashPendingMutation } from '~/query/offline/squash-utils';
 import { mergeServerResponse, syncEntityToCache } from '~/query/offline/update-success-utils';
 import { getRouteOrgId, getRouteTenantId } from '~/query/realtime/sync-priority';
 import { createResourceError } from '~/utils/resource-error';
@@ -210,7 +210,7 @@ export const useAttachmentUpdateMutation = (tenantId: string, organizationId: st
     mutationFn: updateAttachmentMutationFn,
     onMutate: async ({ id, ops }: UpdateAttachmentFullVars) => {
       // If there's a pending create for this entity, fold update ops into it
-      if (coalescePendingCreate(queryClient, keys.create, id, ops as Record<string, unknown>)) {
+      if (squashIntoPendingCreate(queryClient, keys.create, id, ops as Record<string, unknown>)) {
         return { coalesced: true };
       }
 

--- a/frontend/src/modules/attachment/tests/download-service.test.ts
+++ b/frontend/src/modules/attachment/tests/download-service.test.ts
@@ -260,7 +260,7 @@ describe('downloadService — auth fail-fast (401/403)', () => {
   });
 });
 
-describe('flushStores clears attachment IDB', () => {
+describe('teardownUserState clears attachment IDB', () => {
   beforeEach(async () => {
     await attachmentsDb.blobs.clear();
     await attachmentsDb.downloadQueue.clear();
@@ -273,12 +273,12 @@ describe('flushStores clears attachment IDB', () => {
 
   it('deletes the appdb on sign-out, wiping all attachment data', async () => {
     const { getAppDb, bindAppDb } = await import('~/query/app-db');
-    const { flushStores } = await import('~/utils/flush-stores');
+    const { teardownUserState } = await import('~/utils/teardown-user-state');
 
     // Sanity: the appdb is bound (attachment data reachable) before sign-out.
     expect(getAppDb()).not.toBeNull();
 
-    await flushStores();
+    await teardownUserState();
 
     // Sign-out deletes and unbinds the appdb.
     expect(getAppDb()).toBeNull();

--- a/frontend/src/modules/auth/sign-out.tsx
+++ b/frontend/src/modules/auth/sign-out.tsx
@@ -6,7 +6,7 @@ import { signOut } from 'sdk';
 import { appConfig } from 'shared';
 import { ContentPlaceholder } from '~/modules/common/content-placeholder';
 import { toaster } from '~/modules/common/toaster/toaster';
-import { flushStores } from '~/utils/flush-stores';
+import { teardownUserState } from '~/utils/teardown-user-state';
 
 // Sign out user and clear all stores and query cache
 export function SignOut() {
@@ -23,7 +23,7 @@ export function SignOut() {
 
     const handleSignOut = async () => {
       try {
-        flushStores();
+        teardownUserState();
         if (!force) await signOut();
         toaster(t('c:success.signed_out'), 'success');
       } catch (error) {

--- a/frontend/src/modules/common/board/board-layout.tsx
+++ b/frontend/src/modules/common/board/board-layout.tsx
@@ -101,7 +101,7 @@ export function BoardLayout({
   }));
 
   // Persisting is debounced at the storage layer (`idbKvStorage`), so a window resize firing
-  // onLayoutChanged ~per frame coalesces into a single write, so no extra throttling is needed here.
+  // onLayoutChanged ~per frame batches into a single write, so no extra throttling is needed here.
   const handleLayoutChanged = useCallback(
     (layout: Record<string, number>) => {
       onLayoutChanged?.(layout);

--- a/frontend/src/modules/common/data-grid/hooks/use-grid-dimensions.ts
+++ b/frontend/src/modules/common/data-grid/hooks/use-grid-dimensions.ts
@@ -98,7 +98,7 @@ export function useGridDimensions(
       notifyRef.current();
     };
 
-    // rAF throttle coalesces rapid scroll / resize calls into one frame.
+    // rAF throttle batches rapid scroll / resize calls into one frame.
     let rafId = 0;
     const scheduleUpdate = (fn: () => void) => {
       cancelAnimationFrame(rafId);

--- a/frontend/src/modules/common/resizable-panels/resizable-panels.tsx
+++ b/frontend/src/modules/common/resizable-panels/resizable-panels.tsx
@@ -27,7 +27,7 @@ interface HintState {
 interface LayoutResult {
   widths: Record<string, number>;
   hints: HintState[];
-  /** G12: true when the expand gate (G3) has been passed this frame */
+  /** G12: true when the expand threshold (G3) has been passed this frame */
   expandSnapped?: boolean;
 }
 
@@ -112,7 +112,7 @@ function resolveLayout(
   const growIndex = draggingLeft ? separatorIndex + 1 : separatorIndex;
   const growPanel = panels[growIndex];
 
-  // ─── Expand gate (G3) ─────────────────────────────────────────────────
+  // ─── Expand threshold (G3) ─────────────────────────────────────────────────
   if (growPanel && collapsedAtStart.has(growPanel.id) && growPanel.collapsible) {
     const expandThreshold = growPanel.minWidth - growPanel.collapsedWidth;
     if (absDx < expandThreshold) {
@@ -141,7 +141,7 @@ function resolveLayout(
   let remaining = absDx;
   const expandCost = isExpandingFromCollapsed && growPanel ? growPanel.minWidth - growPanel.collapsedWidth : 0;
   // In overflow mode the expand consumes trailing gap (O1), so victims
-  // only shrink for px beyond the gate. In autoFill the expand must be
+  // only shrink for px beyond the threshold. In autoFill the expand must be
   // zero-sum: victims fund the full expand cost.
   if (expandCost > 0 && !autoFill) {
     remaining -= expandCost;

--- a/frontend/src/modules/docs/sidebar/page-tree-item.tsx
+++ b/frontend/src/modules/docs/sidebar/page-tree-item.tsx
@@ -180,7 +180,7 @@ export function buildPageNodeTree(pages: DocPage[]): PageNode[] {
   const validIds = new Set(pages.map((p) => p.id));
   const byParent = new Map<string | null, DocPage[]>();
   for (const p of pages) {
-    // Treat orphans (parent missing from visible set) as roots
+    // Treat parentless pages (parent missing from visible set) as roots
     const key = p.parentId && validIds.has(p.parentId) ? p.parentId : null;
     const list = byParent.get(key);
     if (list) list.push(p);

--- a/frontend/src/modules/docs/sidebar/pages-sidebar.tsx
+++ b/frontend/src/modules/docs/sidebar/pages-sidebar.tsx
@@ -33,7 +33,7 @@ export function PagesSidebar({ onClose }: PagesSidebarProps) {
     return new Map(pages.map((p) => [p.id, p.parentId && validIds.has(p.parentId) ? p.parentId : null]));
   }, [pages]);
 
-  // Accordion: expanding an id evicts its siblings (same effective parent) from the set
+  // Accordion: expanding an id collapses its siblings (same effective parent, removed from the set)
   const expandExclusive = (next: Set<string>, id: string) => {
     const parent = parentById.get(id) ?? null;
     for (const other of [...next]) if (parentById.get(other) === parent) next.delete(other);

--- a/frontend/src/modules/memberships/members-table/members-table.tsx
+++ b/frontend/src/modules/memberships/members-table/members-table.tsx
@@ -44,7 +44,7 @@ function MembersTable({ channelEntity, isSheet = false, children }: MembersTable
   const organizationId = organization.id;
 
   // Managing members is a channel-scoped affordance (not a per-row question), and the enriched
-  // entity carries no `createdBy` to resolve `'own'` against — so gate on an unconditional grant.
+  // entity carries no `createdBy` to resolve `'own'` against — so require an unconditional grant.
   const canUpdate = isUnconditionalPermission(channelEntity.can?.[channelEntity.entityType]?.update);
 
   // Table state

--- a/frontend/src/modules/organization/route-logic.ts
+++ b/frontend/src/modules/organization/route-logic.ts
@@ -32,7 +32,7 @@ export const organizationLayoutBeforeLoad = async ({ params, cause }: Organizati
   if (organizationId) {
     const orgOptions = organizationQueryOptions(organizationId, tenantId);
 
-    // Seed detail cache from list cache so ensureQueryData returns immediately
+    // Prime detail cache from list cache so ensureQueryData returns immediately
     // instead of blocking on a fetch. It will still revalidate in background if stale.
     if (cached && !queryClient.getQueryData(orgOptions.queryKey)) {
       queryClient.setQueryData(orgOptions.queryKey, cached);

--- a/frontend/src/query/basic/create-query-keys.ts
+++ b/frontend/src/query/basic/create-query-keys.ts
@@ -45,7 +45,7 @@ export function isDefaultListView(filters: Record<string, unknown>, defaults: Re
  * Standardized query keys for an entity module. Key hierarchy (prefix-matchable):
  *   [entity, 'list']                              broadest (all queries)
  *   [entity, 'list', organizationId]              all queries for one org
- *   [entity, 'list', organizationId, projectId]  canonical scope (product entities)
+ *   [entity, 'list', organizationId, projectId]  canonical scope: the base list live sync patches (product entities)
  *   [entity, 'list', organizationId, {filters}]  specific filtered query
  *
  * Scope ancestors derived from hierarchy-config: task -> scope(organizationId, projectId), page -> scope().

--- a/frontend/src/query/idb-kv-storage.ts
+++ b/frontend/src/query/idb-kv-storage.ts
@@ -1,7 +1,7 @@
 import type { StateStorage } from 'zustand/middleware';
 import { type AppDatabase, getAppDb } from '~/query/app-db';
 
-/** Trailing-debounce window: coalesces write bursts (e.g. per-frame resize) into one txn. */
+/** Trailing-debounce window: batches write bursts (e.g. per-frame resize) into one txn. */
 const WRITE_DEBOUNCE_MS = 250;
 
 /** Flush callbacks for every live store, invoked on tab hide for best-effort durability. */

--- a/frontend/src/query/offline/failed-sync.ts
+++ b/frontend/src/query/offline/failed-sync.ts
@@ -12,7 +12,7 @@ export interface FailedSyncRecord {
   entityType?: ProductEntityType;
   /** Client cache version (appConfig.clientCacheVersion) the client was on when it failed. */
   clientCacheVersion: string;
-  /** HTTP status of the failed replay. */
+  /** HTTP status of the failed offline replay. */
   status: number;
   /** Serialized mutation variables (for export / manual repair). */
   variables: unknown;

--- a/frontend/src/query/offline/squash-utils.ts
+++ b/frontend/src/query/offline/squash-utils.ts
@@ -53,9 +53,9 @@ export function squashPendingMutation(
 
 /**
  * If a pending create exists for the entity (matched by temp `id`), merge the update `ops` into its
- * variables and return true — the caller then skips the normal update flow. False if none to coalesce.
+ * variables and return true — the caller then skips the normal update flow. False if none to squash into.
  */
-export function coalescePendingCreate(
+export function squashIntoPendingCreate(
   queryClient: QueryClient,
   createMutationKey: readonly unknown[],
   entityId: string,

--- a/frontend/src/query/offline/tests/offline-reconciliation.test.ts
+++ b/frontend/src/query/offline/tests/offline-reconciliation.test.ts
@@ -252,7 +252,7 @@ describe('create + edit coalescing', () => {
     const createVars = { id: 'temp-1', name: 'New Task', status: 'todo' };
     cleanups.push(queuePendingMutation(queryClient, createKey, createVars));
 
-    // User edits the description while still offline; coalescePendingCreate merges into the pending create.
+    // User edits the description while still offline; squashIntoPendingCreate merges into the pending create.
     const mutations = queryClient.getMutationCache().findAll({ mutationKey: createKey });
     const pendingCreate = mutations.find((m) => {
       const vars = m.state.variables as { id?: string } | undefined;

--- a/frontend/src/query/offline/tests/squash-utils.test.ts
+++ b/frontend/src/query/offline/tests/squash-utils.test.ts
@@ -1,6 +1,6 @@
 import { MutationObserver, QueryClient } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { coalescePendingCreate, squashPendingMutation } from '../squash-utils';
+import { squashIntoPendingCreate, squashPendingMutation } from '../squash-utils';
 
 /**
  * Helper: create a mutation that stays "pending" by never resolving its mutationFn.
@@ -140,7 +140,7 @@ describe('squashPendingMutation', () => {
   });
 });
 
-describe('coalescePendingCreate', () => {
+describe('squashIntoPendingCreate', () => {
   let queryClient: QueryClient;
   const createKey = ['task', 'create'] as const;
   const cleanups: (() => void)[] = [];
@@ -158,7 +158,7 @@ describe('coalescePendingCreate', () => {
   });
 
   it('returns false when no pending create exists', () => {
-    const result = coalescePendingCreate(queryClient, createKey, 'entity-1', { name: 'Updated' });
+    const result = squashIntoPendingCreate(queryClient, createKey, 'entity-1', { name: 'Updated' });
     expect(result).toBe(false);
   });
 
@@ -166,7 +166,7 @@ describe('coalescePendingCreate', () => {
     const variables = { id: 'entity-1', name: 'Original' };
     cleanups.push(queuePendingMutation(queryClient, createKey, variables));
 
-    const result = coalescePendingCreate(queryClient, createKey, 'entity-1', { description: 'Added' });
+    const result = squashIntoPendingCreate(queryClient, createKey, 'entity-1', { description: 'Added' });
 
     expect(result).toBe(true);
     // Fields merged into existing create variables
@@ -176,7 +176,7 @@ describe('coalescePendingCreate', () => {
   it('ignores creates for different entities', () => {
     cleanups.push(queuePendingMutation(queryClient, createKey, { id: 'entity-2', name: 'Other' }));
 
-    const result = coalescePendingCreate(queryClient, createKey, 'entity-1', { name: 'X' });
+    const result = squashIntoPendingCreate(queryClient, createKey, 'entity-1', { name: 'X' });
     expect(result).toBe(false);
   });
 });

--- a/frontend/src/query/on-error.ts
+++ b/frontend/src/query/on-error.ts
@@ -5,7 +5,7 @@ import { toaster } from '~/modules/common/toaster/toaster';
 import { checkConnectivity } from '~/query/offline/connectivity';
 import { isNetworkError } from '~/query/offline/network-retry';
 import type { QueryMeta } from '~/query/react-query';
-import { flushStores } from '~/utils/flush-stores';
+import { teardownUserState } from '~/utils/teardown-user-state';
 
 /** Fallback messages for common errors, called lazily so i18next is initialized. */
 const getFallbackMessage = (status: number): string | undefined => {
@@ -114,9 +114,9 @@ export const onError = (error: Error | ApiError, meta?: QueryMeta) => {
         redirectOptions.search = { redirect: redirectPath };
       }
 
-      // Soft-flush sensitive stores, then go to sign-in. Pass `false` so the appdb (unsynced offline
+      // Close sensitive stores without wiping, then go to sign-in. Pass `false` so the appdb (unsynced offline
       // work) stays on disk: a 401 is involuntary and the same user usually re-auths and recovers it.
-      flushStores(false);
+      teardownUserState(false);
       // Dynamic import breaks circular dep: query-client -> on-error -> router -> route tree -> query-client
       import('~/routes/router').then(({ router: r }) => r.navigate(redirectOptions));
     }

--- a/frontend/src/query/query-client.ts
+++ b/frontend/src/query/query-client.ts
@@ -13,7 +13,7 @@ function entityTypeOf(key: unknown): ProductEntityType | undefined {
   return typeof head === 'string' && productEntitySet.has(head) ? (head as ProductEntityType) : undefined;
 }
 
-// Lazy import to break circular dependency: query-client -> on-error -> flush-stores -> query-client
+// Lazy import to break circular dependency: query-client -> on-error -> teardown-user-state -> query-client
 // Without this, HMR re-evaluation hits a TDZ error on `onError`.
 const handleError = (error: ApiError, meta: QueryMeta | undefined) =>
   import('~/query/on-error').then((m) => m.onError(error, meta));

--- a/frontend/src/query/realtime/cache-ops.ts
+++ b/frontend/src/query/realtime/cache-ops.ts
@@ -215,7 +215,7 @@ export function removeEntityFromListCache(entityId: string, keys: EntityQueryKey
 /**
  * Apply one server-truth row to detail + list caches — the single applicator shared by both
  * realtime paths (seq-range fetches and seq-less single fetches). Tombstones remove; rows
- * already cached update in place; unknown rows insert into their canonical scope lists only.
+ * already cached update in place; unknown rows insert only into their canonical scope list (the base per-scope list that live sync patches).
  * Returns true when the row was new to every scanned list cache, so callers can invalidate
  * filtered lists (object key segments — server-side filters we can't replicate) once per flush.
  */

--- a/frontend/src/query/realtime/stream-store.ts
+++ b/frontend/src/query/realtime/stream-store.ts
@@ -71,13 +71,13 @@ function createStreamStore(name: string) {
 }
 
 /**
- * Module-level gate that resolves when the first stream completes catchup
+ * Module-level promise (the initial-catchup gate) that resolves when the first stream completes catchup
  * after page load. Used by the query provider to delay `resumePausedMutations`
  * until the cache is fresh, even though the provider's `onSuccess` fires
  * before any stream has called `connect()`.
  *
- * The gate is created eagerly at import time. Once resolved it stays resolved
- * for the lifetime of the page (we only need to gate the initial cache restore).
+ * The promise is created eagerly at import time. Once resolved it stays resolved
+ * for the lifetime of the page (only the initial cache restore needs to wait).
  */
 let initialCatchupResolve: (() => void) | null = null;
 const initialCatchupGate: Promise<void> = new Promise<void>((resolve) => {

--- a/frontend/src/query/tests/on-error.test.ts
+++ b/frontend/src/query/tests/on-error.test.ts
@@ -4,7 +4,7 @@ const mockCheckConnectivity = vi.fn();
 const mockToaster = vi.fn();
 const mockSetDownAlert = vi.fn();
 const mockNavigate = vi.fn();
-const mockFlushStores = vi.fn();
+const mockTeardownUserState = vi.fn();
 
 vi.mock('~/query/offline/connectivity', () => ({ checkConnectivity: mockCheckConnectivity }));
 vi.mock('~/modules/common/toaster/toaster', () => ({ toaster: mockToaster }));
@@ -12,7 +12,7 @@ vi.mock('~/modules/common/alerter/alert-store', () => ({
   useAlertStore: { getState: () => ({ setDownAlert: mockSetDownAlert }) },
 }));
 vi.mock('~/routes/router', () => ({ default: { navigate: mockNavigate } }));
-vi.mock('~/utils/flush-stores', () => ({ flushStores: mockFlushStores }));
+vi.mock('~/utils/teardown-user-state', () => ({ teardownUserState: mockTeardownUserState }));
 vi.mock('i18next', () => {
   const t = (key: string) => key;
   return { default: { t, exists: () => false }, t, exists: () => false };

--- a/frontend/src/utils/teardown-user-state.ts
+++ b/frontend/src/utils/teardown-user-state.ts
@@ -5,7 +5,7 @@ import { deleteAppDb } from '~/query/app-db';
 import { queryClient } from '~/query/query-client';
 
 /**
- * Flush client state when the user leaves the authenticated app.
+ * Tear down client state when the user leaves the authenticated app.
  *
  * Cross-user isolation is structural: all per-user data lives in one IndexedDB named for the
  * owner (`~/query/app-db`). Nulling the user drives the auth-driven lifecycle
@@ -18,7 +18,7 @@ import { queryClient } from '~/query/query-client';
  *   The DB is only closed, so the SAME user recovers their offline work (queued mutations, drafts)
  *   and gets a prefilled sign-in after re-authenticating. Avoids data loss on a transient expiry.
  */
-export const flushStores = async (wipe = true): Promise<void> => {
+export const teardownUserState = async (wipe = true): Promise<void> => {
   queryClient.clear();
 
   // Hard sign-out only: destroy all per-user persisted data while the owner is still known.
@@ -28,7 +28,7 @@ export const flushStores = async (wipe = true): Promise<void> => {
   useUIStore.getState().reset();
 
   // Nulling the user drives the appdb lifecycle to unbind (close) the DB and reset every
-  // per-user store's in-memory state. A hard wipe also forgets `lastUser`; a soft flush keeps it.
+  // per-user store's in-memory state. A hard wipe also forgets `lastUser`; a soft teardown keeps it.
   if (wipe) useUserStore.getState().reset();
   else useUserStore.setState({ user: null as unknown as MeUser, isSystemAdmin: false, yjsTokens: {} });
 };

--- a/infra/lib/stack/control-store.ts
+++ b/infra/lib/stack/control-store.ts
@@ -16,14 +16,14 @@ export interface GenRef {
 }
 
 /**
- * Per-service rollout ledger. The pointers (not a single mutable gen number) are
+ * Per-service rollout record (the S3 control object). The pointers (not a single mutable gen number) are
  * the source of truth so a partial deploy is always recoverable by recomputing
  * desired-vs-live rather than replaying a transition:
  *   - `active`: the generation currently serving live on the LB.
  *   - `pendingSha`: a deploy INTENT, the SHA being rolled in. The genId is
  *                  derived and materialized by the Pulumi program (the genId
  *                  authority), then read back by the orchestrator, so the
- *                  ledger never has to predict an id the program owns.
+ *                  control object never has to predict an id the program owns.
  *   - `seq`: monotonic counter, bumped on each promotion (ordering + GC).
  * No `previous` is kept: the old generation is reaped once the new one is
  * healthy, and rollback is a revert commit + forward redeploy (recreates every
@@ -197,7 +197,7 @@ export function serializeControlState(state: ControlState): string {
   return `${JSON.stringify(state, null, 2)}\n`
 }
 
-// Pure ledger transitions: every rollout state change is a total function over
+// Pure rollout-state transitions: every state change is a total function over
 // the previous rollout, so the orchestrator never hand-mutates pointer fields
 // and the transitions are unit-tested in isolation.
 

--- a/infra/resources/generations.ts
+++ b/infra/resources/generations.ts
@@ -137,7 +137,7 @@ export function activeGenerations(svc: ServiceDefinition): Generation[] {
   add(pending)
 
   if (generations.length === 0) {
-    // First provision, before any deploy seeds the ledger: a single default gen.
+    // First provision, before any deploy initializes the control object: a single default gen.
     const sha = 'latest'
     add({ id: deriveGenId(sha, fingerprint), sha })
   }

--- a/infra/tasks/sync-rollout-config.ts
+++ b/infra/tasks/sync-rollout-config.ts
@@ -24,7 +24,7 @@ export function parseRolloutGenerations(raw: string): RolloutGeneration[] {
     const { service, genId, sha } = item
     if (typeof service !== 'string' || typeof sha !== 'string') continue
     // Only rows for services the registry knows. A stale output row for a
-    // removed service must not seed the ledger.
+    // removed service must not enter the control object.
     if (!(serviceNames as readonly string[]).includes(service)) continue
     rows.push({ service: service as ServiceName, sha, genId: typeof genId === 'string' ? genId : '' })
   }
@@ -81,8 +81,8 @@ export async function syncRolloutConfig(argv = process.argv.slice(2)): Promise<v
 }
 
 /**
- * Seed the `active` pointer for any service that has none yet: first adoption
- * of a live generation into the ledger. Deliberately NEVER promotes a pending
+ * Initialize the `active` pointer for any service that has none yet: first adoption
+ * of a live generation into the control object. Deliberately NEVER promotes a pending
  * generation or demotes an existing active: the orchestrator (deploy-service)
  * owns promotion after a health-gated cutover, so a freshly-materialised but
  * un-cutover generation must not be mistaken for "live" here (that was the old

--- a/shared/src/schema-evolution/README.md
+++ b/shared/src/schema-evolution/README.md
@@ -2,6 +2,12 @@
 
 Schema-evolution lens registry (doba lenses).
 
+**Vocabulary:** a **canonical** field name is the name in the entity's *current*
+schema version; an **alias** is a pre-rename name that old clients may still
+send. During an expand window both are accepted: lens seams normalize alias
+keys to canonical ones before any body access, and writes mirror to the twin
+field so old readers stay fresh.
+
 ## Lens convention: [`define.ts`](./define.ts)
 
 A lens declares a single breaking schema change once; everything else

--- a/yjs/src/data/storage.ts
+++ b/yjs/src/data/storage.ts
@@ -13,7 +13,7 @@ export async function loadState({ entityType, entityId, tenantId, userId }: DocC
 }
 
 /**
- * Overwrites the stored Y.Doc state. Called on debounced flush from the relay.
+ * Overwrites the stored Y.Doc state. Called on debounced save from the relay.
  * `lastEditedBy` records the last writer for materialization attribution: it lets
  * the startup sweep persist crash-orphaned sessions on behalf of the right user.
  */

--- a/yjs/src/server/upgrade.ts
+++ b/yjs/src/server/upgrade.ts
@@ -10,7 +10,7 @@ import { verifyToken } from './auth';
 import { stripYjsPrefix } from './path-prefix';
 import { checkConnectionRate } from './rate-limiter';
 import { joinCollab, leaveCollab } from '../sync/session-manager';
-import { handleMessage, flushPendingBuffer, discardPendingBuffer } from '../sync/relay';
+import { handleMessage, releaseBufferedMessages, discardPendingBuffer } from '../sync/relay';
 
 /**
  * Reject the upgrade at the HTTP level: no WebSocket handshake is completed.
@@ -26,11 +26,11 @@ function rejectUpgrade(socket: Duplex, code: number, reason: string): void {
   );
 }
 
-/** Apply the result of entity verification: flush buffered messages on success, discard and close on failure. */
+/** Apply the result of entity verification: release buffered messages on success, discard and close on failure. */
 function applyVerifyResult(ws: WebSocket, ctx: DocContext, allowed: boolean): void {
   if (allowed) {
     ctx.verified = true;
-    flushPendingBuffer(ws);
+    releaseBufferedMessages(ws);
     log.debug(`Entity verified for ${ctx.entityType}:${ctx.entityId}`, { userId: ctx.userId });
   } else {
     log.warn(`Entity access denied for ${ctx.entityType}:${ctx.entityId}`);

--- a/yjs/src/sync/materialize.ts
+++ b/yjs/src/sync/materialize.ts
@@ -58,8 +58,8 @@ export function stateToBlocksJson(state: Uint8Array): string | null {
 
 /**
  * Materialize a session's current state into the entity's durable record.
- * Diffs against the session's last materialized content, so cursor-only save
- * windows and seed-only sessions cost nothing. On `retry` the baseline stays
+ * Diffs against the session's last materialized content, so caret-only save
+ * windows and seed-only (never-edited) sessions cost nothing. On `retry` the baseline stays
  * stale so the next save window (or gated cleanup) tries again.
  */
 export async function materializeState(collab: MaterializableSession, state: Uint8Array): Promise<MaterializeResult> {

--- a/yjs/src/sync/relay.ts
+++ b/yjs/src/sync/relay.ts
@@ -19,7 +19,7 @@ const awarenessTimestamps = new WeakMap<WebSocket, number>();
 
 /**
  * Per-client message buffer: queues all sync messages (reads and writes) while entity verification is pending.
- * Once verified, the buffer is flushed. If denied, it's discarded.
+ * Once verified, the buffered messages are released and applied. If denied, they're discarded.
  */
 const pendingBuffers = new WeakMap<WebSocket, { ctx: DocContext; messages: Uint8Array[] }>();
 
@@ -36,8 +36,8 @@ function bufferMessage(ws: WebSocket, ctx: DocContext, rawMessage: Uint8Array): 
   }
 }
 
-/** Flush queued messages after entity verification succeeds. Replays them through handleMessage. */
-export function flushPendingBuffer(ws: WebSocket): void {
+/** Release queued messages after entity verification succeeds. Replays them through handleMessage. */
+export function releaseBufferedMessages(ws: WebSocket): void {
   const buf = pendingBuffers.get(ws);
   if (!buf || buf.messages.length === 0) {
     pendingBuffers.delete(ws);
@@ -49,7 +49,7 @@ export function flushPendingBuffer(ws: WebSocket): void {
 
   for (const raw of messages) {
     handleMessage(ctx, ws, raw).catch((err) => {
-      log.error(`Failed to flush buffered message for ${ctx.entityType}:${ctx.entityId}`, { err: err });
+      log.error(`Failed to apply buffered message for ${ctx.entityType}:${ctx.entityId}`, { err: err });
     });
   }
 }
@@ -92,7 +92,7 @@ export async function handleMessage(ctx: DocContext, ws: WebSocket, data: Uint8A
   const messageType = decoding.readVarUint(decoder);
 
   if (messageType === YMessage.Sync) {
-    // Gate all sync messages (reads + writes) until entity access is verified
+    // Buffer all sync messages (reads + writes) until entity access is verified
     if (!ctx.verified) {
       bufferMessage(ws, ctx, data);
       return;

--- a/yjs/src/sync/session-manager.ts
+++ b/yjs/src/sync/session-manager.ts
@@ -115,7 +115,7 @@ export function leaveCollab(entityType: string, entityId: string, ws: WebSocket)
         }
       }
 
-      // Gate deletion on a final materialization: the durable record must absorb the
+      // Delete only after a final materialization: the durable record must absorb the
       // session before its state is destroyed. Only 'retry' (backend/network down)
       // blocks: reschedule and keep the row. 'permanent' (entity deleted, permission
       // revoked) can never converge, so deletion proceeds.


### PR DESCRIPTION
## What

Executes the ambiguous-jargon scan findings (`.todos/JARGON_SCAN.md`, local): comment vocabulary that was technical yet vague about the exact programmatic goal, carried multiple mechanically different meanings under one word, and wasn't defined in any README. Where a metaphor hid the mechanism, the comment (or local identifier) now names what the code does or uses the README's own name for the thing.

## Identifier renames (3, all internal — no fork-facing contracts touched)

| Before | After | Why |
|---|---|---|
| `flushStores` / `flush-stores.ts` | `teardownUserState` / `teardown-user-state.ts` | The worst "flush" in the repo: read as *persist*, meant *wipe/close* on sign-out |
| `flushPendingBuffer` (yjs) | `releaseBufferedMessages` | Releases messages held during entity verification — nothing is written out |
| `coalescePendingCreate` | `squashIntoPendingCreate` | Aligns with sibling `squashPendingMutation` and the `squash-utils.ts` module name |

## Comment/wording sweeps

- **predicate** → "cleanup WHERE clause" (bench), "collection read filter" (seen queries) — the bare word stays reserved for permission row predicates (`RowPredicate` identifiers untouched)
- **infra "rollout ledger"** → "control object" — the name `infra/README` already uses for `control/<stack>.json`
- **gate** → the actual mechanism where it wasn't a deploy/health gate: buffer (yjs relay), promise (stream-store), threshold (resizable-panels, matching the existing `expandThreshold` identifier), require-grant (members-table), controls-visibility (channel-entity-columns)
- **coalesce** → "batches" for debounce/rAF batching; the word stays reserved for request-coalescing and SQL `COALESCE`
- **seed** → "prime" (detail-cache priming), "initialize" (infra pointers), "keys the RNG" (mocks); DB/test/bench seeding keeps the standard term
- **canonical** → lens-seam comments now say "normalize old-shape field names to their current names" (matching the `normalizeBody` call below them); "canonical scope" comments define the term in place; the alias↔canonical vocabulary is now documented in `shared/src/schema-evolution/README.md`
- **minor**: cursor-only → caret-only (yjs saves), evicts → collapses (docs accordion), orphans → parentless pages (docs tree), mint → create (rate-limit buckets), "failed replay" → "failed offline replay"

## Deliberately out of scope

- **Seen-module + realtime files** (`seen-store.ts`, `app-stream-handler.ts`, `lazy-sync-scheduler.ts`, `catchup-processor.ts`, `shared/seen-window.ts`, …): under the in-flight unseen-ledger rename in a parallel working tree — touching them would guarantee conflicts. The 8 stale "ledger" comments there are listed in the scan doc for that branch to pick up.
- **Fork-facing contracts**: `flushedIds`, `markEntitySeen`, `RowPredicate`, `canonicalKeys` — renames would break forks (raak) and need coordinated migrations.
- **`generation: 'random' | 'manual'`** in `infra/config/runtime-secrets.config.ts` → `valueSource`: a fork API change that should ship with a cella migration note, not a comment sweep.

## Verification

- Pre-commit hook: workspace-wide typecheck (all 11 packages), biome, OpenAPI/SDK regen (SDK unchanged), commitlint — all pass
- Frontend: full vitest suite, 689 tests pass (includes renamed-symbol suites: on-error, squash-utils, offline-reconciliation, download-service)
- yjs: 87 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
