### PR TITLE
fix: release tab leadership when leaving the app

### DIFF
--- a/cella/AGENTS.md
+++ b/cella/AGENTS.md
@@ -128,6 +128,13 @@ The permission system in `backend/src/permissions/` provides: the `checkAccess*`
 - Code comments explain non-trivial logic only. Do not narrate decision history, what was considered and rejected, or how the code evolved; that belongs in commit messages, not source. A comment should describe _what_ the code does and _why_, not _what it replaced_ or _what it is not_.
 - **Never use em dashes (`—`, U+2014) anywhere in text**: source comments, YAML, config files, and docs. Split the sentence, use a colon, or remove the secondary clause. `pnpm check` runs `shared/scripts/check-comment-style.ts`, which fails the build on any em dash. Treat contrast, history, and conversational phrases such as `instead`, `rather than`, `previously`, `used to`, `maybe`, and `we should` as review signals. Rewrite useful comments around the current behavior or constraint, and delete the rest.
 - Reserve `materialize` and `materialization` for the named Yjs operation that converts collaborative state into durable entity data. Use concrete verbs such as `persist`, `provision`, `create`, or `resolve` elsewhere.
+- **Reserved domain vocabulary.** These words already name a subsystem; do not reuse them for anything else, and check what a word means here before naming a new module or export:
+  - `sync` -> the entity sync engine (`sync-store`, `sync-service`, `SyncTier`, `syncStaleTime`, `declareSyncView`).
+  - `schema` / `lens` -> schema evolution (`currentSchemaVersion`, `defineLens`, `markBundleStale`).
+  - `channel` -> channel entities (`ChannelEntityType`, `channelId`); not a transport or a `BroadcastChannel`.
+  - `own` / `owner` -> the permission engine's creator relation.
+  - `leader tab` / `election` -> cross-tab coordination of the single SSE connection (`tab-coordinator`).
+  Name modules for the role they play in the domain, not the primitive they are built on: a name like `leader-lease` describes a mechanism (and stops being true when the mechanism changes), while `tab-coordinator` describes the job. When splitting a module, name the remainder deliberately; a leftover named after its payload plus a generic verb is how collisions get introduced.
 - Storybook: Stories in `stories/` folder within the module, named `<component-filename>.stories.tsx`.
 - Icons: lucide with Icon suffix (e.g., `PencilIcon`).
 - UI primitives: Base UI (`@base-ui/react`), **not** Radix. Shadcn-style components in `frontend/src/modules/ui/` wrap Base UI primitives.

--- a/frontend/src/modules/common/blocknote/blocknote-editor.tsx
+++ b/frontend/src/modules/common/blocknote/blocknote-editor.tsx
@@ -2,6 +2,7 @@ import '@blocknote/shadcn/style.css';
 import '~/modules/common/blocknote/styles.css';
 import '~/modules/common/blocknote/custom-elements/checklist/checklist-styles.css';
 
+import { withCollaboration } from '@blocknote/core/yjs';
 import type { FilePanelProps } from '@blocknote/react';
 import { FilePanelController, GridSuggestionMenuController, useCreateBlockNote } from '@blocknote/react';
 import { BlockNoteView } from '@blocknote/shadcn';
