### PR TITLE
feat(infra): add "Reset database" CLI task

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -343,6 +343,31 @@ The `.github/workflows/` files are tightly coupled to this package: `deploy.yml`
 
 ## Advanced operations
 
+### Reset the database
+
+Wipes the app's logical database and rebuilds it from migrations + the admin seed. For large rewrites, where replaying migration history is not worth it and a clean baseline is. **Pre-production, or with services deliberately quiesced — this is a hard outage.**
+
+Run the CLI (`pnpm infra`) and pick **Reset database**. It takes a backup (aborting unless it reports ready), deletes and recreates the logical database over the Scaleway API with a bootstrap key, and re-grants both roles. It never exposes the database and never runs `pulumi up`.
+
+Then run the two steps it prints, on the serial console:
+
+```bash
+cd /opt/app
+docker compose --profile backend run --rm migrate
+docker compose --profile backend run --rm -e ADMIN_EMAIL=you@example.com migrate node dist/seeds-bundle.js init
+```
+
+Confirm with `curl https://<your-app>/api/health?depth=full` — all components `healthy`.
+
+Four things are worth understanding before running it:
+
+- **Nothing but you stops this.** Scaleway's API deletes a live database with connected clients and an active replication slot; PostgreSQL alone refuses that. Maintenance mode is a convention here, not an interlock — the typed `<database>@<instance>` confirmation is the guard.
+- **Re-granting is mandatory, and the task owns it.** Deleting a database drops its Scaleway privileges, and neither a recreate nor a *backup restore* brings them back — a per-database `pg_dump` carries table ACLs but not database-level ones, so `CONNECT` is absent and the app reports `database_unreachable`.
+- **Pulumi is untouched.** Scaleway's resource IDs are name-derived, so a same-name recreate yields identical IDs and stack state stays correct. No `pulumi up`, no secret churn, no VM roll.
+- **The CDC worker needs no restart** — it re-ensures its replication slot on every retry.
+
+If the task fails after the delete, it prints the exact `scw rdb backup restore` command plus the two `privilege set` calls a restore does not perform.
+
 ### Updating the boot agent
 
 The boot agent is a normal registry container, not a baked base image. CI rebuilds and pushes it per commit ([agent/Dockerfile](agent/Dockerfile)), so any change under [agent/](agent/) ships on the next deploy with no extra step. To build it locally:

--- a/infra/cli/actions/reset-database.ts
+++ b/infra/cli/actions/reset-database.ts
@@ -1,0 +1,115 @@
+import { input } from '@inquirer/prompts'
+import { pc } from 'shared/cli-utils/colors'
+import { checkMark, crossMark, warningMark } from 'shared/utils/console'
+import { deriveInfra } from '../../lib/naming'
+import { createRdbClient, waitForBackupReady } from '../../lib/scaleway/scaleway-rdb'
+import { errorMessage } from '../../lib/utils/errors'
+import {
+  backupName,
+  ResetIrrecoverableError,
+  type ResetTarget,
+  restoreHint,
+  sequenceDatabaseReset,
+  serialConsoleSteps,
+} from '../../tasks/reset-database'
+import { maskedSecret } from '../prompts/masked-secret'
+import { envOr, type InfraContext } from '../shared'
+
+/** Roles Pulumi provisions on the instance (`resources/database.ts`). Both must be re-granted. */
+const ROLES = ['admin_role', 'runtime_role'] as const
+
+/** Retention for the pre-reset backup. Long enough to notice a bad reset the next working week. */
+const BACKUP_RETENTION_DAYS = 7
+
+/**
+ * Render the target for approval. The database list comes from the live instance, so aiming at the
+ * wrong instance is visible here rather than after the fact — these keys reach every RDB instance
+ * in the project, not just this app's.
+ */
+function describeTarget(target: ResetTarget, region: string): string {
+  const others = target.databases
+    .filter((database) => database.name !== target.databaseName)
+    .map((database) => database.name)
+
+  return [
+    '',
+    pc.bold('Reset target'),
+    `  instance   ${pc.bold(target.instanceName)} ${pc.dim(`(${target.instanceId}, ${region})`)}`,
+    `  database   ${pc.red(pc.bold(target.databaseName))} ${pc.dim('— will be DELETED and recreated empty')}`,
+    `  survives   ${others.length ? others.join(', ') : pc.dim('(none)')}`,
+    '',
+    `${warningMark} ${pc.bold('Everything in')} ${pc.red(target.databaseName)} ${pc.bold('is destroyed.')} A backup is taken first, and the`,
+    `  reset aborts unless it reports ready. Nothing else stops this: Scaleway deletes a live`,
+    `  database with connected clients and an active replication slot without complaint.`,
+    '',
+  ].join('\n')
+}
+
+/**
+ * "Reset database": delete + recreate this app's logical database over the Scaleway API with a
+ * bootstrap key, then re-grant both roles. Pulumi is not involved — same-name recreate keeps its
+ * state correct — and the database is never exposed.
+ */
+export async function runResetDatabase(context: InfraContext): Promise<void> {
+  if (context.state !== 'bootstrapped') {
+    console.error(`${warningMark} "Reset database" requires a fully bootstrapped stack (state=${context.state}).`)
+    process.exit(1)
+  }
+
+  const { appConfig } = context
+  const { naming, region } = deriveInfra(appConfig)
+  const instanceName = naming.resource('postgres')
+  const databaseName = naming.dbName
+
+  console.info(pc.dim('\nReset database: delete + recreate the logical database, then re-grant roles.'))
+  console.info(pc.dim('Pre-production use, or with services quiesced — this is a hard outage.\n'))
+
+  // Only the secret key is needed: the Scaleway API authenticates with X-Auth-Token alone.
+  const bootSecret = await envOr('SCW_BOOTSTRAP_SECRET_KEY', () => maskedSecret({ message: 'Scaleway bootstrap secret key' }))
+
+  const client = createRdbClient({ secretKey: bootSecret, region })
+  const expiresAt = new Date(Date.now() + BACKUP_RETENTION_DAYS * 86_400_000).toISOString()
+
+  try {
+    const result = await sequenceDatabaseReset({
+      instanceName,
+      databaseName,
+      roles: ROLES,
+      permission: 'all',
+      backupName: backupName(databaseName, new Date()),
+      backupExpiresAt: expiresAt,
+
+      findInstance: (name) => client.findInstance(name),
+      listDatabases: (instanceId) => client.listDatabases(instanceId),
+      createBackup: (input) => client.createBackup(input),
+      waitForBackup: (backupId) => waitForBackupReady(client, backupId),
+      deleteDatabase: (instanceId, name) => client.deleteDatabase(instanceId, name),
+      createDatabase: (instanceId, name) => client.createDatabase(instanceId, name),
+      setPrivilege: (instanceId, database, user, permission) => client.setPrivilege(instanceId, database, user, permission),
+      log: (message) => console.info(`  ${message}`),
+
+      confirm: async (target) => {
+        console.info(describeTarget(target, region))
+        const typed = await input({
+          message: `Type ${pc.bold(target.token)} to reset it, anything else to abort:`,
+        })
+        return typed.trim() === target.token
+      },
+    })
+
+    if (result.aborted) return
+
+    console.info(`\n${checkMark} ${pc.green(`${databaseName} recreated`)} — empty, with ${result.granted.join(' + ')} re-granted.`)
+    console.info(`  ${pc.dim(`Backup retained ${BACKUP_RETENTION_DAYS} days: ${result.backupId}`)}\n`)
+    console.info(serialConsoleSteps(databaseName))
+    console.info(`\n  ${pc.dim(`Then confirm: curl ${appConfig.backendUrl}/health?depth=full`)}`)
+  } catch (error) {
+    if (error instanceof ResetIrrecoverableError) {
+      console.error(`\n${restoreHint(error, region)}\n`)
+      process.exit(1)
+    }
+    console.error(`\n${crossMark} Reset aborted: ${errorMessage(error)}`)
+    console.error(`  ${pc.dim('Nothing was destroyed — the guards run before the delete.')}\n`)
+    process.exit(1)
+  }
+}

