### PR TITLE
perf: faster SW install and reload UX (serwist, chunking, compression)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -115,6 +115,7 @@
     "remark-gfm": "^4.0.1",
     "remark-mdx-frontmatter": "^5.2.0",
     "sdk": "workspace:*",
+    "serwist": "^9.5.12",
     "shared": "workspace:*",
     "shiki": "^4.3.1",
     "slugify": "1.6.9",
@@ -174,11 +175,6 @@
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.10",
     "workbox-build": "^7.4.1",
-    "workbox-core": "^7.4.1",
-    "workbox-expiration": "^7.4.1",
-    "workbox-precaching": "^7.4.1",
-    "workbox-routing": "^7.4.1",
-    "workbox-strategies": "^7.4.1",
     "yaml": "^2.9.0"
   },
   "browserslist": [

--- a/frontend/src/lib/sw.ts
+++ b/frontend/src/lib/sw.ts
@@ -1,11 +1,9 @@
 /// <reference lib="webworker" />
-import { clientsClaim } from 'workbox-core';
-import { ExpirationPlugin } from 'workbox-expiration';
-import { cleanupOutdatedCaches, createHandlerBoundToURL, precacheAndRoute } from 'workbox-precaching';
-import { NavigationRoute, registerRoute } from 'workbox-routing';
-import { StaleWhileRevalidate } from 'workbox-strategies';
+import { ExpirationPlugin, type PrecacheEntry, Serwist, StaleWhileRevalidate } from 'serwist';
 
-declare const self: ServiceWorkerGlobalScope;
+declare const self: ServiceWorkerGlobalScope & {
+  __WB_MANIFEST: (PrecacheEntry | string)[];
+};
 
 // Periodic Background Sync API (Chromium-only), not yet in lib.dom.
 interface PeriodicSyncEvent extends ExtendableEvent {
@@ -18,40 +16,41 @@ declare global {
 }
 declare const __BACKEND_URL__: string;
 
-// Take control of all pages immediately
-clientsClaim();
-
-// Allow the client to trigger skipWaiting via postMessage
-self.addEventListener('message', (event) => {
-  if (event.data && event.data.type === 'SKIP_WAITING') {
-    self.skipWaiting();
-  }
-});
-
-// Workbox precaching: manifest injected by vite-plugin-pwa.
-cleanupOutdatedCaches();
-precacheAndRoute(self.__WB_MANIFEST);
-
-// Serve the precached app shell for offline SPA navigation.
-// Exclude a same-origin backend prefix so OAuth and download navigations retain network
-// responses; cross-origin backends do not match this navigation route.
+// Exclude a same-origin backend prefix from the SPA navigation fallback so OAuth and
+// download navigations retain network responses; cross-origin backends never match it.
 const apiPathPrefix = new URL(__BACKEND_URL__, self.location.origin).pathname.replace(/\/+$/, '');
 const navigationDenylist = apiPathPrefix
   ? [new RegExp(`^${apiPathPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/`)]
   : [];
-registerRoute(new NavigationRoute(createHandlerBoundToURL('index.html'), { denylist: navigationDenylist }));
 
-// Cache runtime docs data after its first visit so the section works offline.
-// Stale-while-revalidate refreshes these non-content-hashed files after each deploy.
-registerRoute(
-  ({ url }) =>
-    url.origin === self.location.origin &&
-    (url.pathname.startsWith('/static/docs.gen/') || url.pathname === '/static/openapi.json'),
-  new StaleWhileRevalidate({
-    cacheName: 'docs-gen',
-    plugins: [new ExpirationPlugin({ maxEntries: 40 })],
-  }),
-);
+// Serwist wires precaching (manifest injected by vite-plugin-pwa), the offline app-shell
+// navigation fallback, and runtime caching. `skipWaiting: false` keeps the update prompt
+// contract: Serwist itself listens for the client's `{type: 'SKIP_WAITING'}` message.
+const serwist = new Serwist({
+  precacheEntries: self.__WB_MANIFEST,
+  skipWaiting: false,
+  clientsClaim: true,
+  precacheOptions: {
+    cleanupOutdatedCaches: true,
+    // Number of parallel precache downloads during SW install
+    concurrency: 10,
+    navigateFallback: 'index.html',
+    navigateFallbackDenylist: navigationDenylist,
+  },
+  runtimeCaching: [
+    {
+      // Cache runtime docs data after its first visit so the section works offline.
+      // Stale-while-revalidate refreshes these non-content-hashed files after each deploy.
+      matcher: ({ url }) =>
+        url.origin === self.location.origin &&
+        (url.pathname.startsWith('/static/docs.gen/') || url.pathname === '/static/openapi.json'),
+      handler: new StaleWhileRevalidate({
+        cacheName: 'docs-gen',
+        plugins: [new ExpirationPlugin({ maxEntries: 40 })],
+      }),
+    },
+  ],
+});
 
 // Chromium-only (Chrome 80+, Edge). Fires at browser-determined intervals.
 // Fetches the real unseen count from the server so badge stays accurate.
@@ -61,6 +60,8 @@ self.addEventListener('periodicsync', (event) => {
     event.waitUntil(updateBadge());
   }
 });
+
+serwist.addEventListeners();
 
 async function updateBadge() {
   try {

--- a/frontend/src/lib/sw.ts
+++ b/frontend/src/lib/sw.ts
@@ -1,5 +1,5 @@
 /// <reference lib="webworker" />
-import { ExpirationPlugin, type PrecacheEntry, Serwist, StaleWhileRevalidate } from 'serwist';
+import { CacheFirst, ExpirationPlugin, type PrecacheEntry, Serwist, StaleWhileRevalidate } from 'serwist';
 
 declare const self: ServiceWorkerGlobalScope & {
   __WB_MANIFEST: (PrecacheEntry | string)[];
@@ -47,6 +47,16 @@ const serwist = new Serwist({
       handler: new StaleWhileRevalidate({
         cacheName: 'docs-gen',
         plugins: [new ExpirationPlugin({ maxEntries: 40 })],
+      }),
+    },
+    {
+      // Syntax-highlight grammar/theme chunks are excluded from the precache (globIgnores
+      // in vite.config.ts). Content-hashed and immutable, so cache-first is safe; this
+      // keeps highlighting working offline after a language loads once.
+      matcher: ({ url }) => url.origin === self.location.origin && /^\/assets\/grammars-/.test(url.pathname),
+      handler: new CacheFirst({
+        cacheName: 'grammars',
+        plugins: [new ExpirationPlugin({ maxEntries: 80 })],
       }),
     },
   ],

--- a/frontend/src/modules/common/reload-prompt.tsx
+++ b/frontend/src/modules/common/reload-prompt.tsx
@@ -1,4 +1,5 @@
 import { useRegisterSW } from 'virtual:pwa-register/react';
+import { LoaderCircleIcon } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { appConfig } from 'shared';
@@ -10,9 +11,6 @@ const SW_UPDATE_INTERVAL = 15 * 60 * 1000;
 export function ReloadPrompt() {
   const { t } = useTranslation();
   const [reloading, setReloading] = useState(false);
-
-  // replaced dynamically
-  const buildDate = '__DATE__';
 
   const {
     needRefresh: [needRefresh, setNeedRefresh],
@@ -50,13 +48,16 @@ export function ReloadPrompt() {
     }
   }, [needRefresh, updateServiceWorker]);
 
-  // Attempt SW-driven reload, force a hard reload if nothing happens after 5s
+  // Attempt SW-driven reload, force a hard reload if nothing happens after 5s.
+  // The gap between click and reload is the new SW's activate phase (stale
+  // precache cleanup), so the button shows a spinner until the page goes away.
   const reload = useCallback(() => {
+    if (reloading) return;
     setReloading(true);
     // Guaranteed fallback: if the SW update doesn't trigger a reload, force one
     setTimeout(() => window.location.reload(), 5000);
     updateServiceWorker(true);
-  }, [updateServiceWorker]);
+  }, [reloading, updateServiceWorker]);
 
   const close = () => {
     setNeedRefresh(false);
@@ -70,18 +71,18 @@ export function ReloadPrompt() {
             <span>{t('c:refresh_pwa_app.text')}</span>
           </div>
           <div className="space-x-2">
-            {needRefresh && (
-              <Button onClick={reload} loading={reloading}>
-                {t('c:reload')}
-              </Button>
-            )}
-            <Button variant="secondary" onClick={() => close()}>
+            <Button onClick={reload} disabled={reloading} aria-busy={reloading || undefined}>
+              <span className="relative inline-flex items-center">
+                <span className={reloading ? 'invisible' : undefined}>{t('c:reload')}</span>
+                {reloading && <LoaderCircleIcon className="absolute inset-0 m-auto animate-spin" />}
+              </span>
+            </Button>
+            <Button variant="secondary" onClick={close} disabled={reloading}>
               {t('c:close')}
             </Button>
           </div>
         </div>
       )}
-      <div className="hidden">{buildDate}</div>
     </>
   );
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -106,19 +106,30 @@ const viteConfig = {
         codeSplitting: {
           minSize: 50 * 1024, // Minimum chunk size of 50 Kb
           groups: [
+            // One group per grammar/theme module: each language stays its own lazily
+            // loadable chunk, and the grammars- prefix keeps all of them out of the SW
+            // precache (globIgnores). The name encodes the package variant so the
+            // plain and precompiled builds of a language never merge into one chunk.
+            // The shiki core engine is untouched and stays in precached chunks.
+            {
+              name: (id: string) => {
+                // The oniguruma WASM engine is dynamically importable but unused: the app
+                // CSP has no 'unsafe-eval', so the JavaScript regex engine is always used
+                if (/node_modules[\\/]@shikijs[\\/]engine-oniguruma[\\/]/.test(id)) return 'grammars-wasm';
+                const m = id.match(
+                  /node_modules[\\/]@shikijs[\\/](langs|langs-precompiled|themes)[\\/]dist[\\/]([\w.+-]+?)\.m?js$/
+                );
+                if (!m || m[2] === 'index') return null;
+                const variant = m[1] === 'langs-precompiled' ? 'pc-' : m[1] === 'themes' ? 'theme-' : '';
+                return `grammars-${variant}${m[2].replace(/[^\w-]/g, '-')}`;
+              },
+              // The top-level minSize is inherited as the group default and would silently
+              // drop languages smaller than it back to automatic (precached) chunking
+              minSize: 0,
+            },
             // Merge all lucide icon modules into one shared chunk to keep request count low
             { name: 'icons', test: /node_modules[\\/]lucide-react[\\/]/ },
           ],
-        },
-        // Prefix lazily imported grammar/theme chunks so the SW precache can exclude
-        // them by glob while each language still loads on demand. The shiki core
-        // engine is statically imported and keeps its normal (precached) chunk.
-        chunkFileNames(chunk) {
-          const grammarModule = /node_modules[\\/](shiki|@shikijs|tm-grammars|tm-themes)[\\/]/;
-          if (chunk.facadeModuleId && grammarModule.test(chunk.facadeModuleId)) {
-            return 'assets/grammars-[hash].js';
-          }
-          return 'assets/[name]-[hash].js';
         },
       },
     },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -129,6 +129,61 @@ const viteConfig = {
             },
             // Merge all lucide icon modules into one shared chunk to keep request count low
             { name: 'icons', test: /node_modules[\\/]lucide-react[\\/]/ },
