### PR TITLE
fix(bench): make artillery run on Node 24

### DIFF
--- a/patches/artillery@2.0.33.patch
+++ b/patches/artillery@2.0.33.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/util/prepare-test-execution-plan.js b/lib/util/prepare-test-execution-plan.js
+index b7b637a00059bccf36119337f86350bc187a4ddd..3073cd22fad3a2f53d0dde1f722e1732efafa7b4 100644
+--- a/lib/util/prepare-test-execution-plan.js
++++ b/lib/util/prepare-test-execution-plan.js
+@@ -146,7 +146,7 @@ async function readPayload(script) {
+ }
+ 
+ function transpileTypeScript(entryPoint, outputPath, userExternalPackages) {
+-  const esbuild = require('esbuild-wasm');
++  const esbuild = require('esbuild');
+ 
+   esbuild.buildSync({
+     entryPoints: [entryPoint],
+@@ -191,7 +191,7 @@ function replaceProcessorIfTypescript(script, scriptPath) {
+ 
+   //TODO: move require to top of file when Lambda bundle size issue is solved
+   //must be conditionally required for now as this package is removed in Lambda for now to avoid bigger package sizes
+-  const esbuild = require('esbuild-wasm');
++  const esbuild = require('esbuild');
+ 
+   try {
+     esbuild.buildSync({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,11 @@ overrides:
   esbuild@>=0.27.3 <0.28.1: ^0.28.1
   protobufjs@>=8.0.0 <8.4.1: 8.6.5
 
+packageExtensionsChecksum: sha256-EbkdiE+4yJTKyGo02FtjbCIAUmI46E1GxzTUU97RFSE=
+
+patchedDependencies:
+  artillery@2.0.33: c417c250791ed794a3adeac0c699c5c328a924d252303b01cc82858bb1c75fb5
+
 importers:
 
   .:
@@ -370,7 +375,7 @@ importers:
         version: 1.0.5
       artillery:
         specifier: ^2.0.33
-        version: 2.0.33(@types/node@26.1.1)(supports-color@8.1.1)
+        version: 2.0.33(patch_hash=c417c250791ed794a3adeac0c699c5c328a924d252303b01cc82858bb1c75fb5)(@types/node@26.1.1)(supports-color@8.1.1)
       artillery-plugin-ensure:
         specifier: ^1.27.0
         version: 1.27.0
@@ -12781,7 +12786,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@artilleryio/sketches-js@2.1.1': {}
+  '@artilleryio/sketches-js@2.1.1':
+    dependencies:
+      protobufjs: 7.6.5
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -19461,7 +19468,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  artillery@2.0.33(@types/node@26.1.1)(supports-color@8.1.1):
+  artillery@2.0.33(patch_hash=c417c250791ed794a3adeac0c699c5c328a924d252303b01cc82858bb1c75fb5)(@types/node@26.1.1)(supports-color@8.1.1):
     dependencies:
       '@artilleryio/int-commons': 2.24.0
       '@artilleryio/int-core': 2.28.0(supports-color@8.1.1)
@@ -19503,6 +19510,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       dotenv: 16.6.1
       driftless: 2.0.3
+      esbuild: 0.28.1
       esbuild-wasm: 0.19.12
       eventemitter3: 5.0.4
       fs-extra: 11.3.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,6 +22,13 @@ overrides:
   esbuild@<0.28.1: ^0.28.1
   esbuild@>=0.27.3 <0.28.1: ^0.28.1
   'protobufjs@>=8.0.0 <8.4.1': 8.6.5
+packageExtensions:
+  '@artilleryio/sketches-js':
+    dependencies:
+      protobufjs: ^7.2.4
+  artillery:
+    dependencies:
+      esbuild: ^0.28.1
 packages:
   - mcp
   - backend
@@ -34,6 +41,8 @@ packages:
   - studio
   - yjs
   - bench
+patchedDependencies:
+  artillery@2.0.33: patches/artillery@2.0.33.patch
 peerDependencyRules:
   allowedVersions:
     '@opentelemetry/api': '>=1'


### PR DESCRIPTION
## What

`pnpm bench` crashed on Node 24.x with two latent bugs in the artillery stack (added with the bench in #917). Both were **surfaced, not caused**, by a routine `pnpm install` (the reinstall that bumped biome/knip/tsx re-linked node_modules).

### 1. `Cannot find module 'protobufjs/minimal'`
`@artilleryio/sketches-js@2.1.1` `require`s `protobufjs/minimal` at runtime but declares `protobufjs` only in **devDependencies**, so pnpm's strict node_modules never links it (and it isn't hoisted to a reachable spot). The artillery worker dies before running anything.

**Fix:** `packageExtensions` promotes `protobufjs` to a real dependency of `sketches-js`.

### 2. `RangeError: Invalid array length` → "Failed to compile Typescript processor"
This was hiding behind #1. Artillery transpiles each scenario's `.ts` processor via `require('esbuild-wasm').buildSync()`. The wasm CLI shim writes through `SyncWriteStream`, which overflows **inside artillery's worker thread** on Node 24 — at *any* esbuild-wasm version (bumping it does not help). Native esbuild's `buildSync` spawns the Go binary via `spawnSync` and never touches that path.

**Fix:** a 2-line `pnpm patch` on artillery swapping `require('esbuild-wasm')` → `require('esbuild')`, plus a `packageExtensions` entry so the bare `esbuild` specifier resolves to the already-pinned native `esbuild@^0.28.1`.

> Note: the esbuild-wasm crash only reproduces in artillery's worker thread — calling `buildSync` standalone under `node` works fine, which is why it first looked version-specific.

## Changes
- `pnpm-workspace.yaml`: `packageExtensions` (protobufjs → sketches-js, esbuild → artillery) + `patchedDependencies` entry
- `patches/artillery@2.0.33.patch`: 2-line require swap
- `pnpm-lock.yaml`: regenerated

All three are fork-friendly, so forks on Node 24 inherit the fix on pull.

## Verification
- `pnpm bench --all --short` → all 5 scenarios pass (attachment-edit, cdc-attachment, get-me, page-load, sse-fanout), exit 0
- `pnpm check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