--- a/infra/cli/infra-cli.ts
+++ b/infra/cli/infra-cli.ts
@@ -10,6 +10,7 @@ import { detectComputeDeferred, detectStackState, pickStackShort } from '../lib/
 import { infraDir } from '../lib/utils/paths'
 import { runApply } from './actions/apply'
 import { runPreview } from './actions/preview'
+import { runResetDatabase } from './actions/reset-database'
 import { runRotatePassphrase } from './actions/rotate-passphrase'
 import { runSecrets } from './actions/secrets'
 import { runSetup } from './actions/setup'
@@ -112,6 +113,7 @@ const mode: CliMode =
           { name: 'Apply infra change', value: 'apply', description: 'Privileged converge: one-shot `pulumi up` with a bootstrap key for DB/VPC/PN changes the CI key cannot. No refresh (buckets are CI-scoped).' },
           { name: 'Preview', value: 'preview', description: 'Read-only `pulumi preview`. Validates auth & shows drift; makes no changes.' },
           { name: 'Manage runtime secrets', value: 'secrets', description: 'List, set, rotate, or delete operator-managed runtime secrets in Scaleway Secret Manager.' },
+          { name: 'Reset database', value: 'reset-database', description: 'DESTRUCTIVE: delete + recreate the app database empty (backup first, roles re-granted), then migrate/seed on the serial console. Pre-production, or with services quiesced.' },
           { name: 'Unlock', value: 'unlock', description: 'Clear a stale stack lock left by an interrupted apply/deploy. Use only when no run is actually in progress.' },
         ],
       })
