### PR TITLE
fix: index each list item as its own docs search section

### DIFF
--- a/frontend/src/query/tests/on-error.test.ts
+++ b/frontend/src/query/tests/on-error.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockCheckConnectivity = vi.fn();
-const mockToaster = vi.fn();
+// onError dispatches by severity (toaster.error/warning/info), so the mock needs those methods.
+const mockToaster = Object.assign(vi.fn(), { error: vi.fn(), warning: vi.fn(), info: vi.fn(), success: vi.fn() });
 const mockSetDownAlert = vi.fn();
 const mockNavigate = vi.fn();
 const mockTeardownUserState = vi.fn();

--- a/frontend/vite/docs-frontmatter.test.ts
+++ b/frontend/vite/docs-frontmatter.test.ts
@@ -131,9 +131,28 @@ describe('extractStructure sections', () => {
     ].join('\n');
     const texts = extractStructure(src).sections.map((s) => s.text);
     expect(texts).toContain('A bold link with code.');
-    expect(texts).toContain('item one item two');
+    expect(texts).toContain('item one');
+    expect(texts).toContain('item two');
     expect(texts.join(' ')).toContain('cell a cell b');
     expect(texts.join(' ')).not.toMatch(/import|Tiles|note to self|\||\*\*/);
+  });
+
+  it('splits uninterrupted lists into one section per item, keeping wrapped lines attached', () => {
+    const src = [
+      '## Components',
+      '',
+      '- **First:** alpha bravo',
+      '  wrapped continuation line',
+      '- **Second:** charlie with `singleVm` on',
+      '1. numbered delta',
+      '2. numbered echo',
+    ].join('\n');
+    expect(extractStructure(src).sections).toEqual([
+      { headingId: 'spy-components', text: 'First: alpha bravo wrapped continuation line' },
+      { headingId: 'spy-components', text: 'Second: charlie with singleVm on' },
+      { headingId: 'spy-components', text: 'numbered delta' },
+      { headingId: 'spy-components', text: 'numbered echo' },
+    ]);
   });
 
   it('skips the leading h1 of repo docs but keeps its text under null anchor', () => {

--- a/frontend/vite/docs-frontmatter.ts
+++ b/frontend/vite/docs-frontmatter.ts
@@ -72,6 +72,9 @@ function toPlainText(markdown: string): string {
 
 const HEADING_LINE_SINGLE = /^(#{1,6})[ \t]+(.+?)[ \t]*#*[ \t]*$/;
 
+/** Lookahead for a list-item start: each bullet indexes as its own section. */
+const LIST_ITEM_BOUNDARY = /\n(?=[ \t]*(?:[-*+]|\d+\.)[ \t])/;
+
 /**
  * Extract headings and sections with one slugger so anchors and duplicate suffixes agree.
  * Optionally strip the repository document H1 to match rendering.
@@ -89,10 +92,13 @@ export function extractStructure(
   let firstHeading = true;
 
   const flush = () => {
-    // Paragraph-level sections: split on blank lines before whitespace collapses.
+    // Paragraph-level sections: split on blank lines before whitespace collapses, then at
+    // list-item starts so an uninterrupted list never collapses into one capped section.
     for (const paragraph of buffer.join('\n').split(/\n[ \t]*\n+/)) {
-      const text = toPlainText(paragraph);
-      if (text) sections.push({ headingId: currentHeadingId, text: text.slice(0, MAX_SECTION_LENGTH) });
+      for (const block of paragraph.split(LIST_ITEM_BOUNDARY)) {
+        const text = toPlainText(block);
+        if (text) sections.push({ headingId: currentHeadingId, text: text.slice(0, MAX_SECTION_LENGTH) });
+      }
     }
     buffer = [];
   };

--- a/infra/tests/unit/compute.test.ts
+++ b/infra/tests/unit/compute.test.ts
@@ -129,7 +129,8 @@ describe('compute module source contracts', () => {
     expect(source).not.toMatch(/stableInternalGen_/)
     expect(source).not.toMatch(/stablePrivateIp/)
     expect(source).toMatch(/deleteBeforeReplace: true/)
-    expect(source).toMatch(/content-addressed id for a pending SHA/)
+    // A pending SHA derives its content-addressed generation id from the service fingerprint.
+    expect(source).toMatch(/deriveGenId\(entry\.pendingSha, fingerprint\)/)
   })
 
   it('envPool does not bind backend secrets as compose env values', () => {


### PR DESCRIPTION
## Problem

Docs search misses terms that live in bullet lists, e.g. searching `singleVm` returns nothing even though `infra/README.md` mentions it in prose.

The corpus extractor in `frontend/vite/docs-frontmatter.ts` split sections only on blank lines. Markdown lists have no blank lines between items, so a whole list collapsed into one "paragraph", which `MAX_SECTION_LENGTH = 500` then truncated. For the infra README components list (~2,600 chars) the cut landed mid-first-bullet, silently dropping bullets 2-8 (including both `singleVm` mentions) from the Orama index. Any list-heavy page (`ARCHITECTURE.md`, `PERMISSIONS.md`, ...) lost content the same way.

Orama itself was innocent: inline-code markers are unwrapped before indexing and camelCase terms match fine once the text is actually indexed.

## Fix

Split each blank-line paragraph further at list-item boundaries (`-`/`*`/`+`/`1.` starts, lookahead so wrapped continuation lines stay attached to their bullet) before applying the cap. Every bullet now indexes as its own snippet-sized section, which is also what keeps `threshold: 0` multi-term matching honest (no false matches across unrelated bullets) and BM25 ranking tight. The 500-char cap stays as a per-item backstop.

Raising the cap alone was considered and rejected: any cap still truncates some longer list, and oversized sections degrade both matching and ranking.

## Testing

- Updated the extractor test that pinned the old whole-list-as-one-section behavior; added a test covering bullet/numbered lists, wrapped lines, and an inline-code camelCase term.
- Verified against the real file: `singleVm` now lands in its own section anchored to the infra README Overview heading.
- `pnpm check` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also included: two stale test-double repairs

- `infra/tests/unit/compute.test.ts` matched a comment string that was reworded in `generations.ts`; the assertion now pins the invariant to the code itself (`deriveGenId(entry.pendingSha, fingerprint)`) so prose edits cannot break it.
- `frontend/src/query/tests/on-error.test.ts` mocked the toaster as a bare `vi.fn()` while `onError` dispatches severity methods (`toaster.error/warning/info`), so the 500-ApiError path threw a TypeError. The mock now carries those methods.
