### PR TITLE
feat(infra): expose/unexpose database publicly via the infra CLI

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -272,24 +272,29 @@ The backend image ships a bundled, production-safe seed runner ([backend/scripts
 
 3. Open the app, request a magic link for `you@example.com`, and sign in.
 
-**Alternative: break-glass from your laptop.** If you'd rather not use the serial console, temporarily expose the database, run the seed locally against `DATABASE_ADMIN_URL`, then close the endpoint again. This is heavier (two bootstrap-key `pulumi up` runs to open and re-close the RDB public endpoint) and briefly exposes the DB, so prefer the serial-console path:
+**Alternative: break-glass from your laptop.** If you'd rather not use the serial console, temporarily expose the database with the CLI, run the seed locally against `DATABASE_ADMIN_URL`, then close it again. This briefly exposes the DB (ACL-locked to your IP), so prefer the serial-console path:
 
-1. Open the DB public endpoint locked to your IP (bootstrap-owned RDB, see [Changing infrastructure](#changing-infrastructure)):
-
-   ```bash
-   cd infra
-   pulumi config set infra:dbPublicEndpoint true
-   pulumi config set infra:dbPublicAcl "<your.ip>/32"
-   # then Apply infra change (pnpm infra → Apply infra change) with a bootstrap key
-   ```
-
-2. Run the seed locally against the admin connection string:
+1. Expose the DB, locked to your IP (needs a bootstrap key):
 
    ```bash
-   ADMIN_EMAIL=you@example.com DATABASE_ADMIN_URL='<admin connection string>' pnpm --filter backend seed:production init
+   pnpm infra   # → "Expose database publicly"
    ```
 
-3. **Close the endpoint again**: unset `infra:dbPublicEndpoint`/`infra:dbPublicAcl` and re-run Apply infra change, then revoke the bootstrap key.
+   It detects your public IP, defaults the ACL to `<your.ip>/32` (refusing open ranges), converges with a bootstrap key, and prints the admin connection string.
+
+2. Run the seed locally against the printed connection string:
+
+   ```bash
+   ADMIN_EMAIL=you@example.com DATABASE_ADMIN_URL='<printed connection string>' pnpm --filter backend seed:production init
+   ```
+
+3. **Close the endpoint again**, then revoke the bootstrap key:
+
+   ```bash
+   pnpm infra   # → "Stop public DB exposure"
+   ```
+
+These two modes are general-purpose break-glass for any scoped operator task against the live database (data inspection, one-off migrations, debugging), not only seeding.
 
 ## Architecture reference
 

--- a/infra/cli/actions/db-exposure-acl.test.ts
+++ b/infra/cli/actions/db-exposure-acl.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { isIpv4, parseAclInput, toValidatedCidr } from './db-exposure-acl'
+
+describe('isIpv4', () => {
+  it('accepts valid dotted-quads', () => {
+    expect(isIpv4('203.0.113.7')).toBe(true)
+    expect(isIpv4('0.0.0.0')).toBe(true)
+    expect(isIpv4('255.255.255.255')).toBe(true)
+  })
+
+  it('rejects malformed, out-of-range, and leading-zero octets', () => {
+    expect(isIpv4('256.0.0.1')).toBe(false)
+    expect(isIpv4('203.0.113')).toBe(false)
+    expect(isIpv4('203.0.113.01')).toBe(false)
+    expect(isIpv4('not-an-ip')).toBe(false)
+  })
+})
+
+describe('toValidatedCidr', () => {
+  it('adds /32 to a bare address', () => {
+    expect(toValidatedCidr('203.0.113.7')).toEqual({ ok: true, cidr: '203.0.113.7/32' })
+  })
+
+  it('keeps a valid explicit prefix', () => {
+    expect(toValidatedCidr(' 198.51.100.0/24 ')).toEqual({ ok: true, cidr: '198.51.100.0/24' })
+  })
+
+  it('refuses all-internet ranges', () => {
+    expect(toValidatedCidr('0.0.0.0/0').ok).toBe(false)
+    expect(toValidatedCidr('203.0.113.7/0').ok).toBe(false)
+    expect(toValidatedCidr('0.0.0.0/32').ok).toBe(false)
+  })
+
+  it('rejects malformed input', () => {
+    expect(toValidatedCidr('203.0.113.7/33').ok).toBe(false)
+    expect(toValidatedCidr('203.0.113.7/24/8').ok).toBe(false)
+    expect(toValidatedCidr('').ok).toBe(false)
+  })
+})
+
+describe('parseAclInput', () => {
+  it('parses and de-duplicates a comma-separated list', () => {
+    expect(parseAclInput('203.0.113.7, 198.51.100.0/24, 203.0.113.7/32')).toEqual({
+      ok: true,
+      cidrs: ['203.0.113.7/32', '198.51.100.0/24'],
+    })
+  })
+
+  it('fails on the first invalid entry', () => {
+    const result = parseAclInput('203.0.113.7, 0.0.0.0/0')
+    expect(result.ok).toBe(false)
+  })
+
+  it('fails when empty', () => {
+    expect(parseAclInput('   ').ok).toBe(false)
+  })
+})

--- a/infra/cli/actions/db-exposure-acl.ts
+++ b/infra/cli/actions/db-exposure-acl.ts
@@ -1,0 +1,72 @@
+// Pure helpers for validating the operator-supplied public-endpoint ACL. Kept
+// free of prompts and I/O so the validation rules are unit-testable in isolation.
+
+const IPV4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/
+
+/** True when a dotted-quad has four 0-255 octets with no leading zeros. */
+export function isIpv4(ip: string): boolean {
+  const match = IPV4.exec(ip.trim())
+  if (!match) return false
+  return match.slice(1).every((octet) => {
+    const n = Number(octet)
+    return n >= 0 && n <= 255 && String(n) === octet
+  })
+}
+
+/** Result of validating one operator ACL entry into a canonical CIDR. */
+export interface CidrCheck {
+  ok: boolean
+  cidr?: string
+  reason?: string
+}
+
+/**
+ * Normalize a single operator entry to a canonical IPv4 CIDR and validate it. A
+ * bare address gains a `/32` host suffix. Rejects malformed input and any range
+ * that would open the database to the whole internet (`0.0.0.0/...` or a `/0`).
+ */
+export function toValidatedCidr(entry: string): CidrCheck {
+  const raw = entry.trim()
+  if (!raw) return { ok: false, reason: 'empty entry' }
+
+  const parts = raw.split('/')
+  if (parts.length > 2) return { ok: false, reason: `malformed CIDR '${raw}'` }
+  const [ip, prefixRaw] = parts
+  if (!ip || !isIpv4(ip)) return { ok: false, reason: `not a valid IPv4 address: '${ip ?? raw}'` }
+
+  let prefix = 32
+  if (prefixRaw !== undefined) {
+    if (!/^\d{1,2}$/.test(prefixRaw)) return { ok: false, reason: `invalid prefix in '${raw}'` }
+    prefix = Number(prefixRaw)
+    if (prefix > 32) return { ok: false, reason: `prefix out of range in '${raw}'` }
+  }
+
+  const cidr = `${ip}/${prefix}`
+  if (ip === '0.0.0.0' || prefix === 0) {
+    return { ok: false, reason: `'${cidr}' would expose the database to the entire internet` }
+  }
+  return { ok: true, cidr }
+}
+
+/** Validated ACL parse result: the normalized CIDR list, or the first error. */
+export type AclParse = { ok: true; cidrs: string[] } | { ok: false; reason: string }
+
+/**
+ * Parse a comma-separated operator ACL string into canonical CIDRs. Returns the
+ * first validation failure, or the de-duplicated normalized list.
+ */
+export function parseAclInput(raw: string): AclParse {
+  const entries = raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+  if (entries.length === 0) return { ok: false, reason: 'no CIDRs provided' }
+
+  const cidrs: string[] = []
+  for (const entry of entries) {
+    const check = toValidatedCidr(entry)
+    if (!check.ok || !check.cidr) return { ok: false, reason: check.reason ?? `invalid CIDR '${entry}'` }
+    if (!cidrs.includes(check.cidr)) cidrs.push(check.cidr)
+  }
+  return { ok: true, cidrs }
+}

--- a/infra/cli/actions/db-exposure.ts
+++ b/infra/cli/actions/db-exposure.ts
@@ -1,0 +1,213 @@
+import { spawnSync } from 'node:child_process'
+import { confirm, input } from '@inquirer/prompts'
+import { pc } from 'shared/cli-utils/colors';
+import { checkMark, crossMark, warningMark } from 'shared/utils/console'
+import { adoptOrphanedPolicy } from '../../lib/scaleway/adopt-orphaned-policy'
+import { adoptOrphanedSecrets } from '../../lib/scaleway/adopt-orphaned-secrets'
+import { buildProviderEnv } from '../../lib/scaleway/bootstrap-scw-env'
+import { resolveOrganizationId } from '../../lib/scaleway/scaleway-iam'
+import { deriveInfra } from '../../lib/naming'
+import { errorMessage } from '../../lib/utils/errors'
+import { infraDir } from '../../lib/utils/paths'
+import { parseOrphanedDeletes, pruneOrphanedDeletes, runPulumiUpWithHint } from '../../lib/stack/pulumi-up'
+import { maskedSecret } from '../prompts/masked-secret'
+import { acquireStackLockOrExit, envOr, type InfraContext, promptRequiredInput, promptStackName, pulumiLoginAndSelect, resolveVerifiedPassphrase } from '../shared'
+import { parseAclInput } from './db-exposure-acl'
+
+// Pulumi config keys consumed by resources/database.ts and the output it exports.
+const DB_ENDPOINT_KEY = 'infra:dbPublicEndpoint'
+const DB_ACL_KEY = 'infra:dbPublicAcl'
+const PUBLIC_DSN_OUTPUT = 'dbConnectionStringAdminPublic'
+
+/** Detect the operator's current public IPv4 via a well-known echo service. */
+async function detectPublicIp(): Promise<string | undefined> {
+  try {
+    const res = await fetch('https://api.ipify.org', { signal: AbortSignal.timeout(5000) })
+    if (!res.ok) return undefined
+    const body = (await res.text()).trim()
+    return body || undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** Set one plaintext stack config key, exiting on failure. */
+function pulumiConfigSet(env: NodeJS.ProcessEnv, stack: string, key: string, value: string): void {
+  const result = spawnSync('pulumi', ['config', 'set', key, value, '--stack', stack], { cwd: infraDir, env, stdio: 'inherit' })
+  if (result.status !== 0) {
+    console.error(`${crossMark} pulumi config set ${key} failed (exit ${result.status}).`)
+    process.exit(result.status ?? 1)
+  }
+}
+
+/** Remove one stack config key. Best-effort: a missing key is not an error here. */
+function pulumiConfigRm(env: NodeJS.ProcessEnv, stack: string, key: string): void {
+  const result = spawnSync('pulumi', ['config', 'rm', key, '--stack', stack], { cwd: infraDir, env, stdio: 'inherit' })
+  if (result.status !== 0) console.warn(`${warningMark} pulumi config rm ${key} exited ${result.status} (already unset?) — continuing.`)
+}
+
+/** Read the public admin DSN stack output (empty when the endpoint is disabled). */
+function readPublicDsn(env: NodeJS.ProcessEnv, stack: string): string {
+  const result = spawnSync('pulumi', ['stack', 'output', PUBLIC_DSN_OUTPUT, '--show-secrets', '--stack', stack], { cwd: infraDir, env, encoding: 'utf8' })
+  return result.status === 0 ? (result.stdout ?? '').trim() : ''
+}
+
+/**
+ * The privileged bootstrap-key converge shared by expose/unexpose: acquire keys
+ * and the stack lock, adopt any orphaned IAM/secret state, reconcile rollout
+ * config from live state (so a local `up` cannot revert compute to a stale
+ * generation), apply the caller's config mutation, then run `pulumi up`. Returns
+ * the provider env and stack so the caller can read outputs after the lock is
+ * released. Exits the process on any hard failure.
+ */
+async function convergePublicEndpoint(
+  context: InfraContext,
+  operation: string,
+  mutate: (env: NodeJS.ProcessEnv, stack: string) => void,
+): Promise<{ env: NodeJS.ProcessEnv; stack: string }> {
+  if (context.state !== 'bootstrapped') {
+    console.error(`${warningMark} This action requires a fully bootstrapped stack (state=${context.state}). Run Resume first.`)
+    process.exit(1)
+  }
+
+  const passphrase = await resolveVerifiedPassphrase(context.stackYaml)
+  const { projectId, appConfig } = context
+
+  const bootAccess = await envOr('SCW_BOOTSTRAP_ACCESS_KEY', () => promptRequiredInput('Scaleway bootstrap access key'))
+  const bootSecret = await envOr('SCW_BOOTSTRAP_SECRET_KEY', () => maskedSecret({ message: 'Scaleway bootstrap secret key' }))
+  const stack = await promptStackName(context)
+
+  const env = buildProviderEnv(infraDir, { accessKey: bootAccess, secretKey: bootSecret, projectId, passphrase })
+  pulumiLoginAndSelect(infraDir, env, appConfig, stack)
+
+  const stackLock = await acquireStackLockOrExit({ appConfig, accessKey: bootAccess, secretKey: bootSecret, stack, operation })
+
+  // Adopt IAM/secret state that exists in Scaleway but is missing from Pulumi
+  // state, so `pulumi up` does not fail trying to recreate it. Best-effort,
+  // exactly as the apply path does.
+  try {
+    const organizationId = await resolveOrganizationId(bootSecret, projectId)
+    env.SCW_DEFAULT_ORGANIZATION_ID = organizationId
+    const policyName = deriveInfra(appConfig).naming.resource('vm-reader-policy')
+    await adoptOrphanedPolicy({ stack, cwd: infraDir, env, pulumiName: 'vm-reader-policy', policyName, secretKey: bootSecret, organizationId })
+    await adoptOrphanedSecrets({ stack, cwd: infraDir, env, secretKey: bootSecret, projectId, region: appConfig.s3.region, path: `/${appConfig.slug}-${context.environment}/` })
+  } catch (error) {
+    console.warn(`${warningMark} orphan-state adoption skipped: ${errorMessage(error)}`)
+  }
+
+  // Reconcile gen/sha into local config from live state before `up`, so a stale
+  // committed Pulumi.<stack>.yaml cannot converge compute back to an old
+  // generation and destroy newer live VMs. A hard failure aborts.
+  console.info(pc.dim('\n→ Reconciling rollout config from live state (sync-rollout-config)…'))
+  const sync = spawnSync('pnpm', ['--filter', 'infra', 'sync-rollout-config', '--stack', stack], { cwd: infraDir, env, stdio: 'inherit' })
+  if (sync.status !== 0) {
+    await stackLock.release()
+    console.error(`${warningMark} sync-rollout-config failed (exit ${sync.status}). Aborting to avoid applying against stale gen/sha.`)
+    process.exit(sync.status ?? 1)
+  }
+
+  mutate(env, stack)
+
+  while (true) {
+    const { code, output } = await runPulumiUpWithHint(stack, infraDir, env)
+    if (code === 0) break
+    const orphans = parseOrphanedDeletes(output)
+    if (orphans.length > 0 && (await confirm({ message: `Prune ${orphans.length} stale state entr${orphans.length === 1 ? 'y' : 'ies'} and retry?`, default: true }))) {
+      pruneOrphanedDeletes(orphans, stack, infraDir, env)
+      continue
+    }
+    if (!(await confirm({ message: 'Retry pulumi up?', default: false }))) {
+      await stackLock.release()
+      console.error(`${crossMark} converge did not complete; stack config may be partially applied. Re-run to finish.`)
+      process.exit(1)
+    }
+  }
+
+  await stackLock.release()
+  return { env, stack }
+}
+
+/** Loud reminder to revoke the short-lived bootstrap key after the run. */
+function revokeReminder(): void {
+  console.info(`\n${pc.dim('Reminder:')} revoke the bootstrap key now (Scaleway console → IAM → API keys).`)
+}
+
+/**
+ * Open the database's public endpoint for scoped operator access (prototyping,
+ * debugging). Prompts for the client ACL (defaults to the operator's detected
+ * /32), converges with a bootstrap key, then prints the admin DSN. The endpoint
+ * is internet-reachable but restricted to the ACL; run "Stop public DB
+ * exposure" when finished.
+ */
+export async function runExposeDatabase(context: InfraContext): Promise<void> {
+  console.info(pc.dim('\nExpose database publicly: add a scoped, temporary public endpoint for operator tasks.\n'))
+
+  const detected = await detectPublicIp()
+  const suggestion = detected ? `${detected}/32` : ''
+  if (detected) console.info(`Detected your public IP: ${pc.cyan(detected)} → default ACL ${pc.cyan(suggestion)}`)
+  else console.warn(`${warningMark} Could not auto-detect your public IP; enter the client CIDR(s) manually.`)
+
+  const raw = await input({
+    message: 'Allowed client CIDR(s), comma-separated',
+    default: suggestion || undefined,
+    validate: (value) => {
+      const parsed = parseAclInput(value)
+      return parsed.ok || parsed.reason
+    },
+  })
+  const parsed = parseAclInput(raw)
+  if (!parsed.ok) {
+    console.error(`${crossMark} ${parsed.reason}`)
+    process.exit(1)
+  }
+  const acl = parsed.cidrs.join(',')
+
+  console.warn(
+    `\n${pc.yellow(pc.bold('⚠  This opens an internet-reachable database endpoint'))}, restricted to: ${pc.cyan(acl)}.\n` +
+      `  ${pc.dim('The stack config file records the endpoint as enabled — do not commit it. Run "Stop public DB exposure" when done.')}\n`,
+  )
+  if (!(await confirm({ message: 'Proceed with exposing the database?', default: false }))) {
+    console.info('Aborted; no changes made.')
+    return
+  }
+
+  const { env, stack } = await convergePublicEndpoint(context, 'expose-db', (e, s) => {
+    pulumiConfigSet(e, s, DB_ENDPOINT_KEY, 'true')
+    pulumiConfigSet(e, s, DB_ACL_KEY, acl)
+  })
+
+  const dsn = readPublicDsn(env, stack)
+  if (!dsn) {
+    console.warn(`${warningMark} Endpoint applied but no public DSN output yet — Scaleway may still be provisioning the load balancer. Re-run to read it.`)
+  } else {
+    console.info(`\n${checkMark} ${pc.bold('Database exposed.')} Admin connection string:\n\n    ${pc.cyan(dsn)}\n`)
+    console.info(`  ${pc.dim('Example:')} psql "${dsn}"`)
+  }
+  console.info(`\n  ${pc.bold('When finished, run "Stop public DB exposure" to close it again.')}`)
+  revokeReminder()
+}
+
+/**
+ * Close the database's public endpoint: clears the opt-in config, tears down the
+ * load balancer and ACL, and verifies the database is private-only again.
+ */
+export async function runUnexposeDatabase(context: InfraContext): Promise<void> {
+  console.info(pc.dim('\nStop public DB exposure: remove the public endpoint and ACL, return to private-only.\n'))
+  if (!(await confirm({ message: 'Close the public database endpoint now?', default: true }))) {
+    console.info('Aborted; no changes made.')
+    return
+  }
+
+  const { env, stack } = await convergePublicEndpoint(context, 'unexpose-db', (e, s) => {
+    pulumiConfigSet(e, s, DB_ENDPOINT_KEY, 'false')
+    pulumiConfigRm(e, s, DB_ACL_KEY)
+  })
+
+  const dsn = readPublicDsn(env, stack)
+  if (dsn) {
+    console.warn(`${warningMark} Public DSN output is still present — the endpoint may not have torn down. Re-run "Stop public DB exposure".`)
+  } else {
+    console.info(`\n${checkMark} ${pc.bold('Public endpoint closed.')} The database is private-only again.`)
+  }
+  revokeReminder()
+}

--- a/infra/cli/infra-cli.ts
+++ b/infra/cli/infra-cli.ts
@@ -11,6 +11,7 @@ import { infraDir } from '../lib/utils/paths'
 import { runApply } from './actions/apply'
 import { runPreview } from './actions/preview'
 import { runResetDatabase } from './actions/reset-database'
+import { runExposeDatabase, runUnexposeDatabase } from './actions/db-exposure'
 import { runRotatePassphrase } from './actions/rotate-passphrase'
 import { runSecrets } from './actions/secrets'
 import { runSetup } from './actions/setup'
@@ -105,6 +106,8 @@ const mode: CliMode =
           { name: 'Preview', value: 'preview', description: 'Read-only `pulumi preview`. Validates auth & shows drift; makes no changes.' },
           { name: 'Manage runtime secrets', value: 'secrets', description: 'List, set, rotate, or delete operator-managed runtime secrets in Scaleway Secret Manager.' },
           { name: 'Reset database', value: 'reset-database', description: 'DESTRUCTIVE: delete + recreate the app database empty (backup first, roles re-granted), then migrate/seed on the serial console. Pre-production, or with services quiesced.' },
+          { name: 'Expose database publicly', value: 'expose-db', description: 'Add a scoped, temporary public DB endpoint (ACL-restricted to your IP) for prototyping/debugging. Prints the admin connection string. Remember to close it.' },
+          { name: 'Stop public DB exposure', value: 'unexpose-db', description: 'Remove the public DB endpoint and ACL, returning the database to private-only access.' },
           { name: 'Unlock', value: 'unlock', description: 'Clear a stale stack lock left by an interrupted apply/deploy. Use only when no run is actually in progress.' },
         ],
       })
@@ -132,6 +135,16 @@ if (mode === 'secrets') {
 
 if (mode === 'reset-database') {
   await runResetDatabase(context)
+  process.exit(0)
+}
+
+if (mode === 'expose-db') {
+  await runExposeDatabase(context)
+  process.exit(0)
+}
+
+if (mode === 'unexpose-db') {
+  await runUnexposeDatabase(context)
   process.exit(0)
 }
 

--- a/infra/cli/shared.ts
+++ b/infra/cli/shared.ts
@@ -12,7 +12,7 @@ import { maskedSecret } from './prompts/masked-secret'
 type AppConfigType = typeof AppConfig
 
 /** Infra CLI operation modes */
-export type CliMode = 'resume' | 'rotate' | 'rotate-passphrase' | 'apply' | 'preview' | 'secrets' | 'reset-database' | 'unlock'
+export type CliMode = 'resume' | 'rotate' | 'rotate-passphrase' | 'apply' | 'preview' | 'secrets' | 'reset-database' | 'expose-db' | 'unexpose-db' | 'unlock'
 
 /**
  * Context for the infra CLI, including stack information and state. Passed to each service handler to provide necessary information about the current infra status and configuration.

--- a/infra/vitest.config.ts
+++ b/infra/vitest.config.ts
@@ -7,7 +7,7 @@ const integration = process.env.INTEGRATION === '1'
 export default defineProject({
   logLevel: 'error',
   test: {
-    include: ['agent/**/*.test.ts', 'compose/**/*.test.ts', 'tasks/**/*.test.ts', 'lib/**/*.test.ts', 'tests/**/*.test.ts', 'resources/**/*.test.ts', '*.test.ts'],
+    include: ['agent/**/*.test.ts', 'cli/**/*.test.ts', 'compose/**/*.test.ts', 'tasks/**/*.test.ts', 'lib/**/*.test.ts', 'tests/**/*.test.ts', 'resources/**/*.test.ts', '*.test.ts'],
     exclude: ['node_modules/**', 'dist/**', ...(integration ? [] : ['tests/integration/**'])],
     testTimeout: 5000,
   },


### PR DESCRIPTION
## Why

Debugging prod (e.g. the current CDC replication issue) and prototyping need scoped, short-lived direct access to the live database. The primitives for a public RDB endpoint already exist in `infra/resources/database.ts` (`infra:dbPublicEndpoint` + `infra:dbPublicAcl`, with a guard refusing an endpoint without an ACL), but opening/closing it was a manual, error-prone `pulumi config set` + Apply dance. This makes it a first-class, safe CLI toggle.

## What

Two new `pnpm infra` menu modes:

- **Expose database publicly** — auto-detects the operator's public IP, defaults the ACL to `<ip>/32` (override allowed; `0.0.0.0/0` and `/0` hard-refused), confirms, sets the config, converges with a bootstrap key, and prints the admin connection string (usable from `psql`, TablePlus, etc.).
- **Stop public DB exposure** — clears the config, tears down the load balancer + ACL, and verifies the DB is private-only again.

Both reuse the `apply` path's safety machinery: bootstrap-key provider env, S3 stack lock, orphan-state adoption, and `sync-rollout-config` (so a laptop `pulumi up` cannot revert compute to a stale generation). The DB instance's `protect: isProduction` blocks any accidental replace. `apply.ts` is left untouched.

## Files

- `cli/actions/db-exposure.ts` — the two actions + a shared privileged converge.
- `cli/actions/db-exposure-acl.ts` — pure IP/CIDR validation (adds `/32`, de-dups, refuses open ranges).
- `cli/actions/db-exposure-acl.test.ts` — 9 unit tests.
- `cli/shared.ts` / `cli/infra-cli.ts` — `CliMode` + menu entries + dispatch.
- `vitest.config.ts` — include `cli/**` tests.
- `README.md` — break-glass section now points at the modes.

## Validation

- `pnpm check` clean; full infra suite green (496 tests, incl. 9 new).
- Not exercised against a live `pulumi up` (needs a bootstrap key). First real run should confirm via `pulumi preview` that toggling `dbPublicEndpoint` is an in-place update, not a replace (it is designed to be, and `protect` blocks a replace regardless).

## Note

The public endpoint uses `admin_role` (`BYPASSRLS`), so it bypasses RLS. It is intended for break-glass; keep it short-lived and close it when done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