@@ -134,6 +136,11 @@ if (mode === 'preview') {
 
 if (mode === 'secrets') {
   await runSecrets(context)
+  process.exit(0)
+}
+
+if (mode === 'reset-database') {
+  await runResetDatabase(context)
   process.exit(0)
 }
 

--- a/infra/cli/shared.ts
+++ b/infra/cli/shared.ts
@@ -12,7 +12,7 @@ import { maskedSecret } from './prompts/masked-secret'
 type AppConfigType = typeof AppConfig
 
 /** Infra CLI operation modes */
-export type CliMode = 'resume' | 'rotate' | 'rotate-passphrase' | 'apply' | 'preview' | 'secrets' | 'unlock'
+export type CliMode = 'resume' | 'rotate' | 'rotate-passphrase' | 'apply' | 'preview' | 'secrets' | 'reset-database' | 'unlock'
 
 /**
  * Context for the infra CLI, including stack information and state. Passed to each service handler to provide necessary information about the current infra status and configuration.

--- a/infra/lib/naming.test.ts
+++ b/infra/lib/naming.test.ts
@@ -19,6 +19,21 @@ describe('deriveInfra', () => {
     expect(deriveInfra(fakeConfig({ slug: 'my-cool-app' })).naming.registryNamespace).toBe('mycoolapp')
   })
 
+  it('dbName replaces hyphens with underscores (PostgreSQL identifier constraint)', () => {
+    expect(deriveInfra(fakeConfig()).naming.dbName).toBe('cella')
+    expect(deriveInfra(fakeConfig({ slug: 'cella-staging' })).naming.dbName).toBe('cella_staging')
+  })
+
+  it('dbName is the single source for the logical database name', () => {
+    // `resources/database.ts` creates this database and the reset task deletes it *by name* over
+    // the Scaleway API. If the two derived it separately and drifted, the reset would address the
+    // wrong database — or create a second, empty one alongside the real one.
+    const derived = deriveInfra(fakeConfig({ slug: 'my-cool-app' }))
+    expect(derived.naming.dbName).toBe('my_cool_app')
+    expect(derived.naming.dbName).not.toContain('-')
+    expect(derived.naming.resource('postgres')).toBe('my-cool-app-postgres')
+  })
+
   it('all bucket names are unique within a stack', () => {
     const d = deriveInfra(fakeConfig())
     const names = [

--- a/infra/lib/naming.ts
+++ b/infra/lib/naming.ts
@@ -52,6 +52,11 @@ export function deriveInfra(appConfig: Cfg) {
       // Registry namespace names require >= 4 chars and no hyphens; slug length
       // is validated at config load, so only hyphens need stripping here.
       registryNamespace: appConfig.slug.replace(/-/g, ''),
+      // The logical database inside the managed instance. Shared rather than re-derived: the
+      // reset task addresses this database by name over the Scaleway API, and a name that
+      // disagrees with the one `resources/database.ts` creates would target the wrong thing —
+      // or nothing. PostgreSQL identifiers cannot contain hyphens.
+      dbName: appConfig.slug.replace(/-/g, '_'),
     },
     // DNS zone the app's records live under (e.g. `cellajs.com`). Per-service
     // hostnames (api/yjs/mcp/www) come from the service registry, not here.

--- a/infra/lib/scaleway/scaleway-rdb.test.ts
+++ b/infra/lib/scaleway/scaleway-rdb.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createRdbClient, type RdbClient, waitForBackupReady } from './scaleway-rdb'
+
+type Call = { url: string; method: string; body: unknown }
+
+/**
+ * Fetch stub recording method/url/body. The URL and verb of every write are asserted below because
+ * they were captured from the live API (`scw --debug`) rather than read from docs — a silent drift
+ * here would only ever be discovered by a destructive call in production.
+ */
+function makeFetch(routes: Array<{ method: string; match: string; body?: unknown; status?: number }>) {
+  const calls: Call[] = []
+  const fn = vi.fn(async (input: string | URL | Request, init: RequestInit = {}) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const method = (init.method ?? 'GET').toUpperCase()
+    calls.push({ url, method, body: init.body ? JSON.parse(init.body as string) : undefined })
+
+    const route = routes.find((candidate) => candidate.method === method && url.includes(candidate.match))
+    if (!route) return new Response(`no mock for ${method} ${url}`, { status: 599 })
+    if (route.status === 204) return new Response(null, { status: 204 })
+    return new Response(JSON.stringify(route.body ?? {}), { status: route.status ?? 200, headers: { 'Content-Type': 'application/json' } })
+  })
+  return { fn, calls }
+}
+
+const client = (fetchImpl: ReturnType<typeof makeFetch>['fn']) =>
+  createRdbClient({ secretKey: 'scw-secret', region: 'nl-ams', fetchImpl })
+
+describe('createRdbClient', () => {
+  it('finds an instance by exact name', async () => {
+    const { fn, calls } = makeFetch([
+      { method: 'GET', match: '/instances', body: { instances: [{ id: 'i-1', name: 'cella-postgres', status: 'ready' }], total_count: 1 } },
+    ])
+
+    const found = await client(fn).findInstance('cella-postgres')
+
+    expect(found).toMatchObject({ id: 'i-1', status: 'ready' })
+    expect(calls[0]).toMatchObject({ url: 'https://api.scaleway.com/rdb/v1/regions/nl-ams/instances?name=cella-postgres' })
+  })
+
+  it('does not accept a prefix match for an instance name', async () => {
+    // `?name=` is a filter, not an exact match — `cella` must never resolve to `cella-staging`.
+    const { fn } = makeFetch([
+      { method: 'GET', match: '/instances', body: { instances: [{ id: 'i-2', name: 'cella-postgres-staging', status: 'ready' }], total_count: 1 } },
+    ])
+
+    expect(await client(fn).findInstance('cella-postgres')).toBeUndefined()
+  })
+
+  it('creates a database with POST .../databases', async () => {
+    const { fn, calls } = makeFetch([{ method: 'POST', match: '/databases', body: { name: 'cella' } }])
+
+    await client(fn).createDatabase('i-1', 'cella')
+
+    expect(calls[0]).toMatchObject({
+      method: 'POST',
+      url: 'https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/i-1/databases',
+      body: { name: 'cella' },
+    })
+  })
+
+  it('deletes a database with DELETE .../databases/{name}', async () => {
+    const { fn, calls } = makeFetch([{ method: 'DELETE', match: '/databases/', status: 204 }])
+
+    await client(fn).deleteDatabase('i-1', 'cella')
+
+    expect(calls[0]).toMatchObject({
+      method: 'DELETE',
+      url: 'https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/i-1/databases/cella',
+    })
+  })
+
+  it('sets a privilege with PUT .../privileges', async () => {
+    const { fn, calls } = makeFetch([
+      { method: 'PUT', match: '/privileges', body: { database_name: 'cella', user_name: 'runtime_role', permission: 'all' } },
+    ])
+
+    await client(fn).setPrivilege('i-1', 'cella', 'runtime_role', 'all')
+
+    expect(calls[0]).toMatchObject({
+      method: 'PUT',
+      url: 'https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/i-1/privileges',
+      body: { database_name: 'cella', user_name: 'runtime_role', permission: 'all' },
+    })
+  })
+
+  it('creates a backup at the region root, not under the instance', async () => {
+    const { fn, calls } = makeFetch([{ method: 'POST', match: '/backups', body: { id: 'bk-1', status: 'creating' } }])
+
+    await client(fn).createBackup({ instanceId: 'i-1', databaseName: 'cella', name: 'pre-reset', expiresAt: '2026-07-24T00:00:00Z' })
+
+    expect(calls[0]).toMatchObject({
+      method: 'POST',
+      url: 'https://api.scaleway.com/rdb/v1/regions/nl-ams/backups',
+      body: { instance_id: 'i-1', database_name: 'cella', name: 'pre-reset', expires_at: '2026-07-24T00:00:00Z' },
+    })
+  })
+
+  it('omits expires_at when no retention is given', async () => {
+    const { fn, calls } = makeFetch([{ method: 'POST', match: '/backups', body: { id: 'bk-1' } }])
+
+    await client(fn).createBackup({ instanceId: 'i-1', databaseName: 'cella', name: 'pre-reset' })
+
+    expect(calls[0]?.body).not.toHaveProperty('expires_at')
+  })
+
+  it('surfaces a failed API call rather than returning a partial result', async () => {
+    const { fn } = makeFetch([{ method: 'DELETE', match: '/databases/', body: { message: 'denied' }, status: 403 }])
+
+    await expect(client(fn).deleteDatabase('i-1', 'cella')).rejects.toThrow(/403/)
+  })
+})
+
+describe('waitForBackupReady', () => {
+  const stub = (statuses: string[]): RdbClient =>
+    ({
+      getBackup: vi.fn(async () => ({
+        id: 'bk-1',
+        name: 'pre-reset',
+        database_name: 'cella',
+        status: statuses.shift() ?? 'ready',
+      })),
+    }) as unknown as RdbClient
+
+  it('polls until the backup reports ready', async () => {
+    const client = stub(['creating', 'creating', 'ready'])
+
+    const backup = await waitForBackupReady(client, 'bk-1', { intervalMs: 0, sleep: async () => {} })
+
+    expect(backup.status).toBe('ready')
+    expect(client.getBackup).toHaveBeenCalledTimes(3)
+  })
+
+  it('throws on an errored backup instead of waiting out the timeout', async () => {
+    await expect(waitForBackupReady(stub(['error']), 'bk-1', { intervalMs: 0, sleep: async () => {} })).rejects.toThrow(/failed/)
+  })
+
+  it('throws once the deadline passes — the delete must not proceed on a stuck backup', async () => {
+    let clock = 0
+    const client = stub(Array(50).fill('creating'))
+
+    await expect(
+      waitForBackupReady(client, 'bk-1', {
+        timeoutMs: 1_000,
+        intervalMs: 400,
+        now: () => clock,
+        sleep: async (ms) => {
+          clock += ms
+        },
+      }),
+    ).rejects.toThrow(/not ready after 1s \(status: creating\)/)
+  })
+})