@@ -103,31 +104,35 @@ function BlockNote({
   );
 
   // Parse initial content once at creation time so the undo history starts clean
-  // (BlockNote's recommended pattern from https://www.blocknotejs.org/examples/backend/saving-loading)
-  // In collaboration mode, the Yjs provider supplies the document state.
   const initialContent = collaborative ? undefined : getParsedContent(defaultValue);
 
-  const editor = useCreateBlockNote({
+  const baseOptions = {
     schema: customSchema,
     initialContent,
     heading: { levels: headingLevels },
     trailingBlock,
     dictionary: getDictionary(),
-    // Only the Yjs wiring goes to the editor; the entity identity in the bundle
-    // is consumed by the SSE suppression hook below.
-    collaboration: collaboration
-      ? { provider: collaboration.provider, fragment: collaboration.fragment, user: collaboration.user }
-      : undefined,
-
     extensions: [checkedExtension(), ...(extensions ?? [])],
     resolveFileUrl: createResolveFileUrl({ baseFilePanelProps }),
-  });
+  };
+
+  const editor = useCreateBlockNote(
+    collaboration
+      ? withCollaboration({
+          ...baseOptions,
+          collaboration: {
+            fragment: collaboration.fragment,
+            user: collaboration.user,
+            provider: collaboration.provider,
+          },
+        })
+      : baseOptions,
+  );
 
   // Re-subscribe Yjs UndoManager after TipTap mount cycles so CMD+Z keeps working.
   useYjsUndoManagerFix(editor, collaborative);
 
-  // Shield Yjs-owned fields from SSE while this editor is active. The relay owns
-  // persistence and seeding, so no client sends description updates.
+  // Shield Yjs-owned fields from SSE while this editor is active.
   useYjsSseSuppression(
     collaboration ? { entityType: collaboration.entityType, entityId: collaboration.entityId } : null,
   );
@@ -163,8 +168,7 @@ function BlockNote({
     editor,
     containerRef: blockNoteRef,
     onBlur: () => {
-      // In `commitOnEveryChange` mode, every change is already pushed via onChange,
-      // so blur is a no-op. Otherwise we commit pending edits to the cache here.
+      // In `commitOnEveryChange` mode, every change is already pushed via onChange.
       // Guarded with `!editor.isEmpty` to avoid writing empty content before Yjs sync.
       if (!commitOnEveryChange && !editor.isEmpty) handleUpdateData(editor);
     },

--- a/frontend/src/query/realtime/tab-coordinator.test.ts
+++ b/frontend/src/query/realtime/tab-coordinator.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('shared/schema-evolution', () => ({ currentSchemaVersion: 1 }));
+vi.mock('~/query/schema-version-guard', () => ({ markBundleStale: vi.fn() }));
+
+/**
+ * Minimal Web Locks fake: one named lock with a FIFO waiter queue. `ifAvailable` grants-or-nulls
+ * immediately; a signalled request queues until the lock frees and rejects with AbortError if the
+ * signal fires first. A granted lock is held until the callback's returned promise settles.
+ */
+class FakeLocks {
+  private held = new Set<string>();
+  private queues = new Map<string, Array<() => void>>();
+
+  request(name: string, optionsOrCb: unknown, maybeCb?: (lock: unknown) => unknown): Promise<unknown> {
+    const opts = (typeof optionsOrCb === 'object' && optionsOrCb !== null ? optionsOrCb : {}) as {
+      ifAvailable?: boolean;
+      signal?: AbortSignal;
+    };
+    const cb = (typeof optionsOrCb === 'function' ? optionsOrCb : maybeCb) as (lock: unknown) => unknown;
+
+    if (opts.ifAvailable) {
+      if (this.held.has(name)) return Promise.resolve(cb(null));
+      return this.grant(name, cb);
+    }
+
+    if (!this.held.has(name)) return this.grant(name, cb);
+
+    return new Promise((resolve, reject) => {
+      const signal = opts.signal;
+      const attempt = () => {
+        signal?.removeEventListener('abort', onAbort);
+        this.grant(name, cb).then(resolve, reject);
+      };
+      const onAbort = () => {
+        const queue = this.queues.get(name);
+        const index = queue?.indexOf(attempt) ?? -1;
+        if (queue && index >= 0) queue.splice(index, 1);
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+      };
+      if (signal?.aborted) return onAbort();
+      signal?.addEventListener('abort', onAbort, { once: true });
+      const queue = this.queues.get(name) ?? [];
+      queue.push(attempt);
+      this.queues.set(name, queue);
+    });
+  }
+
+  private grant(name: string, callback: (lock: unknown) => unknown): Promise<unknown> {
+    this.held.add(name);
+    const result = Promise.resolve(callback({ name }));
+    result.finally(() => {
+      this.held.delete(name);
+      this.queues.get(name)?.shift()?.();
+    });
+    return result;
+  }
+
+  isHeld(name: string): boolean {
+    return this.held.has(name);
+  }
+
+  reset(): void {
+    this.held.clear();
+    this.queues.clear();
+  }
+}
+
+class FakeBroadcastChannel {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  constructor(public name: string) {}
+  postMessage(): void {}
+  close(): void {}
+}
+
+const fakeLocks = new FakeLocks();
+vi.stubGlobal('navigator', { locks: fakeLocks });
+vi.stubGlobal('BroadcastChannel', FakeBroadcastChannel);
+
+const { initTabCoordinator, releaseTabLeadership, isLeader } = await import('./tab-coordinator');
+
+/** Flush microtasks + timers so lock grants and promotions settle. */
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  releaseTabLeadership();
+  fakeLocks.reset();
+});
+
+afterEach(async () => {
+  releaseTabLeadership();
+  await tick();
+  fakeLocks.reset();
+});
+
+describe('tab coordinator leadership', () => {
+  it('becomes leader and holds the lock when it is free', async () => {
+    await initTabCoordinator();
+
+    expect(isLeader()).toBe(true);
+    expect(fakeLocks.isHeld('tab-leader')).toBe(true);
+  });
+
+  it('releases the lock on release so a later return re-elects', async () => {
+    await initTabCoordinator();
+    releaseTabLeadership();
+    await tick();
+
+    expect(isLeader()).toBe(false);
+    expect(fakeLocks.isHeld('tab-leader')).toBe(false);
+
+    await initTabCoordinator();
+    expect(isLeader()).toBe(true);
+  });
+
+  it('parks as follower while another tab holds leadership', async () => {
+    fakeLocks.request('tab-leader', () => new Promise<void>(() => {}));
+
+    await initTabCoordinator();
+
+    expect(isLeader()).toBe(false);
+  });
+
+  it('promotes a follower when the leader releases on leaving the app', async () => {
+    // Another tab is leader (it is in the app, holding the stream).
+    let releaseOther: () => void = () => {};
+    const otherHold = new Promise<void>((resolve) => {
+      releaseOther = resolve;
+    });
+    fakeLocks.request('tab-leader', () => otherHold);
+
+    await initTabCoordinator();
+    expect(isLeader()).toBe(false); // follower: listening to broadcasts only
+
+    // The leader navigates to a public route and releases leadership.
+    releaseOther();
+    await tick();
+
+    // The follower must take over so the SSE stream stays alive for every tab.
+    expect(isLeader()).toBe(true);
+    expect(fakeLocks.isHeld('tab-leader')).toBe(true);
+  });
+});

--- a/frontend/src/query/realtime/tab-coordinator.tsx
+++ b/frontend/src/query/realtime/tab-coordinator.tsx
@@ -46,6 +46,17 @@ const isWebLocksAvailable = (): boolean => {
 };
 
 /**
+ * Resolve when `signal` aborts. A lock callback awaits this to hold the lock releasably: the
+ * callback returns once the signal fires, which frees the lock for a waiting follower without
+ * requiring the tab to close.
+ */
+const untilAborted = (signal: AbortSignal): Promise<void> =>
+  new Promise<void>((resolve) => {
+    if (signal.aborted) return resolve();
+    signal.addEventListener('abort', () => resolve(), { once: true });
+  });
+
+/**
  * Check if BroadcastChannel is available.
  */
 const isBroadcastChannelAvailable = (): boolean => {
@@ -92,10 +103,34 @@ export const initTabCoordinator = async (): Promise<void> => {
   return initPromise;
 };
 
+/**
+ * Release this tab's leadership so a waiting follower is promoted. Call when the tab leaves the
+ * authenticated app: leadership gates who maintains the SSE stream, so a tab that holds it while no
+ * longer streaming starves every follower. A full tab close frees the lock via realm destruction.
+ *
+ * Clearing `initPromise` lets a later return to the app run the election again and take whichever
+ * role is open: follower while another tab leads, leader when none does. That re-run also restores
+ * the pending promotion request, so a sole tab picks the stream back up when it returns.
+ */
+export const releaseTabLeadership = (): void => {
+  const store = useTabCoordinatorStore.getState();
+
+  lockController?.abort();
+  lockController = null;
+  initPromise = null;
+
+  store.setIsLeader(false);
+  store.setIsReady(false);
+  store.setIsActive(false);
+};
+
 /** Acquire the leader lock (first tab to acquire it becomes leader); resolves once leader status is known. */
 const attemptLeaderElection = (): Promise<void> => {
   const store = useTabCoordinatorStore.getState();
+  // One controller per election: aborting it releases whichever lock this tab currently holds or
+  // awaits. `ifAvailable` cannot be combined with a signal, so the callback checks it by hand.
   lockController = new AbortController();
+  const { signal } = lockController;
 
   return new Promise<void>((resolveElection) => {
     // Debug: Query existing locks first
@@ -123,9 +158,9 @@ const attemptLeaderElection = (): Promise<void> => {
           store.setIsReady(true);
           resolveElection();
 
-          // Keep the lock by returning a never-resolving promise
-          // The lock is held until the tab closes or releases it
-          return new Promise<void>(() => {});
+          // Hold the lock until leadership is released (or the tab closes), then return to free it
+          await untilAborted(signal);
+          return;
         }
 
         // Lock not available - we're a follower
@@ -134,9 +169,9 @@ const attemptLeaderElection = (): Promise<void> => {
         store.setIsReady(true);
         resolveElection();
 
-        // Now wait for leadership in case current leader closes
+        // Now wait for leadership in case current leader closes or leaves the app
         // This runs in background and doesn't block initialization
-        waitForLeadership();
+        waitForLeadership(signal);
 
         return undefined;
       })
@@ -154,17 +189,16 @@ const attemptLeaderElection = (): Promise<void> => {
  * Wait in background for leadership to become available.
  * Called by follower tabs to eventually become leader when current leader closes.
  */
-const waitForLeadership = (): void => {
+const waitForLeadership = (signal: AbortSignal): void => {
   const store = useTabCoordinatorStore.getState();
-  lockController = new AbortController();
 
   navigator.locks
-    .request(leaderLockName, { signal: lockController.signal }, async () => {
+    .request(leaderLockName, { signal }, async () => {
       console.debug('[TabCoordinator] Promoted to leader');
       store.setIsLeader(true);
 
-      // Keep the lock by returning a never-resolving promise
-      return new Promise<void>(() => {});
+      // Hold the lock until leadership is released, then return to free it
+      await untilAborted(signal);
     })
     .catch((error) => {
       if (error instanceof DOMException && error.name === 'AbortError') {

--- a/frontend/src/routes/router.ts
+++ b/frontend/src/routes/router.ts
@@ -3,6 +3,7 @@ import { useSheeter } from '~/modules/common/sheeter/use-sheeter';
 import { useNavigationStore } from '~/modules/navigation/navigation-store';
 import { useUIStore } from '~/modules/ui/ui-store';
 import { appStreamManager } from '~/query/realtime/stream-store';
+import { releaseTabLeadership } from '~/query/realtime/tab-coordinator';
 import { createNotFoundComponent } from '~/routes/-route-utils';
 import { setRouter } from '~/routes/-router-instance';
 import { routeTree } from '~/routes/routeTree.gen';
@@ -41,7 +42,12 @@ const cleanupOnBoundaryChange = (current?: BoundaryType, pending?: BoundaryType)
   if (!current || !pending || current === pending) return;
   useSheeter.getState().remove(undefined, { isCleanup: true });
   useNavigationStore.getState().setNavSheetOpen(null);
-  if (pending === 'public') appStreamManager.disconnect();
+  if (pending === 'public') {
+    // Leaving the app: tear down the stream and release leadership so a follower tab is promoted
+    // and keeps the SSE alive. Retaining it here would starve every other tab.
+    appStreamManager.disconnect();
+    releaseTabLeadership();
+  }
 };
 
 /**


### PR DESCRIPTION
Adopts fixes that were made downstream in a fork but belong upstream in cella. All three files were byte-identical to the fork's base, so the patches applied without conflicts.

## Leader election could starve follower tabs

`tab-coordinator` held the Web Locks leader lock by returning a never-resolving promise, so the lock only freed when the tab's realm was destroyed (a full close). A tab that navigated to a public route tore down its SSE stream via `appStreamManager.disconnect()` but kept leadership, leaving every follower tab without realtime updates until that tab was closed.

- Leadership is now held by awaiting an `AbortSignal` (`untilAborted`), so returning from the lock callback frees the lock.
- One `AbortController` per election, shared with `waitForLeadership()`, so a follower's pending promotion request is aborted by the same signal.
- New `releaseTabLeadership()` aborts the controller, resets the store, and clears `initPromise` so a later return to the app re-runs the election and takes whichever role is open.
- `cleanupOnBoundaryChange` in `frontend/src/routes/router.ts` calls it alongside the stream disconnect.

## Other adopted changes

- **blocknote**: wire collaborative editors through `withCollaboration()` from `@blocknote/core/yjs` rather than passing `collaboration` inline to `useCreateBlockNote`.
- **AGENTS.md**: document reserved domain vocabulary (`sync`, `schema`/`lens`, `channel`, `own`/`owner`, `leader tab`/`election`) so new modules do not reuse names that already denote a subsystem.

## Tests

New `frontend/src/query/realtime/tab-coordinator.test.ts` runs the coordinator against a fake Web Locks implementation with a FIFO waiter queue, covering election, release-and-re-elect, follower parking, and promotion when the leader leaves the app. 4 passing.

`pnpm check` is clean. One comment was reworded to satisfy cella's `comments:check` gate (`contrast-history` rule), which the fork does not run.

Note: `src/query/tests/on-error.test.ts` fails on this branch, but it fails identically on `main` (fallout from the toaster API alignment in #949) and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