+            // Broadly shared vendor packages, one chunk each. Groups get an explicit
+            // minSize: 0 because the top-level minSize is inherited as the group default
+            // and silently drops groups that accumulate less than it.
+            { name: 'base-ui', test: /node_modules[\\/](@base-ui|@floating-ui)[\\/]/, minSize: 0 },
+            { name: 'tanstack', test: /node_modules[\\/]@tanstack[\\/]/, minSize: 0 },
+            // Heavy or foundational libraries each get their own chunk. Group capture
+            // includes a captured module's unclaimed dependencies, so without these the
+            // app groups below would fold whole libraries into eagerly loaded chunks.
+            { name: 'react', test: /node_modules[\\/](react|react-dom|scheduler)[\\/]/, minSize: 0 },
+            { name: 'zod', test: /node_modules[\\/]zod[\\/]/, minSize: 0 },
+            { name: 'motion', test: /node_modules[\\/](framer-motion|motion-dom|motion-utils)[\\/]/, minSize: 0 },
+            { name: 'forms', test: /node_modules[\\/](react-hook-form|@hookform)[\\/]/, minSize: 0 },
+            {
+              name: 'editor',
+              test: /node_modules[\\/](@blocknote|prosemirror-[\w-]+|@tiptap|yjs|y-protocols|y-prosemirror|lib0)[\\/]/,
+              minSize: 0,
+            },
+            { name: 'pdf', test: /node_modules[\\/](pdfjs-dist|react-pdf|jspdf[\w.-]*)[\\/]/, minSize: 0 },
+            { name: 'media', test: /node_modules[\\/](media-chrome|player\.style)[\\/]/, minSize: 0 },
+            { name: 'gleap', test: /node_modules[\\/]gleap[\\/]/, minSize: 0 },
+            { name: 'react-scan', test: /node_modules[\\/]react-scan[\\/]/, minSize: 0 },
+            { name: 'maps', test: /node_modules[\\/](@vis\.gl|@googlemaps)[\\/]/, minSize: 0 },
+            { name: 'uppy', test: /node_modules[\\/](@uppy|@transloadit)[\\/]/, minSize: 0 },
+            {
+              // Curated list of tiny ubiquitous libraries; a blanket node_modules match
+              // would fold heavy lazy libraries (blocknote, pdf) into an eager chunk
+              name: 'vendor',
+              test: /node_modules[\\/](zustand|clsx|dayjs|nanoid|use-sync-external-store|use-debounce|react-error-boundary|react-intersection-observer|slugify|react-i18next|i18next[\w-]*|@babel[\\/]runtime)[\\/]/,
+              minSize: 0,
+            },
+            // App-wide primitives loaded on any real screen
+            {
+              name: 'app-core',
+              test: /[\\/]src[\\/](hooks|utils|query)[\\/]|[\\/]src[\\/]modules[\\/]ui[\\/]/,
+              minSize: 0,
+            },
+            {
+              // Shared app components. The blocknote wrappers stay out: they statically
+              // import the heavy editor, and group capture includes dependencies, which
+              // would pull it into this eagerly loaded chunk.
+              name: 'common',
+              test: (id: string) =>
+                /[\\/]src[\\/]modules[\\/]common[\\/]/.test(id) && !/[\\/]common[\\/]blocknote[\\/]/.test(id),
+              minSize: 0,
+            },
+            // Route shims are thin glue; route components stay in their module chunks
+            { name: 'routes', test: /[\\/]src[\\/]routes[\\/]/, minSize: 0 },
+            {
+              // One chunk per remaining feature module folder, keeping feature-level laziness
+              name: (id: string) => {
+                const m = id.match(/[\\/]src[\\/]modules[\\/]([\w-]+)[\\/]/);
+                return m ? `m-${m[1]}` : null;
+              },
+              minSize: 0,
+            },
           ],
         },
       },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -102,13 +102,23 @@ const viteConfig = {
   build: {
     rollupOptions: {
       output: {
+        // Rolldown ignores `manualChunks` when `codeSplitting` is set, so all grouping lives here
         codeSplitting: {
           minSize: 50 * 1024, // Minimum chunk size of 50 Kb
+          groups: [
+            // Merge all lucide icon modules into one shared chunk to keep request count low
+            { name: 'icons', test: /node_modules[\\/]lucide-react[\\/]/ },
+          ],
         },
-        manualChunks(id) {
-          if (id.includes('shiki')) {
-            return 'shiki'; // Ensures all shiki-related modules go into one chunk
+        // Prefix lazily imported grammar/theme chunks so the SW precache can exclude
+        // them by glob while each language still loads on demand. The shiki core
+        // engine is statically imported and keeps its normal (precached) chunk.
+        chunkFileNames(chunk) {
+          const grammarModule = /node_modules[\\/](shiki|@shikijs|tm-grammars|tm-themes)[\\/]/;
+          if (chunk.facadeModuleId && grammarModule.test(chunk.facadeModuleId)) {
+            return 'assets/grammars-[hash].js';
           }
+          return 'assets/[name]-[hash].js';
         },
       },
     },
@@ -286,8 +296,9 @@ viteConfig.plugins?.push(
       ],
     },
     injectManifest: {
-      globPatterns: ['**/*.{js,css,html,svg,png,svg,ico,woff2}'],
-      globIgnores: ['**/shiki.*', '**/shiki/**', '**/static/common/flags/**/*'],
+      globPatterns: ['**/*.{js,css,html,svg,png,ico,woff2}'],
+      // `grammars-*` is the codeSplitting group for shiki/tm-grammars: runtime-loaded, not precached
+      globIgnores: ['**/grammars-*.js', '**/static/common/flags/**/*'],
       maximumFileSizeToCacheInBytes: 100 * 1024 * 1024, // 100MB
     },
   })

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -32,6 +32,10 @@
 		format console
 	}
 