--- a/infra/lib/scaleway/scaleway-rdb.ts
+++ b/infra/lib/scaleway/scaleway-rdb.ts
@@ -1,0 +1,173 @@
+import type { FetchLike } from '../utils/fetch-like'
+import { type ScwAuth, scwFetch, scwSend } from './scw-fetch'
+
+const RDB_BASE = 'https://api.scaleway.com/rdb/v1'
+
+export interface RdbInstance {
+  id: string
+  name: string
+  status: string
+  engine?: string
+  node_type?: string
+}
+
+export interface RdbDatabase {
+  name: string
+  owner?: string
+  managed?: boolean
+  size?: string
+}
+
+export interface RdbUser {
+  name: string
+  is_admin?: boolean
+}
+
+export interface RdbPrivilege {
+  database_name: string
+  user_name: string
+  permission: string
+}
+
+export interface RdbBackup {
+  id: string
+  name: string
+  status: string
+  database_name: string
+  instance_id?: string
+  size?: string
+  expires_at?: string | null
+}
+
+/** Scaleway's coarse per-database permission. `all` is what `database.ts` declares for both roles. */
+export type RdbPermission = 'readonly' | 'readwrite' | 'all' | 'custom' | 'none'
+
+interface InstanceListResponse {
+  instances: RdbInstance[]
+  total_count: number
+}
+interface DatabaseListResponse {
+  databases: RdbDatabase[]
+  total_count: number
+}
+interface UserListResponse {
+  users: RdbUser[]
+  total_count: number
+}
+interface PrivilegeListResponse {
+  privileges: RdbPrivilege[]
+  total_count: number
+}
+
+export interface RdbClientOptions {
+  secretKey: string
+  region: string
+  fetchImpl?: FetchLike
+}
+
+/**
+ * Minimal Scaleway Managed Database (RDB) client — only the calls the database reset needs.
+ *
+ * Every endpoint below was verified against the live API (via `scw --debug`) rather than taken from
+ * docs, because the reset is destructive and a wrong method or body is not a failure you want to
+ * discover in production.
+ *
+ * Note `deleteDatabase` will succeed on a database that is actively in use, including one with a
+ * held logical replication slot. PostgreSQL itself refuses that ("is used by an active logical
+ * replication slot"); Scaleway's control plane goes through it anyway. There is no interlock — the
+ * caller is responsible for the confirmation, not the platform.
+ */
+export function createRdbClient(opts: RdbClientOptions) {
+  const auth: ScwAuth = { secretKey: opts.secretKey, fetchImpl: opts.fetchImpl }
+  const region = encodeURIComponent(opts.region)
+  const base = `${RDB_BASE}/regions/${region}`
+  const instanceBase = (instanceId: string) => `${base}/instances/${encodeURIComponent(instanceId)}`
+
+  return {
+    /** Exact-name lookup. Returns undefined when no instance matches. */
+    async findInstance(name: string): Promise<RdbInstance | undefined> {
+      const res = await scwFetch<InstanceListResponse>(auth, 'GET', `${base}/instances?name=${encodeURIComponent(name)}`)
+      return res.instances.find((instance) => instance.name === name)
+    },
+
+    async listDatabases(instanceId: string): Promise<RdbDatabase[]> {
+      const res = await scwFetch<DatabaseListResponse>(auth, 'GET', `${instanceBase(instanceId)}/databases`)
+      return res.databases
+    },
+
+    async listUsers(instanceId: string): Promise<RdbUser[]> {
+      const res = await scwFetch<UserListResponse>(auth, 'GET', `${instanceBase(instanceId)}/users`)
+      return res.users
+    },
+
+    async listPrivileges(instanceId: string, databaseName: string): Promise<RdbPrivilege[]> {
+      const url = `${instanceBase(instanceId)}/privileges?database_name=${encodeURIComponent(databaseName)}`
+      const res = await scwFetch<PrivilegeListResponse>(auth, 'GET', url)
+      return res.privileges
+    },
+
+    async createDatabase(instanceId: string, name: string): Promise<RdbDatabase> {
+      return scwFetch<RdbDatabase>(auth, 'POST', `${instanceBase(instanceId)}/databases`, { name })
+    },
+
+    /** Destructive and un-interlocked — see the note on this module. */
+    async deleteDatabase(instanceId: string, name: string): Promise<void> {
+      await scwSend(auth, 'DELETE', `${instanceBase(instanceId)}/databases/${encodeURIComponent(name)}`)
+    },
+
+    /**
+     * Grant a role on a database. Mandatory after a delete+create: deleting a database drops its
+     * privileges, and neither a recreate nor a backup restore brings them back — a per-database
+     * `pg_dump` carries table ACLs but not database-level ones, so `CONNECT` is simply absent and
+     * the app reports `database_unreachable` until this runs.
+     */
+    async setPrivilege(instanceId: string, databaseName: string, userName: string, permission: RdbPermission): Promise<void> {
+      await scwFetch<RdbPrivilege>(auth, 'PUT', `${instanceBase(instanceId)}/privileges`, {
+        database_name: databaseName,
+        user_name: userName,
+        permission,
+      })
+    },
+
+    async createBackup(input: { instanceId: string; databaseName: string; name: string; expiresAt?: string }): Promise<RdbBackup> {
+      return scwFetch<RdbBackup>(auth, 'POST', `${base}/backups`, {
+        instance_id: input.instanceId,
+        database_name: input.databaseName,
+        name: input.name,
+        ...(input.expiresAt ? { expires_at: input.expiresAt } : {}),
+      })
+    },
+
+    async getBackup(backupId: string): Promise<RdbBackup> {
+      return scwFetch<RdbBackup>(auth, 'GET', `${base}/backups/${encodeURIComponent(backupId)}`)
+    },
+  }
+}
+
+export type RdbClient = ReturnType<typeof createRdbClient>
+
+/**
+ * Poll a backup until it reports `ready`. The reset must not proceed on a backup that never
+ * materialised — it is the only undo, and staging has `disableBackup: true` so no automatic
+ * backup exists to fall back on.
+ */
+export async function waitForBackupReady(
+  client: RdbClient,
+  backupId: string,
+  opts: { timeoutMs?: number; intervalMs?: number; now?: () => number; sleep?: (ms: number) => Promise<void> } = {},
+): Promise<RdbBackup> {
+  const timeoutMs = opts.timeoutMs ?? 10 * 60_000
+  const intervalMs = opts.intervalMs ?? 3_000
+  const now = opts.now ?? (() => Date.now())
+  const sleep = opts.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)))
+
+  const deadline = now() + timeoutMs
+  let last: RdbBackup = await client.getBackup(backupId)
+  while (last.status !== 'ready') {
+    if (last.status === 'error') throw new Error(`Backup ${backupId} failed (status: error)`)
+    if (now() >= deadline) throw new Error(`Backup ${backupId} not ready after ${Math.round(timeoutMs / 1000)}s (status: ${last.status})`)
+    await sleep(intervalMs)
+    last = await client.getBackup(backupId)
+  }
+  return last
+}

