### PR TITLE
refactor: align toaster API with Sonner

### DIFF
--- a/cella/migrations/20260722T2050-sonner-style-toaster-api/README.md
+++ b/cella/migrations/20260722T2050-sonner-style-toaster-api/README.md
@@ -1,0 +1,74 @@
+# Adopt the Sonner-style toaster API
+
+## What & why
+
+Cella's wrapper now follows Sonner's callable API. Calls move from the positional
+`toaster(message, severity, options)` contract to `toaster.success(message, options)`,
+`toaster.info(...)`, `toaster.warning(...)`, or `toaster.error(...)`. The base
+`toaster(message, options)` form remains available for default toasts. The wrapper also exposes
+Sonner's `loading`, `message`, `promise`, `custom`, `dismiss`, `getHistory`, and `getToasts`
+methods, accepts Sonner's complete options type, and returns toast ids.
+
+String messages without an explicit `options.id` receive a stable Cella id. Repeating the same
+message updates one active toast through Sonner's native id behavior. Callers can provide their own
+id when they need a distinct identity or controlled updates.
+
+## Blast radius
+
+This is fork-breaking for frontend code that still passes severity as the second positional
+argument. The codemod safely handles literal severities and reports dynamic severities for manual
+review. Forks without custom toaster calls are unaffected because upstream call sites arrive
+already migrated.
+
+There is no database, OpenAPI, SDK, persisted entity, or wire-shape change. No
+`clientCacheVersion` bump or schema lens is needed.
+
+## Run
+
+From the repository root, inspect the fork-specific work first and then apply it:
+
+```sh
+pnpm exec tsx cella/migrations/20260722T2050-sonner-style-toaster-api/sonner-style-toaster-api.ts inventory frontend/src
+pnpm exec tsx cella/migrations/20260722T2050-sonner-style-toaster-api/sonner-style-toaster-api.ts rewrite   frontend/src
+```
+
+If a fork imports the same `toaster` export from another module path, add the repeatable module
+flag:
+
+```sh
+pnpm exec tsx cella/migrations/20260722T2050-sonner-style-toaster-api/sonner-style-toaster-api.ts rewrite frontend/src --module "~/fork/toaster"
+```
+
+## Manual steps
+
+1. Resolve every call reported as a dynamic second argument. When the value is restricted to
+   `success | error | info | warning`, use indexed method access:
+
+   ```ts
+   toaster[severity](message, options);
+   ```
+
+   If the value can also be `default`, branch to the callable form:
+
+   ```ts
+   if (severity === 'default') toaster(message, options);
+   else toaster[severity](message, options);
+   ```
+
+2. Review direct `toast` imports from `sonner`. They are not changed automatically because they
+   may intentionally use dependency-specific behavior. App notifications that need Cella's
+   duplicate-message policy should import `toaster` from
+   `~/modules/common/toaster/toaster`.
+
+3. Review any call skipped because the imported binding is shadowed. Rename the nested binding,
+   then rerun the codemod, or update the intended wrapper call by hand.
+
+## Verify
+
+The second inventory must report zero rewrites and no skipped legacy calls:
+
+```sh
+pnpm exec tsx cella/migrations/20260722T2050-sonner-style-toaster-api/sonner-style-toaster-api.test.ts
+pnpm exec tsx cella/migrations/20260722T2050-sonner-style-toaster-api/sonner-style-toaster-api.ts inventory frontend/src
+pnpm check
+```

--- a/cella/migrations/20260722T2050-sonner-style-toaster-api/sonner-style-toaster-api.test.ts
+++ b/cella/migrations/20260722T2050-sonner-style-toaster-api/sonner-style-toaster-api.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { transformSource } from './sonner-style-toaster-api';
+
+const modulePath = '~/modules/common/toaster/toaster';
+
+const legacy = `
+import { toaster as notify } from '${modulePath}';
+
+notify(message, 'success');
+notify(
+  translate('failed'),
+  'error',
+  { description: details },
+);
+notify(message, severity);
+`;
+
+const transformed = transformSource(legacy, 'fixture.ts');
+assert.equal(transformed.rewrites, 2);
+assert.deepEqual(transformed.rewritesBySeverity, { error: 1, success: 1 });
+assert.match(transformed.output, /notify\.success\(message\)/);
+assert.match(transformed.output, /notify\.error\(translate\('failed'\), \{ description: details \}\)/);
+assert.match(transformed.output, /notify\(message, severity\)/);
+assert.equal(transformed.skipped.length, 1);
+assert.match(transformed.skipped[0].reason, /dynamic second argument/);
+
+const defaults = transformSource(
+  `import { toaster } from '${modulePath}';\ntoaster(message, 'default', options);\ntoaster(message, options);`,
+  'defaults.ts',
+);
+assert.match(defaults.output, /toaster\(message, options\);\ntoaster\(message, options\);/);
+assert.equal(defaults.rewrites, 1);
+assert.equal(defaults.skipped.length, 1);
+
+const unrelated = transformSource(
+  `import { toaster } from 'another-package';\ntoaster(message, 'info');`,
+  'unrelated.ts',
+);
+assert.equal(unrelated.output, `import { toaster } from 'another-package';\ntoaster(message, 'info');`);
+assert.equal(unrelated.rewrites, 0);
+
+const alreadyMigrated = transformSource(
+  `import { toaster } from '${modulePath}';\ntoaster.warning(message);`,
+  'migrated.ts',
+);
+assert.equal(alreadyMigrated.output, `import { toaster } from '${modulePath}';\ntoaster.warning(message);`);
+assert.equal(alreadyMigrated.rewrites, 0);
+
+const shadowed = transformSource(
+  `import { toaster } from '${modulePath}';\nfunction run(toaster) { toaster(message, 'error'); }`,
+  'shadowed.ts',
+);
+assert.equal(shadowed.rewrites, 0);
+assert.match(shadowed.skipped[0].reason, /shadowed/);
+
+const idempotent = transformSource(transformed.output, 'fixture.ts');
+assert.equal(idempotent.rewrites, 0);
+assert.equal(idempotent.output, transformed.output);
+
+const comments = transformSource(
+  `import { toaster } from '${modulePath}';\ntoaster(\n  // Keep this message context.\n  message,\n  'info',\n);`,
+  'comments.ts',
+);
+assert.match(comments.output, /toaster\.info\(\/\/ Keep this message context\.\n  message\)/);
+
+console.info('sonner-style-toaster-api codemod tests passed');

