### PR TITLE
fix(test): drop the impossible ON CONFLICT arbiter on partitioned seen_by

### DIFF
--- a/backend/tests/integration/rls-security.test.ts
+++ b/backend/tests/integration/rls-security.test.ts
@@ -722,10 +722,13 @@ const rlsSuiteReady = await (async () => {
     it('drops the count once the entity is marked seen', async () => {
       if (!rolesAvailable || !requiredTablesAvailable || !seenByAvailable) return;
       const seenId = '00000000-0000-4000-a000-0000000000a1';
+      // No ON CONFLICT arbiter: seen_by is partitioned by created_at, so a unique index on
+      // (user_id, entity_id) cannot exist — every unique index on a partitioned table must carry
+      // the partition column. mark-seen dedups with NOT EXISTS for the same reason. A plain insert
+      // is right here anyway: the row is a fixture with a fixed id, dropped again in `finally`.
       await adminDb.execute(sql`
         INSERT INTO seen_by (id, user_id, entity_id, entity_type, channel_id, organization_id, tenant_id, created_at)
         VALUES (${seenId}, ${TEST_USER_A}, ${TEST_ATTACHMENT_A}, 'attachment', ${TEST_ORG_A}, ${TEST_ORG_A}, ${TEST_TENANT_A}, NOW())
-        ON CONFLICT (user_id, entity_id) DO NOTHING
       `);
       try {
         const rows = await queryAsRuntimeRole<UnseenRow>(TEST_TENANT_A, TEST_USER_A, countUnseen);


### PR DESCRIPTION
Fixes the `test` job, which has been failing on every PR since #905 landed.

## The failure

`backend/tests/integration/rls-security.test.ts > drops the count once the entity is marked seen`

```
INSERT INTO seen_by (...) ON CONFLICT (user_id, entity_id) DO NOTHING
error: there is no unique or exclusion constraint matching the ON CONFLICT specification  (42P10)
```

`seen_by` is partitioned by `created_at`, and every unique index on a partitioned table must carry the partition column — so a `(user_id, entity_id)` arbiter cannot exist, and Postgres rejects the statement outright.

This was the **last stale caller** of that arbiter. #905 removed the impossible `seen_by_user_entity_unique` from the schema and moved `mark-seen` to `NOT EXISTS` dedup for exactly this reason; this test fixture was missed.

## The failure is evidence that #905 worked

Worth spelling out, because it looks like #905 broke something when it actually fixed something:

Before #905, the impossible unique constraint made partman's conversion fail — **silently**, inside its `EXCEPTION WHEN OTHERS` — which left `seen_by` an unpartitioned plain table that still carried the unique. The arbiter resolved, and the test passed. Removing the constraint let the conversion actually succeed, and the arbiter went with it.

Verified on a current database:

| | |
|---|---|
| `seen_by` relkind | `p` — partitioned |
| constraints | only `seen_by_pkey (id, created_at)` |
| `(user_id, entity_id)` | plain index, no unique |

## No production deploy risk

I checked, since #905 turned that silent skip into a `RAISE EXCEPTION` (partman guard 1b: a non-PK unique aborts the conversion). An existing database still carrying `seen_by_user_entity_unique` would therefore abort the migration.

It doesn't: #905's schema-diff migration `20260717100121_careful_maggott` drops the constraint and creates the plain index, and it sorts **before** `20260717103742_side_effects`, so partman's guard sees a clean table.

## The fix

Drop the `ON CONFLICT` clause. A plain insert is correct here regardless — the row is a fixture with a fixed id, deleted again in `finally`.

## Testing

- `pnpm test:full` — **201 files, 1801 passing** (was `1 failed | 1826 passed`).
- The test is still meaningful, not vacuously green: stubbing the fixture insert to a no-op makes it fail.

## Note

`ci.yml` is `on: pull_request` only, so `main` is never tested directly — which is how this reached `main` unnoticed. Might be worth a scheduled or push-triggered run on `main`; happy to do it separately if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
