### PR TITLE
feat: seed system admin from ADMIN_EMAIL in the migrate companion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions: {}
 #     release-please PR. That PR is what you merge to cut the release + deploy,
 #     so gating its merge gates production. On feature PRs these jobs are
 #     skipped, which a required status check treats as a pass, so the heavy
-#     suites run once per release batch instead of on every feature PR.
+#     suites run only on the release PR, once per release batch.
 on:
   pull_request:
     branches: [main]

--- a/backend/scripts/seeds/00-init.seed.ts
+++ b/backend/scripts/seeds/00-init.seed.ts
@@ -30,17 +30,19 @@ const isUserSeeded = async () => {
 };
 
 /**
- * Seed an admin user for first-time app access. ADMIN_EMAIL takes precedence when set, otherwise
- * falls back to the fixture default (admin-test@cellajs.com); ADMIN_EMAIL is required in production.
+ * Seed an admin user for first-time app access. Uses ADMIN_EMAIL, which is required in production:
+ * a missing value throws and fails the migrate companion, so production is never left without an
+ * admin. Outside production it falls back to the fixture default (admin-test@cellajs.com). Idempotent:
+ * skips when the users table is already populated.
  */
 export const initSeed = async () => {
-  // Determine admin email: env var takes precedence, then fixture default
-  const adminEmail = env.ADMIN_EMAIL ?? defaultAdminUser.email;
-
-  // In production, ADMIN_EMAIL is required
+  // ADMIN_EMAIL is required in production: throw when it is missing.
   if (isProduction && !env.ADMIN_EMAIL) {
-    return console.error('ADMIN_EMAIL environment variable is required for production seeding.');
+    throw new Error('ADMIN_EMAIL is required for production seeding.');
   }
+
+  // Determine admin email: env var takes precedence, then fixture default (non-production only)
+  const adminEmail = env.ADMIN_EMAIL ?? defaultAdminUser.email;
 
   // Records already exist → skip seeding
   if (await isUserSeeded()) return console.warn('Users table is not empty → skip seeding');

--- a/backend/src/main.migrate.ts
+++ b/backend/src/main.migrate.ts
@@ -18,10 +18,21 @@ try {
   await pgMigrate(migrationDb, migrateConfig);
 
   console.info(pc.green(`${timestamp()} [migrate] ✓ Migrations complete`));
+
+  // Provision the system admin from ADMIN_EMAIL. Idempotent: the seed skips when
+  // the users table is already populated, so this no-ops on every deploy after
+  // the first and only seeds a fresh database (e.g. a new prod, or after a
+  // database reset). Lazy import keeps the seed's mock helpers out of the
+  // migrate path until this point.
+  console.info(`${timestamp()} [migrate] Seeding system admin (idempotent)...`);
+  const { initSeed } = await import('../scripts/seeds/00-init.seed');
+  await initSeed();
+  console.info(pc.green(`${timestamp()} [migrate] ✓ Admin seed complete`));
+
   process.exit(0);
 } catch (error) {
   const msg = error instanceof Error ? error.message : String(error);
-  console.error(pc.red(`${timestamp()} [migrate] ✗ Migration failed: ${msg}`));
+  console.error(pc.red(`${timestamp()} [migrate] ✗ Migrate companion failed: ${msg}`));
   // Drizzle wraps the underlying pg/driver error as `cause`; its message holds
   // the real reason (TLS identity mismatch, auth failure, missing role, …),
   // which the top-level message omits. Surface it so a failed migrate on a
@@ -37,7 +48,7 @@ try {
   // The OTel transport batches with a 5s schedule; wait past it so the export
   // actually leaves before the one-shot container exits.
   const { baseLog } = await import('#/lib/pino');
-  baseLog.fatal('Migration failed', { err: error });
+  baseLog.fatal('Migrate companion failed', { err: error });
   await new Promise((resolve) => setTimeout(resolve, 6000));
   process.exit(1);
 }


### PR DESCRIPTION
## Why

Prod deploys 0.5.0–0.5.2 failed cutover and prod ended up on an empty database after a `reset-database`. The one-shot **migrate companion** (`MODE=migrate`) applies schema migrations but **never seeds**, so a fresh/reset production DB comes up with no system admin. The documented recovery is to run the seed manually over the Scaleway serial console, but the VMs have **no interactive login** (no SSH key attached, no cloud-init password, security group fully closed), so that step isn't actually runnable.

## What

- **[`main.migrate.ts`](../blob/feat/migrate-seed-admin/backend/src/main.migrate.ts):** after migrations succeed, run the idempotent init seed (lazy `import` of `00-init.seed`), inside the existing `try/catch` so seed failures ship the same OTel/`cause` diagnostics and exit non-zero.
- **[`00-init.seed.ts`](../blob/feat/migrate-seed-admin/backend/scripts/seeds/00-init.seed.ts):** `ADMIN_EMAIL` is now **strictly required in production** — a missing value throws instead of logging and continuing, so a misconfigured prod boot fails loudly rather than yielding an admin-less DB. Fixture fallback retained for non-production.
- **`ci.yml`:** fixed a pre-existing comment-style violation that blocked the check gate.

The seed skips when the users table is already populated, so it **no-ops on every deploy after the first** and only provisions an admin on a fresh database.

## Net effect

Each fresh generation's boot now migrates **and** seeds. A new/empty prod DB auto-provisions the system admin from the delivered `admin-email` runtime secret — no serial console, no manual step. `ADMIN_EMAIL` was already required at the env schema (`z.email()`) and delivered as a required runtime secret; the only gap was that `MODE=migrate` never seeded.

## Validation

- `pnpm check` clean (sdk + typecheck + lint + comment style).
- Backend build succeeds; verified the seed logic (seed step, required-`ADMIN_EMAIL` throw, idempotency skip) is bundled into `dist/main.js` (the artifact the companion runs via `MODE=migrate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)