--- a/cella/migrations/20260722T2050-sonner-style-toaster-api/sonner-style-toaster-api.ts
+++ b/cella/migrations/20260722T2050-sonner-style-toaster-api/sonner-style-toaster-api.ts
@@ -1,0 +1,261 @@
+/**
+ * Codemod: convert Cella's positional toaster severity to Sonner-style methods.
+ *
+ * Usage from the repository root:
+ *   pnpm exec tsx cella/migrations/<id>/sonner-style-toaster-api.ts inventory frontend/src
+ *   pnpm exec tsx cella/migrations/<id>/sonner-style-toaster-api.ts rewrite frontend/src
+ */
+
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { extname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const defaultModule = '~/modules/common/toaster/toaster';
+const severities = new Set(['success', 'error', 'info', 'warning']);
+const extensions = new Set(['.js', '.jsx', '.ts', '.tsx']);
+const skipDirectories = new Set(['.git', '.turbo', 'build', 'coverage', 'dist', 'node_modules']);
+
+interface Rewrite {
+  end: number;
+  severity: string;
+  start: number;
+  text: string;
+}
+
+/** A call the codemod cannot safely classify without project-specific type information. */
+export interface SkippedCall {
+  column: number;
+  expression: string;
+  line: number;
+  reason: string;
+}
+
+/** Result of transforming one JavaScript or TypeScript source file. */
+export interface TransformResult {
+  output: string;
+  rewrites: number;
+  rewritesBySeverity: Record<string, number>;
+  skipped: SkippedCall[];
+}
+
+function scriptKind(file: string): ts.ScriptKind {
+  if (file.endsWith('.tsx')) return ts.ScriptKind.TSX;
+  if (file.endsWith('.jsx')) return ts.ScriptKind.JSX;
+  if (file.endsWith('.js')) return ts.ScriptKind.JS;
+  return ts.ScriptKind.TS;
+}
+
+function matchesModule(specifier: string, modules: Set<string>): boolean {
+  return modules.has(specifier) || specifier.endsWith('/modules/common/toaster/toaster');
+}
+
+function importedBindings(sourceFile: ts.SourceFile, modules: Set<string>): Set<string> {
+  const bindings = new Set<string>();
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    if (!matchesModule(statement.moduleSpecifier.text, modules)) continue;
+    const namedBindings = statement.importClause?.namedBindings;
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) continue;
+    for (const element of namedBindings.elements) {
+      const importedName = element.propertyName?.text ?? element.name.text;
+      if (importedName === 'toaster') bindings.add(element.name.text);
+    }
+  }
+  return bindings;
+}
+
+function bindingContains(name: ts.BindingName, identifier: string): boolean {
+  if (ts.isIdentifier(name)) return name.text === identifier;
+  return name.elements.some((element) => !ts.isOmittedExpression(element) && bindingContains(element.name, identifier));
+}
+
+function hasNestedDeclaration(sourceFile: ts.SourceFile, identifier: string): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (
+      (ts.isVariableDeclaration(node) || ts.isParameter(node)) &&
+      bindingContains(node.name, identifier)
+    ) {
+      found = true;
+      return;
+    }
+    if (
+      (ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isClassDeclaration(node) ||
+        ts.isClassExpression(node)) &&
+      node.name?.text === identifier
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  return found;
+}
+
+function argumentText(source: string, sourceFile: ts.SourceFile, argument: ts.Expression): string {
+  return source.slice(argument.getFullStart(), argument.getEnd()).trim();
+}
+
+function callText(
+  source: string,
+  sourceFile: ts.SourceFile,
+  callee: string,
+  severity: string,
+  message: ts.Expression,
+  options: ts.Expression | undefined,
+): string {
+  const target = severity === 'default' ? callee : `${callee}.${severity}`;
+  const messageText = argumentText(source, sourceFile, message);
+  const args = options ? `${messageText}, ${argumentText(source, sourceFile, options)}` : messageText;
+  return `${target}(${args})`;
+}
+
+/** Transform legacy toaster calls in one source string. */
+export function transformSource(
+  source: string,
+  file = 'source.ts',
+  moduleSpecifiers: Iterable<string> = [defaultModule],
+): TransformResult {
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, scriptKind(file));
+  const bindings = importedBindings(sourceFile, new Set(moduleSpecifiers));
+  const shadowedBindings = new Set([...bindings].filter((binding) => hasNestedDeclaration(sourceFile, binding)));
+  const edits: Rewrite[] = [];
+  const skipped: SkippedCall[] = [];
+
+  const skip = (node: ts.CallExpression, reason: string): void => {
+    const location = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+    skipped.push({
+      line: location.line + 1,
+      column: location.character + 1,
+      reason,
+      expression: node.getText(sourceFile).replace(/\s+/g, ' '),
+    });
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && bindings.has(node.expression.text)) {
+      const callee = node.expression.text;
+      if (shadowedBindings.has(callee)) {
+        skip(node, `the imported binding '${callee}' is shadowed elsewhere in this file`);
+      } else if (node.arguments.length >= 2) {
+        const [message, severityNode, options] = node.arguments;
+        const severity =
+          ts.isStringLiteral(severityNode) || ts.isNoSubstitutionTemplateLiteral(severityNode)
+            ? severityNode.text
+            : undefined;
+
+        if (severity && (severities.has(severity) || severity === 'default')) {
+          if (node.arguments.length > 3) skip(node, 'legacy toaster calls accept at most three arguments');
+          else {
+            edits.push({
+              start: node.getStart(sourceFile),
+              end: node.getEnd(),
+              severity,
+              text: callText(source, sourceFile, callee, severity, message, options),
+            });
+          }
+        } else if (severity) skip(node, `unsupported severity '${severity}'`);
+        else if (!ts.isObjectLiteralExpression(severityNode) && severityNode.kind !== ts.SyntaxKind.UndefinedKeyword) {
+          skip(node, 'dynamic second argument; verify whether it is a severity or Sonner options');
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  let output = source;
+  const rewritesBySeverity: Record<string, number> = {};
+  for (const edit of edits.sort((a, b) => b.start - a.start)) {
+    output = `${output.slice(0, edit.start)}${edit.text}${output.slice(edit.end)}`;
+    rewritesBySeverity[edit.severity] = (rewritesBySeverity[edit.severity] ?? 0) + 1;
+  }
+
+  return { output, rewrites: edits.length, rewritesBySeverity, skipped };
+}
+
+function collectFiles(root: string, output: string[]): void {
+  const stats = statSync(root);
+  if (!stats.isDirectory()) {
+    if (extensions.has(extname(root))) output.push(root);
+    return;
+  }
+
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (entry.isDirectory() && skipDirectories.has(entry.name)) continue;
+    const file = join(root, entry.name);
+    if (entry.isDirectory()) collectFiles(file, output);
+    else if (extensions.has(extname(entry.name)) && !entry.name.includes('.gen.')) output.push(file);
+  }
+}
+
+function parseArguments(args: string[]): { mode: 'inventory' | 'rewrite'; modules: Set<string>; roots: string[] } {
+  const [mode, ...rest] = args;
+  if (mode !== 'inventory' && mode !== 'rewrite') {
+    throw new Error('Usage: <inventory|rewrite> <roots...> [--module <specifier>]');
+  }
+
+  const modules = new Set([defaultModule]);
+  const roots: string[] = [];
+  for (let index = 0; index < rest.length; index += 1) {
+    if (rest[index] === '--module') {
+      const specifier = rest[index + 1];
+      if (!specifier) throw new Error('--module requires an import specifier');
+      modules.add(specifier);
+      index += 1;
+    } else roots.push(rest[index]);
+  }
+  if (roots.length === 0) throw new Error('Pass at least one source root, for example frontend/src.');
+  return { mode, modules, roots };
+}
+
+function main(): void {
+  let parsed: ReturnType<typeof parseArguments>;
+  try {
+    parsed = parseArguments(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+    return;
+  }
+
+  const files: string[] = [];
+  for (const root of parsed.roots) collectFiles(root, files);
+
+  let changedFiles = 0;
+  let rewriteCount = 0;
+  const rewriteCounts: Record<string, number> = {};
+  const skipped: Array<SkippedCall & { file: string }> = [];
+  for (const file of files) {
+    const source = readFileSync(file, 'utf8');
+    const result = transformSource(source, file, parsed.modules);
+    rewriteCount += result.rewrites;
+    for (const [severity, count] of Object.entries(result.rewritesBySeverity)) {
+      rewriteCounts[severity] = (rewriteCounts[severity] ?? 0) + count;
+    }
+    skipped.push(...result.skipped.map((item) => ({ ...item, file })));
+    if (result.output === source) continue;
+    changedFiles += 1;
+    if (parsed.mode === 'rewrite') writeFileSync(file, result.output);
+  }
+
+  const verb = parsed.mode === 'rewrite' ? 'Rewrote' : 'Would rewrite';
+  console.info(`${verb} ${rewriteCount} call(s) in ${changedFiles} file(s) across ${files.length} scanned.`);
+  for (const [severity, count] of Object.entries(rewriteCounts).sort()) {
+    console.info(`  ${severity}: ${count}`);
+  }
+  if (skipped.length > 0) {
+    console.info(`Skipped ${skipped.length} ambiguous call(s) for manual review:`);
+    for (const item of skipped) {
+      console.info(`  ${item.file}:${item.line}:${item.column} ${item.reason}\n    ${item.expression}`);
+    }
+  }
+}
+
+const entryFile = process.argv[1] ? resolve(process.argv[1]) : undefined;
+if (entryFile === fileURLToPath(import.meta.url)) main();

--- a/cella/migrations/manifest.json
+++ b/cella/migrations/manifest.json
@@ -24,6 +24,18 @@
       "roots": ["backend/src", "frontend/src", "shared", "cdc/src"],
       "requires": ["pnpm sdk", "pnpm check"],
       "summary": "PropagationHint fields sourceType->embeddedProduct, targetType->hostProduct, field->hostColumn on StreamNotification.propagation + catchup propagation; propagationTargets->hostsByEmbeddedProduct; product-type wire fields tightened to z.enum(productEntityTypes). Manual (field names too generic to codemod); forks bump clientCacheVersion."
+    },
+    {
+      "id": "20260722T2050-sonner-style-toaster-api",
+      "version": "next",
+      "title": "Adopt the Sonner-style toaster API",
+      "kind": "codemod",
+      "forkBreaking": true,
+      "clientCacheBump": false,
+      "script": "cella/migrations/20260722T2050-sonner-style-toaster-api/sonner-style-toaster-api.ts",
+      "roots": ["frontend/src"],
+      "requires": ["pnpm check"],
+      "summary": "Rewrite toaster(message, severity, options) calls to Sonner-style toaster.success/info/warning/error methods. TypeScript-AST codemod handles literal severities and reports dynamic calls for manual review; internal API only, no wire-shape change."
     }
   ]
 }

--- a/frontend/src/modules/attachment/query.ts
+++ b/frontend/src/modules/attachment/query.ts
@@ -291,9 +291,8 @@ const attachmentDeleteOptions = (
       keys,
       organizationId: variables.organizationId,
     });
-    toaster(
+    toaster.info(
       i18n.t('c:resources_delete_denied', { count: rejectedIds.length, total: variables.attachments.length }),
-      'info',
     );
   },
   onSettled: (_data, error, variables) => {

--- a/frontend/src/modules/attachment/table/attachment-cells.tsx
+++ b/frontend/src/modules/attachment/table/attachment-cells.tsx
@@ -108,7 +108,7 @@ export const DownloadCell = ({ row, tabIndex }: DownloadCellProps) => {
 
   useEffect(() => {
     if (!error) return;
-    toaster(t('error:download_failed'), 'error');
+    toaster.error(t('error:download_failed'));
   }, [error, t]);
 
   // Local-first: a stored blob (downloaded earlier, or local-only pending upload) saves
@@ -128,7 +128,7 @@ export const DownloadCell = ({ row, tabIndex }: DownloadCellProps) => {
       if (!url) throw new Error('No cloud URL for attachment');
       await download(url, row.filename);
     } catch {
-      toaster(t('error:download_failed'), 'error');
+      toaster.error(t('error:download_failed'));
     }
   };
 

--- a/frontend/src/modules/attachment/table/use-attachments-upload-dialog.tsx
+++ b/frontend/src/modules/attachment/table/use-attachments-upload-dialog.tsx
@@ -20,7 +20,7 @@ export const useAttachmentsUploadDialog = (tenantId: string, organizationId: str
       useUploader.getState().remove();
 
       if (attachments.length === 0) {
-        toaster(t('error:create_resource', { resource: t('c:attachment').toLowerCase() }), 'error');
+        toaster.error(t('error:create_resource', { resource: t('c:attachment').toLowerCase() }));
         return;
       }
 

--- a/frontend/src/modules/auth/magic-link-strategy.tsx
+++ b/frontend/src/modules/auth/magic-link-strategy.tsx
@@ -21,7 +21,7 @@ export function MagicLinkStrategy({ email }: { email?: string }) {
       setMagicLinkMode('signin');
       setStep('magicLinkSent', targetEmail);
     },
-    onError: () => toaster(t('error:reported_try_later'), 'error'),
+    onError: () => toaster.error(t('error:reported_try_later')),
   });
 
   if (!targetEmail) return null;