+	# S3 stores objects uncompressed, so compress proxied responses here.
+	# Without this every asset (and the full SW precache) ships raw bytes.
+	encode zstd gzip
+
 	header {
 		Content-Security-Policy "{$FRONTEND_CSP}"
 		Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"

--- a/infra/tests/unit/caddyfile.test.ts
+++ b/infra/tests/unit/caddyfile.test.ts
@@ -75,6 +75,10 @@ describe('frontend Caddyfile', () => {
   it('disables auto_https since the LB terminates TLS', () => {
     expect(caddyfile).toMatch(/auto_https\s+off/)
   })
+
+  it('compresses responses (S3 origin stores objects uncompressed)', () => {
+    expect(caddyfile).toMatch(/encode\s+zstd\s+gzip/)
+  })
 })
 
 describe('frontend Caddy Dockerfile', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -763,6 +763,9 @@ importers:
       sdk:
         specifier: workspace:*
         version: link:../sdk
+      serwist:
+        specifier: ^9.5.12
+        version: 9.5.12(browserslist@4.28.2)(typescript@6.0.3)
       shared:
         specifier: workspace:*
         version: link:../shared
@@ -935,21 +938,6 @@ importers:
       workbox-build:
         specifier: ^7.4.1
         version: 7.4.1(@types/babel__core@7.20.5)(supports-color@8.1.1)
-      workbox-core:
-        specifier: ^7.4.1
-        version: 7.4.1
-      workbox-expiration:
-        specifier: ^7.4.1
-        version: 7.4.1
-      workbox-precaching:
-        specifier: ^7.4.1
-        version: 7.4.1
-      workbox-routing:
-        specifier: ^7.4.1
-        version: 7.4.1
-      workbox-strategies:
-        specifier: ^7.4.1
-        version: 7.4.1
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -5783,6 +5771,14 @@ packages:
     resolution: {integrity: sha512-GQ9t+RSTx5s3b/aZrLFuL4nrwPLMah5NiZk5cjxJmgmOSgm3nMdO8gdqCedDch5B13F3YsxtaQYjSJnzLz8M5A==}
     engines: {node: '>=18'}
 
+  '@serwist/utils@9.5.12':
+    resolution: {integrity: sha512-BHDwiGL7H7JS7wFvVlAWTFHGt0ffHuPgKtdkaYP0lEWJFl6fKJRCnTDZhwhusFvBhicf37XP8Y6PouTZbcLmgg==}
+    peerDependencies:
+      browserslist: '>=4'
+    peerDependenciesMeta:
+      browserslist:
+        optional: true
+
   '@shikijs/core@4.3.1':
     resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
     engines: {node: '>=20'}
@@ -8934,6 +8930,9 @@ packages:
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
 
+  idb@8.0.3:
+    resolution: {integrity: sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==}
+
   ignore-walk@8.0.0:
     resolution: {integrity: sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -11382,6 +11381,14 @@ packages:
   seroval@1.5.5:
     resolution: {integrity: sha512-bSjOuPcwPKLSJNhr9+bZxA20nQxVle5J5MNsYRVE6cIg7KpRLXGupymePavu0jrxlPiPsr4xGZSB8yUY2sH2sw==}
     engines: {node: '>=10'}
+
+  serwist@9.5.12:
+    resolution: {integrity: sha512-PwREKJrSb3ja40XJyBntPOm7okcYZJCJPd++jUVz8tzxY1VYO9dyKSm0MimZ8LtUk0pIUTN0q2cfGe7R0wQsaQ==}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -17879,6 +17886,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@serwist/utils@9.5.12(browserslist@4.28.2)':
+    optionalDependencies:
+      browserslist: 4.28.2
+
   '@shikijs/core@4.3.1':
     dependencies:
       '@shikijs/primitive': 4.3.1
@@ -21406,6 +21417,8 @@ snapshots:
 
   idb@7.1.1: {}
 
+  idb@8.0.3: {}
+
   ignore-walk@8.0.0:
     dependencies:
       minimatch: 10.2.5
@@ -24329,6 +24342,15 @@ snapshots:
       seroval: 1.5.5
 
   seroval@1.5.5: {}
+
+  serwist@9.5.12(browserslist@4.28.2)(typescript@6.0.3):
+    dependencies:
+      '@serwist/utils': 9.5.12(browserslist@4.28.2)
+      idb: 8.0.3
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - browserslist
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
## Problem

Two UX issues after a service worker update:

1. **No feedback after clicking "Reload"** — the screen appears frozen for 2-4s.
2. **The SW installs 300+ resources sequentially** — mostly tiny JS chunks, so install is slow due to request *quantity*.

Investigation surfaced more than the report: the precache manifest was **833 entries / ~23 MB**, the shiki grammar exclusion was silently broken (3.2 MB of grammars precached for everyone), and the frontend was served **uncompressed** from S3.

## Root causes

- **Frozen reload**: the button's `loading` prop was silently discarded by the base `Button` (only `SubmitButton` renders a spinner), so clicking produced zero visual change. The actual delay is the new SW's `activate` phase deleting hundreds of stale precache entries one-by-one; that download of 300+ files happens earlier, at install, before the prompt appears.
- **Slow install**: Workbox v7 precaches strictly sequentially (an open feature request since 2021, still unmerged). Install time scales with request count × per-request latency.
- **Broken grammar exclusion**: rolldown ignores `manualChunks` when `codeSplitting` is set, so the shiki grouping rule never ran; grammars arrived as 47+ language chunks, all precached.
- **Uncompressed assets**: Caddy reverse-proxies the S3 origin (objects stored raw) with no `encode` directive.

## Changes

1. **Caddy compression** — add `encode zstd gzip`; text assets compress ~70%. Applies to all traffic, not just the SW. Pinned by a new Caddyfile contract test. Takes effect on the next deploy (image is baked per release).
2. **Reload feedback** — render a real spinner in the reload prompt, disable both buttons while reloading, guard against double reload; keep the existing 5s hard-reload fallback. Removed a dead `__DATE__` placeholder that shipped as a literal string.
3. **Serwist service worker** — swap the `workbox-*` imports in `sw.ts` for the `serwist` library while keeping vite-plugin-pwa for manifest injection, webmanifest generation, and the `useRegisterSW` client flow. Serwist precaches with 10 parallel requests; `skipWaiting: false` preserves the update-prompt contract (Serwist listens for the client's `SKIP_WAITING` message). This hybrid is proven in production on the same Vite 8 + vite-plugin-pwa stack (PuruVJ/macos-web).
4. **Chunk regrouping** — consolidate into rolldown's `codeSplitting.groups`: one group per shiki language/theme (all grammars now excluded from precache, including the shared embedded grammars and the unused 608 KB oniguruma WASM), plus grouped chunks for base-ui, tanstack, curated tiny vendors, app-core, common (minus blocknote), route shims, per-feature modules, and front-line groups for heavy libraries (react, zod, motion, editor, pdf, media, gleap, etc.) so dependency capture doesn't fold them into eager chunks. A SW `CacheFirst` runtime route keeps grammars available offline after first use.

## Results (measured)

| | Before | After |
|---|---|---|
| Precache entries | 833 | 130 |
| Precache size (raw) | 23 MB | 10.3 MB |
| Non-grammar JS chunks | 400+ | 60 |
| SW install @ 40ms RTT (clean profile, register→installed) | ~21.5s (workbox) | **~2.0s** |
| SW install unthrottled | ~1.1s | ~0.35s |

With Caddy compression, real-world wire cost drops to roughly 3-4 MB.

## Runtime verification

Drove a headless browser against the production grouped build + Serwist SW:

- App boots; Serwist SW registers, activates, and controls the page.
- Grammar chunks load at runtime with status 200 via the CacheFirst route (not precached).
- **All 16 group chunks (editor, pdf, media, gleap, base-ui, tanstack, …) import and evaluate with zero errors** — no circular-dependency / load-order bug from grouping.
- Docs Shiki highlighting renders (build-time token spans + runtime highlighter modules load).

Not functionally exercised (behind auth + backend + yjs, and unchanged source): full BlockNote editor and PDF viewer *rendering with live data*. Their grouping-relevant risk (chunk evaluation) is covered by the eval test above.

## Notes for reviewers

- `title` is `feat!`-free on purpose: no OpenAPI/wire-shape change, so no `clientCacheVersion` bump needed.
- First update after this ships does one full re-precache because Serwist uses its own precache cache name; steady-state gains follow.
- `workbox-build` / `workbox-window` remain (vite-plugin-pwa peers).
- `pnpm check` passes clean on every commit.

## Possible follow-ups (not in this PR)

- Tune Serwist `concurrency` above 10 on the small-file manifest.
- Runtime-cache the heaviest lazy chunks (blocknote, gleap, pdf) out of the precache entirely.
- Investigate the duplicate `@shikijs/langs` vs `langs-precompiled` grammars (a dependency-dedup question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
