### PR TITLE
refactor(query): key canonical lists by home channel, replacing ances…

### DIFF
--- a/frontend/src/modules/attachment/query.ts
+++ b/frontend/src/modules/attachment/query.ts
@@ -94,9 +94,9 @@ export const attachmentsListQueryOptions = (params: AttachmentsListParams) => {
 };
 
 /**
- * Canonical attachment query: one flat query per org (keys.list.org), fetching all its attachments.
- * Consumers derive views via select() for groupId filtering. Sync (SSE + delta fetch) keeps it
- * fresh; staleTime follows sync liveness.
+ * Canonical attachment query: one flat home list per org (keys.list.home — attachments are
+ * org-homed), fetching all its attachments. Consumers derive views via select() for groupId
+ * filtering. Sync (SSE + delta fetch) keeps it fresh; staleTime follows sync liveness.
  */
 export const attachmentsCanonicalOptions = ({
   organizationId,
@@ -106,7 +106,7 @@ export const attachmentsCanonicalOptions = ({
   tenantId: string;
 }) => {
   return queryOptions({
-    queryKey: keys.list.org(organizationId),
+    queryKey: keys.list.home(organizationId),
     queryFn: async () => {
       return fetchAllPages(
         ({ limit, offset }) =>

--- a/frontend/src/query/basic/create-query-keys.ts
+++ b/frontend/src/query/basic/create-query-keys.ts
@@ -1,4 +1,4 @@
-import { appConfig, type EntityType, hierarchy } from 'shared';
+import type { EntityType } from 'shared';
 
 type StandardEntityKeys<
   E extends EntityType,
@@ -8,14 +8,12 @@ type StandardEntityKeys<
   all: [E];
   list: {
     base: [E, 'list'];
-    /** Org-scoped prefix: prefix-matches all list queries for one org */
+    /** Org-scoped prefix: prefix-matches all list queries for one org. A scan/invalidation prefix, never a data key. */
     org: (organizationId: string) => [E, 'list', string];
     /** List key qualified with filters (default: no org segment) */
     filtered: (filters: LF) => [E, 'list', LF];
-    /** Canonical scope key: args are hierarchy ancestor IDs (root-first) */
-    scope: (...ancestorIds: string[]) => readonly [E, 'list', ...string[]];
-    /** Ancestor ID column keys in root-first order, e.g. ['organizationId', 'projectId'] for task */
-    scopeKeys: readonly string[];
+    /** Canonical home list: one flat list per home channel (org-homed rows: omit homeChannelId) */
+    home: (organizationId: string, homeChannelId?: string) => [E, 'list', string, string];
   };
   detail: {
     base: [E, 'detail'];
@@ -28,10 +26,10 @@ type StandardEntityKeys<
 
 /**
  * True when a list view's filters all sit at their defaults (absent, empty, or equal). The
- * signal to serve the view from the entity's canonical scope query, which live sync keeps
+ * signal to serve the view from the entity's canonical home list, which live sync keeps
  * fresh and splices creates into. Filtered queries can only be invalidated.
  *
- * Only valid for entities whose default list response IS the unfiltered scope: delta rows
+ * Only valid for entities whose default list response IS the unfiltered home list: delta rows
  * must be row-identical to default-list rows. Fork feeds with implicit server-side filters
  * (e.g. draft exclusion) must keep their filtered keys and not adopt this.
  */
@@ -43,31 +41,34 @@ export function isDefaultListView(filters: Record<string, unknown>, defaults: Re
 
 /**
  * Standardized query keys for an entity module. Key hierarchy (prefix-matchable):
- *   [entity, 'list']                              broadest (all queries)
- *   [entity, 'list', organizationId]              all queries for one org
- *   [entity, 'list', organizationId, projectId]  canonical scope: the base list live sync patches (product entities)
- *   [entity, 'list', organizationId, {filters}]  specific filtered query
+ *   [entity, 'list']                                 broadest (all queries)
+ *   [entity, 'list', organizationId]                 all queries for one org (a prefix, never a data key)
+ *   [entity, 'list', organizationId, homeChannelId]  canonical home list: the one list live sync splices into
+ *   [entity, 'list', organizationId, {filters}]      specific filtered query (invalidation-synced)
  *
- * Scope ancestors derived from hierarchy-config: task -> scope(organizationId, projectId), page -> scope().
- * `list.scopeKeys` exposes ancestor ID column names for entity-agnostic scope derivation.
+ * The cache is keyed the way SSE is routed: every row belongs to exactly one canonical home
+ * list, its effective home channel's (deepest non-null ancestor; the org itself for org-homed
+ * rows — see resolve-row-channel). Views derive from the home list via select(). Any list that
+ * spans home channels or applies server-side filters is a filtered key: live sync cannot
+ * splice rows into it and invalidates it instead.
  */
 export function createEntityKeys<
   LF extends object,
   SID extends string | number = string,
   E extends EntityType = EntityType,
 >(entityType: E): StandardEntityKeys<E, LF, SID> {
-  // Derive scope ancestors from hierarchy (reverse to root-first order for key segments)
-  const ancestors = [...hierarchy.getOrderedAncestors(entityType)].reverse();
-  const scopeKeys = Object.freeze(ancestors.map((a) => appConfig.entityIdColumnKeys[a as EntityType]));
-
   return {
     all: [entityType],
     list: {
       base: [entityType, 'list'],
       org: (organizationId: string) => [entityType, 'list', organizationId],
       filtered: (filters: LF) => [entityType, 'list', filters],
-      scope: (...ancestorIds: string[]) => [entityType, 'list', ...ancestorIds] as const,
-      scopeKeys,
+      home: (organizationId: string, homeChannelId?: string) => [
+        entityType,
+        'list',
+        organizationId,
+        homeChannelId ?? organizationId,
+      ],
     },
     detail: {
       base: [entityType, 'detail'],

--- a/frontend/src/query/basic/entity-query-registry.ts
+++ b/frontend/src/query/basic/entity-query-registry.ts
@@ -1,4 +1,4 @@
-import { appConfig, type EntityType, hierarchy } from 'shared';
+import type { EntityType } from 'shared';
 import type { ItemData } from '~/query/basic/types';
 
 /** Minimal query keys interface needed by stream handlers. */
@@ -6,10 +6,8 @@ export interface EntityQueryKeys {
   list: {
     base: readonly unknown[];
     org: (organizationId: string) => readonly unknown[];
-    /** Canonical scope key: args are hierarchy ancestor IDs (root-first) */
-    scope: (...ancestorIds: string[]) => readonly unknown[];
-    /** Ancestor ID column keys in root-first order, e.g. ['organizationId', 'projectId'] for task */
-    scopeKeys: readonly string[];
+    /** Canonical home list key: one flat list per home channel (org-homed rows: omit homeChannelId) */
+    home: (organizationId: string, homeChannelId?: string) => readonly unknown[];
   };
   detail: { base: readonly unknown[]; byId: (id: string) => readonly unknown[] };
 }
@@ -47,29 +45,17 @@ const deltaFetchRegistry = new Map<string, DeltaFetchFn>();
  * Register query keys for an entity type at module init. Optional `deltaFetch` lets the catchup
  * processor fetch only changed entities via `seqCursor`, avoiding a full list refetch.
  *
- * Sub-org-homed entities must expose their home channel's id column in `list.scopeKeys`. Viewing
- * detection (`observed-channels.ts`) derives "this channel is on screen" from observed list keys,
- * and keys that cannot carry the channel id would silently demote every on-screen scope to the
- * background sync tier. Keys built with `createEntityKeys` always satisfy this; the throw exists
- * for hand-rolled keys, at module load so it cannot reach production.
+ * Canonical list data must live at `keys.list.home(orgId, homeChannelId)`: live sync splices
+ * new rows only into a row's home list, and viewing detection (`observed-channels.ts`) derives
+ * "this channel is on screen" from the channel id segment in observed list keys. Keys built
+ * with `createEntityKeys` carry both by construction; cache-ops warns at runtime when a fetched
+ * new row lands in no cache (the symptom of a hand-rolled key shape).
  */
 export function registerEntityQueryKeys(
   entityType: EntityType,
   keys: EntityQueryKeys,
   deltaFetch?: DeltaFetchFn,
 ): void {
-  const ancestors = hierarchy.getOrderedAncestors(entityType);
-  const homeChannel = ancestors[0];
-  if (homeChannel && homeChannel !== ancestors[ancestors.length - 1]) {
-    const column = (appConfig.entityIdColumnKeys as Record<string, string>)[homeChannel];
-    if (column && !keys.list.scopeKeys.includes(column)) {
-      throw new Error(
-        `Query keys for '${entityType}' lack home channel column '${column}' in list.scopeKeys — ` +
-          `viewing detection cannot see '${homeChannel}' scopes. Use createEntityKeys or add the column.`,
-      );
-    }
-  }
-
   entityQueryKeysRegistry.set(entityType, keys);
   if (deltaFetch) deltaFetchRegistry.set(entityType, deltaFetch);
 }

--- a/frontend/src/query/realtime/cache-ops.test.ts
+++ b/frontend/src/query/realtime/cache-ops.test.ts
@@ -1,12 +1,29 @@
+import type { EntityType } from 'shared';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+// Synthetic sub-org topology: 'task' is a product homed at the `project` channel so home-list
+// placement (deepest non-null ancestor) is exercised; base cella only has org-homed attachments.
 vi.mock('shared', () => ({
   appConfig: {
-    channelEntityTypes: ['organization'],
-    entityIdColumnKeys: { organization: 'organizationId' },
+    channelEntityTypes: ['organization', 'project'],
+    entityIdColumnKeys: { organization: 'organizationId', project: 'projectId' },
   },
   hierarchy: {
-    getOrderedAncestors: () => ['organization'],
+    getOrderedAncestors: (entityType: string) => {
+      if (entityType === 'task') return ['project', 'organization'];
+      return ['organization'];
+    },
+  },
+  resolveDeepestAncestorId: (
+    hierarchy: { getOrderedAncestors: (entityType: string) => readonly string[] },
+    entityType: string,
+    row: Record<string, unknown>,
+  ) => {
+    for (const type of hierarchy.getOrderedAncestors(entityType)) {
+      const id = row[`${type}Id`];
+      if (typeof id === 'string' && id) return id;
+    }
+    return null;
   },
 }));
 
@@ -30,9 +47,13 @@ const { registerEntityQueryKeys } = await import('~/query/basic/entity-query-reg
 const { queryClient } = await import('~/query/query-client');
 const { fetchRangeAndPatch } = await import('./cache-ops');
 
+// The synthetic 'task' type exists only in this file's shared mock, hence the cast.
+const TASK = 'task' as EntityType;
+
 describe('realtime cache ops', () => {
   afterEach(() => {
     queryClient.clear();
+    vi.restoreAllMocks();
   });
 
   it('removes tombstone rows returned by seq range fetch', async () => {
@@ -49,7 +70,7 @@ describe('realtime cache ops', () => {
     }));
 
     queryClient.setQueryData(keys.detail.byId('attachment-1'), { id: 'attachment-1', organizationId: 'org-1' });
-    queryClient.setQueryData(keys.list.org('org-1'), {
+    queryClient.setQueryData(keys.list.home('org-1'), {
       items: [{ id: 'attachment-1', organizationId: 'org-1' }],
       total: 1,
     });
@@ -58,17 +79,17 @@ describe('realtime cache ops', () => {
 
     expect(status).toBe('ok');
     expect(queryClient.getQueryData(keys.detail.byId('attachment-1'))).toBeUndefined();
-    expect(queryClient.getQueryData(keys.list.org('org-1'))).toEqual({ items: [], total: 0 });
+    expect(queryClient.getQueryData(keys.list.home('org-1'))).toEqual({ items: [], total: 0 });
   });
 
-  it('inserts a brand-new row into the canonical scope list and bumps total', async () => {
+  it('inserts a brand-new row into the canonical home list and bumps total', async () => {
     const keys = createEntityKeys<Record<string, never>>('attachment');
     registerEntityQueryKeys('attachment', keys, async () => ({
       items: [{ id: 'attachment-2', organizationId: 'org-1', name: 'fresh' }],
       total: 1,
     }));
 
-    queryClient.setQueryData(keys.list.org('org-1'), {
+    queryClient.setQueryData(keys.list.home('org-1'), {
       items: [{ id: 'attachment-1', organizationId: 'org-1' }],
       total: 1,
     });
@@ -76,9 +97,64 @@ describe('realtime cache ops', () => {
     const { status } = await fetchRangeAndPatch('attachment', 'org-1', 'tenant-1', '7,7', keys);
 
     expect(status).toBe('ok');
-    const list = queryClient.getQueryData<{ items: { id: string }[]; total: number }>(keys.list.org('org-1'));
+    const list = queryClient.getQueryData<{ items: { id: string }[]; total: number }>(keys.list.home('org-1'));
     expect(list?.items.map((i) => i.id)).toEqual(['attachment-2', 'attachment-1']);
     expect(list?.total).toBe(2);
+  });
+
+  it('splices a sub-org-homed row only into its own home channel list', async () => {
+    const keys = createEntityKeys<Record<string, never>>(TASK);
+    registerEntityQueryKeys(TASK, keys, async () => ({
+      items: [{ id: 'task-1', organizationId: 'org-1', projectId: 'project-1', name: 'fresh' }],
+      total: 1,
+    }));
+
+    queryClient.setQueryData(keys.list.home('org-1', 'project-1'), { items: [], total: 0 });
+    queryClient.setQueryData(keys.list.home('org-1', 'project-2'), { items: [], total: 0 });
+    queryClient.setQueryData(keys.list.home('org-1'), { items: [], total: 0 });
+
+    const { status } = await fetchRangeAndPatch(TASK, 'org-1', 'tenant-1', '3,3', keys);
+
+    expect(status).toBe('ok');
+    const home = queryClient.getQueryData<{ items: { id: string }[] }>(keys.list.home('org-1', 'project-1'));
+    expect(home?.items.map((i) => i.id)).toEqual(['task-1']);
+    // Sibling and org home lists hold rows homed elsewhere: no splice.
+    expect(queryClient.getQueryData(keys.list.home('org-1', 'project-2'))).toEqual({ items: [], total: 0 });
+    expect(queryClient.getQueryData(keys.list.home('org-1'))).toEqual({ items: [], total: 0 });
+  });
+
+  it('splices an org-homed row (null sub-ancestors) into the org home list only', async () => {
+    const keys = createEntityKeys<Record<string, never>>(TASK);
+    registerEntityQueryKeys(TASK, keys, async () => ({
+      items: [{ id: 'task-2', organizationId: 'org-1', projectId: null, name: 'org level' }],
+      total: 1,
+    }));
+
+    queryClient.setQueryData(keys.list.home('org-1'), { items: [], total: 0 });
+    queryClient.setQueryData(keys.list.home('org-1', 'project-1'), { items: [], total: 0 });
+
+    await fetchRangeAndPatch(TASK, 'org-1', 'tenant-1', '4,4', keys);
+
+    const orgHome = queryClient.getQueryData<{ items: { id: string }[] }>(keys.list.home('org-1'));
+    expect(orgHome?.items.map((i) => i.id)).toEqual(['task-2']);
+    expect(queryClient.getQueryData(keys.list.home('org-1', 'project-1'))).toEqual({ items: [], total: 0 });
+  });
+
+  it('does not splice into the bare org prefix key and warns that the row landed nowhere', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const keys = createEntityKeys<Record<string, never>>(TASK);
+    registerEntityQueryKeys(TASK, keys, async () => ({
+      items: [{ id: 'task-3', organizationId: 'org-1', projectId: 'project-1', name: 'orphan' }],
+      total: 1,
+    }));
+
+    // Canonical data cached at the org PREFIX (a key-shape bug: prefixes are never data keys).
+    queryClient.setQueryData(keys.list.org('org-1'), { items: [], total: 0 });
+
+    await fetchRangeAndPatch(TASK, 'org-1', 'tenant-1', '5,5', keys);
+
+    expect(queryClient.getQueryData(keys.list.org('org-1'))).toEqual({ items: [], total: 0 });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('landed in no list cache'));
   });
 
   it('invalidates filtered lists for a new row instead of splicing (server-side filter unknown)', async () => {

--- a/frontend/src/query/realtime/cache-ops.ts
+++ b/frontend/src/query/realtime/cache-ops.ts
@@ -1,6 +1,6 @@
 import type { QueryKey } from '@tanstack/react-query';
 import type { ProductEntityType } from 'shared';
-import { appConfig } from 'shared';
+import { appConfig, hierarchy, resolveDeepestAncestorId } from 'shared';
 import { getYjsOwnedFields, isYjsEditorActive } from '~/modules/common/blocknote/yjs-editor';
 import {
   type EntityQueryKeys,
@@ -78,21 +78,26 @@ function stripYjsOwnedFields(entityType: string, entity: ItemData, detailKey: Qu
 }
 
 /**
- * Whether `queryKey` is the canonical scope key for `entity`.
- * Keys shaped like [entityType, 'list', ...ancestorIds] match when every string segment
- * equals the entity's corresponding ancestor ID column. Filtered keys (object segments)
- * never match, those lists are scoped by server-side filters we can't replicate here.
+ * The row's effective home channel id: deepest non-null ancestor, the org itself for org-homed
+ * rows. The same resolution SSE routing uses (resolve-row-channel), so cache placement and
+ * stream routing can never disagree.
  */
-function matchesCanonicalScope(queryKey: readonly unknown[], entity: ItemData, scopeKeys: readonly string[]): boolean {
-  const segments = queryKey.slice(2);
+function resolveHomeChannelId(entityType: string, entity: ItemData): string | null {
   const entityRecord = entity as unknown as Record<string, unknown>;
-  for (let i = 0; i < segments.length; i++) {
-    const seg = segments[i];
-    if (typeof seg !== 'string') return false;
-    const expected = entityRecord[scopeKeys[i]];
-    if (typeof expected !== 'string' || expected !== seg) return false;
-  }
-  return true;
+  const home = resolveDeepestAncestorId(hierarchy, entityType, entityRecord);
+  if (home) return home;
+  const organizationId = entityRecord.organizationId;
+  return typeof organizationId === 'string' ? organizationId : null;
+}
+
+/**
+ * Whether `queryKey` is the canonical home list for a row homed at `homeChannelId`:
+ * [entityType, 'list', organizationId, homeChannelId]. Every row belongs to exactly one home
+ * list. Filtered keys (object segments) never match, those lists are scoped by server-side
+ * filters we can't replicate here; string keys at other depths are prefixes, never data keys.
+ */
+function matchesCanonicalHome(queryKey: readonly unknown[], organizationId: string, homeChannelId: string): boolean {
+  return queryKey.length === 4 && queryKey[2] === organizationId && queryKey[3] === homeChannelId;
 }
 
 /**
@@ -189,7 +194,7 @@ export function invalidateEntityListForOrg(
 
 /**
  * Invalidate org-scoped lists whose key tail contains a filter object (i.e. filtered lists).
- * Canonical scope lists (string-only tails) are left alone, they're patched directly.
+ * Canonical home lists (string-only tails) are left alone, they're patched directly.
  */
 function invalidateFilteredLists(orgListKey: readonly unknown[]): void {
   queryClient.invalidateQueries({
@@ -215,7 +220,8 @@ export function removeEntityFromListCache(entityId: string, keys: EntityQueryKey
 /**
  * Apply one server-truth row to detail and list caches through the shared applicator for both
  * realtime paths (seq-range fetches and seq-less single fetches). Tombstones remove; rows
- * already cached update in place; unknown rows insert only into their canonical scope list (the base per-scope list that live sync patches).
+ * already cached update in place; unknown rows insert only into their canonical home list
+ * (the row's effective home channel — see matchesCanonicalHome).
  * Returns true when the row was new to every scanned list cache, so callers can invalidate
  * filtered lists with object key segments, whose server-side filters cannot be replicated, once per flush.
  */
@@ -245,9 +251,15 @@ function applyServerEntity(
     return { ...old, ...filtered };
   });
 
+  const homeChannelId = resolveHomeChannelId(entityType, filtered);
+
   let seen = false;
+  let spliced = false;
+  let sawFilteredList = false;
   const listPrefix = organizationId ? keys.list.org(organizationId) : keys.list.base;
   for (const [queryKey, queryData] of queryClient.getQueriesData({ queryKey: listPrefix })) {
+    sawFilteredList ||= queryKey.slice(2).some((seg) => typeof seg === 'object' && seg !== null);
+
     let cachedItem: ItemData | undefined;
     let change: typeof changeQueryData;
     if (isInfiniteQueryData<ItemData>(queryData)) {
@@ -266,14 +278,22 @@ function applyServerEntity(
       continue;
     }
 
-    // Cached rows update in place. New rows insert only into lists that canonically scope
-    // to this entity; 'update' elsewhere is a deliberate no-op ('create' on a cached row
-    // would also drift `total` because updateArrayItems dedupes but the total adjustment does not).
+    // Cached rows update in place. New rows insert only into the row's canonical home list;
+    // 'update' elsewhere is a deliberate no-op ('create' on a cached row would also drift
+    // `total` because updateArrayItems dedupes but the total adjustment does not).
+    const isHomeList =
+      !!organizationId && !!homeChannelId && matchesCanonicalHome(queryKey, organizationId, homeChannelId);
     seen = seen || !!cachedItem;
-    change(
-      queryKey,
-      [filtered],
-      cachedItem || !matchesCanonicalScope(queryKey, filtered, keys.list.scopeKeys) ? 'update' : 'create',
+    spliced ||= !cachedItem && isHomeList;
+    change(queryKey, [filtered], cachedItem || !isHomeList ? 'update' : 'create');
+  }
+
+  // A new row that no home list spliced and no filtered list will refetch stays invisible until
+  // an unrelated refetch — always a key-shape bug (canonical data cached outside keys.list.home).
+  if (organizationId && homeChannelId && !seen && !spliced && !sawFilteredList) {
+    console.warn(
+      `[CacheOps] New ${entityType} row ${entity.id} landed in no list cache — ` +
+        `no canonical home list ${JSON.stringify(keys.list.home(organizationId, homeChannelId))} and no filtered list to invalidate.`,
     );
   }
 

--- a/frontend/src/query/realtime/catchup-processor.test.ts
+++ b/frontend/src/query/realtime/catchup-processor.test.ts
@@ -15,6 +15,17 @@ vi.mock('shared', () => ({
     },
     getParent: () => null,
   },
+  resolveDeepestAncestorId: (
+    hierarchy: { getOrderedAncestors: (entityType: string) => readonly string[] },
+    entityType: string,
+    row: Record<string, unknown>,
+  ) => {
+    for (const type of hierarchy.getOrderedAncestors(entityType)) {
+      const id = row[`${type}Id`];
+      if (typeof id === 'string' && id) return id;
+    }
+    return null;
+  },
 }));
 
 vi.mock('~/modules/common/blocknote/yjs-editor', () => ({
@@ -163,7 +174,7 @@ describe('catchup processor', () => {
 
     useSyncStore.getState().setOrgTenantId('org-1', 'tenant-1');
     useSyncStore.getState().setChannelSeq('org-1', 'project-1', 'attachment', 5);
-    queryClient.setQueryData(keys.list.scope('org-1', 'project-1'), {
+    queryClient.setQueryData(keys.list.home('org-1', 'project-1'), {
       items: [{ id: 'attachment-1', organizationId: 'org-1', projectId: 'project-1', seq: 5, name: 'stale' }],
       total: 1,
     });
@@ -182,7 +193,7 @@ describe('catchup processor', () => {
     expect(useSyncStore.getState().getChannelSeq('org-1', 'project-1', 'attachment')).toBe(8);
     // Org-level screening seq also advances for context-handled types
     expect(useSyncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(8);
-    expect(queryClient.getQueryData(keys.list.scope('org-1', 'project-1'))).toMatchObject({
+    expect(queryClient.getQueryData(keys.list.home('org-1', 'project-1'))).toMatchObject({
       items: [{ name: 'fresh' }],
     });
   });
@@ -191,7 +202,7 @@ describe('catchup processor', () => {
     const keys = createEntityKeys<Record<string, never>>('attachment');
     registerEntityQueryKeys('attachment', keys);
 
-    const scopedListKey = keys.list.scope('org-1', 'project-1');
+    const scopedListKey = keys.list.home('org-1', 'project-1');
     // Cached total deliberately disagrees with the server count: caches are
     // predicate-filtered per user, so equality with shared counts means nothing
     queryClient.setQueryData(scopedListKey, {

--- a/frontend/src/query/realtime/observed-channels.test.ts
+++ b/frontend/src/query/realtime/observed-channels.test.ts
@@ -68,7 +68,7 @@ describe('observed-channels', () => {
   it('marks a channel observed while its canonical scope query has an observer, and clears on unsubscribe', () => {
     expect(isObservedChannel('project-1')).toBe(false);
 
-    const unsubscribe = observe(taskKeys.list.scope('org-1', 'project-1'));
+    const unsubscribe = observe(taskKeys.list.home('org-1', 'project-1'));
     expect(isObservedChannel('project-1')).toBe(true);
 
     unsubscribe();
@@ -76,7 +76,7 @@ describe('observed-channels', () => {
   });
 
   it('does not count cached data without observers (prefetching sibling channels stays background)', () => {
-    queryClient.setQueryData([...taskKeys.list.scope('org-1', 'project-2')], []);
+    queryClient.setQueryData([...taskKeys.list.home('org-1', 'project-2')], []);
     expect(isObservedChannel('project-2')).toBe(false);
   });
 
@@ -89,7 +89,7 @@ describe('observed-channels', () => {
   });
 
   it('keeps a channel observed while any of its queries still has an observer', () => {
-    const first = observe(taskKeys.list.scope('org-1', 'project-4'));
+    const first = observe(taskKeys.list.home('org-1', 'project-4'));
     const second = observe(['task', 'list', { projectId: 'project-4' }]);
 
     first();
@@ -118,7 +118,7 @@ describe('isViewingScope with sub-org channels', () => {
 
   it('requires the route org to match, regardless of observation', () => {
     routeMatches = [{ context: { organization: { id: 'org-1' } } }];
-    const unsubscribe = observe(taskKeys.list.scope('org-2', 'project-7'));
+    const unsubscribe = observe(taskKeys.list.home('org-2', 'project-7'));
 
     expect(isViewingScope('org-2', 'project-7')).toBe(false);
 
@@ -135,25 +135,10 @@ describe('isViewingScope with sub-org channels', () => {
     routeMatches = [{ context: { organization: { id: 'org-1' } } }]; // Slug routes and boards name no project.
     expect(isViewingScope('org-1', 'project-8')).toBe(false);
 
-    const unsubscribe = observe(taskKeys.list.scope('org-1', 'project-8'));
+    const unsubscribe = observe(taskKeys.list.home('org-1', 'project-8'));
     expect(isViewingScope('org-1', 'project-8')).toBe(true);
 
     unsubscribe();
     expect(isViewingScope('org-1', 'project-8')).toBe(false);
-  });
-});
-
-describe('registerEntityQueryKeys scope-key guard', () => {
-  it('rejects sub-org-homed entities whose keys cannot carry the channel id', () => {
-    const badKeys = {
-      list: { base: ['task', 'list'], org: () => [], scope: () => [], scopeKeys: ['organizationId'] },
-      detail: { base: ['task', 'detail'], byId: (id: string) => ['task', 'detail', id] },
-    };
-    expect(() => registerEntityQueryKeys(TASK, badKeys)).toThrow(/projectId/);
-  });
-
-  it('accepts createEntityKeys-built keys and org-homed entities', () => {
-    expect(() => registerEntityQueryKeys(TASK, createEntityKeys(TASK))).not.toThrow();
-    expect(() => registerEntityQueryKeys('attachment', createEntityKeys('attachment'))).not.toThrow();
   });
 });


### PR DESCRIPTION
…tor-scope matching

Every row now belongs to exactly one canonical home list, keyed [entity, 'list', orgId, homeChannelId] via keys.list.home() — the same effective-home-channel resolution SSE routing uses (resolve-row-channel), so cache placement and stream routing can never disagree. Views derive from the home list via select(); anything spanning home channels or using server-side filters is a filtered key with invalidation sync.

Positional ancestor-prefix matching (list.scope + scopeKeys) is removed. It silently broke for entities with nullable ancestors: a fork's hand-rolled placement keys fell outside both the splice and invalidation paths, so remote creates never became visible. For strict-chain entities the home key is byte-identical to the old full-chain scope key.

- create-query-keys: list.home() replaces list.scope()/scopeKeys; list.org() is documented as a scan/invalidation prefix, never a data key
- cache-ops: home matcher via shared resolveDeepestAncestorId; warns when a fetched new row lands in no cache (the silent failure that hid the bug)
- entity-query-registry: drop scopeKeys guard, now enforced by construction
- attachment: canonical query keyed list.home(orgId)