### PR TITLE
ci: gate heavy suites on the release PR instead of a deploy-time release-gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,18 @@ name: CI
 # Deny-by-default: each job opts in to the scopes it actually needs.
 permissions: {}
 
-# CI runs in two contexts:
-#   • pull_request: fast feedback while iterating (cheap checks only).
-#   • merge_group: the merge queue. The heavy suites run here, once, when a
-#     PR is enqueued to merge. This is what gates the actual merge to main, so
-#     the branch-protection "required status checks" must live in this context.
+# CI runs on pull_request only (there is no merge queue). Two tiers of checks:
+#   • Every PR: cheap checks (lint, pr-title, schema-bust-gate) for fast feedback.
+#   • Release PR only: the heavy suites (test, storybook-test) run on the
+#     release-please PR. That PR is what you merge to cut the release + deploy,
+#     so gating its merge gates production. On feature PRs these jobs are
+#     skipped, which a required status check treats as a pass, so the heavy
+#     suites run once per release batch instead of on every feature PR.
 on:
   pull_request:
     branches: [main]
-  merge_group:
 
-# pull_request: cancel older runs of the same PR when a new push arrives.
-# merge_group: each queue entry has a unique ref, so nothing is cancelled.
+# Cancel older runs of the same PR when a new push arrives.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -80,9 +80,9 @@ jobs:
       - name: Run lens checks (append-only / collision / purity / wire completeness)
         run: pnpm --filter shared lens:check
 
-  # Runs all tests (full mode with PostgreSQL). Heavy: merge queue only.
+  # Runs all tests (full mode with PostgreSQL). Heavy: runs on the release PR only.
   test:
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please--branches--main')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -135,9 +135,9 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
 
-  # Storybook component tests (Vitest browser mode via Playwright). Heavy: merge queue only.
+  # Storybook component tests (Vitest browser mode via Playwright). Heavy: runs on the release PR only.
   storybook-test:
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please--branches--main')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -187,8 +187,7 @@ jobs:
           fetch-depth: 0 # need base-branch blobs to diff
 
       - name: Breaking-change gate
-        # pull_request supplies github.base_ref; merge_group does not (the queue
-        # always targets main), so fall back to main.
+        # pull_request always supplies github.base_ref; keep a main fallback for safety.
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,81 +34,13 @@ env:
 
 jobs:
   # -------------------------------------------------------------------------
