### PR TITLE
fix(frontend): strip text/background color styles on paste in blocknote

### DIFF
--- a/frontend/src/modules/common/blocknote/blocknote-config.ts
+++ b/frontend/src/modules/common/blocknote/blocknote-config.ts
@@ -1,5 +1,5 @@
 import { codeBlockOptions } from '@blocknote/code-block';
-import { BlockNoteSchema, createCodeBlockSpec, type Dictionary } from '@blocknote/core';
+import { BlockNoteSchema, createCodeBlockSpec, type Dictionary, defaultStyleSpecs } from '@blocknote/core';
 import type { DefaultSuggestionItem } from '@blocknote/core/extensions';
 import { blockTypeSelectItems, type DefaultReactSuggestionItem, getDefaultReactSlashMenuItems } from '@blocknote/react';
 import { codeBlockConfig } from 'shared/utils/blocknote-schema-configs';
@@ -22,9 +22,14 @@ import type {
  *  Basic Configuration
  */
 
+// Drop the color inline styles so pasted content cannot carry hardcoded text/background
+// colors that render invisible against the app theme. The toolbar already hides the color
+// picker (textColorSelect: false), so only bold/italic/underline/strike/code stay reachable.
+const { textColor: _textColor, backgroundColor: _backgroundColor, ...safeStyleSpecs } = defaultStyleSpecs;
+
 // Base custom schema: block/inline configs are shared with the Yjs relay's
 // server-side seeder (shared/blocknote-schema-configs); only renders live here.
-export const customSchema = BlockNoteSchema.create().extend({
+export const customSchema = BlockNoteSchema.create({ styleSpecs: safeStyleSpecs }).extend({
   blockSpecs: {
     checklistItem: checklistItemBlock(),
     notify: notifyBlock(), // Adds Notify block

--- a/frontend/src/modules/common/blocknote/styles.css
+++ b/frontend/src/modules/common/blocknote/styles.css
@@ -136,13 +136,6 @@ li:has(.is-focused) {
   padding: 0.5rem !important;
 }
 
-/* Override hardcoded inline text colors from pasted content that break dark mode.
- * Since textColorSelect is disabled, explicit colors only enter via paste and should inherit. */
-.bn-default-styles [data-style-type="textColor"],
-.bn-default-styles span[style*="color:"] {
-  color: inherit !important;
-}
-
 /* Dense mode - tighter line height and no vertical spacing between blocks */
 .bn-shadcn.bn-dense p {
   line-height: 1.3;


### PR DESCRIPTION
## Problem

Pasting rich text into the BlockNote editor could make text **invisible**. Pasted HTML carries hardcoded inline `color` / `background-color`, which BlockNote's default schema parses into `textColor` / `backgroundColor` inline styles. Against the app theme these render as e.g. `rgb(68,77,86)` text or a white highlight in dark mode.

The formatting toolbar already disables the color picker (`textColorSelect: false`), so color is never intentionally added — it only ever enters via paste. A prior CSS band-aid forced pasted text color to `inherit`, but it only covered `color:` and never the `background-color:` (white highlight) case.

## Fix

`BlockNoteSchema.create({ styleSpecs })` replaces the default style set (`.extend()` can only add, not remove). Destructure `textColor`/`backgroundColor` out of `defaultStyleSpecs` and keep the safe markdown-ish styles (bold, italic, underline, strike, code). Paste now drops color at parse time for both text and background.

- `frontend/src/modules/common/blocknote/blocknote-config.ts` — remove the two color inline styles from the schema.
- `frontend/src/modules/common/blocknote/styles.css` — drop the now-obsolete CSS override (dead once the marks no longer exist, and it never handled background color anyway).

Frontend-only: the shared Yjs server-side seeder config carries block/code config, not style specs, so there's no server coupling. Existing stored entities with color marks render without color (visible) rather than erroring — unknown styles are dropped on parse.

## Test

`pnpm check` passes clean (SDK regen + typecheck across all workspaces + biome + comment/doc style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)