--- a/infra/resources/database.ts
+++ b/infra/resources/database.ts
@@ -7,8 +7,8 @@ import { privateNetworkId } from './network'
 const dbNodeType = infra.dbNodeType
 const dbVolumeSize = infra.dbVolumeSize
 
-/** Database name derived from slug (e.g. 'cella') */
-const dbSlug = naming.slug.replace(/-/g, '_') // PostgreSQL identifiers can't have hyphens
+/** Database name derived from slug (e.g. 'cella'). Shared with the reset task via `naming`. */
+const dbSlug = naming.dbName
 
 // Passwords: one per role, each from stack config secret or generated.
 

--- a/infra/tasks/README.md
+++ b/infra/tasks/README.md
@@ -44,3 +44,33 @@ tsx infra/tasks/cutover.ts --service backend --sha <git-sha> \
 ```
 
 `SCW_SECRET_KEY` must be set in the environment for the live LB call.
+
+## Database reset: [`reset-database.ts`](./reset-database.ts)
+
+`sequenceDatabaseReset` deletes and recreates the app's logical database over the
+Scaleway RDB API, then re-grants both roles. Like the cutover sequencer it is
+pure — every side effect (instance lookup, backup, delete, create, grant, the
+operator confirmation) arrives on the plan, so the unit tests assert exact step
+order and every guard without touching the network. The live wiring is in
+[`cli/actions/reset-database.ts`](../cli/actions/reset-database.ts) ("Reset
+database" in `pnpm infra`).
+
+The order is the safety property, and the tests pin it: the operator's typed
+`<database>@<instance>` confirmation and a backup reporting `ready` both precede
+the delete. Everything before the delete is a guard and fails harmlessly;
+everything after is recovery-critical and rethrows as `ResetIrrecoverableError`,
+carrying the backup id and printing the `scw rdb backup restore` command — plus
+the two `privilege set` calls, because a restore does not bring privileges back.
+
+The API surface (`lib/scaleway/scaleway-rdb.ts`) was captured from the live API
+with `scw --debug` rather than read from docs: a wrong verb or body on a
+destructive call is not something to discover in production. The tests assert
+each URL and method for that reason.
+
+Two steps are deliberately not automated — `migrate` is `restart: 'no'` in
+compose, cloud-init is first-boot only, and the boot-replay unit merely cats a
+log, so no reboot re-runs migrations. `serialConsoleSteps()` prints them.
+
+Scaleway deletes a database that is actively in use, including one holding a
+logical replication slot, which PostgreSQL itself refuses. There is no platform
+interlock; the confirmation is the only one.

--- a/infra/tasks/reset-database.test.ts
+++ b/infra/tasks/reset-database.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RdbBackup, RdbDatabase, RdbInstance } from '../lib/scaleway/scaleway-rdb'
+import { backupName, ResetIrrecoverableError, type ResetDatabasePlan, sequenceDatabaseReset, serialConsoleSteps } from './reset-database'
+
+const INSTANCE: RdbInstance = { id: 'inst-1', name: 'cella-postgres', status: 'ready' }
+const DATABASES: RdbDatabase[] = [{ name: 'cella' }, { name: 'rdb' }]
+const BACKUP: RdbBackup = { id: 'bk-1', name: 'pre-reset-cella', status: 'ready', database_name: 'cella' }
+
+/** A plan whose effects all succeed, recording call order into `calls`. */
+function makePlan(overrides: Partial<ResetDatabasePlan> = {}) {
+  const calls: string[] = []
+  const plan: ResetDatabasePlan = {
+    instanceName: 'cella-postgres',
+    databaseName: 'cella',
+    roles: ['admin_role', 'runtime_role'],
+    permission: 'all',
+    backupName: 'pre-reset-cella',
+
+    findInstance: vi.fn(async () => {
+      calls.push('findInstance')
+      return INSTANCE
+    }),
+    listDatabases: vi.fn(async () => {
+      calls.push('listDatabases')
+      return DATABASES
+    }),
+    confirm: vi.fn(async () => {
+      calls.push('confirm')
+      return true
+    }),
+    createBackup: vi.fn(async () => {
+      calls.push('createBackup')
+      return { ...BACKUP, status: 'creating' }
+    }),
+    waitForBackup: vi.fn(async () => {
+      calls.push('waitForBackup')
+      return BACKUP
+    }),
+    deleteDatabase: vi.fn(async () => {
+      calls.push('deleteDatabase')
+    }),
+    createDatabase: vi.fn(async () => {
+      calls.push('createDatabase')
+      return { name: 'cella' }
+    }),
+    setPrivilege: vi.fn(async (_i: string, _d: string, user: string) => {
+      calls.push(`setPrivilege:${user}`)
+    }),
+    log: () => {},
+    ...overrides,
+  }
+  return { plan, calls }
+}
+
+describe('sequenceDatabaseReset', () => {
+  it('backs up before deleting, then recreates and re-grants every role', async () => {
+    const { plan, calls } = makePlan()
+
+    const result = await sequenceDatabaseReset(plan)
+
+    // Order is the safety property: confirm and a ready backup both precede the delete.
+    expect(calls).toEqual([
+      'findInstance',
+      'listDatabases',
+      'confirm',
+      'createBackup',
+      'waitForBackup',
+      'deleteDatabase',
+      'createDatabase',
+      'setPrivilege:admin_role',
+      'setPrivilege:runtime_role',
+    ])
+    expect(result).toMatchObject({ instanceId: 'inst-1', backupId: 'bk-1', granted: ['admin_role', 'runtime_role'] })
+  })
+
+  it('destroys nothing when the operator declines', async () => {
+    const { plan, calls } = makePlan({ confirm: vi.fn(async () => false) })
+
+    const result = await sequenceDatabaseReset(plan)
+
+    expect(result.aborted).toBe('declined')
+    expect(calls).not.toContain('createBackup')
+    expect(calls).not.toContain('deleteDatabase')
+    expect(plan.deleteDatabase).not.toHaveBeenCalled()
+  })
+
+  it('never deletes when the backup fails to become ready', async () => {
+    const { plan } = makePlan({
+      waitForBackup: vi.fn(async () => {
+        throw new Error('Backup bk-1 failed (status: error)')
+      }),
+    })
+
+    await expect(sequenceDatabaseReset(plan)).rejects.toThrow(/Backup bk-1 failed/)
+    expect(plan.deleteDatabase).not.toHaveBeenCalled()
+  })
+
+  it('refuses an unknown instance before touching anything', async () => {
+    const { plan } = makePlan({ findInstance: vi.fn(async () => undefined) })
+
+    await expect(sequenceDatabaseReset(plan)).rejects.toThrow(/No managed database instance named 'cella-postgres'/)
+    expect(plan.confirm).not.toHaveBeenCalled()
+    expect(plan.deleteDatabase).not.toHaveBeenCalled()
+  })
+
+  it('refuses an instance that is not ready', async () => {
+    const { plan } = makePlan({ findInstance: vi.fn(async () => ({ ...INSTANCE, status: 'backuping' })) })
+
+    await expect(sequenceDatabaseReset(plan)).rejects.toThrow(/is 'backuping', not 'ready'/)
+    expect(plan.confirm).not.toHaveBeenCalled()
+  })
+
+  it('refuses when the target database is absent, naming what it did find', async () => {
+    // Guards against a right-instance/wrong-name reset silently creating a new empty database.
+    const { plan } = makePlan({ listDatabases: vi.fn(async () => [{ name: 'rdb' }]) })
+
+    await expect(sequenceDatabaseReset(plan)).rejects.toThrow(/has no database 'cella' \(found: rdb\)/)
+    expect(plan.confirm).not.toHaveBeenCalled()
+  })
+
+  it('shows the operator the exact token and every database on the instance', async () => {
+    const confirm = vi.fn(async () => true)
+    const { plan } = makePlan({ confirm })
+
+    await sequenceDatabaseReset(plan)
+
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ token: 'cella@cella-postgres', instanceId: 'inst-1', databases: DATABASES }),
+    )
+  })
+
+  it('surfaces the backup id when the database is gone and cannot be rebuilt', async () => {
+    const { plan } = makePlan({
+      createDatabase: vi.fn(async () => {
+        throw new Error('quota exceeded')
+      }),
+    })
+
+    // The one unrecoverable window: deleted, not recreated. The error must carry the way back.
+    const error = await sequenceDatabaseReset(plan).catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(ResetIrrecoverableError)
+    expect(error).toMatchObject({ backupId: 'bk-1', instanceId: 'inst-1', databaseName: 'cella' })
+    expect((error as Error).message).toMatch(/quota exceeded/)
+  })
+
+  it('treats a failed re-grant as unrecoverable — an ungranted database is an outage', async () => {
+    const { plan } = makePlan({
+      setPrivilege: vi.fn(async (_i: string, _d: string, user: string) => {
+        if (user === 'runtime_role') throw new Error('boom')
+      }),
+    })
+
+    const error = await sequenceDatabaseReset(plan).catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(ResetIrrecoverableError)
+    expect((error as ResetIrrecoverableError).backupId).toBe('bk-1')
+  })
+
+  it('keeps a failed delete a plain error — nothing was destroyed', async () => {
+    const { plan } = makePlan({
+      deleteDatabase: vi.fn(async () => {
+        throw new Error('403 forbidden')
+      }),
+    })
+
+    const error = await sequenceDatabaseReset(plan).catch((e: unknown) => e)
+    expect(error).not.toBeInstanceOf(ResetIrrecoverableError)
+    expect((error as Error).message).toMatch(/Failed to delete 'cella'.*403 forbidden/)
+  })
+})
+
+describe('serialConsoleSteps', () => {
+  it('prints the two steps the CLI cannot run, and no worker restart', () => {
+    const steps = serialConsoleSteps('cella')
+
+    expect(steps).toContain('docker compose --profile backend run --rm migrate')
+    expect(steps).toContain('dist/seeds-bundle.js init')
+    // The slot is re-ensured on every retry, so a restart would be cargo cult.
+    expect(steps).toMatch(/no restart/i)
+  })
+})
+
+describe('backupName', () => {
+  it('stamps the backup so the list sorts chronologically', () => {
+    expect(backupName('cella', new Date('2026-07-17T13:45:12.345Z'))).toBe('pre-reset-cella-20260717-1345')
+  })
+
+  it('names the database it belongs to, so a multi-database instance stays legible', () => {
+    expect(backupName('cella_staging', new Date('2026-01-02T03:04:05.000Z'))).toBe('pre-reset-cella_staging-20260102-0304')
+  })
+})

--- a/infra/tasks/reset-database.ts
+++ b/infra/tasks/reset-database.ts
@@ -1,0 +1,199 @@
+import { pc } from 'shared/cli-utils/colors'
+import { checkMark, crossMark, warningMark } from 'shared/utils/console'
+import type { RdbBackup, RdbDatabase, RdbInstance, RdbPermission } from '../lib/scaleway/scaleway-rdb'
+
+/**
+ * Wipe the managed database's *contents* by deleting and recreating the logical database over the
+ * Scaleway API, then re-granting both roles. For large rewrites, where replaying migration history
+ * is not worth it and a clean baseline is.
+ *
+ * Why the control plane and not SQL inside the database: every database on the instance is owned by
+ * `_rdb_superadmin`, so `admin_role` cannot drop `SCHEMA public`; and reaching the database at all
+ * from outside means exposing it. The API needs neither.
+ *
+ * Why delete+create under the SAME name rather than a new one: Scaleway's resource IDs are
+ * name-derived (`{region}/{instance_id}/{DBNAME}`, and `{…}/{db}/{user}` for privileges), so a
+ * same-name recreate yields identical IDs and Pulumi's state stays correct — no `pulumi up`, no
+ * generation bump, no secret churn, no VM roll.
+ *
+ * The migrate and seed steps cannot be automated from here: `migrate` is `restart: 'no'` in
+ * compose, cloud-init is first-boot only, and the boot-replay unit merely cats a log — so no reboot
+ * re-runs migrations. They are printed for the operator to run on the serial console.
+ *
+ * The sequencer is pure: every side effect arrives on the plan, so the unit tests assert exact step
+ * order and the guards without touching the network.
+ *
+ * @see .todos/DB_RESET_DESIGN.md — measured constraints behind each step.
+ */
+
+/** What the operator is asked to confirm — resolved from the live API, not from config. */
+export interface ResetTarget {
+  instanceName: string
+  instanceId: string
+  databaseName: string
+  /** Every database on the instance, so a wrong instance is visible before anything is destroyed. */
+  databases: RdbDatabase[]
+  /** `<database>@<instance>` — the exact string the operator must type. */
+  token: string
+}
+
+export interface ResetDatabasePlan {
+  instanceName: string
+  databaseName: string
+  /** Roles re-granted after the recreate. Both must succeed or the app stays down. */
+  roles: readonly string[]
+  permission: RdbPermission
+  backupName: string
+  backupExpiresAt?: string
+
+  // Injected effects
+  findInstance: (name: string) => Promise<RdbInstance | undefined>
+  listDatabases: (instanceId: string) => Promise<RdbDatabase[]>
+  createBackup: (input: { instanceId: string; databaseName: string; name: string; expiresAt?: string }) => Promise<RdbBackup>
+  waitForBackup: (backupId: string) => Promise<RdbBackup>
+  deleteDatabase: (instanceId: string, name: string) => Promise<void>
+  createDatabase: (instanceId: string, name: string) => Promise<RdbDatabase>
+  setPrivilege: (instanceId: string, databaseName: string, userName: string, permission: RdbPermission) => Promise<void>
+  /** Typed confirmation. Returning false aborts before anything is touched. */
+  confirm: (target: ResetTarget) => Promise<boolean>
+  log: (message: string) => void
+}
+
+export interface ResetDatabaseResult {
+  instanceId: string
+  backupId: string
+  granted: string[]
+  aborted?: 'declined'
+}
+
+/** Thrown once the database is gone, carrying the backup needed to put it back. */
+export class ResetIrrecoverableError extends Error {
+  constructor(
+    message: string,
+    readonly backupId: string,
+    readonly instanceId: string,
+    readonly databaseName: string,
+  ) {
+    super(message)
+    this.name = 'ResetIrrecoverableError'
+  }
+}
+
+/**
+ * Order the reset over injected effects.
+ *
+ * Everything before the delete is a guard; everything after is recovery-critical. Nothing mutates
+ * before `confirm` returns true, and the delete never runs until a backup reports `ready` — it is
+ * the only undo, and staging has `disableBackup: true`, so no automatic backup exists to fall back
+ * on. Failures after the delete rethrow as {@link ResetIrrecoverableError} carrying the backup id.
+ */
+export async function sequenceDatabaseReset(plan: ResetDatabasePlan): Promise<ResetDatabaseResult> {
+  const instance = await plan.findInstance(plan.instanceName)
+  if (!instance) throw new Error(`No managed database instance named '${plan.instanceName}' in this region/project.`)
+  if (instance.status !== 'ready') {
+    throw new Error(`Instance '${plan.instanceName}' is '${instance.status}', not 'ready' — refusing to reset.`)
+  }
+
+  const databases = await plan.listDatabases(instance.id)
+  if (!databases.some((database) => database.name === plan.databaseName)) {
+    throw new Error(
+      `Instance '${plan.instanceName}' has no database '${plan.databaseName}' (found: ${databases.map((d) => d.name).join(', ') || 'none'}).`,
+    )
+  }
+
+  const target: ResetTarget = {
+    instanceName: plan.instanceName,
+    instanceId: instance.id,
+    databaseName: plan.databaseName,
+    databases,
+    token: `${plan.databaseName}@${plan.instanceName}`,
+  }
+
+  if (!(await plan.confirm(target))) {
+    plan.log('Aborted; nothing was touched.')
+    return { instanceId: instance.id, backupId: '', granted: [], aborted: 'declined' }
+  }
+
+  plan.log(`Backing up ${plan.databaseName}...`)
+  const created = await plan.createBackup({
+    instanceId: instance.id,
+    databaseName: plan.databaseName,
+    name: plan.backupName,
+    expiresAt: plan.backupExpiresAt,
+  })
+  const backup = await plan.waitForBackup(created.id)
+  plan.log(`${checkMark} Backup ready: ${backup.name} (${backup.id})`)
+
+  // --- past here the database is being destroyed; failures are recoverable only from `backup` ---
+
+  try {
+    await plan.deleteDatabase(instance.id, plan.databaseName)
+    plan.log(`${checkMark} Deleted database ${plan.databaseName}`)
+  } catch (error) {
+    // Nothing was destroyed if the delete itself failed, so this stays a normal error.
+    throw new Error(`Failed to delete '${plan.databaseName}': ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  try {
+    await plan.createDatabase(instance.id, plan.databaseName)
+    plan.log(`${checkMark} Created empty database ${plan.databaseName}`)
+
+    // Mandatory: deleting the database dropped its privileges. Neither the recreate nor a restore
+    // brings them back, and without them the app reports `database_unreachable`.
+    const granted: string[] = []
+    for (const role of plan.roles) {
+      await plan.setPrivilege(instance.id, plan.databaseName, role, plan.permission)
+      granted.push(role)
+      plan.log(`${checkMark} Granted ${plan.permission} on ${plan.databaseName} to ${role}`)
+    }
+
+    return { instanceId: instance.id, backupId: backup.id, granted }
+  } catch (error) {
+    throw new ResetIrrecoverableError(
+      `${plan.databaseName} was deleted but could not be rebuilt: ${error instanceof Error ? error.message : String(error)}`,
+      backup.id,
+      instance.id,
+      plan.databaseName,
+    )
+  }
+}
+
+/** e.g. `pre-reset-cella-20260717-1345` — sorts chronologically in the backup list. */
+export function backupName(databaseName: string, now: Date): string {
+  const stamp = now.toISOString().replace(/[-:]/g, '').replace('T', '-').slice(0, 13)
+  return `pre-reset-${databaseName}-${stamp}`
+}
+
+/** The two steps the CLI cannot run: they need the image on the VM, over the serial console. */
+export function serialConsoleSteps(databaseName: string): string {
+  return [
+    `${warningMark} ${pc.bold('Two steps remain, on the Scaleway serial console')} ${pc.dim(`(${databaseName} is empty until they run)`)}:`,
+    '',
+    `  ${pc.dim('# 1. schema — self-verifying since the 99-verify block; a bad migrate aborts loudly')}`,
+    `  cd /opt/app && docker compose --profile backend run --rm migrate`,
+    '',
+    `  ${pc.dim('# 2. first admin — signs in by magic link')}`,
+    `  cd /opt/app && docker compose --profile backend run --rm \\`,
+    `    -e ADMIN_EMAIL=you@example.com migrate node dist/seeds-bundle.js init`,
+    '',
+    `  ${pc.dim('The CDC worker needs no restart: it re-ensures its replication slot on every retry.')}`,
+  ].join('\n')
+}
+
+/** Recovery instructions, printed when the database is gone and could not be rebuilt. */
+export function restoreHint(error: ResetIrrecoverableError, region: string): string {
+  return [
+    `${crossMark} ${pc.red(pc.bold('The database was deleted and NOT rebuilt.'))}`,
+    `  ${error.message}`,
+    '',
+    `  ${pc.bold('Restore it from the backup taken moments ago:')}`,
+    `  scw rdb backup restore ${error.backupId} instance-id=${error.instanceId} \\`,
+    `    database-name=${error.databaseName} region=${region}`,
+    '',
+    `  ${pc.dim('Then re-grant both roles — a restore does not bring privileges back:')}`,
+    `  scw rdb privilege set instance-id=${error.instanceId} region=${region} \\`,
+    `    database-name=${error.databaseName} user-name=admin_role permission=all`,
+    `  scw rdb privilege set instance-id=${error.instanceId} region=${region} \\`,
+    `    database-name=${error.databaseName} user-name=runtime_role permission=all`,
+  ].join('\n')
+}