-  # Release gate: heavy security + e2e checks too expensive to run on every
-  # feature PR. Gates every PRODUCTION deploy: the `release: published` event
-  # (always production) or a manual production dispatch. Skipped for staging
-  # dispatches. If it fails, `setup` is skipped and the whole deploy halts, so
-  # a bad release is published but never rolled out (same as the old chained
-  # release-gate → deploy-production ordering).
-  # -------------------------------------------------------------------------
-  release-gate:
-    if: ${{ github.event_name == 'release' || inputs.environment == 'production' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    permissions:
-      contents: read
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_DB: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Security audit (high+ severity)
-        run: pnpm audit --audit-level=high
-
-      - name: Create .env files
-        run: |
-          cp ./backend/.env.example ./backend/.env
-          cp ./frontend/.env.example ./frontend/.env
-
-      - name: Install Playwright browsers
-        run: cd frontend && pnpm exec playwright install
-
-      - name: Generate OpenAPI spec
-        run: pnpm sdk
-
-      - name: Run database migrations
-        run: pnpm --filter backend push
-        env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
-
-      - name: Run tests (full mode)
-        run: pnpm test:full
-        env:
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
-
-  # -------------------------------------------------------------------------
-  # Determine environment and detect which services changed
+  # Determine environment and detect which services changed. The heavy test +
+  # storybook suites already ran as required checks on the release-please PR
+  # (see .github/workflows/ci.yml), so deploy assumes validated code and goes
+  # straight to build + rollout. A manual workflow_dispatch bypasses those
+  # checks by design.
   # -------------------------------------------------------------------------
   setup:
-    # Wait on the gate. `skipped` (staging dispatch, gate did not run) is an
-    # acceptable predecessor; only a real gate failure halts the deploy.
-    needs: [release-gate]
-    if: ${{ !cancelled() && (needs.release-gate.result == 'success' || needs.release-gate.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/cella/RELEASES.md
+++ b/cella/RELEASES.md
@@ -64,5 +64,5 @@ While on `0.x` (`bump-minor-pre-major`), breaking changes bump the minor and fea
 
 **Repo settings:**
 
-- `main` ruleset: squash-merge only, linear history, require `pr-title`, `lint`, `test`, `storybook-test`, `schema-bust-gate`. `test` and `storybook-test` run for real only on the release PR and `skip` (pass) on feature PRs, so keeping them required is what blocks merging a release PR whose heavy suites fail.
+- `main` ruleset: squash-merge only, linear history, require `lint`, `test`, `storybook-test`, `schema-bust-gate`. `test` and `storybook-test` run for real only on the release PR and `skip` (pass) on feature PRs, so keeping them required is what blocks merging a release PR whose heavy suites fail.
 - "Allow GitHub Actions to create and approve pull requests" can stay **disabled**: the App, not Actions, creates the release PR.

--- a/cella/RELEASES.md
+++ b/cella/RELEASES.md
@@ -6,21 +6,21 @@ Releases are automated with [release-please](https://github.com/googleapis/relea
 
 1. Land work on `main` with Conventional Commit messages (a lefthook `commit-msg` hook runs commitlint locally).
 2. release-please keeps an open **release PR per package**, continuously updating the proposed version bump and generated [Changelog](/docs/page/changelog).
-3. Merge the release PR when ready: it bumps the version, updates the changelog, tags, and publishes the GitHub Release.
-4. On merge, the `release-gate` job (security audit + full e2e) runs before the GitHub Release is finalized (see below).
+3. The release PR runs the full CI, including the heavy suites (see [Gating](#gating)). Merge it when green: it bumps the version, updates the changelog, tags, and publishes the GitHub Release.
 
 ## Deploy timing
 
 Production deploys fire only when the `cella` template GitHub Release is published, not on every merge: [deploy.yml](../.github/workflows/deploy.yml) listens for `release: published`. Manual staging/production deploys remain available via `workflow_dispatch`.
 
-## Release gate
+## Gating
 
-Heavy checks run **only at release time** in [release.yml](../.github/workflows/release.yml), not as branch-protection required checks:
+The heavy suites (full test suite + Storybook component tests) are too slow to run on every feature PR, so they run **only on the release-please PR**, as required status checks in [ci.yml](../.github/workflows/ci.yml):
 
-- On release-PR merge, the `release-gate` job runs the security audit (`pnpm audit --audit-level=high`) and the full test/e2e suite.
-- The GitHub Release is finalized only if the gate passes, so a failed gate ships nothing.
+- Feature PRs run cheap checks only (`lint`, `pr-title`, `schema-bust-gate`). The heavy jobs report `skipped`, which a required check treats as a pass, so they don't block day-to-day PRs.
+- When release-please refreshes its PR (on each merge to `main`), the heavy jobs run for real against the current `main`.
+- The release PR can't be merged until they pass, so a broken `main` blocks the release before any tag or deploy.
 
-This keeps day-to-day PRs fast and gates only the irreversible publish. Add release-only checks as steps in `release-gate`; no ruleset changes needed.
+There is no separate release-time gate: [deploy.yml](../.github/workflows/deploy.yml) does build + rollout only and assumes validated code. A manual `workflow_dispatch` deploy bypasses CI by design.
 
 ## Packages
 
@@ -64,5 +64,5 @@ While on `0.x` (`bump-minor-pre-major`), breaking changes bump the minor and fea
 
 **Repo settings:**
 
-- `main` ruleset: squash-merge only, linear history, require `pr-title`, `lint`, `test`, `test-cella-cli`. Do **not** require `release-gate` (it runs at release time, not on PRs).
+- `main` ruleset: squash-merge only, linear history, require `pr-title`, `lint`, `test`, `storybook-test`, `schema-bust-gate`. `test` and `storybook-test` run for real only on the release PR and `skip` (pass) on feature PRs, so keeping them required is what blocks merging a release PR whose heavy suites fail.
 - "Allow GitHub Actions to create and approve pull requests" can stay **disabled**: the App, not Actions, creates the release PR.


### PR DESCRIPTION
## Why

The heavy `test` and `storybook-test` jobs were gated to `merge_group`, but the merge queue was removed on purpose — so they ran **nowhere** on PRs (`storybook-test` never ran in CI at all). The only heavy gate was `release-gate` in `deploy.yml`, which ran **after** the GitHub Release was already published: a failure left a published-but-undeployable tag.

## What

Run the heavy suites as required checks on the **release-please PR** instead:

- `test` + `storybook-test` now `if: pull_request && startsWith(github.head_ref, 'release-please--branches--main')`. They run for real each time release-please refreshes its PR (once per merge-to-main / release batch), and report `skipped` (a vacuous pass for required checks) on feature PRs — so feature PRs stay fast.
- The release PR can't be merged until they pass, so the gate now runs **before** the release is cut. A broken `main` blocks the release rather than producing a bad tag.
- Deleted `release-gate` from `deploy.yml`; `setup` is now the first job. Deploy does build + rollout only and assumes validated code. A manual `workflow_dispatch` deploy bypasses CI **by design**.
- Dropped the dead `merge_group` trigger; refreshed `cella/RELEASES.md` to match.

## Flow after this change

1. Feature PRs → cheap checks only (`lint`, `pr-title`, `schema-bust-gate`).
2. Every merge to `main` refreshes the release PR → its checks re-run, now including the **full** heavy suite (backend `test:full` **and** `storybook-test`).
3. All results visible in one place: the release PR's check list, green on the exact code that ships.
4. Merge the release PR → release-please tags + publishes the Release → `deploy.yml` fires and does build + rollout with **no test re-run**.

## Note

Keep `test` and `storybook-test` on the `main` ruleset's required-check list — that's what makes a release PR with failing heavy suites un-mergeable. No ruleset changes are needed beyond confirming that list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)