--- a/frontend/src/modules/auth/mfa-page.tsx
+++ b/frontend/src/modules/auth/mfa-page.tsx
@@ -25,7 +25,7 @@ export function MfaPage() {
   const handleCancelMfa = async () => {
     try {
       await signOut();
-      toaster(t('c:success.cancel_mfa'), 'success');
+      toaster.success(t('c:success.cancel_mfa'));
     } catch (error) {
       console.error('Failed to retrieve data:', error);
     } finally {

--- a/frontend/src/modules/auth/oauth-providers.tsx
+++ b/frontend/src/modules/auth/oauth-providers.tsx
@@ -45,7 +45,7 @@ export function OAuthProviders({ authStep = 'signIn' }: { authStep: AuthStep }) 
       const providerUrl = `${baseUrl}?${params.toString()}`;
       window.location.assign(providerUrl);
     } catch (error) {
-      toaster(t('c:url_malformed'), 'error');
+      toaster.error(t('c:url_malformed'));
       setLoadingProvider(null);
     }
   };

--- a/frontend/src/modules/auth/passkey-strategy.tsx
+++ b/frontend/src/modules/auth/passkey-strategy.tsx
@@ -44,7 +44,7 @@ export function PasskeyStrategy({ email, type }: PasskeyStrategyProps) {
       if (type === 'mfa' && error instanceof ApiError) {
         navigate({ to: '/error', search: { error: error.type, severity: error.severity } });
       }
-      if (type === 'authentication') toaster(t('error:passkey_verification_failed'), 'error');
+      if (type === 'authentication') toaster.error(t('error:passkey_verification_failed'));
     },
   });
 

--- a/frontend/src/modules/auth/sign-out.tsx
+++ b/frontend/src/modules/auth/sign-out.tsx
@@ -25,10 +25,10 @@ export function SignOut() {
       try {
         teardownUserState();
         if (!force) await signOut();
-        toaster(t('c:success.signed_out'), 'success');
+        toaster.success(t('c:success.signed_out'));
       } catch (error) {
         console.error('Sign out error:', error);
-        toaster(t('c:already_signed_out'), 'warning');
+        toaster.warning(t('c:already_signed_out'));
       }
       // Force full page reload to ensure clean state
       window.location.href = appConfig.aboutUrl;

--- a/frontend/src/modules/auth/steps/sign-in.tsx
+++ b/frontend/src/modules/auth/steps/sign-in.tsx
@@ -71,7 +71,7 @@ export function SignInStep() {
         setSignedIn(true);
         navigate({ to: appConfig.defaultRedirectPath, replace: true });
       } catch {
-        toaster(t('error:passkey_verification_failed'), 'error');
+        toaster.error(t('error:passkey_verification_failed'));
       }
     };
 

--- a/frontend/src/modules/auth/steps/sign-up.tsx
+++ b/frontend/src/modules/auth/steps/sign-up.tsx
@@ -47,7 +47,7 @@ export function SignUpStep({ tokenData }: { tokenData?: TokenData }) {
       setMagicLinkMode('signup');
       setStep('magicLinkSent', form.getValues('email') || email);
     },
-    onError: () => toaster(t('error:reported_try_later'), 'error'),
+    onError: () => toaster.error(t('error:reported_try_later')),
   });
 
   const onSubmit = () => sendMagic();