### PR DESCRIPTION
Adds **Reset database** to `pnpm infra`: wipe the app's managed database and rebuild it from migrations + the admin seed. For large rewrites, where replaying migration history is not worth it and a clean baseline is. Pre-production, or with services quiesced — this is a hard outage.

## What it does

Backup → delete + create (same name) → re-grant both roles, all over the Scaleway RDB API with a bootstrap key. Then it prints the two steps it cannot run, for the serial console: `migrate` and the admin seed.

The database is never exposed and `pulumi up` is never run.

## Why the control plane, and why the same name

Every database on the instance is owned by `_rdb_superadmin`, so `admin_role` cannot drop `SCHEMA public` — an in-database reset was never viable. And reaching the database from outside would mean opening a public endpoint.

Same-name recreate keeps Pulumi's state correct **on its own**: Scaleway's resource IDs are name-derived (`{region}/{instance_id}/{DBNAME}`, and `{…}/{db}/{user}` for privileges), so identical names yield identical IDs. No `pulumi up`, no generation bump, no secret churn, no VM roll.

## Three things that are measured, not assumed

Established by deleting and restoring the live `cella` database (see [`.todos/DB_RESET_DESIGN.md`](.todos/DB_RESET_DESIGN.md)):

- **There is no interlock.** Scaleway deletes a live database with connected clients and an active replication slot — PostgreSQL itself refuses that. Maintenance mode is a convention, so the typed `<database>@<instance>` confirmation is the only guard, and the task owns it.
- **Re-granting is mandatory.** Deleting a database drops its Scaleway privileges, and neither a recreate nor a *backup restore* returns them: a per-database `pg_dump` carries table ACLs but not database-level ones, so `CONNECT` is absent and the app reports `database_unreachable`. This is why re-grant is a task step and not an operator instruction.
- **The CDC worker needs no restart** — it re-ensures its slot on every retry (verified against a live worker: slot dropped underneath it, recreated and reattached in ~700ms).

