### PR TITLE
refactor(frontend): consolidate the offline-mutation template into shared primitives

### DIFF
--- a/frontend/src/modules/attachment/query.ts
+++ b/frontend/src/modules/attachment/query.ts
@@ -1,5 +1,5 @@
-import type { QueryClient } from '@tanstack/react-query';
-import { infiniteQueryOptions, queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { QueryClient, UseMutationOptions } from '@tanstack/react-query';
+import { infiniteQueryOptions, queryOptions, useQuery, useQueryClient } from '@tanstack/react-query';
 import i18n from 'i18next';
 import { type Attachment, type GetAttachmentsData, getAttachment, getAttachments } from 'sdk';
 import { zAttachment } from 'sdk/zod.gen';
@@ -17,7 +17,8 @@ import {
 } from '~/modules/attachment/query-mutations';
 import { attachmentsSearchDefaults } from '~/modules/attachment/search-params-schemas';
 import { toaster } from '~/modules/common/toaster/toaster';
-import { cacheCreate, cacheRemove, cacheUpdate } from '~/query/basic/cache-mutations';
+import { insertEntitiesIntoHome } from '~/query/basic/apply-entity-to-lists';
+import { cacheRemove, cacheUpdate } from '~/query/basic/cache-mutations';
 import { createOptimisticEntity } from '~/query/basic/create-optimistic';
 import { createEntityKeys } from '~/query/basic/create-query-keys';
 import { registerEntityQueryKeys, SYNC_CHUNK_SIZE } from '~/query/basic/entity-query-registry';
@@ -26,7 +27,9 @@ import { createCacheFinder } from '~/query/basic/find-in-list-cache';
 import { baseInfiniteQueryOptions } from '~/query/basic/infinite-query-options';
 import { invalidateIfLastMutation, removePendingMutations } from '~/query/basic/invalidation-helpers';
 import { syncStaleTime } from '~/query/basic/sync-stale-config';
+import type { ItemData } from '~/query/basic/types';
 import { addMutationRegistrar } from '~/query/mutation-registry';
+import { type PreparedVars, usePreparedMutation } from '~/query/offline/prepared-mutation';
 import { removePausedCreates, squashIntoPendingCreate, squashPendingMutation } from '~/query/offline/squash-utils';
 import { createStxForCreate, createStxForDelete, createStxForUpdate } from '~/query/offline/stx-utils';
 import { mergeServerResponse, syncEntityToCache } from '~/query/offline/update-success-utils';
@@ -171,194 +174,218 @@ export function useGroupAttachments(
 // --- Mutations ---
 // The mutation functions live in ./query-mutations (shared with the offline-replay defaults).
 
+type CreateData = Awaited<ReturnType<typeof createAttachmentsMutationFn>>;
+type UpdateData = Awaited<ReturnType<typeof updateAttachmentMutationFn>>;
+type DeleteData = Awaited<ReturnType<typeof deleteAttachmentsMutationFn>>;
+
+/**
+ * Full options for one attachment op, shared by the live hook and the offline-replay defaults so a
+ * replay reconciles like the live one. Callbacks take the QueryClient explicitly and derive the org
+ * key from durable variables. On replay onMutate does not re-run, so onSettled invalidation recovers.
+ */
+const attachmentCreateOptions = (
+  queryClient: QueryClient,
+): UseMutationOptions<CreateData, Error, CreateAttachmentVars, { optimisticAttachments: ItemData[] }> => ({
+  mutationKey: keys.create,
+  scope: { id: 'attachment' },
+  mutationFn: createAttachmentsMutationFn,
+  meta: { suppressGlobalErrorToast: true },
+  onMutate: async ({ organizationId, data }) => {
+    const orgKey = keys.list.org(organizationId);
+    await queryClient.cancelQueries({ queryKey: orgKey });
+    // Optimistic rows keep their pre-upload id (also the local blob key); insert into the canonical
+    // home list only, never filtered/search lists.
+    const optimisticAttachments = data.map((att) => createOptimisticEntity(zAttachment, att));
+    insertEntitiesIntoHome(queryClient, {
+      entityType: 'attachment',
+      entities: optimisticAttachments,
+      keys,
+      organizationId,
+    });
+    return { optimisticAttachments };
+  },
+  onError: (_err, variables, context) => {
+    handleError('create');
+    if (context?.optimisticAttachments)
+      cacheRemove(keys.list.org(variables.organizationId), context.optimisticAttachments);
+  },
+  onSuccess: (result, variables, context) => {
+    const orgKey = keys.list.org(variables.organizationId);
+    if (context?.optimisticAttachments) cacheRemove(orgKey, context.optimisticAttachments);
+    // Upsert into the canonical home (updates in place if a concurrent SSE already inserted it).
+    insertEntitiesIntoHome(queryClient, {
+      entityType: 'attachment',
+      entities: result.data,
+      keys,
+      organizationId: variables.organizationId,
+    });
+  },
+  // Error-only: onSuccess patches cache, SSE handles other users.
+  onSettled: (_data, error, variables) => {
+    if (error)
+      invalidateIfLastMutation(queryClient, attachmentsMutationKeyBase, keys.list.org(variables.organizationId));
+  },
+});
+
+const attachmentUpdateOptions = (
+  queryClient: QueryClient,
+): UseMutationOptions<UpdateData, Error, UpdateAttachmentFullVars, { previousAttachment: Attachment | undefined }> => ({
+  mutationKey: keys.update,
+  // Same scope as create/delete: attachment writes serialize, so a squashed update never replays before its paused create.
+  scope: { id: 'attachment' },
+  mutationFn: updateAttachmentMutationFn,
+  meta: { suppressGlobalErrorToast: true },
+  // Squash/coalesce runs in the hook's prepare step, so variables already carry the merge; onMutate keeps only cache work.
+  onMutate: async ({ organizationId, id, ops }) => {
+    const orgKey = keys.list.org(organizationId);
+    await queryClient.cancelQueries({ queryKey: orgKey });
+    await queryClient.cancelQueries({ queryKey: keys.detail.byId(id) });
+
+    const previousAttachment = findAttachmentInCache(id);
+    if (previousAttachment) {
+      const optimisticAttachment = { ...previousAttachment, ...ops, updatedAt: new Date().toISOString() };
+      cacheUpdate(orgKey, [optimisticAttachment]);
+      queryClient.setQueryData(keys.detail.byId(id), optimisticAttachment);
+    }
+    return { previousAttachment };
+  },
+  onError: (_err, variables, context) => {
+    handleError('update');
+    if (context?.previousAttachment) {
+      cacheUpdate(keys.list.org(variables.organizationId), [context.previousAttachment]);
+      queryClient.setQueryData(keys.detail.byId(context.previousAttachment.id), context.previousAttachment);
+    }
+  },
+  onSuccess: (updatedAttachment, variables) => {
+    const orgKey = keys.list.org(variables.organizationId);
+    const detailKey = keys.detail.byId(updatedAttachment.id);
+    const cached = findAttachmentInCache(updatedAttachment.id);
+    const mutatedKeys = variables.ops ? Object.keys(variables.ops) : [];
+    const merged = mergeServerResponse({ cached, serverEntity: updatedAttachment, mutatedKeys });
+    syncEntityToCache({ entity: merged, listKey: orgKey, detailKey, queryClient });
+  },
+  onSettled: (_data, error, variables) => {
+    if (error)
+      invalidateIfLastMutation(queryClient, attachmentsMutationKeyBase, keys.list.org(variables.organizationId));
+  },
+});
+
+const attachmentDeleteOptions = (
+  queryClient: QueryClient,
+): UseMutationOptions<DeleteData, Error, DeleteAttachmentVars, { deletedAttachments: Attachment[] }> => ({
+  mutationKey: keys.delete,
+  scope: { id: 'attachment' },
+  mutationFn: deleteAttachmentsMutationFn,
+  meta: { suppressGlobalErrorToast: true },
+  onMutate: async ({ organizationId, attachments }) => {
+    const orgKey = keys.list.org(organizationId);
+    removePendingMutations(
+      queryClient,
+      keys.update,
+      attachments.map((a) => a.id),
+    );
+    await queryClient.cancelQueries({ queryKey: orgKey });
+    cacheRemove(orgKey, attachments);
+    for (const { id } of attachments) queryClient.removeQueries({ queryKey: keys.detail.byId(id) });
+    return { deletedAttachments: attachments };
+  },
+  onError: (_err, variables, context) => {
+    handleError('delete');
+    if (context?.deletedAttachments) {
+      insertEntitiesIntoHome(queryClient, {
+        entityType: 'attachment',
+        entities: context.deletedAttachments,
+        keys,
+        organizationId: variables.organizationId,
+      });
+    }
+  },
+  onSuccess: (result, variables) => {
+    // Partial rejection (200 + rejectedIds): backend kept permission-denied rows; restore them to the
+    // home list so they don't reappear on next sync, and notify. A full rejection arrives as a 403 via onError.
+    const rejectedIds = result?.rejectedIds ?? [];
+    if (rejectedIds.length === 0) return;
+    const rejectedSet = new Set(rejectedIds);
+    insertEntitiesIntoHome(queryClient, {
+      entityType: 'attachment',
+      entities: variables.attachments.filter((a) => rejectedSet.has(a.id)),
+      keys,
+      organizationId: variables.organizationId,
+    });
+    toaster(
+      i18n.t('c:resources_delete_denied', { count: rejectedIds.length, total: variables.attachments.length }),
+      'info',
+    );
+  },
+  // Error-only: onMutate removed the attachment from all caches, SSE handles other users.
+  onSettled: (_data, error, variables) => {
+    if (error)
+      invalidateIfLastMutation(queryClient, attachmentsMutationKeyBase, keys.list.org(variables.organizationId));
+  },
+});
+
 export const useAttachmentCreateMutation = (tenantId: string, organizationId: string) => {
   const queryClient = useQueryClient();
-  const orgKey = keys.list.org(organizationId);
-
-  const mutation = useMutation({
-    mutationKey: keys.create,
-    scope: { id: 'attachment' },
-    mutationFn: createAttachmentsMutationFn,
-    onMutate: async ({ data }: CreateAttachmentVars) => {
-      await queryClient.cancelQueries({ queryKey: orgKey });
-      // Attachments are minted with an id before upload (`onBeforeFileAdded`), which the
-      // optimistic entity preserves. That id also keys the local blob, so the optimistic row
-      // can resolve its own bytes while the create is still in flight or paused offline.
-      const optimisticAttachments = data.map((att) => createOptimisticEntity(zAttachment, att));
-      cacheCreate(orgKey, optimisticAttachments);
-      return { optimisticAttachments };
-    },
-    meta: { suppressGlobalErrorToast: true },
-    onError: (_err, _newData, context) => {
-      handleError('create');
-      if (context?.optimisticAttachments) cacheRemove(orgKey, context.optimisticAttachments);
-    },
-    onSuccess: (result, _variables, context) => {
-      if (context?.optimisticAttachments) cacheRemove(orgKey, context.optimisticAttachments);
-      // Upsert to avoid duplicates from concurrent SSE + onSuccess race
-      for (const attachment of result.data) {
-        if (findAttachmentInCache(attachment.id)) cacheUpdate(orgKey, [attachment]);
-        else cacheCreate(orgKey, [attachment]);
-      }
-    },
-    // Error-only: onSuccess patches cache, SSE handles other users
-    onSettled: (_data, error) => {
-      if (error) invalidateIfLastMutation(queryClient, attachmentsMutationKeyBase, orgKey);
-    },
-  });
-
-  // Inject org context AND stx so persisted variables replay correctly after a reload with
-  // the ORIGINAL mutation id and timestamps (D4); callers pass just the data.
-  return {
-    ...mutation,
-    mutate: (data: CreateAttachmentInput, options?: Parameters<typeof mutation.mutate>[1]) =>
-      mutation.mutate({ tenantId, organizationId, data, stx: createStxForCreate() }, options),
-    mutateAsync: (data: CreateAttachmentInput, options?: Parameters<typeof mutation.mutateAsync>[1]) =>
-      mutation.mutateAsync({ tenantId, organizationId, data, stx: createStxForCreate() }, options),
-  };
+  // Inject org context + stx so a replay reuses the original mutation id and timestamps; callers pass just the data.
+  return usePreparedMutation<
+    CreateData,
+    Error,
+    CreateAttachmentVars,
+    { optimisticAttachments: ItemData[] },
+    CreateAttachmentInput
+  >(attachmentCreateOptions(queryClient), (data) => ({
+    kind: 'run',
+    vars: { tenantId, organizationId, data, stx: createStxForCreate() },
+  }));
 };
 
 export const useAttachmentUpdateMutation = (tenantId: string, organizationId: string) => {
   const queryClient = useQueryClient();
-  const orgKey = keys.list.org(organizationId);
-
-  const mutation = useMutation({
-    mutationKey: keys.update,
-    // Same scope as create/delete: attachment writes serialize, so an update squashed past a
-    // paused create can never replay before it (D6).
-    scope: { id: 'attachment' },
-    mutationFn: updateAttachmentMutationFn,
-    // Squash/coalesce happens in the wrapped mutate() below, BEFORE this mutation exists, so
-    // the request variables carry the merge; onMutate keeps only cache work.
-    onMutate: async ({ id, ops }: UpdateAttachmentFullVars) => {
-      await queryClient.cancelQueries({ queryKey: orgKey });
-      await queryClient.cancelQueries({ queryKey: keys.detail.byId(id) });
-
-      const previousAttachment = findAttachmentInCache(id);
-      if (previousAttachment) {
-        const optimisticAttachment = { ...previousAttachment, ...ops, updatedAt: new Date().toISOString() };
-        cacheUpdate(orgKey, [optimisticAttachment]);
-        queryClient.setQueryData(keys.detail.byId(id), optimisticAttachment);
-      }
-      return { previousAttachment };
-    },
-    meta: { suppressGlobalErrorToast: true },
-    onError: (_err, _variables, context) => {
-      handleError('update');
-      if (context?.previousAttachment) {
-        cacheUpdate(orgKey, [context.previousAttachment]);
-        queryClient.setQueryData(keys.detail.byId(context.previousAttachment.id), context.previousAttachment);
-      }
-    },
-    onSuccess: (updatedAttachment, variables) => {
-      const detailKey = keys.detail.byId(updatedAttachment.id);
-      const cached = findAttachmentInCache(updatedAttachment.id);
-      const mutatedKeys = variables.ops ? Object.keys(variables.ops) : [];
-      const merged = mergeServerResponse({ cached, serverEntity: updatedAttachment, mutatedKeys });
-      syncEntityToCache({ entity: merged, listKey: orgKey, detailKey, queryClient });
-    },
-    // Error-only: onSuccess patches cache, SSE handles other users
-    onSettled: (_data, error) => {
-      if (error) invalidateIfLastMutation(queryClient, attachmentsMutationKeyBase, orgKey);
-    },
-  });
 
   /**
-   * Pre-mutation squash/coalesce (D1/D2): runs before the mutation exists, so nothing
-   * self-matches and the REQUEST carries the merge. Returns null when the edit was folded
-   * into a paused create: the create replays with the merged fields and no update mutation
-   * is issued; the optimistic row is patched here since onMutate never runs.
+   * Squash/coalesce before the mutation exists so the request carries the merge. Folding into a
+   * queued create issues no update and patches the optimistic row here (onMutate won't run).
    */
-  const prepareUpdate = ({ id, ops }: UpdateAttachmentVars): UpdateAttachmentFullVars | null => {
+  const prepare = ({ id, ops }: UpdateAttachmentVars): PreparedVars<UpdateAttachmentFullVars> => {
     if (squashIntoPendingCreate(queryClient, keys.create, id, ops as Record<string, unknown>)) {
       const cached = findAttachmentInCache(id);
       if (cached) {
         const optimisticAttachment = { ...cached, ...ops, updatedAt: new Date().toISOString() };
-        cacheUpdate(orgKey, [optimisticAttachment]);
+        cacheUpdate(keys.list.org(organizationId), [optimisticAttachment]);
         queryClient.setQueryData(keys.detail.byId(id), optimisticAttachment);
       }
-      return null;
+      return { kind: 'coalesced' };
     }
-    const mergedOps = squashPendingMutation(queryClient, keys.update, id, ops as Record<string, unknown>);
-    // stx minted at intent time and carried in variables (D4): a replay reuses the original
-    // mutation id and HLCs, never restamping at execution.
-    return {
-      tenantId,
-      organizationId,
+    // Coalesce queued offline edits; squashPendingMutation keeps each inherited field's original
+    // timestamp so LWW arbitrates by intent time, and only the changed fields carry this edit's stamps.
+    const newStx = createStxForUpdate(Object.keys(ops));
+    const { ops: mergedOps, stx } = squashPendingMutation(
+      queryClient,
+      keys.update,
       id,
-      ops: mergedOps,
-      stx: createStxForUpdate(Object.keys(mergedOps)),
-    };
+      ops as Record<string, unknown>,
+      newStx,
+    );
+    return { kind: 'run', vars: { tenantId, organizationId, id, ops: mergedOps, stx } };
   };
 
-  return {
-    ...mutation,
-    mutate: (vars: UpdateAttachmentVars, options?: Parameters<typeof mutation.mutate>[1]) => {
-      const prepared = prepareUpdate(vars);
-      if (prepared) mutation.mutate(prepared, options);
-    },
-    mutateAsync: async (vars: UpdateAttachmentVars, options?: Parameters<typeof mutation.mutateAsync>[1]) => {
-      const prepared = prepareUpdate(vars);
-      return prepared ? mutation.mutateAsync(prepared, options) : undefined;
-    },
-  };
+  return usePreparedMutation<
+    UpdateData,
+    Error,
+    UpdateAttachmentFullVars,
+    { previousAttachment: Attachment | undefined },
+    UpdateAttachmentVars
+  >(attachmentUpdateOptions(queryClient), prepare);
 };
 
 export const useAttachmentDeleteMutation = (tenantId: string, organizationId: string) => {
   const queryClient = useQueryClient();
-  const orgKey = keys.list.org(organizationId);
-
-  const mutation = useMutation({
-    mutationKey: keys.delete,
-    scope: { id: 'attachment' },
-    mutationFn: deleteAttachmentsMutationFn,
-    onMutate: async ({ attachments }: DeleteAttachmentVars) => {
-      removePendingMutations(
-        queryClient,
-        keys.update,
-        attachments.map((a) => a.id),
-      );
-      await queryClient.cancelQueries({ queryKey: orgKey });
-      cacheRemove(orgKey, attachments);
-      for (const { id } of attachments) {
-        queryClient.removeQueries({ queryKey: keys.detail.byId(id) });
-      }
-      return { deletedAttachments: attachments };
-    },
-    meta: { suppressGlobalErrorToast: true },
-    onError: (_err, _attachments, context) => {
-      handleError('delete');
-      if (context?.deletedAttachments) cacheCreate(orgKey, context.deletedAttachments);
-    },
-    onSuccess: (result, variables) => {
-      // Partial rejection (200 + rejectedIds): the backend kept permission-denied rows.
-      // Restore them into the cache NOW so they don't silently reappear on the
-      // next sync, and tell the user. (A full rejection arrives as a 403 via onError.)
-      const rejectedIds = result?.rejectedIds ?? [];
-      if (rejectedIds.length === 0) return;
-      const rejectedSet = new Set(rejectedIds);
-      cacheCreate(
-        orgKey,
-        variables.attachments.filter((a) => rejectedSet.has(a.id)),
-      );
-      toaster(
-        i18n.t('c:resources_delete_denied', { count: rejectedIds.length, total: variables.attachments.length }),
-        'info',
-      );
-    },
-    // Error-only: onMutate removed the attachment from all caches, SSE handles other users.
-    onSettled: (_data, error) => {
-      if (error) invalidateIfLastMutation(queryClient, attachmentsMutationKeyBase, orgKey);
-    },
-  });
 
   /**
-   * Pre-mutation create cancellation (D3): rows with a paused create never reached the
-   * server: cancel the create, clear their paused updates, finish their deletion
-   * cache-side, and keep them OUT of the delete request. Returns the rows that still need
-   * a server delete, or null when none do (including the empty-selection edge).
+   * Cancel queued creates for rows deleted while offline (they never reached the server), clear their
+   * queued updates, finish deletion cache-side, and keep them out of the request. `noop` when nothing remains.
    */
-  const prepareDelete = (attachments: Attachment[]): Attachment[] | null => {
+  const prepare = (attachments: Attachment[]): PreparedVars<DeleteAttachmentVars> => {
     const cancelled = new Set(
       removePausedCreates(
         queryClient,
@@ -373,34 +400,27 @@ export const useAttachmentDeleteMutation = (tenantId: string, organizationId: st
         keys.update,
         localOnly.map((a) => a.id),
       );
-      cacheRemove(orgKey, localOnly);
+      cacheRemove(keys.list.org(organizationId), localOnly);
       for (const { id } of localOnly) queryClient.removeQueries({ queryKey: keys.detail.byId(id) });
     }
     const remaining = attachments.filter((a) => !cancelled.has(a.id));
-    return remaining.length > 0 ? remaining : null;
+    if (remaining.length === 0) return { kind: 'noop' };
+    return { kind: 'run', vars: { tenantId, organizationId, attachments: remaining, stx: createStxForDelete() } };
   };
 
-  return {
-    ...mutation,
-    mutate: (attachments: Attachment[], options?: Parameters<typeof mutation.mutate>[1]) => {
-      const remaining = prepareDelete(attachments);
-      if (remaining)
-        mutation.mutate({ tenantId, organizationId, attachments: remaining, stx: createStxForDelete() }, options);
-    },
-    mutateAsync: async (attachments: Attachment[], options?: Parameters<typeof mutation.mutateAsync>[1]) => {
-      const remaining = prepareDelete(attachments);
-      return remaining
-        ? mutation.mutateAsync({ tenantId, organizationId, attachments: remaining, stx: createStxForDelete() }, options)
-        : undefined;
-    },
-  };
+  return usePreparedMutation<
+    DeleteData,
+    Error,
+    DeleteAttachmentVars,
+    { deletedAttachments: Attachment[] },
+    Attachment[]
+  >(attachmentDeleteOptions(queryClient), prepare);
 };
 
 // --- Mutation defaults (offline persistence) ---
 
 addMutationRegistrar((queryClient: QueryClient) => {
-  // Detail query defaults for SSE stream handlers, resolves organizationId/tenantId from:
-  // 1. meta (SSE handler), 2. cached entity, 3. router context
+  // Detail defaults for SSE handlers: resolve org/tenant from meta, then the cached entity, then the router.
   queryClient.setQueryDefaults(keys.detail.base, {
     queryFn: ({ queryKey, meta }) => {
       const id = queryKey[2] as string;
@@ -412,9 +432,8 @@ addMutationRegistrar((queryClient: QueryClient) => {
     },
   });
 
-  // Same functions the hooks use, so a mutation replayed from the persisted queue after a reload
-  // (when the hook's closure is gone) runs identically to the live one.
-  queryClient.setMutationDefaults(keys.create, { mutationFn: createAttachmentsMutationFn });
-  queryClient.setMutationDefaults(keys.update, { mutationFn: updateAttachmentMutationFn });
-  queryClient.setMutationDefaults(keys.delete, { mutationFn: deleteAttachmentsMutationFn });
+  // The SAME full options the hooks use (not just mutationFn), so a replayed mutation runs the same reconciliation callbacks.
+  queryClient.setMutationDefaults(keys.create, attachmentCreateOptions(queryClient));
+  queryClient.setMutationDefaults(keys.update, attachmentUpdateOptions(queryClient));
+  queryClient.setMutationDefaults(keys.delete, attachmentDeleteOptions(queryClient));
 });

--- a/frontend/src/query/basic/apply-entity-to-lists.ts
+++ b/frontend/src/query/basic/apply-entity-to-lists.ts
@@ -1,0 +1,128 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { appConfig, hierarchy, resolveDeepestAncestorId } from 'shared';
+import { changeInfiniteQueryData, changeQueryData } from '~/query/basic/helpers';
+import { isInfiniteQueryData, isQueryData } from '~/query/basic/mutate-query';
+import type { ItemData } from '~/query/basic/types';
+import type { EntityQueryKeys } from './entity-query-registry';
+
+/**
+ * The row's effective home channel id: deepest non-null ancestor, the org itself for org-homed
+ * rows. The same resolution SSE routing uses (resolve-row-channel), so cache placement and stream
+ * routing can never disagree.
+ */
+export function resolveHomeChannelId(entityType: string, entity: ItemData): string | null {
+  const entityRecord = entity as unknown as Record<string, unknown>;
+  const home = resolveDeepestAncestorId(hierarchy, entityType, entityRecord);
+  if (home) return home;
+  const organizationId = entityRecord.organizationId;
+  return typeof organizationId === 'string' ? organizationId : null;
+}
+
+/**
+ * Whether `queryKey` is the canonical home list for a row homed at `homeChannelId`:
+ * [entityType, 'list', organizationId, homeChannelId]. Every row belongs to exactly one home list.
+ * Filtered keys (object segments) never match: those lists are scoped by server-side filters we
+ * can't replicate here; string keys at other depths are prefixes, never data keys.
+ */
+export function matchesCanonicalHome(
+  queryKey: readonly unknown[],
+  organizationId: string,
+  homeChannelId: string,
+): boolean {
+  return queryKey.length === 4 && queryKey[2] === organizationId && queryKey[3] === homeChannelId;
+}
+
+/** True when the row moved to a different parent channel (any context id column differs). */
+function hasParentChannelChanged(cached: ItemData, incoming: ItemData): boolean {
+  const c = cached as unknown as Record<string, unknown>;
+  const i = incoming as unknown as Record<string, unknown>;
+  for (const entityType of appConfig.channelEntityTypes) {
+    const key = appConfig.entityIdColumnKeys[entityType];
+    if (typeof c[key] === 'string' && typeof i[key] === 'string' && c[key] !== i[key]) return true;
+  }
+  return false;
+}
+
+export interface SpliceResult {
+  /** The row was already present in at least one scanned list cache. */
+  seen: boolean;
+  /** The row was newly inserted into its canonical home list. */
+  spliced: boolean;
+  /** At least one filtered list (object key segment) was scanned; its server-side filter can't be
+   *  replicated locally, so callers invalidate those separately. */
+  sawFilteredList: boolean;
+}
+
+/**
+ * Apply one entity to every list cache under its org, following the canonical-home policy shared by
+ * the realtime and mutation paths:
+ *   - a row already cached in a list updates in place;
+ *   - an unknown row inserts ONLY into its canonical home list;
+ *   - an unknown row is never inserted into a filtered/search list (its filter can't be evaluated
+ *     client-side, so a non-matching row would leak in).
+ *
+ * With `removeOnParentChannelChange`, a cached row whose parent channel changed is removed from the
+ * list (the realtime path sets this when the server moves a row to a different parent).
+ */
+export function spliceEntityIntoListCaches(
+  queryClient: QueryClient,
+  opts: {
+    entity: ItemData;
+    keys: EntityQueryKeys;
+    organizationId: string | null;
+    homeChannelId: string | null;
+    removeOnParentChannelChange?: boolean;
+  },
+): SpliceResult {
+  const { entity, keys, organizationId, homeChannelId, removeOnParentChannelChange = false } = opts;
+
+  let seen = false;
+  let spliced = false;
+  let sawFilteredList = false;
+  const listPrefix = organizationId ? keys.list.org(organizationId) : keys.list.base;
+
+  for (const [queryKey, queryData] of queryClient.getQueriesData({ queryKey: listPrefix })) {
+    sawFilteredList ||= queryKey.slice(2).some((seg) => typeof seg === 'object' && seg !== null);
+
+    let cachedItem: ItemData | undefined;
+    let change: typeof changeQueryData;
+    if (isInfiniteQueryData<ItemData>(queryData)) {
+      cachedItem = queryData.pages.flatMap((p) => p.items).find((item) => item.id === entity.id);
+      change = changeInfiniteQueryData;
+    } else if (isQueryData<ItemData>(queryData)) {
+      cachedItem = queryData.items.find((item) => item.id === entity.id);
+      change = changeQueryData;
+    } else {
+      continue;
+    }
+
+    if (removeOnParentChannelChange && cachedItem && hasParentChannelChanged(cachedItem, entity)) {
+      change(queryKey, [entity], 'remove');
+      continue;
+    }
+
+    const isHomeList =
+      !!organizationId && !!homeChannelId && matchesCanonicalHome(queryKey, organizationId, homeChannelId);
+    seen = seen || !!cachedItem;
+    spliced ||= !cachedItem && isHomeList;
+    change(queryKey, [entity], cachedItem || !isHomeList ? 'update' : 'create');
+  }
+
+  return { seen, spliced, sawFilteredList };
+}
+
+/**
+ * Insert (or update in place) optimistic or server-confirmed rows into their canonical home lists,
+ * never into filtered/search lists. The mutation-path counterpart of the realtime splice: creates
+ * splice into the home list live sync owns; a row already present anywhere updates in place.
+ */
+export function insertEntitiesIntoHome(
+  queryClient: QueryClient,
+  opts: { entityType: string; entities: ItemData[]; keys: EntityQueryKeys; organizationId: string },
+): void {
+  const { entityType, entities, keys, organizationId } = opts;
+  for (const entity of entities) {
+    const homeChannelId = resolveHomeChannelId(entityType, entity);
+    spliceEntityIntoListCaches(queryClient, { entity, keys, organizationId, homeChannelId });
+  }
+}

--- a/frontend/src/query/basic/helpers.ts
+++ b/frontend/src/query/basic/helpers.ts
@@ -44,8 +44,16 @@ export const changeInfiniteQueryData = (queryKey: QueryKey, items: ItemData[], a
       if (!hasMatch) return data;
     }
 
-    // Adjust total based on the action
-    const totalAdjustment = action === 'create' ? items.length : action === 'remove' ? -items.length : 0;
+    // Adjust total by how many items actually change membership: creates count only rows not
+    // already present (updateArrayItems dedupes); removes count only rows actually present. Using
+    // items.length would drift `total` when the input partially overlaps this query.
+    const existingIds = new Set(data.pages.flatMap((page) => page.items).map(({ id }) => id));
+    const totalAdjustment =
+      action === 'create'
+        ? items.filter(({ id }) => !existingIds.has(id)).length
+        : action === 'remove'
+          ? -items.filter(({ id }) => existingIds.has(id)).length
+          : 0;
 
     // Update items in each page and adjust the total
     const pages = data.pages.map((page) => ({
@@ -71,8 +79,16 @@ export const changeQueryData = (queryKey: QueryKey, items: ItemData[], action: Q
       if (!data.items.some((existing) => updateIds.has(existing.id))) return data;
     }
 
-    // Adjust total based on the action
-    const totalAdjustment = action === 'create' ? items.length : action === 'remove' ? -items.length : 0;
+    // Adjust total by how many items actually change membership: creates count only rows not
+    // already present (updateArrayItems dedupes); removes count only rows actually present. Using
+    // items.length would drift `total` when the input partially overlaps this query.
+    const existingIds = new Set(data.items.map(({ id }) => id));
+    const totalAdjustment =
+      action === 'create'
+        ? items.filter(({ id }) => !existingIds.has(id)).length
+        : action === 'remove'
+          ? -items.filter(({ id }) => existingIds.has(id)).length
+          : 0;
 
     // Update items and adjust the total
     return {

--- a/frontend/src/query/basic/invalidation-helpers.ts
+++ b/frontend/src/query/basic/invalidation-helpers.ts
@@ -1,15 +1,20 @@
 import type { QueryClient, QueryKey } from '@tanstack/react-query';
 import type { ChannelEntityType } from 'shared';
+import { isQueued } from '~/query/offline/mutation-queue';
 import { getEntityQueryKeys } from './entity-query-registry';
 
 /**
- * Remove pending update mutations for entities about to be deleted.
- * Prevents stale updates from firing after the entity is deleted.
+ * Remove QUEUED (offline-parked) update mutations for entities about to be deleted, so a stale
+ * offline edit does not replay after the delete. Active (in-flight) updates are left in the mutation
+ * cache: removing one does not cancel its request but does drop it from the scope queue, which would
+ * let the delete start alongside it and defeat same-scope serialization. Those stay queued and the
+ * delete serializes behind them.
  */
 export function removePendingMutations(queryClient: QueryClient, updateKey: QueryKey, ids: string[]): void {
   const idSet = new Set(ids);
   const mutationCache = queryClient.getMutationCache();
   for (const mutation of mutationCache.findAll({ mutationKey: updateKey })) {
+    if (!isQueued(mutation)) continue;
     const vars = mutation.state.variables as { id?: string } | undefined;
     if (vars?.id && idSet.has(vars.id)) {
       mutationCache.remove(mutation);

--- a/frontend/src/query/basic/tests/apply-entity-to-lists.test.ts
+++ b/frontend/src/query/basic/tests/apply-entity-to-lists.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { EntityQueryKeys } from '~/query/basic/entity-query-registry';
+import type { ItemData } from '~/query/basic/types';
+
+// Base cella has only org-homed attachments; mock a minimal org-only topology so home resolution
+// (deepest non-null ancestor, org for org-homed rows) is deterministic here.
+vi.mock('shared', () => ({
+  appConfig: {
+    channelEntityTypes: ['organization'],
+    entityIdColumnKeys: { organization: 'organizationId' },
+  },
+  hierarchy: { getOrderedAncestors: () => ['organization'] },
+  resolveDeepestAncestorId: (
+    hierarchy: { getOrderedAncestors: (entityType: string) => readonly string[] },
+    entityType: string,
+    row: Record<string, unknown>,
+  ) => {
+    for (const type of hierarchy.getOrderedAncestors(entityType)) {
+      const id = row[`${type}Id`];
+      if (typeof id === 'string' && id) return id;
+    }
+    return null;
+  },
+}));
+vi.mock('~/query/offline', () => ({ sourceId: 'test-source' }));
+vi.stubGlobal('window', { addEventListener: vi.fn(), removeEventListener: vi.fn() });
+vi.stubGlobal('navigator', { onLine: true });
+
+// The change* helpers write through the module-singleton queryClient, so tests use that instance.
+const { queryClient } = await import('~/query/query-client');
+const { insertEntitiesIntoHome, spliceEntityIntoListCaches } = await import('~/query/basic/apply-entity-to-lists');
+
+const orgId = 'org-1';
+
+const keys = {
+  all: ['attachment'],
+  list: {
+    base: ['attachment', 'list'],
+    org: (o: string) => ['attachment', 'list', o],
+    filtered: (f: unknown) => ['attachment', 'list', f],
+    home: (o: string, h?: string) => ['attachment', 'list', o, h ?? o],
+  },
+  detail: { base: ['attachment', 'detail'], byId: (id: string) => ['attachment', 'detail', id] },
+  create: ['attachment', 'create'],
+  update: ['attachment', 'update'],
+  delete: ['attachment', 'delete'],
+} as unknown as EntityQueryKeys;
+
+const homeKey = ['attachment', 'list', orgId, orgId];
+const filteredKey = ['attachment', 'list', orgId, { q: 'foo' }];
+
+const row = (id: string, extra: Record<string, unknown> = {}): ItemData =>
+  ({ id, entityType: 'attachment', organizationId: orgId, ...extra }) as unknown as ItemData;
+
+describe('spliceEntityIntoListCaches: canonical-home policy', () => {
+  afterEach(() => queryClient.clear());
+
+  it('inserts a new row into the canonical home list ONLY, never the filtered/search list', () => {
+    queryClient.setQueryData(homeKey, { items: [], total: 0 });
+    queryClient.setQueryData(filteredKey, { pages: [{ items: [], total: 0 }], pageParams: [{ page: 0 }] });
+
+    const result = spliceEntityIntoListCaches(queryClient, {
+      entity: row('a'),
+      keys,
+      organizationId: orgId,
+      homeChannelId: orgId,
+    });
+
+    const home = queryClient.getQueryData<{ items: ItemData[]; total: number }>(homeKey);
+    const filtered = queryClient.getQueryData<{ pages: { items: ItemData[]; total: number }[] }>(filteredKey);
+
+    expect(home?.items.map((i) => i.id)).toEqual(['a']);
+    expect(home?.total).toBe(1);
+    // The search list did not gain the non-matching row.
+    expect(filtered?.pages[0].items).toEqual([]);
+    expect(filtered?.pages[0].total).toBe(0);
+    expect(result).toMatchObject({ seen: false, spliced: true, sawFilteredList: true });
+  });
+
+  it('updates an existing row in place across home and filtered lists without inserting', () => {
+    queryClient.setQueryData(homeKey, { items: [row('a', { name: 'old' })], total: 1 });
+    queryClient.setQueryData(filteredKey, {
+      pages: [{ items: [row('a', { name: 'old' })], total: 1 }],
+      pageParams: [{ page: 0 }],
+    });
+
+    const result = spliceEntityIntoListCaches(queryClient, {
+      entity: row('a', { name: 'new' }),
+      keys,
+      organizationId: orgId,
+      homeChannelId: orgId,
+    });
+
+    const home = queryClient.getQueryData<{ items: ItemData[]; total: number }>(homeKey);
+    const filtered = queryClient.getQueryData<{ pages: { items: ItemData[]; total: number }[] }>(filteredKey);
+
+    expect(home?.items[0]).toMatchObject({ name: 'new' });
+    expect(home?.total).toBe(1);
+    // Present in the filtered list, so it updates there too (no leak, no total drift).
+    expect(filtered?.pages[0].items[0]).toMatchObject({ name: 'new' });
+    expect(filtered?.pages[0].total).toBe(1);
+    expect(result.seen).toBe(true);
+  });
+});
+
+describe('insertEntitiesIntoHome: resolves the org-homed attachment home key', () => {
+  afterEach(() => queryClient.clear());
+
+  it('splices an org-homed row into [type, list, org, org]', () => {
+    queryClient.setQueryData(homeKey, { items: [], total: 0 });
+
+    insertEntitiesIntoHome(queryClient, {
+      entityType: 'attachment',
+      entities: [row('a')],
+      keys,
+      organizationId: orgId,
+    });
+
+    const home = queryClient.getQueryData<{ items: ItemData[]; total: number }>(homeKey);
+    expect(home?.items.map((i) => i.id)).toEqual(['a']);
+    expect(home?.total).toBe(1);
+  });
+});

--- a/frontend/src/query/offline/mutation-queue.ts
+++ b/frontend/src/query/offline/mutation-queue.ts
@@ -1,0 +1,38 @@
+import { onlineManager } from '@tanstack/react-query';
+
+/** Minimal shape of a mutation's observable state; avoids depending on the generic Mutation type. */
+type MutationLike = { state: { status: string; isPaused: boolean } };
+
+/**
+ * A mutation currently executing (on the wire). Its variables are committed to a request, so
+ * coalescing must never merge into it or remove it.
+ */
+export function isActive(mutation: MutationLike): boolean {
+  return mutation.state.status === 'pending' && !mutation.state.isPaused;
+}
+
+/**
+ * A mutation parked offline awaiting reconnect. This is the only state coalescing may merge into
+ * or cancel: while offline it cannot have completed a server round trip.
+ */
+export function isQueued(mutation: MutationLike): boolean {
+  return mutation.state.status === 'pending' && mutation.state.isPaused;
+}
+
+/** Any pending mutation (active or queued). True while a remote cache write should defer to optimistic state. */
+export function isPending(mutation: MutationLike): boolean {
+  return mutation.state.status === 'pending';
+}
+
+/**
+ * Coalescing (folding later intent into a queued mutation, or cancelling a queued create) is only
+ * safe while offline. A queued mutation is paused because connectivity is down, so it has not
+ * committed a server change; merging or cancelling cannot lose one. Once back online we issue
+ * separate, scope-serialized mutations and let backend idempotency + field-timestamp LWW arbitrate.
+ *
+ * Checked synchronously immediately before the merge, so the window where connectivity returns
+ * between this check and the merge is a single synchronous block.
+ */
+export function canCoalesce(): boolean {
+  return !onlineManager.isOnline();
+}

--- a/frontend/src/query/offline/prepared-mutation.ts
+++ b/frontend/src/query/offline/prepared-mutation.ts
@@ -1,0 +1,64 @@
+import { type UseMutationOptions, useMutation } from '@tanstack/react-query';
+
+/**
+ * Result of preparing public input into durable mutation variables:
+ *   - `run`: issue the mutation with `vars`;
+ *   - `coalesced`: the intent was folded into a queued mutation, issue nothing;
+ *   - `noop`: nothing to send (e.g. an all-local selection was cancelled cache-side).
+ */
+export type PreparedVars<TVars> = { kind: 'run'; vars: TVars } | { kind: 'coalesced' } | { kind: 'noop' };
+
+/**
+ * Sentinel resolved by `mutateAsync` when the intent was coalesced or was a no-op. Awaiting callers
+ * proceed without hanging on a promise that never settles (removing a queued mutation from the
+ * cache does not settle its own promise, so coalesced work is reported here, at the call site).
+ */
+export const COALESCED = Symbol('coalesced');
+
+/** The subset of a mutation the prepared handlers drive. */
+interface Mutatable<TData, TVars> {
+  mutate: (vars: TVars, opts?: unknown) => void;
+  mutateAsync: (vars: TVars, opts?: unknown) => Promise<TData>;
+}
+
+/**
+ * Wrap a mutation's `mutate`/`mutateAsync` with a preparation step that turns public input into
+ * durable variables exactly once, before the mutation runs. Pure (no React), so it is unit-testable
+ * with a fake mutation.
+ *
+ * `mutate` issues nothing for `coalesced`/`noop`. `mutateAsync` resolves immediately with COALESCED
+ * for those, so callers that await (e.g. to close a dialog) never hang on coalesced or empty work.
+ */
+export function buildPreparedHandlers<TData, TVars, TInput>(
+  mutation: Mutatable<TData, TVars>,
+  prepare: (input: TInput) => PreparedVars<TVars>,
+) {
+  const mutate = (input: TInput, opts?: unknown) => {
+    const prepared = prepare(input);
+    if (prepared.kind === 'run') mutation.mutate(prepared.vars, opts);
+  };
+
+  const mutateAsync = async (input: TInput, opts?: unknown): Promise<TData | typeof COALESCED> => {
+    const prepared = prepare(input);
+    if (prepared.kind === 'run') return mutation.mutateAsync(prepared.vars, opts);
+    return COALESCED;
+  };
+
+  return { mutate, mutateAsync };
+}
+
+/**
+ * Hook form: run the mutation with `options` and expose `mutate`/`mutateAsync` that accept the
+ * public input, preparing it (routing context, stx, offline coalescing) via `prepare`.
+ */
+export function usePreparedMutation<TData, TError, TVars, TContext, TInput>(
+  options: UseMutationOptions<TData, TError, TVars, TContext>,
+  prepare: (input: TInput) => PreparedVars<TVars>,
+) {
+  const mutation = useMutation(options);
+  const { mutate, mutateAsync } = buildPreparedHandlers<TData, TVars, TInput>(
+    mutation as Mutatable<TData, TVars>,
+    prepare,
+  );
+  return { ...mutation, mutate, mutateAsync };
+}

--- a/frontend/src/query/offline/squash-utils.ts
+++ b/frontend/src/query/offline/squash-utils.ts
@@ -1,7 +1,9 @@
 import type { QueryClient } from '@tanstack/react-query';
+import type { StxBase } from 'sdk';
 import { type ArrayDelta, isArrayDelta, mergeArrayDeltas } from './array-delta';
+import { canCoalesce, isQueued } from './mutation-queue';
 
-type OpsVariables = { id?: string; ops?: Record<string, unknown> };
+type OpsVariables = { id?: string; ops?: Record<string, unknown>; stx?: StxBase };
 type CreateVariables = { id?: string; data?: Array<Record<string, unknown> | undefined> };
 
 // Merge two ops objects: scalar fields are overwritten by `newer`; AWSet deltas are merged via mergeArrayDeltas.
@@ -18,70 +20,89 @@ function mergeOps(older: Record<string, unknown>, newer: Record<string, unknown>
   return merged;
 }
 
-/** PAUSED mutations only: in-flight requests must never be squashed away (their ops are on the wire). */
-function isPausedPending(mutation: { state: { status: string; isPaused: boolean } }): boolean {
-  return mutation.state.status === 'pending' && mutation.state.isPaused;
-}
+/** Result of coalescing an update: the merged ops and an stx whose field timestamps preserve each
+ * inherited field's original intent time while carrying the incoming edit's timestamps for the
+ * fields it actually changed. */
+export type SquashedUpdate = { ops: Record<string, unknown>; stx: StxBase };
 
 /**
- * Squash PAUSED same-entity update mutations into an update about to be issued: merge their
- * `ops` under the new ones (newer scalars win; AWSet deltas merge via mergeArrayDeltas) and
- * remove the old paused mutations. Returns the merged ops.
+ * Squash QUEUED (offline-parked) same-entity update mutations into an update about to be issued:
+ * merge their `ops` under the new ones (newer scalars win; AWSet deltas merge via mergeArrayDeltas)
+ * and remove the old queued mutations. The returned stx keeps each inherited field's original
+ * timestamp (LWW must arbitrate by intent time, so a restamp would let an old edit beat a newer
+ * one from another client) while the incoming edit's own fields carry `newStx`.
  *
- * Call from the wrapped `mutate()` BEFORE `mutation.mutate(...)` and put the result in the new
- * mutation's variables: the request then carries the merge, so an offline edit A followed by
- * edit B replays as one A+B update. (Calling from `onMutate` is wrong twice: the caller is
- * already a pending cache entry and would squash itself out of the cache, and in-flight
- * mutations would be removed without cancelling their requests.)
+ * No-op while online (returns `{ ops: newOps, stx: newStx }` untouched): a queued mutation can only
+ * be safely merged away while offline, before it has completed a server round trip. Once online the
+ * caller issues a separate, scope-serialized update. See canCoalesce.
+ *
+ * Call from the wrapped `mutate()` BEFORE `mutation.mutate(...)` so nothing self-matches and the
+ * REQUEST carries the merge: an offline edit A followed by edit B replays as one A+B update.
  */
 export function squashPendingMutation(
   queryClient: QueryClient,
   mutationKey: readonly unknown[],
   entityId: string,
   newOps: Record<string, unknown>,
-): Record<string, unknown> {
+  newStx: StxBase,
+): SquashedUpdate {
+  if (!canCoalesce()) return { ops: newOps, stx: newStx };
+
   const mutationCache = queryClient.getMutationCache();
   const mutations = mutationCache.findAll({ mutationKey });
 
-  let mergedOps = { ...newOps };
+  // Accumulate oldest-first so newer queued edits win, then the incoming edit wins over all.
+  let mergedOps: Record<string, unknown> = {};
+  let inheritedTimestamps: Record<string, string> = {};
 
   for (const mutation of mutations) {
-    if (!isPausedPending(mutation)) continue;
+    if (!isQueued(mutation)) continue;
 
     const variables = mutation.state.variables as OpsVariables | undefined;
     if (variables?.id !== entityId) continue;
 
-    // Merge: old ops as base, new ops override (with AWSet-aware merging)
-    if (variables.ops) {
-      mergedOps = mergeOps(variables.ops, mergedOps);
+    if (variables.ops) mergedOps = mergeOps(mergedOps, variables.ops);
+    if (variables.stx?.fieldTimestamps) {
+      inheritedTimestamps = { ...inheritedTimestamps, ...variables.stx.fieldTimestamps };
     }
 
-    // Remove old mutation; the new one will carry merged ops.
+    // Remove old mutation; the new one will carry merged ops and merged timestamps.
     mutationCache.remove(mutation);
   }
 
-  return mergedOps;
+  mergedOps = mergeOps(mergedOps, newOps);
+  const stx: StxBase = {
+    ...newStx,
+    fieldTimestamps: { ...inheritedTimestamps, ...newStx.fieldTimestamps },
+  };
+
+  return { ops: mergedOps, stx };
 }
 
 /**
- * Cancel PAUSED creates for rows about to be deleted: those rows never reached the server, so
- * no delete request may be sent for them either (the create would replay on reconnect and the
- * row would resurrect, or the delete would 404). Removes matching rows from batch-create
- * `data[]` variables (dropping the whole mutation when no rows remain) and removes matching
- * top-level-id creates. Returns the ids whose creates were cancelled; the caller keeps those
+ * Cancel QUEUED (offline-parked) creates for rows about to be deleted: while offline those rows
+ * never reached the server, so no delete request may be sent for them either (the create would
+ * replay on reconnect and the row would resurrect, or the delete would 404). Removes matching rows
+ * from batch-create `data[]` variables (dropping the whole mutation when no rows remain) and removes
+ * matching top-level-id creates. Returns the ids whose creates were cancelled; the caller keeps those
  * ids out of the delete request and finishes their deletion cache-side only.
+ *
+ * No-op while online (returns `[]`): once a create may have reached the server the delete must be
+ * sent and scope serialization runs it after the create.
  */
 export function removePausedCreates(
   queryClient: QueryClient,
   createMutationKey: readonly unknown[],
   ids: string[],
 ): string[] {
+  if (!canCoalesce()) return [];
+
   const idSet = new Set(ids);
   const cancelled: string[] = [];
   const mutationCache = queryClient.getMutationCache();
 
   for (const mutation of mutationCache.findAll({ mutationKey: createMutationKey })) {
-    if (!isPausedPending(mutation)) continue;
+    if (!isQueued(mutation)) continue;
 
     const variables = mutation.state.variables as CreateVariables | undefined;
     if (!variables) continue;
@@ -109,13 +130,14 @@ export function removePausedCreates(
 }
 
 /**
- * If a PAUSED create exists for the entity, merge scalar update `ops` into the create's row and
- * return true, so the caller skips issuing an update mutation entirely (the create replays with
- * the merged fields). Matches both create-variable shapes: a top-level `id` and batch creates
- * carrying `data: [{ id, ... }]`.
+ * If a QUEUED (offline-parked) create exists for the entity, merge scalar update `ops` into the
+ * create's row and return true, so the caller skips issuing an update mutation entirely (the create
+ * replays with the merged fields). Matches both create-variable shapes: a top-level `id` and batch
+ * creates carrying `data: [{ id, ... }]`.
  *
- * Array-delta ops always return false: creates carry full arrays while deltas are relative, so
- * those edits fall through to a normal update (serialized after the create by mutation scope).
+ * No-op while online (returns false): the caller issues a normal update, serialized after the create
+ * by mutation scope. Array-delta ops always return false: creates carry full arrays while deltas are
+ * relative, so those edits fall through to a normal update.
  */
 export function squashIntoPendingCreate(
   queryClient: QueryClient,
@@ -123,13 +145,14 @@ export function squashIntoPendingCreate(
   entityId: string,
   ops: Record<string, unknown>,
 ): boolean {
+  if (!canCoalesce()) return false;
   if (Object.values(ops).some((value) => isArrayDelta(value))) return false;
 
   const mutationCache = queryClient.getMutationCache();
   const mutations = mutationCache.findAll({ mutationKey: createMutationKey });
 
   for (const mutation of mutations) {
-    if (!isPausedPending(mutation)) continue;
+    if (!isQueued(mutation)) continue;
 
     const variables = mutation.state.variables as CreateVariables | undefined;
     if (!variables) continue;

--- a/frontend/src/query/offline/tests/mutation-queue.test.ts
+++ b/frontend/src/query/offline/tests/mutation-queue.test.ts
@@ -1,0 +1,38 @@
+import { onlineManager } from '@tanstack/react-query';
+import { afterEach, describe, expect, it } from 'vitest';
+import { canCoalesce, isActive, isPending, isQueued } from '../mutation-queue';
+
+const paused = { state: { status: 'pending', isPaused: true } };
+const inFlight = { state: { status: 'pending', isPaused: false } };
+const settled = { state: { status: 'success', isPaused: false } };
+
+describe('mutation-queue classification', () => {
+  it('isQueued is true only for a paused pending mutation', () => {
+    expect(isQueued(paused)).toBe(true);
+    expect(isQueued(inFlight)).toBe(false);
+    expect(isQueued(settled)).toBe(false);
+  });
+
+  it('isActive is true only for a non-paused pending mutation', () => {
+    expect(isActive(inFlight)).toBe(true);
+    expect(isActive(paused)).toBe(false);
+    expect(isActive(settled)).toBe(false);
+  });
+
+  it('isPending is true for both active and queued, false once settled', () => {
+    expect(isPending(inFlight)).toBe(true);
+    expect(isPending(paused)).toBe(true);
+    expect(isPending(settled)).toBe(false);
+  });
+});
+
+describe('canCoalesce online gate', () => {
+  afterEach(() => onlineManager.setOnline(true));
+
+  it('is true only while offline', () => {
+    onlineManager.setOnline(false);
+    expect(canCoalesce()).toBe(true);
+    onlineManager.setOnline(true);
+    expect(canCoalesce()).toBe(false);
+  });
+});

--- a/frontend/src/query/offline/tests/offline-reconciliation.test.ts
+++ b/frontend/src/query/offline/tests/offline-reconciliation.test.ts
@@ -63,45 +63,60 @@ describe('offline reconciliation lifecycle', () => {
     queryClient.clear();
   });
 
+  // Minimal stx carrying a timestamp for each supplied field.
+  const stxFor = (keys: string[]) => ({
+    mutationId: `m-${keys.join('-')}`,
+    sourceId: 's',
+    fieldTimestamps: Object.fromEntries(keys.map((k) => [k, `t-${k}`])),
+  });
+
   it('squash accumulates fields from sequential edits to same entity', () => {
     const mutationKey = ['test', 'update'] as const;
 
     // Simulate 3 offline edits to the same entity, each changing different fields
     // First edit: no pending, returns as-is.
-    const fields1 = squashPendingMutation(queryClient, mutationKey, entityId, { name: 'Edit 1' });
-    expect(fields1).toEqual({ name: 'Edit 1' });
+    const r1 = squashPendingMutation(queryClient, mutationKey, entityId, { name: 'Edit 1' }, stxFor(['name']));
+    expect(r1.ops).toEqual({ name: 'Edit 1' });
 
     // Queue first mutation as pending
-    cleanups.push(queuePendingMutation(queryClient, mutationKey, { id: entityId, ops: fields1 }));
+    cleanups.push(queuePendingMutation(queryClient, mutationKey, { id: entityId, ops: r1.ops, stx: r1.stx }));
 
     // Second edit: squashes with first.
-    const fields2 = squashPendingMutation(queryClient, mutationKey, entityId, { description: 'Edit 2' });
-    expect(fields2).toEqual({ name: 'Edit 1', description: 'Edit 2' });
+    const r2 = squashPendingMutation(
+      queryClient,
+      mutationKey,
+      entityId,
+      { description: 'Edit 2' },
+      stxFor(['description']),
+    );
+    expect(r2.ops).toEqual({ name: 'Edit 1', description: 'Edit 2' });
+    // Inherited field keeps its original intent timestamp; the new field carries its own.
+    expect(r2.stx.fieldTimestamps).toEqual({ name: 't-name', description: 't-description' });
 
     // Queue second mutation
-    cleanups.push(queuePendingMutation(queryClient, mutationKey, { id: entityId, ops: fields2 }));
+    cleanups.push(queuePendingMutation(queryClient, mutationKey, { id: entityId, ops: r2.ops, stx: r2.stx }));
 
     // Third edit: squashes with accumulated.
-    const fields3 = squashPendingMutation(queryClient, mutationKey, entityId, { status: 'done' });
-    expect(fields3).toEqual({ name: 'Edit 1', description: 'Edit 2', status: 'done' });
+    const r3 = squashPendingMutation(queryClient, mutationKey, entityId, { status: 'done' }, stxFor(['status']));
+    expect(r3.ops).toEqual({ name: 'Edit 1', description: 'Edit 2', status: 'done' });
   });
 
   it('squash uses latest value when same field is edited multiple times', () => {
     const mutationKey = ['test', 'update'] as const;
 
     // First edit: name = 'Draft 1'
-    const fields1 = squashPendingMutation(queryClient, mutationKey, entityId, { name: 'Draft 1' });
-    cleanups.push(queuePendingMutation(queryClient, mutationKey, { id: entityId, ops: fields1 }));
+    const r1 = squashPendingMutation(queryClient, mutationKey, entityId, { name: 'Draft 1' }, stxFor(['name']));
+    cleanups.push(queuePendingMutation(queryClient, mutationKey, { id: entityId, ops: r1.ops, stx: r1.stx }));
 
     // Second edit: name = 'Draft 2' (overrides)
-    const fields2 = squashPendingMutation(queryClient, mutationKey, entityId, { name: 'Draft 2' });
-    expect(fields2).toEqual({ name: 'Draft 2' });
+    const r2 = squashPendingMutation(queryClient, mutationKey, entityId, { name: 'Draft 2' }, stxFor(['name']));
+    expect(r2.ops).toEqual({ name: 'Draft 2' });
 
-    cleanups.push(queuePendingMutation(queryClient, mutationKey, { id: entityId, ops: fields2 }));
+    cleanups.push(queuePendingMutation(queryClient, mutationKey, { id: entityId, ops: r2.ops, stx: r2.stx }));
 
     // Third edit: name = 'Final' (overrides again)
-    const fields3 = squashPendingMutation(queryClient, mutationKey, entityId, { name: 'Final' });
-    expect(fields3).toEqual({ name: 'Final' });
+    const r3 = squashPendingMutation(queryClient, mutationKey, entityId, { name: 'Final' }, stxFor(['name']));
+    expect(r3.ops).toEqual({ name: 'Final' });
 
     // Result: only 1 mutation queued with the final value
   });

--- a/frontend/src/query/offline/tests/prepared-mutation.test.ts
+++ b/frontend/src/query/offline/tests/prepared-mutation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildPreparedHandlers, COALESCED, type PreparedVars } from '../prepared-mutation';
+
+type Vars = { id: string; value: number };
+
+function fakeMutation() {
+  return {
+    mutate: vi.fn((_vars: Vars, _opts?: unknown) => {}),
+    mutateAsync: vi.fn(async (vars: Vars, _opts?: unknown) => ({ ok: vars.id })),
+  };
+}
+
+describe('buildPreparedHandlers', () => {
+  it('run: mutate issues the prepared vars', () => {
+    const mutation = fakeMutation();
+    const { mutate } = buildPreparedHandlers<{ ok: string }, Vars, string>(mutation, (id) => ({
+      kind: 'run',
+      vars: { id, value: 1 },
+    }));
+
+    mutate('a');
+    expect(mutation.mutate).toHaveBeenCalledWith({ id: 'a', value: 1 }, undefined);
+  });
+
+  it('run: mutateAsync resolves with the mutation result', async () => {
+    const mutation = fakeMutation();
+    const { mutateAsync } = buildPreparedHandlers<{ ok: string }, Vars, string>(mutation, (id) => ({
+      kind: 'run',
+      vars: { id, value: 1 },
+    }));
+
+    await expect(mutateAsync('a')).resolves.toEqual({ ok: 'a' });
+    expect(mutation.mutateAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesced: mutate issues nothing', () => {
+    const mutation = fakeMutation();
+    const { mutate } = buildPreparedHandlers<{ ok: string }, Vars, string>(mutation, () => ({ kind: 'coalesced' }));
+
+    mutate('a');
+    expect(mutation.mutate).not.toHaveBeenCalled();
+  });
+
+  it('coalesced: mutateAsync resolves immediately with COALESCED and never touches the mutation', async () => {
+    const mutation = fakeMutation();
+    const { mutateAsync } = buildPreparedHandlers<{ ok: string }, Vars, string>(mutation, () => ({
+      kind: 'coalesced',
+    }));
+
+    // The key property: an awaiting caller (e.g. a dialog) settles without hanging on a queued
+    // mutation whose own promise never resolves.
+    await expect(mutateAsync('a')).resolves.toBe(COALESCED);
+    expect(mutation.mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('noop: mutate issues nothing and mutateAsync resolves with COALESCED', async () => {
+    const mutation = fakeMutation();
+    const prepare = (): PreparedVars<Vars> => ({ kind: 'noop' });
+    const { mutate, mutateAsync } = buildPreparedHandlers<{ ok: string }, Vars, string>(mutation, prepare);
+
+    mutate('a');
+    await expect(mutateAsync('a')).resolves.toBe(COALESCED);
+    expect(mutation.mutate).not.toHaveBeenCalled();
+    expect(mutation.mutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/query/offline/tests/remove-pending-mutations.test.ts
+++ b/frontend/src/query/offline/tests/remove-pending-mutations.test.ts
@@ -1,0 +1,59 @@
+import { MutationObserver, onlineManager, QueryClient } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { removePendingMutations } from '~/query/basic/invalidation-helpers';
+
+/**
+ * removePendingMutations must not evict an ACTIVE (in-flight) update: eviction drops it from the
+ * scope queue (without cancelling its request), letting a same-scope delete start alongside it.
+ * Only QUEUED (offline-parked) updates are removed.
+ */
+describe('removePendingMutations: preserves active updates for scope serialization', () => {
+  let queryClient: QueryClient;
+  const updateKey = ['attachment', 'update'] as const;
+  const cleanups: (() => void)[] = [];
+
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  });
+
+  afterEach(() => {
+    for (const fn of cleanups) fn();
+    cleanups.length = 0;
+    onlineManager.setOnline(true);
+    queryClient.clear();
+  });
+
+  it('removes a QUEUED update but leaves an ACTIVE update in the mutation cache', async () => {
+    let release: () => void = () => {};
+    const never = new Promise<Record<string, unknown>>((r) => {
+      release = () => r({});
+    });
+    cleanups.push(() => release());
+    // networkMode 'always' keeps this active (on the wire) regardless of connectivity.
+    const active = new MutationObserver(queryClient, {
+      mutationKey: updateKey,
+      networkMode: 'always',
+      mutationFn: (_vars: { id: string }) => never,
+    });
+    active.mutate({ id: 'active-1' }).catch(() => {});
+
+    onlineManager.setOnline(false);
+    const queued = new MutationObserver(queryClient, {
+      mutationKey: updateKey,
+      mutationFn: async (_vars: { id: string }) => ({}),
+    });
+    queued.mutate({ id: 'queued-1' }).catch(() => {});
+
+    const cache = queryClient.getMutationCache();
+    await vi.waitFor(() => {
+      expect(cache.getAll().some((m) => m.state.status === 'pending' && !m.state.isPaused)).toBe(true);
+      expect(cache.getAll().some((m) => m.state.isPaused)).toBe(true);
+    });
+
+    removePendingMutations(queryClient, updateKey, ['active-1', 'queued-1']);
+
+    const pending = cache.findAll({ mutationKey: updateKey });
+    expect(pending.some((m) => (m.state.variables as { id?: string })?.id === 'active-1')).toBe(true);
+    expect(pending.some((m) => (m.state.variables as { id?: string })?.id === 'queued-1')).toBe(false);
+  });
+});

--- a/frontend/src/query/offline/tests/squash-utils.test.ts
+++ b/frontend/src/query/offline/tests/squash-utils.test.ts
@@ -1,10 +1,16 @@
 import { MutationObserver, onlineManager, QueryClient } from '@tanstack/react-query';
+import type { StxBase } from 'sdk';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { removePausedCreates, squashIntoPendingCreate, squashPendingMutation } from '../squash-utils';
 
+/** Build a minimal stx carrying the given field timestamps. */
+function stxWith(fieldTimestamps: Record<string, string> = {}): StxBase {
+  return { mutationId: `mut-${Object.keys(fieldTimestamps).join('-') || 'x'}`, sourceId: 'test', fieldTimestamps };
+}
+
 /**
- * Helper: create a PAUSED mutation (offline at mutate time, so it pauses before the first
- * attempt); the only state squash/coalesce may touch.
+ * Helper: create a QUEUED (offline-parked) mutation. Coalescing only runs while offline, so these
+ * helpers keep the client offline for the duration of the test (afterEach restores online).
  */
 function queuePausedMutation(
   queryClient: QueryClient,
@@ -19,7 +25,11 @@ function queuePausedMutation(
   observer.mutate(variables as Record<string, unknown>).catch(() => {});
 }
 
-/** Helper: create an IN-FLIGHT mutation (pending, not paused) that never resolves. */
+/**
+ * Helper: create an IN-FLIGHT (active: pending, not paused) mutation that never resolves.
+ * networkMode 'always' keeps it running regardless of connectivity, so it stays active even while
+ * the client is offline (the state coalescing runs in), modelling a request truly on the wire.
+ */
 function queueInFlightMutation(
   queryClient: QueryClient,
   mutationKey: readonly unknown[],
@@ -31,6 +41,7 @@ function queueInFlightMutation(
   });
   const observer = new MutationObserver(queryClient, {
     mutationKey,
+    networkMode: 'always',
     mutationFn: (_vars: Record<string, unknown>) => neverResolve,
   });
   observer.mutate(variables).catch(() => {});
@@ -58,8 +69,27 @@ describe('squashPendingMutation', () => {
   });
 
   it('returns new fields when no paused mutation exists', () => {
-    const result = squashPendingMutation(queryClient, mutationKey, 'entity-1', { name: 'New' });
-    expect(result).toEqual({ name: 'New' });
+    onlineManager.setOnline(false);
+    const result = squashPendingMutation(
+      queryClient,
+      mutationKey,
+      'entity-1',
+      { name: 'New' },
+      stxWith({ name: 't1' }),
+    );
+    expect(result.ops).toEqual({ name: 'New' });
+    expect(result.stx.fieldTimestamps).toEqual({ name: 't1' });
+  });
+
+  it('is a no-op while online: returns the new ops and stx untouched, keeps the queued mutation', () => {
+    queuePausedMutation(queryClient, mutationKey, { id: 'entity-1', ops: { name: 'Old' } });
+    onlineManager.setOnline(true); // back online before coalescing
+
+    const result = squashPendingMutation(queryClient, mutationKey, 'entity-1', { status: 'done' }, stxWith());
+
+    expect(result.ops).toEqual({ status: 'done' });
+    // The queued mutation is untouched: it will replay as its own scope-serialized request.
+    expect(queryClient.getMutationCache().findAll({ mutationKey })).toHaveLength(1);
   });
 
   it('merges ops from a paused mutation into the new one and removes it from the cache', () => {
@@ -70,27 +100,68 @@ describe('squashPendingMutation', () => {
     const cache = queryClient.getMutationCache();
     expect(cache.findAll({ mutationKey }).filter((m) => m.state.isPaused)).toHaveLength(1);
 
-    const result = squashPendingMutation(queryClient, mutationKey, 'entity-1', { status: 'done' });
+    const result = squashPendingMutation(queryClient, mutationKey, 'entity-1', { status: 'done' }, stxWith());
 
-    expect(result).toEqual({ name: 'Old', description: 'Desc', status: 'done' });
+    expect(result.ops).toEqual({ name: 'Old', description: 'Desc', status: 'done' });
     expect(cache.findAll({ mutationKey })).toHaveLength(0);
   });
 
   it('new ops override old ops for same key', () => {
     queuePausedMutation(queryClient, mutationKey, { id: 'entity-1', ops: { name: 'First' } });
 
-    const result = squashPendingMutation(queryClient, mutationKey, 'entity-1', { name: 'Second' });
+    const result = squashPendingMutation(queryClient, mutationKey, 'entity-1', { name: 'Second' }, stxWith());
 
-    expect(result).toEqual({ name: 'Second' });
+    expect(result.ops).toEqual({ name: 'Second' });
+  });
+
+  it('preserves the inherited field timestamp for a field this edit does not touch (LWW by intent time)', () => {
+    // A queued edit set `name` at t1; the new edit changes only `description` at t2. The merged
+    // request must carry name@t1 (not restamped to t2), or an older name edit could beat a newer one.
+    queuePausedMutation(queryClient, mutationKey, {
+      id: 'entity-1',
+      ops: { name: 'Old name' },
+      stx: stxWith({ name: 't1' }),
+    });
+
+    const result = squashPendingMutation(
+      queryClient,
+      mutationKey,
+      'entity-1',
+      { description: 'New desc' },
+      stxWith({ description: 't2' }),
+    );
+
+    expect(result.ops).toEqual({ name: 'Old name', description: 'New desc' });
+    expect(result.stx.fieldTimestamps).toEqual({ name: 't1', description: 't2' });
+  });
+
+  it('the incoming edit wins the timestamp for an overwritten field', () => {
+    queuePausedMutation(queryClient, mutationKey, {
+      id: 'entity-1',
+      ops: { name: 'Old name' },
+      stx: stxWith({ name: 't1' }),
+    });
+
+    const result = squashPendingMutation(
+      queryClient,
+      mutationKey,
+      'entity-1',
+      { name: 'New name' },
+      stxWith({ name: 't2' }),
+    );
+
+    expect(result.ops).toEqual({ name: 'New name' });
+    expect(result.stx.fieldTimestamps).toEqual({ name: 't2' });
   });
 
   it('leaves IN-FLIGHT mutations alone: their ops are already on the wire', () => {
+    onlineManager.setOnline(false); // offline so the online gate does not mask the in-flight guard
     cleanups.push(queueInFlightMutation(queryClient, mutationKey, { id: 'entity-1', ops: { name: 'InFlight' } }));
 
-    const result = squashPendingMutation(queryClient, mutationKey, 'entity-1', { status: 'done' });
+    const result = squashPendingMutation(queryClient, mutationKey, 'entity-1', { status: 'done' }, stxWith());
 
     // Not merged, not removed: LWW/delta merge makes the overlap idempotent server-side.
-    expect(result).toEqual({ status: 'done' });
+    expect(result.ops).toEqual({ status: 'done' });
     expect(
       queryClient
         .getMutationCache()
@@ -102,9 +173,9 @@ describe('squashPendingMutation', () => {
   it('ignores mutations for different entities', () => {
     queuePausedMutation(queryClient, mutationKey, { id: 'entity-2', ops: { name: 'Other' } });
 
-    const result = squashPendingMutation(queryClient, mutationKey, 'entity-1', { status: 'done' });
+    const result = squashPendingMutation(queryClient, mutationKey, 'entity-1', { status: 'done' }, stxWith());
 
-    expect(result).toEqual({ status: 'done' });
+    expect(result.ops).toEqual({ status: 'done' });
     expect(
       queryClient
         .getMutationCache()
@@ -117,9 +188,9 @@ describe('squashPendingMutation', () => {
     queuePausedMutation(queryClient, mutationKey, { id: 'entity-1', ops: { name: 'A' } });
     queuePausedMutation(queryClient, mutationKey, { id: 'entity-1', ops: { description: 'B' } });
 
-    const result = squashPendingMutation(queryClient, mutationKey, 'entity-1', { status: 'C' });
+    const result = squashPendingMutation(queryClient, mutationKey, 'entity-1', { status: 'C' }, stxWith());
 
-    expect(result).toEqual({ name: 'A', description: 'B', status: 'C' });
+    expect(result.ops).toEqual({ name: 'A', description: 'B', status: 'C' });
     expect(queryClient.getMutationCache().findAll({ mutationKey })).toHaveLength(0);
   });
 });
@@ -191,10 +262,22 @@ describe('squashIntoPendingCreate', () => {
   });
 
   it('never touches an IN-FLIGHT create', () => {
+    onlineManager.setOnline(false); // offline so the online gate does not mask the in-flight guard
     cleanups.push(queueInFlightMutation(queryClient, createKey, { id: 'entity-1', name: 'Original' }));
 
     const result = squashIntoPendingCreate(queryClient, createKey, 'entity-1', { name: 'X' });
     expect(result).toBe(false);
+  });
+
+  it('is a no-op while online: returns false and leaves the queued create for a separate update', () => {
+    const variables = { id: 'entity-1', name: 'Original' };
+    queuePausedMutation(queryClient, createKey, variables);
+    onlineManager.setOnline(true);
+
+    const result = squashIntoPendingCreate(queryClient, createKey, 'entity-1', { description: 'Added' });
+
+    expect(result).toBe(false);
+    expect(variables).toEqual({ id: 'entity-1', name: 'Original' });
   });
 
   it('ignores creates for different entities', () => {
@@ -262,6 +345,7 @@ describe('removePausedCreates', () => {
   });
 
   it('leaves IN-FLIGHT creates alone: the row may reach the server, the delete must be sent', () => {
+    onlineManager.setOnline(false); // offline so the online gate does not mask the in-flight guard
     cleanups.push(queueInFlightMutation(queryClient, createKey, { id: 'entity-1', name: 'Sending' }));
 
     const cancelled = removePausedCreates(queryClient, createKey, ['entity-1']);
@@ -273,5 +357,15 @@ describe('removePausedCreates', () => {
         .findAll({ mutationKey: createKey })
         .filter((m) => m.state.status === 'pending'),
     ).toHaveLength(1);
+  });
+
+  it('is a no-op while online: returns no cancellations and keeps the queued create', () => {
+    queuePausedMutation(queryClient, createKey, { id: 'entity-1', name: 'Maybe sent' });
+    onlineManager.setOnline(true);
+
+    const cancelled = removePausedCreates(queryClient, createKey, ['entity-1']);
+
+    expect(cancelled).toEqual([]);
+    expect(queryClient.getMutationCache().findAll({ mutationKey: createKey })).toHaveLength(1);
   });
 });

--- a/frontend/src/query/realtime/cache-ops.ts
+++ b/frontend/src/query/realtime/cache-ops.ts
@@ -1,7 +1,7 @@
 import type { QueryKey } from '@tanstack/react-query';
 import type { ProductEntityType } from 'shared';
-import { appConfig, hierarchy, resolveDeepestAncestorId } from 'shared';
 import { getYjsOwnedFields, isYjsEditorActive } from '~/modules/common/blocknote/yjs-editor';
+import { resolveHomeChannelId, spliceEntityIntoListCaches } from '~/query/basic/apply-entity-to-lists';
 import {
   type EntityQueryKeys,
   getEntityDeltaFetch,
@@ -12,6 +12,7 @@ import {
 import { changeInfiniteQueryData, changeQueryData } from '~/query/basic/helpers';
 import { isInfiniteQueryData, isQueryData } from '~/query/basic/mutate-query';
 import type { EntityQueryData, InfiniteEntityQueryData, ItemData } from '~/query/basic/types';
+import { isPending } from '~/query/offline/mutation-queue';
 import { queryClient } from '~/query/query-client';
 
 /**
@@ -23,7 +24,7 @@ export function hasPendingMutationForEntity(entityType: string, entityId: string
   for (const suffix of ['update', 'create', 'delete'] as const) {
     const mutations = mutationCache.findAll({ mutationKey: [entityType, suffix] });
     for (const mutation of mutations) {
-      if (mutation.state.status !== 'pending') continue;
+      if (!isPending(mutation)) continue;
       const variables = mutation.state.variables as { id?: string } | { id?: string }[] | undefined;
       if (Array.isArray(variables)) {
         if (variables.some((v) => v.id === entityId)) return true;
@@ -31,20 +32,6 @@ export function hasPendingMutationForEntity(entityType: string, entityId: string
         return true;
       }
     }
-  }
-  return false;
-}
-
-/**
- * Check if an entity was moved to a different parent context (e.g. different project/workspace).
- * Returns true when any context ID column differs between cached and incoming versions.
- */
-function hasParentChannelChanged(cached: ItemData, incoming: ItemData): boolean {
-  const c = cached as unknown as Record<string, unknown>;
-  const i = incoming as unknown as Record<string, unknown>;
-  for (const entityType of appConfig.channelEntityTypes) {
-    const key = appConfig.entityIdColumnKeys[entityType];
-    if (typeof c[key] === 'string' && typeof i[key] === 'string' && c[key] !== i[key]) return true;
   }
   return false;
 }
@@ -75,29 +62,6 @@ function stripYjsOwnedFields(entityType: string, entity: ItemData, detailKey: Qu
     if (field in source) target[field] = source[field];
   }
   return filtered;
-}
-
-/**
- * The row's effective home channel id: deepest non-null ancestor, the org itself for org-homed
- * rows. The same resolution SSE routing uses (resolve-row-channel), so cache placement and
- * stream routing can never disagree.
- */
-function resolveHomeChannelId(entityType: string, entity: ItemData): string | null {
-  const entityRecord = entity as unknown as Record<string, unknown>;
-  const home = resolveDeepestAncestorId(hierarchy, entityType, entityRecord);
-  if (home) return home;
-  const organizationId = entityRecord.organizationId;
-  return typeof organizationId === 'string' ? organizationId : null;
-}
-
-/**
- * Whether `queryKey` is the canonical home list for a row homed at `homeChannelId`:
- * [entityType, 'list', organizationId, homeChannelId]. Every row belongs to exactly one home
- * list. Filtered keys (object segments) never match, those lists are scoped by server-side
- * filters we can't replicate here; string keys at other depths are prefixes, never data keys.
- */
-function matchesCanonicalHome(queryKey: readonly unknown[], organizationId: string, homeChannelId: string): boolean {
-  return queryKey.length === 4 && queryKey[2] === organizationId && queryKey[3] === homeChannelId;
 }
 
 /**
@@ -253,40 +217,16 @@ function applyServerEntity(
 
   const homeChannelId = resolveHomeChannelId(entityType, filtered);
 
-  let seen = false;
-  let spliced = false;
-  let sawFilteredList = false;
-  const listPrefix = organizationId ? keys.list.org(organizationId) : keys.list.base;
-  for (const [queryKey, queryData] of queryClient.getQueriesData({ queryKey: listPrefix })) {
-    sawFilteredList ||= queryKey.slice(2).some((seg) => typeof seg === 'object' && seg !== null);
-
-    let cachedItem: ItemData | undefined;
-    let change: typeof changeQueryData;
-    if (isInfiniteQueryData<ItemData>(queryData)) {
-      cachedItem = queryData.pages.flatMap((p) => p.items).find((item) => item.id === entity.id);
-      change = changeInfiniteQueryData;
-    } else if (isQueryData<ItemData>(queryData)) {
-      cachedItem = queryData.items.find((item) => item.id === entity.id);
-      change = changeQueryData;
-    } else {
-      continue;
-    }
-
-    // Remove cached items after their parent context changes.
-    if (cachedItem && hasParentChannelChanged(cachedItem, filtered)) {
-      change(queryKey, [filtered], 'remove');
-      continue;
-    }
-
-    // Cached rows update in place. New rows insert only into the row's canonical home list;
-    // 'update' elsewhere is a deliberate no-op ('create' on a cached row would also drift
-    // `total` because updateArrayItems dedupes but the total adjustment does not).
-    const isHomeList =
-      !!organizationId && !!homeChannelId && matchesCanonicalHome(queryKey, organizationId, homeChannelId);
-    seen = seen || !!cachedItem;
-    spliced ||= !cachedItem && isHomeList;
-    change(queryKey, [filtered], cachedItem || !isHomeList ? 'update' : 'create');
-  }
+  // Splice into list caches through the shared canonical-home policy (also used by the mutation
+  // path). Cached rows update in place; new rows insert only into the canonical home list; a row
+  // whose parent channel changed is removed.
+  const { seen, spliced, sawFilteredList } = spliceEntityIntoListCaches(queryClient, {
+    entity: filtered,
+    keys,
+    organizationId,
+    homeChannelId,
+    removeOnParentChannelChange: true,
+  });
 
   // A new row that no home list spliced and no filtered list will refetch stays invisible until
   // an unrelated refetch. This is always a key-shape bug (canonical data cached outside keys.list.home).


### PR DESCRIPTION
## Why

The attachment module is the intended fork template for offline-first entity CRUD, but it re-derived its offline-mutation machinery inline, and several assumptions produced latent bugs that every fork would inherit. This collapses that machinery into four shared primitives so the behavior is defined once, correctly, and fixes the correctness issues on the way.

Scope is deliberately contained: **realtime + the attachment template** adopt the shared primitives now; the other entity modules (organization/user/requests/memberships) keep the existing `cacheCreate/Update/Remove` primitives and migrate in a follow-up sweep.

## What changed (four refactors)

**A — Mutation-queue classifier + hardened coalescing** (`query/offline/mutation-queue.ts`)
- One `isActive`/`isQueued`/`isPending`/`canCoalesce` vocabulary replaces three divergent guard policies that were duplicated across `squash-utils`, `invalidation-helpers`, and `cache-ops`.
- Coalescing is gated on `onlineManager` (offline-only). `failureCount` cannot distinguish "never sent" from "maybe committed" under `networkMode: offlineFirst` (a paused mutation always has `failureCount >= 1`), so the online gate is the signal that closes the resume race.
- `squashPendingMutation` now **preserves each inherited field's original stx timestamp** (LWW by intent time) rather than restamping every merged field.
- `removePendingMutations` no longer evicts an **active** in-flight update, so a same-scope delete can no longer jump the scope queue and defeat serialization.

**B — Shared canonical-home cache applier** (`query/basic/apply-entity-to-lists.ts`)
- Extracts the realtime splice policy: insert only into the canonical home list, update-in-place elsewhere, **never leak a row into a filtered/search list**. Realtime and the attachment mutation path now share it.
- `helpers.ts` adjusts list `total` by **matched count**, not input length, so a partial-overlap create/remove no longer drifts a filtered query's total.

**C — One mutation-options factory per op** (`modules/attachment/query.ts`)
- create/update/delete options are defined once and used by **both** the live hook and `setMutationDefaults`, so a replayed mutation runs the same reconciliation callbacks (only `mutationFn` was registered before). Callbacks derive the org key from durable variables and take the `QueryClient` explicitly, never a hook closure gone after hydration.

**D — Prepared-mutation adapter** (`query/offline/prepared-mutation.ts`)
- Collapses the six `mutate`/`mutateAsync` wrapper closures into one adapter returning `run`/`coalesced`/`noop`; `mutateAsync` settles `coalesced`/`noop` immediately so an awaiting caller (e.g. the delete dialog) never hangs on a superseded queued mutation.

## Maps to review findings

| Finding | Addressed by |
|---|---|
| #1 paused-vs-attempted coalescing | A (online gate + queue classifier) |
| #2 delete breaks scope serialization | A (`removePendingMutations` active-guard) |
| #3 filtered-list cache leakage + total drift | B (home applier + matched-count total) |
| #4 stx lost on squash / stranded promise | A (stx preservation) + D (coalesced settlement) |
| #5 replay not identical | C (full options shared with replay defaults) |
| #6 hidden singleton client | C (explicit QueryClient in callbacks) |

## Tests
- New suites: `mutation-queue`, `apply-entity-to-lists`, `prepared-mutation`, `remove-pending-mutations` (the #2 regression).
- Updated `squash-utils` + `offline-reconciliation` for the stx-preserving signature, including the LWW-timestamp-preservation case the old suite missed.
- Full root `pnpm check` is green; query + attachment vitest suites (264 tests) pass.

## Notes / follow-ups
- **#5 caveat:** on replay `onMutate` does not re-run (its context is not persisted), so context-dependent optimistic rollback is inherently limited; `onSettled` invalidation now drives error recovery, and the full error/reconcile callbacks run (none did before).
- No backend/OpenAPI changes, so no `clientCacheVersion` bump is needed.
- Follow-up: migrate organization/user/requests/memberships onto the shared applier (a `cella/migrations/` sweep) so forks pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