--- a/frontend/src/modules/auth/totp-strategy.tsx
+++ b/frontend/src/modules/auth/totp-strategy.tsx
@@ -35,7 +35,7 @@ export const TotpStrategy = ({
       useAuthStore.getState().setSignedIn(true);
       navigate({ to: appConfig.defaultRedirectPath, replace: true });
     },
-    onError: () => toaster(t('error:totp_verification_failed'), 'error'),
+    onError: () => toaster.error(t('error:totp_verification_failed')),
   });
 
   return (

--- a/frontend/src/modules/common/blocknote/hooks/use-untrusted-media-warning.ts
+++ b/frontend/src/modules/common/blocknote/hooks/use-untrusted-media-warning.ts
@@ -14,7 +14,7 @@ export function useUntrustedMediaWarning() {
   return (document: CustomBlockNoteEditor['document']) => {
     const hasUntrustedMedia = hasUntrustedMediaUrls(document);
     if (hasUntrustedMedia && !hasWarnedRef.current) {
-      toaster(i18n.t('error:untrusted_media_url'), 'warning');
+      toaster.warning(i18n.t('error:untrusted_media_url'));
       hasWarnedRef.current = true;
     } else if (!hasUntrustedMedia) {
       hasWarnedRef.current = false;

--- a/frontend/src/modules/common/blocknote/yjs-connections.ts
+++ b/frontend/src/modules/common/blocknote/yjs-connections.ts
@@ -115,16 +115,16 @@ function acquireConnection(editSessionId: string, entityType: ProductEntityType,
     // Show user-facing feedback based on close code
     switch (event.code) {
       case YJS_CLOSE.TOKEN_INVALID:
-        toaster(i18n.t('error:sync_token_expired.text'), 'warning');
+        toaster.warning(i18n.t('error:sync_token_expired.text'));
         break;
       case YJS_CLOSE.ACCESS_DENIED:
-        toaster(i18n.t('error:no_permission_for_sync.text'), 'warning');
+        toaster.warning(i18n.t('error:no_permission_for_sync.text'));
         break;
       case YJS_CLOSE.BACKEND_UNAVAILABLE:
-        toaster(i18n.t('error:sync_unavailable.text'), 'warning');
+        toaster.warning(i18n.t('error:sync_unavailable.text'));
         break;
       default:
-        toaster(i18n.t('error:sync_failed.text'), 'warning');
+        toaster.warning(i18n.t('error:sync_failed.text'));
     }
 
     // Clear token for this entity type so collaborative mode is disabled until refresh

--- a/frontend/src/modules/common/contact-form/contact-form.tsx
+++ b/frontend/src/modules/common/contact-form/contact-form.tsx
@@ -48,13 +48,13 @@ export function ContactForm({ dialog: isDialog }: { dialog?: boolean }) {
   const onSubmit: SubmitHandler<FormValues> = (body) => {
     createRequest(body, {
       onSuccess: () => {
-        toaster(t('c:message_sent.text'), 'success');
+        toaster.success(t('c:message_sent.text'));
 
         if (isDialog) useDialoger.getState().remove();
         form.reset();
       },
       onError: () => {
-        toaster(t('error:reported_try_later'), 'error');
+        toaster.error(t('error:reported_try_later'));
       },
     });
   };

--- a/frontend/src/modules/common/data-table/data-table.tsx
+++ b/frontend/src/modules/common/data-table/data-table.tsx
@@ -140,9 +140,9 @@ export const DataTable = <TData,>({
       if (newSize > MAX_SELECTABLE_ROWS) {
         // If this is a "select all" attempt (large jump in selection)
         if (newSize - currentSize > 1) {
-          toaster(t('c:selection_limit_all', { max: MAX_SELECTABLE_ROWS }), 'warning');
+          toaster.warning(t('c:selection_limit_all', { max: MAX_SELECTABLE_ROWS }));
         } else {
-          toaster(t('c:selection_limit', { max: MAX_SELECTABLE_ROWS }), 'warning');
+          toaster.warning(t('c:selection_limit', { max: MAX_SELECTABLE_ROWS }));
         }
         return;
       }

--- a/frontend/src/modules/common/data-table/export.tsx
+++ b/frontend/src/modules/common/data-table/export.tsx
@@ -32,7 +32,7 @@ export const Export = <R extends Record<string, any>>({
   const mode = uiStore.getState().mode;
 
   const exportDefault = async (type: 'csv' | 'pdf') => {
-    if (!isOnline) return toaster(t('c:action.offline.text'), 'warning');
+    if (!isOnline) return toaster.warning(t('c:action.offline.text'));
     const rows = await fetchAllRows(fetchRows);
     const filenameWithExtension = `${filename}.${type}`;
 
@@ -41,12 +41,12 @@ export const Export = <R extends Record<string, any>>({
   };
 
   const exportSelected = async (type: 'csv' | 'pdf') => {
-    if (!selectedRows) return toaster(t('error:no_selected_rows'), 'warning');
+    if (!selectedRows) return toaster.warning(t('error:no_selected_rows'));
     const filenameWithExtension = `${filename}.${type}`;
 
     if (type === 'csv') return exportToCsv(columns, selectedRows, filenameWithExtension);
 
-    if (!isOnline) toaster(t('c:action.offline.text'), 'warning');
+    if (!isOnline) toaster.warning(t('c:action.offline.text'));
     return exportToPdf(columns, selectedRows, filenameWithExtension, getRouter().state.location.pathname, mode);
   };
 

--- a/frontend/src/modules/common/focus-view.tsx
+++ b/frontend/src/modules/common/focus-view.tsx
@@ -29,7 +29,7 @@ export const FocusView = ({ className = '', iconOnly }: FocusViewProps) => {
   const removeSheet = sheeter.getState().remove;
 
   const toggleFocus = () => {
-    toaster(focusView ? t('c:left_focus.text') : t('c:entered_focus.text'), 'success');
+    toaster.success(focusView ? t('c:left_focus.text') : t('c:entered_focus.text'));
     setFocusView(!focusView);
     removeSheet();
     setNavSheetOpen(null);

--- a/frontend/src/modules/common/form-fields/avatar.tsx
+++ b/frontend/src/modules/common/form-fields/avatar.tsx
@@ -40,7 +40,7 @@ export function AvatarFormField({ form, label, name, entity, type }: Props) {
 
   // Open upload dialog
   const openUploadDialog = () => {
-    if (!onlineManager.isOnline()) return toaster(t('c:action.offline.text'), 'warning');
+    if (!onlineManager.isOnline()) return toaster.warning(t('c:action.offline.text'));
     upload.create({
       id: 'upload-image',
       isPublic: true,

--- a/frontend/src/modules/common/page/cover.tsx
+++ b/frontend/src/modules/common/page/cover.tsx
@@ -32,7 +32,7 @@ function PageCoverBase({ id, canUpdate, organizationId, url, coverUpdateCallback
 
   // Open upload dialog
   const openUploadDialog = () => {
-    if (!onlineManager.isOnline()) return toaster(t('c:action.offline.text'), 'warning');
+    if (!onlineManager.isOnline()) return toaster.warning(t('c:action.offline.text'));
     upload.create({
       id: 'page-cover',
       isPublic: true,

--- a/frontend/src/modules/common/toaster/toaster-provider.tsx
+++ b/frontend/src/modules/common/toaster/toaster-provider.tsx
@@ -13,7 +13,7 @@ export const ToasterProvider = () => {
 
   useEffect(() => {
     if (!toast) return;
-    toaster(toast.message, toast.severity);
+    toaster[toast.severity](toast.message);
     clearToast();
   }, [toast]);
 

--- a/frontend/src/modules/common/toaster/toaster.test.ts
+++ b/frontend/src/modules/common/toaster/toaster.test.ts
@@ -1,0 +1,83 @@
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sonner = vi.hoisted(() => {
+  const toast = Object.assign(
+    vi.fn(() => 'default-id'),
+    {
+      success: vi.fn(() => 'success-id'),
+      info: vi.fn(() => 'info-id'),
+      warning: vi.fn(() => 'warning-id'),
+      error: vi.fn(() => 'error-id'),
+      loading: vi.fn(() => 'loading-id'),
+      message: vi.fn(() => 'message-id'),
+      custom: vi.fn(() => 'custom-id'),
+      promise: vi.fn(() => ({ unwrap: vi.fn() })),
+      dismiss: vi.fn(() => 'dismissed-id'),
+      getHistory: vi.fn(() => []),
+      getToasts: vi.fn(() => []),
+    },
+  );
+  return { toast };
+});
+
+vi.mock('sonner', () => sonner);
+
+import { toaster } from '~/modules/common/toaster/toaster';
+
+describe('toaster', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('matches the callable Sonner API and returns its toast id', () => {
+    expect(toaster('Saved')).toBe('default-id');
+    expect(sonner.toast).toHaveBeenCalledWith('Saved', { id: 'cella:Saved' });
+  });
+
+  it('provides typed severity methods with complete option forwarding', () => {
+    const options = { description: 'Attachment kept', duration: 8_000 };
+
+    expect(toaster.info('Delete denied', options)).toBe('info-id');
+    expect(sonner.toast.info).toHaveBeenCalledWith('Delete denied', {
+      ...options,
+      id: 'cella:Delete denied',
+    });
+  });
+
+  it('maps every title-bearing Sonner method through message deduplication', () => {
+    const methods = ['success', 'info', 'warning', 'error', 'loading', 'message'] as const;
+
+    for (const method of methods) {
+      expect(toaster[method](`${method} message`)).toBe(`${method}-id`);
+      expect(sonner.toast[method]).toHaveBeenCalledWith(`${method} message`, {
+        id: `cella:${method} message`,
+      });
+    }
+  });
+
+  it('preserves explicit ids and leaves non-string messages without an automatic id', () => {
+    toaster.success('Saved', { id: 'save-operation' });
+    const renderMessage = () => 'Rendered message';
+    toaster.warning(renderMessage);
+
+    expect(sonner.toast.success).toHaveBeenCalledWith('Saved', { id: 'save-operation' });
+    expect(sonner.toast.warning).toHaveBeenCalledWith(renderMessage, undefined);
+  });
+
+  it('delegates lifecycle methods without changing their arguments', () => {
+    const renderer = vi.fn(() => createElement('div'));
+    const promise = Promise.resolve('done');
+    const promiseOptions = { loading: 'Saving' };
+
+    toaster.custom(renderer, { id: 'custom' });
+    toaster.promise(promise, promiseOptions);
+    toaster.dismiss('custom');
+    toaster.getHistory();
+    toaster.getToasts();
+
+    expect(sonner.toast.custom).toHaveBeenCalledWith(renderer, { id: 'custom' });
+    expect(sonner.toast.promise).toHaveBeenCalledWith(promise, promiseOptions);
+    expect(sonner.toast.dismiss).toHaveBeenCalledWith('custom');
+    expect(sonner.toast.getHistory).toHaveBeenCalledOnce();
+    expect(sonner.toast.getToasts).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/modules/common/toaster/toaster.ts
+++ b/frontend/src/modules/common/toaster/toaster.ts
@@ -1,27 +1,33 @@
 import { toast } from 'sonner';
 
-export type ToastSeverity = 'success' | 'error' | 'info' | 'warning' | 'default';
+/** Visual toast variants accepted by the persisted toast store. */
+export type ToastSeverity = 'success' | 'error' | 'info' | 'warning';
 
-export const toaster = (
-  text: string,
-  type: ToastSeverity = 'default',
-  options: { id?: number | string; description?: string | React.ReactNode } = {},
-) => {
-  // Get all active toasts and dismiss the ones with the same title
-  for (const existingToast of toast.getToasts()) {
-    if ('title' in existingToast && existingToast.title !== text) continue;
-    toast.dismiss(existingToast.id); // Dismiss the toast with the same title
-  }
+type ToastMessage = Parameters<typeof toast>[0];
+type ToastOptions = Parameters<typeof toast>[1];
+type ToastMethod = (message: ToastMessage, options?: ToastOptions) => string | number;
 
-  // Determine toast function based on type
-  const toastFn =
-    {
-      success: toast.success,
-      error: toast.error,
-      info: toast.info,
-      warning: toast.warning,
-      default: toast,
-    }[type] || toast;
+/** Add a stable id for string messages so repeated calls update one active toast. */
+function withMessageDeduplication(method: ToastMethod): ToastMethod {
+  return (message, options) => {
+    if (options?.id !== undefined || typeof message !== 'string') return method(message, options);
+    return method(message, { ...options, id: `cella:${message}` });
+  };
+}
 
-  toastFn(text, options);
-};
+const showToast = withMessageDeduplication(toast);
+
+/** Sonner-compatible toast API with Cella's duplicate-message suppression. */
+export const toaster = Object.assign(showToast, {
+  success: withMessageDeduplication(toast.success),
+  info: withMessageDeduplication(toast.info),
+  warning: withMessageDeduplication(toast.warning),
+  error: withMessageDeduplication(toast.error),
+  loading: withMessageDeduplication(toast.loading),
+  message: withMessageDeduplication(toast.message),
+  custom: toast.custom,
+  promise: toast.promise,
+  dismiss: toast.dismiss,
+  getHistory: toast.getHistory,
+  getToasts: toast.getToasts,
+}) satisfies typeof toast;

--- a/frontend/src/modules/common/uploader/use-uppy-upload.tsx
+++ b/frontend/src/modules/common/uploader/use-uppy-upload.tsx
@@ -81,7 +81,7 @@ export function useUploadUppy() {
               statusEventHandler.onComplete?.(assembly.results as UploadedUppyFile<UploadTemplateId>),
             ).catch((err) => {
               console.error('onComplete handler failed:', err);
-              toaster(t('error:create_resource', { resource: t('c:attachment').toLowerCase() }), 'error');
+              toaster.error(t('error:create_resource', { resource: t('c:attachment').toLowerCase() }));
             });
           });
         // Plugin Options

--- a/frontend/src/modules/docs/json-actions.tsx
+++ b/frontend/src/modules/docs/json-actions.tsx
@@ -41,7 +41,7 @@ export const JsonActions = ({
 
   const handleCopy = () => {
     copyToClipboard(JSON.stringify(data, null, 2));
-    toaster(t('c:success.resource_copied', { resource: resourceName ?? 'JSON' }), 'success');
+    toaster.success(t('c:success.resource_copied', { resource: resourceName ?? 'JSON' }));
   };
 
   const handleDownload = () => {

--- a/frontend/src/modules/marketing/subscribe-newsletter-form.tsx
+++ b/frontend/src/modules/marketing/subscribe-newsletter-form.tsx
@@ -24,7 +24,7 @@ export function SubscribeNewsletterForm() {
       { email, type: 'newsletter', message: null },
       {
         onSuccess: () => {
-          toaster(t('c:success.newsletter_sign_up', { appName: appConfig.name }), 'success');
+          toaster.success(t('c:success.newsletter_sign_up', { appName: appConfig.name }));
           formRef.current?.reset();
         },
       },

--- a/frontend/src/modules/me/account-page.tsx
+++ b/frontend/src/modules/me/account-page.tsx
@@ -54,7 +54,7 @@ function UserAccountPage() {
       <DeleteSelf
         dialog
         callback={({ status }: CallbackArgs<User>) => {
-          if (status === 'success') toaster(t('c:success.delete_resource', { resource: t('c:account') }), 'success');
+          if (status === 'success') toaster.success(t('c:success.delete_resource', { resource: t('c:account') }));
         }}
       />,
       {
@@ -68,7 +68,7 @@ function UserAccountPage() {
   };
 
   const authenticateWithProvider = (provider: EnabledOAuthProvider) => {
-    if (!onlineManager.isOnline()) return toaster(t('c:action.offline.text'), 'warning');
+    if (!onlineManager.isOnline()) return toaster.warning(t('c:action.offline.text'));
 
     // Proceed to OAuth URL with redirect and connect
     try {
@@ -84,7 +84,7 @@ function UserAccountPage() {
       window.location.assign(providerUrl);
     } catch (error) {
       console.error('Failed to build OAuth URL:', error);
-      toaster(t('c:url_malformed'), 'error');
+      toaster.error(t('c:url_malformed'));
       setLoadingProvider(null);
     }
   };

--- a/frontend/src/modules/me/passkeys/list.tsx
+++ b/frontend/src/modules/me/passkeys/list.tsx
@@ -22,9 +22,9 @@ export function PasskeysList() {
   const hasPasskey = passkeys.length > 0;
 
   const handleUnlinkPasskey = (id: string) => {
-    if (!onlineManager.isOnline()) return toaster(t('c:action.offline.text'), 'warning');
+    if (!onlineManager.isOnline()) return toaster.warning(t('c:action.offline.text'));
     if (user.mfaRequired && passkeys.length <= 1)
-      return toaster(t('c:unlink_mfa_last', { method: 'the last passkey' }), 'info');
+      return toaster.info(t('c:unlink_mfa_last', { method: 'the last passkey' }));
     deletePasskey({ path: { id } });
   };
   return (

--- a/frontend/src/modules/me/query.ts
+++ b/frontend/src/modules/me/query.ts
@@ -102,7 +102,7 @@ export const useToggleMfaMutation = () => {
     onSuccess: (updatedUser, { mfaRequired: isEnabling }) => {
       updateOnSuccesses(updatedUser);
       if (isEnabling) queryClient.invalidateQueries({ queryKey: meKeys.auth });
-      toaster(t(`mfa_${updatedUser.mfaRequired ? 'enabled' : 'disabled'}`), 'success');
+      toaster.success(t(`mfa_${updatedUser.mfaRequired ? 'enabled' : 'disabled'}`));
     },
     gcTime: 1000 * 10,
   });
@@ -142,12 +142,12 @@ export const useCreatePasskeyMutation = () => {
           passkeys: [newPasskey, ...oldData.passkeys],
         };
       });
-      toaster(t('c:success.passkey_added'), 'success');
+      toaster.success(t('c:success.passkey_added'));
     },
     onError(error) {
       // On cancel throws error NotAllowedError
       console.error('Error during passkey registration:', error);
-      toaster(t('error:passkey_registration_failed'), 'error');
+      toaster.error(t('error:passkey_registration_failed'));
     },
   });
 };
@@ -169,11 +169,11 @@ export const useDeletePasskeyMutation = () => {
           passkeys: oldData.passkeys.filter((passkey) => id !== passkey.id),
         };
       });
-      toaster(t('c:success.passkey_unlinked'), 'success');
+      toaster.success(t('c:success.passkey_unlinked'));
     },
     onError(error) {
       console.error('Error removing passkey:', error);
-      toaster(t('error:passkey_unlink_failed'), 'error');
+      toaster.error(t('error:passkey_unlink_failed'));
     },
   });
 };
@@ -188,7 +188,7 @@ export const useDeleteTotpMutation = () => {
     mutationKey: meKeys.delete.totp,
     mutationFn: () => deleteTotp(),
     onSuccess: () => {
-      toaster(t('c:success.totp_removed'), 'success');
+      toaster.success(t('c:success.totp_removed'));
       queryClient.setQueryData<MeAuthData>(meKeys.auth, (oldData) => {
         if (!oldData) return oldData;
         return { ...oldData, hasTotp: false };
@@ -196,7 +196,7 @@ export const useDeleteTotpMutation = () => {
     },
     onError(error) {
       console.error('Error removing totp:', error);
-      toaster(t('error:totp_remove_failed'), 'error');
+      toaster.error(t('error:totp_remove_failed'));
     },
   });
 };
@@ -235,6 +235,6 @@ export const useHandleInvitationMutation = () =>
         return { ...oldData, items: oldData.items.filter((invite) => invite.entity.id !== settledEntity.id) };
       });
 
-      toaster(t('c:invitation_settled', { action: acceptOrReject === 'accept' ? 'accepted' : 'rejected' }), 'success');
+      toaster.success(t('c:invitation_settled', { action: acceptOrReject === 'accept' ? 'accepted' : 'rejected' }));
     },
   });

--- a/frontend/src/modules/me/sessions-list.tsx
+++ b/frontend/src/modules/me/sessions-list.tsx
@@ -46,15 +46,14 @@ export function SessionsList() {
         };
       });
 
-      toaster(
+      toaster.success(
         ids.length === 1 ? t('c:success.session_terminated', { id: ids[0] }) : t('c:success.sessions_terminated'),
-        'success',
       );
     },
   });
 
   const handleDeleteSessions = (ids: string[]) => {
-    if (!onlineManager.isOnline()) return toaster(t('c:action.offline.text'), 'warning');
+    if (!onlineManager.isOnline()) return toaster.warning(t('c:action.offline.text'));
     _deleteMySessions(ids);
   };
 

--- a/frontend/src/modules/me/totp-setup.tsx
+++ b/frontend/src/modules/me/totp-setup.tsx
@@ -41,7 +41,7 @@ export const SetupTotp = () => {
         if (!oldData) return oldData;
         return { ...oldData, hasTotp: true };
       });
-      toaster(t('c:success.totp_added'), 'success');
+      toaster.success(t('c:success.totp_added'));
     },
     onError: () => {
       // Reset form component to force re-entry of TOTP verify code

--- a/frontend/src/modules/me/totp.tsx
+++ b/frontend/src/modules/me/totp.tsx
@@ -37,8 +37,8 @@ export function Totp() {
   };
 
   const handleDeleteTOTP = () => {
-    if (!onlineManager.isOnline()) return toaster(t('c:action.offline.text'), 'warning');
-    if (user.mfaRequired) return toaster(t('c:unlink_mfa_last', { method: 'TOTP' }), 'info');
+    if (!onlineManager.isOnline()) return toaster.warning(t('c:action.offline.text'));
+    if (user.mfaRequired) return toaster.info(t('c:unlink_mfa_last', { method: 'TOTP' }));
 
     deleteTotp();
   };

--- a/frontend/src/modules/me/user-language.tsx
+++ b/frontend/src/modules/me/user-language.tsx
@@ -23,7 +23,7 @@ export function UserLanguage({ triggerClassName = '' }: Props) {
   const language = user?.language || i18n.languages[0];
 
   const changeLanguage = (lng: Language) => {
-    if (!onlineManager.isOnline()) return toaster(t('c:action.offline.text'), 'warning');
+    if (!onlineManager.isOnline()) return toaster.warning(t('c:action.offline.text'));
     if (window.Gleap) window.Gleap.setLanguage(lng);
     i18n.changeLanguage(lng);
     useDropdowner.getState().remove();

--- a/frontend/src/modules/memberships/leave-channel-button.tsx
+++ b/frontend/src/modules/memberships/leave-channel-button.tsx
@@ -36,7 +36,7 @@ export const LeaveChannelButton = ({
       return await deleteMyMembership({ query: { entityId, entityType: channel.entityType } });
     },
     onSuccess: () => {
-      toaster(t('c:success.you_left_entity', { entity: channel.entityType }), 'success');
+      toaster.success(t('c:success.you_left_entity', { entity: channel.entityType }));
       navigate({ to: redirectPath, replace: true });
 
       // Directly remove entity from list cache so menu updates immediately
@@ -53,7 +53,7 @@ export const LeaveChannelButton = ({
 
   const handleLeave = () => {
     if (!onlineManager.isOnline()) {
-      toaster(t('c:action.offline.text'), 'warning');
+      toaster.warning(t('c:action.offline.text'));
       return;
     }
     leaveChannel();

--- a/frontend/src/modules/memberships/members-table/members-bar.tsx
+++ b/frontend/src/modules/memberships/members-table/members-bar.tsx
@@ -107,7 +107,7 @@ export const MembersTableBar = ({
   };
 
   const openInviteDialog = () => {
-    if (!onlineManager.isOnline()) return toaster(t('c:action.offline.text'), 'warning');
+    if (!onlineManager.isOnline()) return toaster.warning(t('c:action.offline.text'));
 
     createDialog(<InviteUsers channel={channel} mode={null} dialog />, {
       id: 'invite-users',

--- a/frontend/src/modules/memberships/pending-memberships-count.tsx
+++ b/frontend/src/modules/memberships/pending-memberships-count.tsx
@@ -28,7 +28,7 @@ export const PendingMembershipsCount = ({ channel }: { channel: EnrichedChannel 
 
   // Open pending memberships sheet
   const openSheet = () => {
-    if (!onlineManager.isOnline()) return toaster(t('c:action.offline.text'), 'warning');
+    if (!onlineManager.isOnline()) return toaster.warning(t('c:action.offline.text'));
 
     createSheet(
       <div className="container">

--- a/frontend/src/modules/memberships/query-mutations.ts
+++ b/frontend/src/modules/memberships/query-mutations.ts
@@ -256,7 +256,7 @@ export const useMemberUpdateMutation = () =>
       // Invalidate entity queries to ensure counts and data are fresh
       invalidateOnMembershipChange(queryClient, channelType, channelId, organizationId);
 
-      toaster(toastMessage, 'success');
+      toaster.success(toastMessage);
     },
     onError: (_, __, context) => {
       // Invalidate memberships to undo the optimistic update; the enrichment subscriber syncs entity lists.
@@ -308,7 +308,7 @@ export const useMembershipsDeleteMutation = () =>
     onSuccess: (_, { query: { entityId, entityType }, path: { organizationId } }) => {
       // Invalidate entity queries to ensure counts are fresh
       invalidateOnMembershipChange(queryClient, entityType, entityId, organizationId);
-      toaster(t('c:success.delete_members'), 'success');
+      toaster.success(t('c:success.delete_members'));
     },
     onError,
   });
@@ -369,7 +369,7 @@ export const useChangeEntityRoleMutation = () =>
   useMutation<ChangeEntityRoleResult, ApiError, ChangeEntityRoleVariables>({
     mutationFn: async ({ entity, role }) => {
       if (!onlineManager.isOnline()) {
-        toaster(t('c:action.offline.text'), 'warning');
+        toaster.warning(t('c:action.offline.text'));
         throw new Error('offline');
       }
 
@@ -407,9 +407,9 @@ export const useChangeEntityRoleMutation = () =>
       const updatedEntity = { ...entity, membership };
       updateEntityInListCache(entity.entityType, [updatedEntity]);
 
-      toaster(t('c:success.role_updated'), 'success');
+      toaster.success(t('c:success.role_updated'));
     },
     onError: () => {
-      toaster(t('error:error'), 'error');
+      toaster.error(t('error:error'));
     },
   });

--- a/frontend/src/modules/memberships/resend-invitation-button.tsx
+++ b/frontend/src/modules/memberships/resend-invitation-button.tsx
@@ -33,7 +33,7 @@ export const ResendInvitationButton = ({ resendData, wrapperClassName, buttonPro
     mutationFn: (body) => resendInvitationWithToken({ body }),
     onSuccess: () => {
       useDialoger.getState().remove();
-      toaster(t('c:success.resend_invitation'), 'success');
+      toaster.success(t('c:success.resend_invitation'));
       callback?.({ status: 'success' });
     },
     onError: (error) => {
@@ -47,7 +47,7 @@ export const ResendInvitationButton = ({ resendData, wrapperClassName, buttonPro
   });
 
   const resendInvitationClick = () => {
-    if (!onlineManager.isOnline()) return toaster(t('c:action.offline.text'), 'warning');
+    if (!onlineManager.isOnline()) return toaster.warning(t('c:action.offline.text'));
 
     setDisabledResend(true);
     resend(resendData);

--- a/frontend/src/modules/navigation/account-sheet.tsx
+++ b/frontend/src/modules/navigation/account-sheet.tsx
@@ -41,7 +41,7 @@ function AccountButton({ offlineAccess, isOnline, icon: Icon, label, id, action 
           disabled={isDisabled}
           onClick={() => {
             if (isDisabled) {
-              toaster(t('c:action.offline.text'), 'warning');
+              toaster.warning(t('c:action.offline.text'));
               return;
             }
             // Close the nav sheet on navigation unless the user pinned it open

--- a/frontend/src/modules/navigation/menu-sheet/item-edit.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/item-edit.tsx
@@ -25,7 +25,7 @@ export const MenuItemEdit = ({ item, icon: Icon }: MenuItemEditProps) => {
 
   const handleUpdateMembershipKey = (key: 'archived' | 'muted') => {
     if (key === 'archived' && item.membership.archived && !onlineManager.isOnline()) {
-      return toaster(t('c:action.offline.text'), 'warning');
+      return toaster.warning(t('c:action.offline.text'));
     }
 
     const updatedMembership: MutationUpdateMembership = {

--- a/frontend/src/modules/navigation/menu-sheet/item.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/item.tsx
@@ -44,7 +44,7 @@ export const MenuSheetItem = ({ item, icon: Icon, className }: MenuSheetItemProp
     <Link
       disabled={!canAccess}
       onClick={() => {
-        if (!canAccess) toaster(t('c:show_archived.offline.text'), 'warning');
+        if (!canAccess) toaster.warning(t('c:show_archived.offline.text'));
       }}
       data-subitem={isSubitem}
       aria-label={item.name}

--- a/frontend/src/modules/navigation/menu-sheet/offline-access-switch.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/offline-access-switch.tsx
@@ -11,7 +11,7 @@ export const OfflineAccessSwitch = () => {
   const onCheckedChange = (isOffline: boolean) => {
     // Delay the toast until after the switch state updates through QueryProvider.
     setTimeout(() => {
-      toaster(t(`c:offline_access_${isOffline ? 'on' : 'off'}.text`, { appName: appConfig.name }), 'info');
+      toaster.info(t(`c:offline_access_${isOffline ? 'on' : 'off'}.text`, { appName: appConfig.name }));
     }, 0);
 
     toggleOfflineAccess();

--- a/frontend/src/modules/navigation/start-search-action.tsx
+++ b/frontend/src/modules/navigation/start-search-action.tsx
@@ -6,7 +6,7 @@ import { toaster } from '~/modules/common/toaster/toaster';
 import { AppSearch } from '~/modules/navigation/app-search';
 
 export function startSearchAction(triggerRef: RefObject<HTMLButtonElement | null>) {
-  if (!onlineManager.isOnline()) return toaster(i18n.t('c:action.offline.text'), 'warning');
+  if (!onlineManager.isOnline()) return toaster.warning(i18n.t('c:action.offline.text'));
 
   return useDialoger.getState().create(<AppSearch />, {
     id: 'search',

--- a/frontend/src/modules/navigation/stop-impersonation.tsx
+++ b/frontend/src/modules/navigation/stop-impersonation.tsx
@@ -25,7 +25,7 @@ export function StopImpersonation({ isCollapsed }: StopImpersonationProps) {
   const stopImpersonation = async () => {
     await stopImpersonationFlow();
     navigate({ to: appConfig.defaultRedirectPath, replace: true });
-    toaster(t('c:success.stopped_impersonation'), 'success');
+    toaster.success(t('c:success.stopped_impersonation'));
   };
 
   if (!impersonating) return null;

--- a/frontend/src/modules/organization/create-organization-form.tsx
+++ b/frontend/src/modules/organization/create-organization-form.tsx
@@ -70,7 +70,7 @@ export function CreateOrganizationForm({ labelDirection = 'top', children, callb
 
   const onSuccess = (createdOrganization: Organization) => {
     form.reset();
-    toaster(t('c:success.create_resource', { resource: t('c:organization') }), 'success');
+    toaster.success(t('c:success.create_resource', { resource: t('c:organization') }));
     callback?.({ data: createdOrganization, status: 'success' });
     nextStep?.();
   };
@@ -84,7 +84,7 @@ export function CreateOrganizationForm({ labelDirection = 'top', children, callb
         const tenant = await selfCreateTenant({ body: { name: `${values.name} workspace` } });
         resolvedTenantId = tenant.id;
       } catch {
-        toaster(t('error:create_resource', { resource: t('c:tenant') }), 'error');
+        toaster.error(t('error:create_resource', { resource: t('c:tenant') }));
         return;
       }
     }
@@ -95,7 +95,7 @@ export function CreateOrganizationForm({ labelDirection = 'top', children, callb
         onSuccess: (createdOrganization) => onSuccess(createdOrganization),
         onError: (error) => {
           if (error.message === 'org_limit_reached') {
-            toaster(t('error:org_limit_reached'), 'warning');
+            toaster.warning(t('error:org_limit_reached'));
           }
         },
       },

--- a/frontend/src/modules/organization/organization-page.tsx
+++ b/frontend/src/modules/organization/organization-page.tsx
@@ -40,8 +40,8 @@ function OrganizationPage({ organizationId, tenantId }: Props) {
     mutate(
       { path: { tenantId: organization.tenantId, id: organization.id }, body: { bannerUrl } },
       {
-        onSuccess: () => toaster(t('c:success.upload_cover'), 'success'),
-        onError: () => toaster(t('error:image_upload_failed'), 'error'),
+        onSuccess: () => toaster.success(t('c:success.upload_cover')),
+        onError: () => toaster.error(t('error:image_upload_failed')),
       },
     );
   };

--- a/frontend/src/modules/organization/organization-settings.tsx
+++ b/frontend/src/modules/organization/organization-settings.tsx
@@ -50,7 +50,7 @@ function OrganizationSettings({ organization }: { organization: EnrichedOrganiza
         organizations={[organization]}
         callback={({ status }: CallbackArgs<Organization[]>) => {
           if (status === 'success') {
-            toaster(t('c:success.delete_resource', { resource: t('c:organization') }), 'success');
+            toaster.success(t('c:success.delete_resource', { resource: t('c:organization') }));
             navigate({ to: appConfig.defaultRedirectPath, replace: true });
           }
         }}

--- a/frontend/src/modules/organization/update-organization-details-form.tsx
+++ b/frontend/src/modules/organization/update-organization-details-form.tsx
@@ -64,7 +64,7 @@ export function UpdateOrganizationDetailsForm({ organization, callback, sheet: i
         onSuccess: (updatedOrganization) => {
           if (isSheet) useSheeter.getState().remove(formContainerId);
           form.reset(body);
-          toaster(t('c:success.update_resource', { resource: t('c:organization') }), 'success');
+          toaster.success(t('c:success.update_resource', { resource: t('c:organization') }));
           callback?.({ data: updatedOrganization, status: 'success' });
         },
       },
@@ -104,9 +104,9 @@ export function UpdateOrganizationDetailsForm({ organization, callback, sheet: i
                       persistAttachments(attachments, {
                         tenantId: organization.tenantId,
                         organizationId: organization.id,
-                      }).catch(() =>
-                        toaster(t('error:create_resource', { resource: t('c:attachment').toLowerCase() }), 'error'),
-                      ),
+                      }).catch(() => {
+                        toaster.error(t('error:create_resource', { resource: t('c:attachment').toLowerCase() }));
+                      }),
                   }
                 : undefined,
             }}

--- a/frontend/src/modules/organization/update-organization-form.tsx
+++ b/frontend/src/modules/organization/update-organization-form.tsx
@@ -72,7 +72,7 @@ export function UpdateOrganizationForm({ organization, callback, sheet: isSheet 
         onSuccess: (updatedOrganization) => {
           if (isSheet) useSheeter.getState().remove(formContainerId);
           form.reset(body);
-          toaster(t('c:success.update_resource', { resource: t('c:organization') }), 'success');
+          toaster.success(t('c:success.update_resource', { resource: t('c:organization') }));
           callback?.({ data: updatedOrganization, status: 'success' });
         },
       },

--- a/frontend/src/modules/page/utils/edit-doc-page.ts
+++ b/frontend/src/modules/page/utils/edit-doc-page.ts
@@ -30,7 +30,7 @@ export async function editDocPage(slug: string, ops: DocEditOps): Promise<void> 
       throw new Error(detail?.error ?? `Request failed (${res.status})`);
     }
   } catch (err) {
-    toaster(err instanceof Error ? err.message : 'Failed to save page', 'error');
+    toaster.error(err instanceof Error ? err.message : 'Failed to save page');
     throw err;
   }
 }

--- a/frontend/src/modules/page/utils/mutations.ts
+++ b/frontend/src/modules/page/utils/mutations.ts
@@ -154,7 +154,7 @@ export const useTableMutation = <N extends `${EntityType}s`, M extends MutationT
     },
     onError: (_error, _variables, onMutateResult, context) => {
       console.error(_error);
-      toaster(t(`error:${type}_resource`, { resource: t(`c:${table}`) }), 'error');
+      toaster.error(t(`error:${type}_resource`, { resource: t(`c:${table}`) }));
 
       if (!onMutateResult?.length) {
         return;

--- a/frontend/src/modules/requests/query.ts
+++ b/frontend/src/modules/requests/query.ts
@@ -75,8 +75,8 @@ export const useSendApprovalInviteMutation = () => {
   return useMutation<SystemInviteResponse, ApiError, SystemInviteData['body']>({
     mutationKey: requestsKeys.approve(),
     mutationFn: async (body) => await systemInvite({ body }),
-    onSuccess: () => toaster(t('c:success.users_invited'), 'success'),
-    onError: () => toaster(t('error:bad_request_action'), 'error'),
+    onSuccess: () => toaster.success(t('c:success.users_invited')),
+    onError: () => toaster.error(t('error:bad_request_action')),
   });
 };
 

--- a/frontend/src/modules/requests/table/requests-bar.tsx
+++ b/frontend/src/modules/requests/table/requests-bar.tsx
@@ -69,7 +69,7 @@ export const RequestsTableBar = ({
                 count: args.data.length,
                 resources: t('c:request_other').toLowerCase(),
               });
-        toaster(message, 'success');
+        toaster.success(message);
       }
       clearSelection();
     };

--- a/frontend/src/modules/requests/waitlist-form.tsx
+++ b/frontend/src/modules/requests/waitlist-form.tsx
@@ -56,12 +56,12 @@ export const WaitlistForm = ({
   });
 
   const onSubmit = (body: FormValues) => {
-    if (!onlineManager.isOnline()) return toaster(t('c:action.offline.text'), 'warning');
+    if (!onlineManager.isOnline()) return toaster.warning(t('c:action.offline.text'));
 
     createRequest(body, {
       onSuccess: () => {
         navigate({ to: '/about', replace: true });
-        toaster(t('c:success.waitlist_request', { appName: appConfig.name }), 'success');
+        toaster.success(t('c:success.waitlist_request', { appName: appConfig.name }));
 
         if (isDialog) useDialoger.getState().remove();
         callback?.({ status: 'success' });

--- a/frontend/src/modules/system/create-newsletter-form.tsx
+++ b/frontend/src/modules/system/create-newsletter-form.tsx
@@ -58,9 +58,9 @@ export function CreateNewsletterForm({ organizationIds, callback }: CreateNewsle
       return await sendNewsletter({ body, query });
     },
     onSuccess: () => {
-      if (testOnly) return toaster(t('c:success.test_email'), 'success');
+      if (testOnly) return toaster.success(t('c:success.test_email'));
       form.reset();
-      toaster(t('c:success.create_newsletter'), 'success');
+      toaster.success(t('c:success.create_newsletter'));
       useSheeter.getState().remove(formContainerId);
       callback?.({ status: 'success' });
     },

--- a/frontend/src/modules/tenants/create-tenant-form.tsx
+++ b/frontend/src/modules/tenants/create-tenant-form.tsx
@@ -48,7 +48,7 @@ export function CreateTenantForm({ labelDirection = 'top', children, callback }:
     mutate(values, {
       onSuccess: (createdTenant) => {
         form.reset();
-        toaster(t('c:success.create_resource', { resource: t('c:tenant') }), 'success');
+        toaster.success(t('c:success.create_resource', { resource: t('c:tenant') }));
         callback?.({ data: createdTenant, status: 'success' });
       },
     });

--- a/frontend/src/modules/tenants/domains/create-domain-form.tsx
+++ b/frontend/src/modules/tenants/domains/create-domain-form.tsx
@@ -22,7 +22,7 @@ export function CreateDomainForm({ tenantId }: { tenantId: string }) {
       {
         onSuccess: () => {
           setNewDomain('');
-          toaster(t('c:success.create_resource', { resource: t('c:domain') }), 'success');
+          toaster.success(t('c:success.create_resource', { resource: t('c:domain') }));
           useDialoger.getState().remove(createDomainDialogId);
         },
       },

--- a/frontend/src/modules/tenants/domains/domain-tile.tsx
+++ b/frontend/src/modules/tenants/domains/domain-tile.tsx
@@ -44,7 +44,7 @@ export function DomainTile({ domain, tenantId }: DomainTileProps) {
         onSuccess: (result) => {
           setVerifyResult(result);
           if (result.success) {
-            toaster(t('c:success.domain_verified'), 'success');
+            toaster.success(t('c:success.domain_verified'));
           }
         },
       },
@@ -91,7 +91,7 @@ export function DomainTile({ domain, tenantId }: DomainTileProps) {
                   { path: { tenantId, id: domain.id } },
                   {
                     onSuccess: () => {
-                      toaster(t('c:success.delete_resource', { resource: t('c:domain') }), 'success');
+                      toaster.success(t('c:success.delete_resource', { resource: t('c:domain') }));
                     },
                   },
                 );

--- a/frontend/src/modules/tenants/update-tenant-form.tsx
+++ b/frontend/src/modules/tenants/update-tenant-form.tsx
@@ -51,7 +51,7 @@ export function UpdateTenantForm({ tenant, callback, sheet: isSheet }: Props) {
         onSuccess: (updatedTenant) => {
           if (isSheet) useSheeter.getState().remove(formContainerId);
           form.reset(body);
-          toaster(t('c:success.update_resource', { resource: t('c:tenant') }), 'success');
+          toaster.success(t('c:success.update_resource', { resource: t('c:tenant') }));
           callback?.({ data: updatedTenant, status: 'success' });
         },
       },

--- a/frontend/src/modules/ui/button.tsx
+++ b/frontend/src/modules/ui/button.tsx
@@ -118,7 +118,7 @@ export function SubmitButton({
     }
     if (showOfflineWarning) {
       e.preventDefault();
-      return toaster(t('c:action.offline.text'), 'warning');
+      return toaster.warning(t('c:action.offline.text'));
     }
     onClick?.(e);
   };

--- a/frontend/src/modules/ui/stories/sonner.stories.tsx
+++ b/frontend/src/modules/ui/stories/sonner.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { toast } from 'sonner';
 import { action } from 'storybook/actions';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { toaster } from '~/modules/common/toaster/toaster';
 import { Button } from '~/modules/ui/button';
 import { Toaster } from '~/modules/ui/sonner';
 
@@ -23,7 +23,7 @@ const meta: Meta<typeof Toaster> = {
     <div className="flex min-h-96 items-center justify-center space-x-2">
       <Button
         onClick={() =>
-          toast('Event has been created', {
+          toaster('Event has been created', {
             description: new Date().toLocaleString(),
             action: {
               label: 'Undo',
@@ -49,7 +49,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 export const ShouldShowToast: Story = {
-  name: 'when clicking Show Toast button, should show a toast',
+  name: 'when repeating the same toast, should keep one toast',
   tags: ['!dev', '!autodocs'],
   play: async ({ canvasElement, step }) => {
     const canvasBody = within(canvasElement.ownerDocument.body);
@@ -65,7 +65,7 @@ export const ShouldShowToast: Story = {
     await step('create more toasts', async () => {
       await userEvent.click(triggerBtn);
       await userEvent.click(triggerBtn);
-      await waitFor(() => expect(canvasBody.getAllByRole('listitem')).toHaveLength(3));
+      await waitFor(() => expect(canvasBody.getAllByRole('listitem')).toHaveLength(1));
     });
   },
 };

--- a/frontend/src/modules/ui/tag-input.tsx
+++ b/frontend/src/modules/ui/tag-input.tsx
@@ -138,7 +138,7 @@ function TagInputBase(props: TagInputProps, ref: React.ForwardedRef<HTMLInputEle
 
       for (const newTag of splitValues) {
         const errorMessage = newTagValidation(newTag);
-        if (errorMessage) return toaster(errorMessage, 'warning');
+        if (errorMessage) return toaster.warning(errorMessage);
 
         setTags((prevTags) => [...prevTags, newTag]);
         onTagAdd?.(newTag);
@@ -162,7 +162,7 @@ function TagInputBase(props: TagInputProps, ref: React.ForwardedRef<HTMLInputEle
       const newTag = inputValue.trim();
 
       const errorMessage = newTagValidation(newTag);
-      if (errorMessage) return toaster(errorMessage, 'warning');
+      if (errorMessage) return toaster.warning(errorMessage);
 
       setTags([...tags, newTag]);
       onTagAdd?.(newTag);
@@ -186,7 +186,7 @@ function TagInputBase(props: TagInputProps, ref: React.ForwardedRef<HTMLInputEle
       e.preventDefault();
 
       const errorMessage = newTagValidation(trimmedInput);
-      if (errorMessage) return toaster(errorMessage, 'warning');
+      if (errorMessage) return toaster.warning(errorMessage);
 
       setTags([...tags, trimmedInput]);
       onTagAdd?.(trimmedInput);

--- a/frontend/src/modules/user/delete-users.tsx
+++ b/frontend/src/modules/user/delete-users.tsx
@@ -20,7 +20,7 @@ export function DeleteUsers({ users, callback, dialog: isDialog }: Props) {
   const { mutate: _deleteUsers, isPending } = useUserDeleteMutation();
 
   const onDelete = () => {
-    if (!onlineManager.isOnline()) return toaster(t('c:action.offline.text'), 'warning');
+    if (!onlineManager.isOnline()) return toaster.warning(t('c:action.offline.text'));
 
     _deleteUsers(users, {
       onSuccess: () => {

--- a/frontend/src/modules/user/invite-bulk-email-form.tsx
+++ b/frontend/src/modules/user/invite-bulk-email-form.tsx
@@ -54,10 +54,10 @@ export function InviteBulkEmailForm({ channel, dialog: isDialog, children }: Pro
 
     if (invitesSentCount > 0) {
       const resource = t(`c:${invitesSentCount === 1 ? 'user' : 'users'}`).toLowerCase();
-      toaster(t('c:success.resource_count_invited', { count: invitesSentCount, resource }), 'success');
+      toaster.success(t('c:success.resource_count_invited', { count: invitesSentCount, resource }));
     }
     if (rejectedIds.length)
-      toaster(t('c:still_not_accepted', { count: rejectedIds.length, total: submittedEmails.length }), 'info');
+      toaster.info(t('c:still_not_accepted', { count: rejectedIds.length, total: submittedEmails.length }));
   };
 
   const { mutate: membershipInvite, isPending } = useInviteMemberMutation();

--- a/frontend/src/modules/user/invite-email-form.tsx
+++ b/frontend/src/modules/user/invite-email-form.tsx
@@ -42,10 +42,10 @@ export function InviteEmailForm({ channel, dialog: isDialog, children }: Props) 
 
     if (invitesSentCount > 0) {
       const resource = t(`c:${invitesSentCount === 1 ? 'user' : 'users'}`).toLowerCase();
-      toaster(t('c:success.resource_count_invited', { count: invitesSentCount, resource }), 'success');
+      toaster.success(t('c:success.resource_count_invited', { count: invitesSentCount, resource }));
     }
     if (rejectedIds.length)
-      toaster(t('c:still_not_accepted', { count: rejectedIds.length, total: emails.length }), 'info');
+      toaster.info(t('c:still_not_accepted', { count: rejectedIds.length, total: emails.length }));
 
     // Onboarding advances through stepper state; the callback is optional.
     nextStep?.();

--- a/frontend/src/modules/user/invite-search-form.tsx
+++ b/frontend/src/modules/user/invite-search-form.tsx
@@ -40,10 +40,10 @@ export function InviteSearchForm({ channel, dialog: isDialog }: Props) {
           form.reset(undefined, { keepDirtyValues: true });
           if (invitesSentCount > 0) {
             const resource = t(`c:${invitesSentCount === 1 ? 'user' : 'users'}`).toLowerCase();
-            toaster(t('c:success.resource_count_invited', { count: invitesSentCount, resource }), 'success');
+            toaster.success(t('c:success.resource_count_invited', { count: invitesSentCount, resource }));
           }
           if (rejectedIds.length)
-            toaster(t('c:still_not_accepted', { count: rejectedIds.length, total: emails.length }), 'info');
+            toaster.info(t('c:still_not_accepted', { count: rejectedIds.length, total: emails.length }));
 
           if (isDialog) useDialoger.getState().remove();
         },

--- a/frontend/src/modules/user/table/impersonate-row.tsx
+++ b/frontend/src/modules/user/table/impersonate-row.tsx
@@ -15,10 +15,10 @@ interface Props {
 async function handleStartImpersonation(targetUserId: string) {
   try {
     await startImpersonationFlow(targetUserId);
-    toaster(i18n.t('c:success.impersonated'), 'success');
+    toaster.success(i18n.t('c:success.impersonated'));
     getRouter().navigate({ to: appConfig.defaultRedirectPath, replace: true });
   } catch (error) {
-    toaster(i18n.t('error:impersonation_failed'), 'error');
+    toaster.error(i18n.t('error:impersonation_failed'));
     console.error(error);
   }
 }

--- a/frontend/src/modules/user/table/users-bar.tsx
+++ b/frontend/src/modules/user/table/users-bar.tsx
@@ -86,7 +86,7 @@ export const UsersTableBar = ({
                 count: args.data.length,
                 resources: t('c:user_other').toLowerCase(),
               });
-        toaster(message, 'success');
+        toaster.success(message);
       }
       clearSelection();
     };

--- a/frontend/src/modules/user/update-user-form.tsx
+++ b/frontend/src/modules/user/update-user-form.tsx
@@ -66,7 +66,7 @@ export function UpdateUserForm({ user, callback, sheet: isSheet, compact, childr
 
     const onSuccess = (updatedUser: User) => {
       const message = isSelf ? t('c:success.profile_updated') : t('c:success.update_item', { item: t('c:user') });
-      toaster(message, 'success');
+      toaster.success(message);
 
       form.reset(updatedUser);
       if (isSheet) useSheeter.getState().remove(formContainerId);

--- a/frontend/src/modules/user/user-cell.tsx
+++ b/frontend/src/modules/user/user-cell.tsx
@@ -56,7 +56,7 @@ export const UserCell = ({
       onClick={(e) => {
         if (!onlineManager.isOnline()) {
           e.preventDefault();
-          return toaster(t('c:action.offline.text'), 'warning');
+          return toaster.warning(t('c:action.offline.text'));
         }
         if (e.metaKey || e.ctrlKey) return;
         e.preventDefault();

--- a/frontend/src/modules/user/user-profile.tsx
+++ b/frontend/src/modules/user/user-profile.tsx
@@ -35,8 +35,8 @@ export function UserProfilePage({ user, organizationId, isSheet }: Props) {
 
   const coverUpdateCallback = (bannerUrl: string) => {
     const callbacks = {
-      onSuccess: () => toaster(t('c:success.upload_cover'), 'success'),
-      onError: () => toaster(t('error:image_upload_failed'), 'error'),
+      onSuccess: () => toaster.success(t('c:success.upload_cover')),
+      onError: () => toaster.error(t('error:image_upload_failed')),
     };
 
     if (isSelf) {

--- a/frontend/src/query/on-error.ts
+++ b/frontend/src/query/on-error.ts
@@ -98,7 +98,7 @@ export const onError = (error: Error | ApiError, meta?: QueryMeta) => {
 
       // Show toast
       const toastType = error.severity === 'error' ? 'error' : error.severity === 'warn' ? 'warning' : 'info';
-      toaster(errorMessage, toastType, { description });
+      toaster[toastType](errorMessage, { description });
     }
 
     // Redirect to sign-in page if the user is not authenticated (unless already on /auth/*)

--- a/frontend/src/utils/form-on-invalid.ts
+++ b/frontend/src/utils/form-on-invalid.ts
@@ -12,7 +12,7 @@ export const defaultOnInvalid = <TFieldValues extends FieldValues>(errors: Field
   if (messages.length === 0) return;
 
   // Display a toaster with a list of validation errors
-  toaster(t('error:form.invalid_form'), 'error', {
+  toaster.error(t('error:form.invalid_form'), {
     description: createElement(
       'div',
       null,

--- a/frontend/src/utils/resource-error.ts
+++ b/frontend/src/utils/resource-error.ts
@@ -8,5 +8,5 @@ import { toaster } from '~/modules/common/toaster/toaster';
  * `meta: { suppressGlobalErrorToast: true }` so the user only sees this toast.
  */
 export const createResourceError = (resource: string) => (type: 'create' | 'update' | 'delete') => {
-  toaster(t(`error:${type}_resource`, { resource: t(`c:${resource}`) }), 'error');
+  toaster.error(t(`error:${type}_resource`, { resource: t(`c:${resource}`) }));
 };


### PR DESCRIPTION
## Summary

- expose a Sonner-compatible callable toaster with severity and lifecycle methods
- preserve duplicate-message suppression through stable native Sonner ids
- migrate all upstream positional-severity calls and update Storybook coverage
- ship an idempotent TypeScript-AST codemod, migration guide, and manifest entry for forks

## Validation

- pnpm check
- wrapper unit tests: 5 passed
- Sonner Storybook tests: 3 passed
- codemod self-test passed
- post-migration inventory: 0 rewrites, 0 skipped calls
- migration planner: no warnings