## Safety

The sequencer is pure — every side effect arrives on the plan, following `cutover.ts` — so the tests assert exact step order and each guard without touching the network.

- The typed confirmation and a backup reporting `ready` **both precede the delete**. Backups matter here: staging has `disableBackup: true`, so no automatic backup exists to fall back on.
- Everything before the delete is a guard and fails harmlessly.
- Everything after rethrows as `ResetIrrecoverableError`, carrying the backup id and printing the `scw rdb backup restore` command **plus** the two `privilege set` calls a restore does not perform.
- The target is shown with every database on the instance, so a wrong-instance reset is visible before anything is destroyed.

The two mutations that matter are caught: ignoring the operator's decline fails 1 test, skipping the backup-readiness gate fails 2.

## Notes for review

- **The RDB client's endpoints were captured from the live API with `scw --debug`**, not read from docs — a wrong verb or body on a destructive call is not something to discover in production. The tests pin each URL and method.
- **`naming.dbName` is now shared.** `resources/database.ts` creates that database and the task deletes it *by name*; separate derivations could drift and address the wrong database, or create a second empty one alongside the real one.
- Migrate/seed stay manual by necessity: `migrate` is `restart: 'no'` in compose, cloud-init is first-boot only, and the boot-replay unit merely cats a log — so no reboot re-runs migrations.

## Testing

- `pnpm --filter infra test` — 477 passing (33 new).
- `pnpm ts` clean repo-wide (`naming.ts` feeds the Pulumi program).
- `infra/` is outside biome's `includes`, like `cdc/`.
- The task itself has **not** been run end-to-end against a live instance; its primitives were each verified individually during the investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)