### PR TITLE
refactor(frontend): use vanilla stores for imperative state

### DIFF
--- a/frontend/src/modules/attachment/tests/download-service.test.ts
+++ b/frontend/src/modules/attachment/tests/download-service.test.ts
@@ -63,7 +63,7 @@ vi.mock('~/modules/common/form-draft/draft-store', () => ({
 }));
 
 vi.mock('~/modules/seen/seen-store', () => ({
-  useSeenStore: { getState: () => ({ clear: vi.fn() }) },
+  seenStore: { getState: () => ({ clear: vi.fn() }) },
 }));
 
 vi.mock('~/modules/ui/ui-store', () => ({

--- a/frontend/src/modules/seen/seen-mark.tsx
+++ b/frontend/src/modules/seen/seen-mark.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import type { ProductEntityType } from 'shared';
-import { useSeenStore } from '~/modules/seen/seen-store';
+import { seenStore } from '~/modules/seen/seen-store';
 
 type SeenMeta = {
   tenantId: string;
@@ -14,7 +14,7 @@ const elementMeta = new WeakMap<Element, SeenMeta>();
 const markedIds = new Set<string>();
 
 // Seed IDs persisted by the seen store.
-for (const id of useSeenStore.getState().flushedIds) markedIds.add(id);
+for (const id of seenStore.getState().flushedIds) markedIds.add(id);
 
 let sharedObserver: IntersectionObserver | null = null;
 let observerRefCount = 0;
@@ -23,7 +23,7 @@ function getSharedObserver(): IntersectionObserver {
   if (!sharedObserver) {
     sharedObserver = new IntersectionObserver(
       (entries) => {
-        const markProductSeen = useSeenStore.getState().markProductSeen;
+        const markProductSeen = seenStore.getState().markProductSeen;
 
         for (const entry of entries) {
           if (!entry.isIntersecting) continue;

--- a/frontend/src/modules/seen/seen-store.ts
+++ b/frontend/src/modules/seen/seen-store.ts
@@ -1,8 +1,8 @@
 // biome-ignore lint/style/noRestrictedImports: imperative call from Zustand action, batched seen-flush not eligible for a React Query hook.
 import { markSeen } from 'sdk';
 import { appConfig, type ProductEntityType } from 'shared';
-import { create } from 'zustand';
 import { createJSONStorage, devtools, persist } from 'zustand/middleware';
+import { createStore } from 'zustand/vanilla';
 import { isDebugMode } from '~/env';
 import { reportCriticalError } from '~/lib/tracing';
 import { isSeenTracked } from '~/modules/seen/helpers';
@@ -52,11 +52,11 @@ interface SeenStoreState {
 }
 
 /**
- * Store for "seen" entities. Queued from IntersectionObserver, batch-flushed to
+ * Vanilla Zustand store for "seen" entities. Queued from IntersectionObserver, batch-flushed to
  * POST /:tenantId/:organizationId/seen periodically (or on unload via sendBeacon).
  * Pending IDs stay in memory; confirmed IDs persist to prevent resending next session.
  */
-export const useSeenStore = create<SeenStoreState>()(
+export const seenStore = createStore<SeenStoreState>()(
   devtools(
     persist(
       (set, get) => ({
@@ -151,7 +151,7 @@ export const useSeenStore = create<SeenStoreState>()(
  * Fork code must use this accessor and keep store internals private.
  */
 export function isSeenLocally(entityId: string): boolean {
-  if (useSeenStore.getState().flushedIds.has(entityId)) return true;
+  if (seenStore.getState().flushedIds.has(entityId)) return true;
   for (const batch of pending.values()) if (batch.productIds.has(entityId)) return true;
   return false;
 }

--- a/frontend/src/modules/seen/seen-tracker.tsx
+++ b/frontend/src/modules/seen/seen-tracker.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { appConfig } from 'shared';
-import { setupSeenBeaconFlush, useSeenStore } from '~/modules/seen/seen-store';
+import { seenStore, setupSeenBeaconFlush } from '~/modules/seen/seen-store';
 import { useTotalUnseenCount } from './use-unseen-count';
 
 // Periodic Background Sync API (Chromium-only) and dev-only window helper.
@@ -19,7 +19,7 @@ declare global {
 /** Invisible component that boots seen-tracking (flush interval, unload beacon, PWA badge sync). Mount once in the app layout. */
 export function SeenTracker() {
   useEffect(() => {
-    const { startFlushInterval, stopFlushInterval, flush } = useSeenStore.getState();
+    const { startFlushInterval, stopFlushInterval, flush } = seenStore.getState();
     startFlushInterval();
     const cleanupBeacon = setupSeenBeaconFlush();
 

--- a/frontend/src/modules/seen/unseen-sync.test.ts
+++ b/frontend/src/modules/seen/unseen-sync.test.ts
@@ -6,7 +6,7 @@ vi.stubGlobal('navigator', { onLine: true });
 
 const { queryClient } = await import('~/query/query-client');
 const { isSeenTracked, seenKeys } = await import('./helpers');
-const { useSeenStore } = await import('./seen-store');
+const { seenStore } = await import('./seen-store');
 const { applyUnfetchableRemovalUnseen, ingestSyncedRows, noteUnseenReconciled } = await import('./unseen-sync');
 
 // Derive tracked type and effective home from config so the fixture works across fork hierarchies.
@@ -46,7 +46,7 @@ describe('unseen count deltas from synced rows', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     queryClient.setQueryData(seenKeys.unseenCounts, { [CHANNEL]: { [TRACKED]: 5 } });
-    useSeenStore.getState().reset();
+    seenStore.getState().reset();
     noteUnseenReconciled();
   });
 
@@ -73,7 +73,7 @@ describe('unseen count deltas from synced rows', () => {
 
   it('does not count rows outside the seen window or rows this client already saw', async () => {
     vi.advanceTimersByTime(10);
-    useSeenStore.getState().markProductSeen('tenant-1', ORG, CHANNEL, TRACKED, 'seen-1');
+    seenStore.getState().markProductSeen('tenant-1', ORG, CHANNEL, TRACKED, 'seen-1');
     await settle(); // markProductSeen itself queued a -1 (5 → 4)
 
     ingestSyncedRows(TRACKED, CHANNEL, [
@@ -118,7 +118,7 @@ describe('unseen count deltas from synced rows', () => {
     await settle();
     expect(counts()[CHANNEL][TRACKED]).toBe(4);
 
-    useSeenStore.getState().markProductSeen('tenant-1', ORG, CHANNEL, TRACKED, 'gone-2');
+    seenStore.getState().markProductSeen('tenant-1', ORG, CHANNEL, TRACKED, 'gone-2');
     await settle(); // view-mark −1 (4 → 3)
     applyUnfetchableRemovalUnseen(TRACKED, 'gone-2', CHANNEL); // seen → net 0
     await settle();

--- a/frontend/src/query/app-storage.ts
+++ b/frontend/src/query/app-storage.ts
@@ -3,13 +3,13 @@ import { useAlertStore } from '~/modules/common/alerter/alert-store';
 import { useBoardStore } from '~/modules/common/board/board-store';
 import { useDraftStore } from '~/modules/common/form-draft/draft-store';
 import { useNavigationStore } from '~/modules/navigation/navigation-store';
-import { useSeenStore } from '~/modules/seen/seen-store';
+import { seenStore } from '~/modules/seen/seen-store';
 import { useUIStore } from '~/modules/ui/ui-store';
 import { userStore } from '~/modules/user/user-store';
 import { bindAppDb, closeAppDb } from '~/query/app-db';
 import { forkAppKvStores } from '~/query/fork-app-kv-stores';
 import { resetPersisters } from '~/query/persister';
-import { useSyncStore } from '~/query/realtime/sync-store';
+import { syncStore } from '~/query/realtime/sync-store';
 
 /** Minimal contract a per-user kv store must satisfy to join {@link appKvStores}: hydrate on bind, reset on sign-out. */
 export interface AppKvStore {
@@ -21,8 +21,8 @@ export interface AppKvStore {
  *  Each exposes a uniform `reset()` so {@link unbind} can drop in-memory state on sign-out.
  *  Forks append their own stores via {@link forkAppKvStores}. */
 const appKvStores = [
-  useSeenStore,
-  useSyncStore,
+  seenStore,
+  syncStore,
   useNavigationStore,
   useDraftStore,
   useAlertStore,

--- a/frontend/src/query/realtime/app-stream-handler.ts
+++ b/frontend/src/query/realtime/app-stream-handler.ts
@@ -4,7 +4,7 @@ import { invalidateUnseenCounts } from '~/modules/seen/query';
 import { applyUnfetchableRemovalUnseen } from '~/modules/seen/unseen-sync';
 import { type EntityQueryKeys, getEntityQueryKeys } from '~/query/basic/entity-query-registry';
 import { sourceId } from '~/query/offline/stx-utils';
-import { useSyncStore } from '~/query/realtime/sync-store';
+import { syncStore } from '~/query/realtime/sync-store';
 import * as cacheOps from './cache-ops';
 import { enqueueRange } from './fetch-prioritizer';
 import * as membershipOps from './membership-ops';
@@ -25,11 +25,11 @@ export function handleAppStreamNotification(notification: AppStreamNotification)
     () => {
       // Checked before setOrgTenantId creates the entry: an org the sync store has never
       // seen means the SSE connection is not registered on its channel.
-      const isUnknownOrg = !!organizationId && !useSyncStore.getState().orgs[organizationId];
+      const isUnknownOrg = !!organizationId && !syncStore.getState().orgs[organizationId];
 
       // Store tenantId in sync store whenever we see it in a notification
       if (organizationId && tenantId) {
-        useSyncStore.getState().setOrgTenantId(organizationId, tenantId);
+        syncStore.getState().setOrgTenantId(organizationId, tenantId);
       }
 
       // Membership changes use targeted query invalidation, not the seq sync path.

--- a/frontend/src/query/realtime/catchup-processor.test.ts
+++ b/frontend/src/query/realtime/catchup-processor.test.ts
@@ -74,7 +74,7 @@ vi.stubGlobal('localStorage', {
 const { createEntityKeys } = await import('~/query/basic/create-query-keys');
 const { registerEntityQueryKeys } = await import('~/query/basic/entity-query-registry');
 const { queryClient } = await import('~/query/query-client');
-const { useSyncStore } = await import('~/query/realtime/sync-store');
+const { syncStore } = await import('~/query/realtime/sync-store');
 const { flushAllNow, resetFetchPrioritizer } = await import('./fetch-prioritizer');
 const { processAppCatchup } = await import('./catchup-processor');
 
@@ -92,7 +92,7 @@ const okViewResponse = (frontier: number, count = 1, key = 'org-1:attachment'): 
 describe('catchup processor (view-driven)', () => {
   afterEach(() => {
     queryClient.clear();
-    useSyncStore.getState().reset();
+    syncStore.getState().reset();
     vi.clearAllMocks();
   });
 
@@ -104,8 +104,8 @@ describe('catchup processor (view-driven)', () => {
     }));
     registerEntityQueryKeys('attachment', keys, deltaFetch);
 
-    useSyncStore.getState().setOrgTenantId('org-1', 'tenant-1');
-    useSyncStore.getState().setOrgSeq('org-1', 'attachment', 4);
+    syncStore.getState().setOrgTenantId('org-1', 'tenant-1');
+    syncStore.getState().setOrgSeq('org-1', 'attachment', 4);
     queryClient.setQueryData(keys.detail.byId('attachment-1'), {
       id: 'attachment-1',
       organizationId: 'org-1',
@@ -119,7 +119,7 @@ describe('catchup processor (view-driven)', () => {
     await processAppCatchup(okViewResponse(6));
 
     expect(deltaFetch).toHaveBeenCalledWith('org-1', 'tenant-1', '5,6', undefined);
-    expect(useSyncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(6);
+    expect(syncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(6);
     expect(queryClient.getQueryData(keys.detail.byId('attachment-1'))).toMatchObject({ name: 'fresh' });
     expect(queryClient.getQueryData(keys.list.org('org-1'))).toEqual({
       items: [{ id: 'attachment-1', entityType: 'attachment', organizationId: 'org-1', name: 'fresh', seq: 6 }],
@@ -138,8 +138,8 @@ describe('catchup processor (view-driven)', () => {
     }));
     registerEntityQueryKeys('attachment', keys, deltaFetch);
 
-    useSyncStore.getState().setOrgTenantId('org-1', 'tenant-1');
-    useSyncStore.getState().setOrgSeq('org-1', 'attachment', 10);
+    syncStore.getState().setOrgTenantId('org-1', 'tenant-1');
+    syncStore.getState().setOrgSeq('org-1', 'attachment', 10);
     queryClient.setQueryData(keys.detail.byId('att-proj'), {
       id: 'att-proj',
       organizationId: 'org-1',
@@ -154,7 +154,7 @@ describe('catchup processor (view-driven)', () => {
     expect(deltaFetch).toHaveBeenCalledTimes(1);
     expect(deltaFetch).toHaveBeenCalledWith('org-1', 'tenant-1', '11,12', undefined);
     expect(queryClient.getQueryData(keys.detail.byId('att-proj'))).toMatchObject({ name: 'fresh-proj' });
-    expect(useSyncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(12);
+    expect(syncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(12);
   });
 
   it('never advances the cursor silently: a failed delta fetch invalidates before advancing', async () => {
@@ -164,7 +164,7 @@ describe('catchup processor (view-driven)', () => {
     });
     registerEntityQueryKeys('attachment', keys, deltaFetch);
 
-    useSyncStore.getState().setOrgSeq('org-1', 'attachment', 4);
+    syncStore.getState().setOrgSeq('org-1', 'attachment', 4);
     queryClient.setQueryData(keys.list.org('org-1'), { items: [], total: 0 });
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
@@ -172,7 +172,7 @@ describe('catchup processor (view-driven)', () => {
 
     // Fetch failed → list invalidated (recovery handed to react-query), THEN cursor advanced.
     expect(invalidateSpy).toHaveBeenCalledWith(expect.objectContaining({ queryKey: keys.list.org('org-1') }));
-    expect(useSyncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(9);
+    expect(syncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(9);
   });
 
   it('short delivery (ok but empty window) holds the cursor, invalidates, and degrades trust', async () => {
@@ -182,8 +182,8 @@ describe('catchup processor (view-driven)', () => {
     registerEntityQueryKeys('attachment', keys, deltaFetch);
 
     setSyncDeliveryTrusted(true);
-    useSyncStore.getState().setOrgTenantId('org-1', 'tenant-1');
-    useSyncStore.getState().setOrgSeq('org-1', 'attachment', 4);
+    syncStore.getState().setOrgTenantId('org-1', 'tenant-1');
+    syncStore.getState().setOrgSeq('org-1', 'attachment', 4);
     queryClient.setQueryData(keys.list.org('org-1'), { items: [], total: 0 });
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
@@ -191,7 +191,7 @@ describe('catchup processor (view-driven)', () => {
 
     // Fetched the window, but reachedSeq (0) < frontier (9): never advance silently.
     expect(deltaFetch).toHaveBeenCalledWith('org-1', 'tenant-1', '5,9', undefined);
-    expect(useSyncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(4);
+    expect(syncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(4);
     expect(invalidateSpy).toHaveBeenCalledWith(expect.objectContaining({ queryKey: keys.list.org('org-1') }));
     expect(isSyncDeliveryTrusted()).toBe(false);
   });
@@ -201,12 +201,12 @@ describe('catchup processor (view-driven)', () => {
     const deltaFetch = vi.fn(async () => ({ items: [], total: 0 }));
     registerEntityQueryKeys('attachment', keys, deltaFetch);
 
-    useSyncStore.getState().setOrgSeq('org-1', 'attachment', 4);
+    syncStore.getState().setOrgSeq('org-1', 'attachment', 4);
 
     await processAppCatchup(okViewResponse(6));
 
     expect(deltaFetch).not.toHaveBeenCalled();
-    expect(useSyncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(6);
+    expect(syncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(6);
   });
 
   it('a baseline view (cursor 0) stores the frontier without fetching', async () => {
@@ -217,7 +217,7 @@ describe('catchup processor (view-driven)', () => {
     await processAppCatchup(okViewResponse(42));
 
     expect(deltaFetch).not.toHaveBeenCalled();
-    expect(useSyncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(42);
+    expect(syncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(42);
   });
 
   it('a caught-up view (frontier <= cursor) neither fetches nor invalidates the cached list', async () => {
@@ -227,8 +227,8 @@ describe('catchup processor (view-driven)', () => {
     const deltaFetch = vi.fn(async () => ({ items: [], total: 0 }));
     registerEntityQueryKeys('attachment', keys, deltaFetch);
 
-    useSyncStore.getState().setOrgTenantId('org-caughtup', 'tenant-1');
-    useSyncStore.getState().setOrgSeq('org-caughtup', 'attachment', 6);
+    syncStore.getState().setOrgTenantId('org-caughtup', 'tenant-1');
+    syncStore.getState().setOrgSeq('org-caughtup', 'attachment', 6);
     queryClient.setQueryData(keys.list.org('org-caughtup'), { items: [], total: 0 });
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
@@ -239,7 +239,7 @@ describe('catchup processor (view-driven)', () => {
     expect(invalidateSpy).not.toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: keys.list.org('org-caughtup') }),
     );
-    expect(useSyncStore.getState().getOrgSeq('org-caughtup', 'attachment')).toBe(6);
+    expect(syncStore.getState().getOrgSeq('org-caughtup', 'attachment')).toBe(6);
   });
 
   it('an opaque view falls back to invalidation of cached lists, no numbers consumed', async () => {
@@ -247,7 +247,7 @@ describe('catchup processor (view-driven)', () => {
     const deltaFetch = vi.fn(async () => ({ items: [], total: 0 }));
     registerEntityQueryKeys('attachment', keys, deltaFetch);
 
-    useSyncStore.getState().setOrgSeq('org-1', 'attachment', 4);
+    syncStore.getState().setOrgSeq('org-1', 'attachment', 4);
     queryClient.setQueryData(keys.list.org('org-1'), { items: [], total: 0 });
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
@@ -260,7 +260,7 @@ describe('catchup processor (view-driven)', () => {
     expect(deltaFetch).not.toHaveBeenCalled();
     expect(invalidateSpy).toHaveBeenCalledWith(expect.objectContaining({ queryKey: keys.list.org('org-1') }));
     // Cursor untouched: opaque answers carry no frontier to advance to.
-    expect(useSyncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(4);
+    expect(syncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(4);
   });
 
   it('invalidates org lists when a server count CHANGES between catchups (never vs cached totals)', async () => {
@@ -268,7 +268,7 @@ describe('catchup processor (view-driven)', () => {
     const deltaFetch = vi.fn(async () => ({ items: [], total: 0 }));
     registerEntityQueryKeys('attachment', keys, deltaFetch);
 
-    useSyncStore.getState().setOrgSeq('org-1', 'attachment', 6);
+    syncStore.getState().setOrgSeq('org-1', 'attachment', 6);
     queryClient.setQueryData(keys.list.org('org-1'), { items: [], total: 5 });
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
@@ -297,12 +297,12 @@ describe('catchup processor (view-driven)', () => {
 describe('registered grant-boundary views', () => {
   afterEach(() => {
     queryClient.clear();
-    useSyncStore.getState().reset();
+    syncStore.getState().reset();
     vi.clearAllMocks();
   });
 
   const declare = () =>
-    useSyncStore.getState().declareSyncView('org-1:attachment:subtree', {
+    syncStore.getState().declareSyncView('org-1:attachment:subtree', {
       organizationId: 'org-1',
       prefixes: ['org-1/c1'],
       entityTypes: ['attachment'],
@@ -324,7 +324,7 @@ describe('registered grant-boundary views', () => {
       vi.fn(async () => ({ items: [], total: 0 })),
     );
     declare();
-    useSyncStore.getState().setViewCursor('org-1:attachment:subtree', 10);
+    syncStore.getState().setViewCursor('org-1:attachment:subtree', 10);
     queryClient.setQueryData(keys.list.org('org-1'), { items: [], total: 0 });
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
@@ -333,7 +333,7 @@ describe('registered grant-boundary views', () => {
 
     await processAppCatchup(answer({ status: 'ok', frontiers: { attachment: 15 } }));
     expect(invalidateSpy).toHaveBeenCalledWith(expect.objectContaining({ queryKey: keys.list.org('org-1') }));
-    expect(useSyncStore.getState().getView('org-1:attachment:subtree')?.cursor).toBe(15);
+    expect(syncStore.getState().getView('org-1:attachment:subtree')?.cursor).toBe(15);
   });
 
   it('baseline adopts frontier without invalidating; forbidden removes the view', async () => {
@@ -348,18 +348,18 @@ describe('registered grant-boundary views', () => {
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
     await processAppCatchup(answer({ status: 'ok', frontiers: { attachment: 33 } }));
-    expect(useSyncStore.getState().getView('org-1:attachment:subtree')?.cursor).toBe(33);
+    expect(syncStore.getState().getView('org-1:attachment:subtree')?.cursor).toBe(33);
     expect(invalidateSpy).not.toHaveBeenCalledWith(expect.objectContaining({ queryKey: keys.list.org('org-1') }));
 
     await processAppCatchup(answer({ status: 'forbidden' }));
-    expect(useSyncStore.getState().getView('org-1:attachment:subtree')).toBeUndefined();
+    expect(syncStore.getState().getView('org-1:attachment:subtree')).toBeUndefined();
   });
 });
 
 describe('catchup → fetch prioritizer fold', () => {
   afterEach(() => {
     queryClient.clear();
-    useSyncStore.getState().reset();
+    syncStore.getState().reset();
     vi.clearAllMocks();
   });
 
@@ -371,19 +371,19 @@ describe('catchup → fetch prioritizer fold', () => {
     const deltaFetch = vi.fn(async () => ({ items: [{ id: 'att-1', organizationId: 'org-1', seq: 9 }], total: 1 }));
     registerEntityQueryKeys('attachment', keys, deltaFetch);
 
-    useSyncStore.getState().setOrgTenantId('org-1', 'tenant-1');
-    useSyncStore.getState().setOrgSeq('org-1', 'attachment', 4);
+    syncStore.getState().setOrgTenantId('org-1', 'tenant-1');
+    syncStore.getState().setOrgSeq('org-1', 'attachment', 4);
     queryClient.setQueryData(keys.list.org('org-1'), { items: [], total: 0 });
 
     await processAppCatchup(okViewResponse(9));
 
     // Advance-at-flush: the fetch prioritizer owns the cursor for enqueued ranges.
     expect(deltaFetch).not.toHaveBeenCalled();
-    expect(useSyncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(4);
+    expect(syncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(4);
 
     await flushAllNow();
     expect(deltaFetch).toHaveBeenCalledWith('org-1', 'tenant-1', '5,9', undefined);
-    expect(useSyncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(9);
+    expect(syncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(9);
   });
 
   it('still reconciles viewing orgs inline through the fetch prioritizer flush (mutation-replay gate)', async () => {
@@ -394,14 +394,14 @@ describe('catchup → fetch prioritizer fold', () => {
     const deltaFetch = vi.fn(async () => ({ items: [{ id: 'att-1', organizationId: 'org-1', seq: 9 }], total: 1 }));
     registerEntityQueryKeys('attachment', keys, deltaFetch);
 
-    useSyncStore.getState().setOrgTenantId('org-1', 'tenant-1');
-    useSyncStore.getState().setOrgSeq('org-1', 'attachment', 4);
+    syncStore.getState().setOrgTenantId('org-1', 'tenant-1');
+    syncStore.getState().setOrgSeq('org-1', 'attachment', 4);
     queryClient.setQueryData(keys.list.org('org-1'), { items: [], total: 0 });
 
     await processAppCatchup(okViewResponse(9));
 
     // Awaited before processAppCatchup resolved: the delta is already ingested here.
     expect(deltaFetch).toHaveBeenCalledWith('org-1', 'tenant-1', '5,9', undefined);
-    expect(useSyncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(9);
+    expect(syncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(9);
   });
 });

--- a/frontend/src/query/realtime/catchup-processor.ts
+++ b/frontend/src/query/realtime/catchup-processor.ts
@@ -9,7 +9,7 @@ import {
 } from '~/query/basic/entity-query-registry';
 import { isSyncDeliveryTrusted, setSyncDeliveryTrusted } from '~/query/basic/sync-stale-config';
 import { queryClient } from '~/query/query-client';
-import { useSyncStore } from '~/query/realtime/sync-store';
+import { syncStore } from '~/query/realtime/sync-store';
 import * as cacheOps from './cache-ops';
 import { enqueueCatchupRange, flushChannelViewNow, resetFetchPrioritizer } from './fetch-prioritizer';
 import * as membershipOps from './membership-ops';
@@ -23,7 +23,7 @@ import { getSyncTier, getTenantIdForOrg } from './sync-priority';
  */
 export async function processAppCatchup(response: PostAppCatchupResponse, baselineOnly = false): Promise<void> {
   const { changes, views } = response;
-  const syncStore = useSyncStore.getState();
+  const syncState = syncStore.getState();
   let hadGap = false; // any view still behind the server frontier this cycle
 
   // ── Views: product entity sync per (org, entityType) ──────────────────────
@@ -32,8 +32,8 @@ export async function processAppCatchup(response: PostAppCatchupResponse, baseli
 
     for (const answer of views) {
       // Registered grant-boundary views (views.ts) take precedence over org-view keys.
-      if (syncStore.getView(answer.key)) {
-        if (!baselineOnly) processRegisteredViewAnswer(answer, syncStore);
+      if (syncState.getView(answer.key)) {
+        if (!baselineOnly) processRegisteredViewAnswer(answer, syncState);
         continue;
       }
 
@@ -58,7 +58,7 @@ export async function processAppCatchup(response: PostAppCatchupResponse, baseli
       }
 
       const frontier = answer.frontiers?.[entityType] ?? 0;
-      const clientCursor = syncStore.getOrgSeq(organizationId, entityType);
+      const clientCursor = syncState.getOrgSeq(organizationId, entityType);
 
       // Baseline (first session for this org view): store the frontier, let route loaders /
       // hydration supply data. With something already cached, refetch it.
@@ -67,19 +67,19 @@ export async function processAppCatchup(response: PostAppCatchupResponse, baseli
           cacheOps.invalidateEntityListForOrg(keys, organizationId, 'active');
           console.debug(`[CatchupProcessor] View ${answer.key}: first session → full refetch`);
         }
-        syncStore.setOrgSeq(organizationId, entityType, frontier);
+        syncState.setOrgSeq(organizationId, entityType, frontier);
         continue;
       }
 
       if (frontier <= clientCursor) continue; // caught up
       hadGap = true;
 
-      const tenantId = syncStore.getOrgTenantId(organizationId) ?? getTenantIdForOrg(organizationId);
+      const tenantId = syncState.getOrgTenantId(organizationId) ?? getTenantIdForOrg(organizationId);
 
       // Cache-symmetry guard: with nothing cached there is nothing to patch; mount
       // hydration fetches fresh. Advance so the window is not re-offered forever.
       if (!hasAnyCachedList(keys, organizationId)) {
-        syncStore.setOrgSeq(organizationId, entityType, frontier);
+        syncState.setOrgSeq(organizationId, entityType, frontier);
         console.debug(`[CatchupProcessor] View ${answer.key}: no cached list → skip delta`);
         continue;
       }
@@ -118,13 +118,13 @@ export async function processAppCatchup(response: PostAppCatchupResponse, baseli
 
     // Seed the org entry so the NEXT catchup request declares views for it (fresh
     // sessions have no stored orgs yet; membership-derived `changes` names them).
-    syncStore.setOrgTenantId(organizationId, syncStore.getOrgTenantId(organizationId) ?? '');
+    syncState.setOrgTenantId(organizationId, syncState.getOrgTenantId(organizationId) ?? '');
 
     // Membership change via the bump-only membership signal; stored after comparison.
     const serverMembershipSignal = signals?.membership;
     if (serverMembershipSignal !== undefined) {
-      const membershipChanged = serverMembershipSignal !== syncStore.getOrgSeq(organizationId, 'membership');
-      syncStore.setOrgSeq(organizationId, 'membership', serverMembershipSignal);
+      const membershipChanged = serverMembershipSignal !== syncState.getOrgSeq(organizationId, 'membership');
+      syncState.setOrgSeq(organizationId, 'membership', serverMembershipSignal);
       if (membershipChanged && !baselineOnly) membershipOps.invalidateMemberQueries(organizationId);
     }
 
@@ -189,13 +189,13 @@ export function catchupEntityTypes(): string[] {
  */
 function processRegisteredViewAnswer(
   answer: NonNullable<PostAppCatchupResponse['views']>[number],
-  syncStore: ReturnType<typeof useSyncStore.getState>,
+  syncState: ReturnType<typeof syncStore.getState>,
 ): void {
-  const view = syncStore.getView(answer.key);
+  const view = syncState.getView(answer.key);
   if (!view) return;
 
   if (answer.status === 'forbidden') {
-    syncStore.removeSyncView(answer.key);
+    syncState.removeSyncView(answer.key);
     console.debug(`[CatchupProcessor] View ${answer.key}: forbidden → removed`);
     return;
   }
@@ -219,14 +219,14 @@ function processRegisteredViewAnswer(
   const frontier = Math.max(0, ...Object.values(answer.frontiers ?? {}));
   if (view.cursor === 0) {
     // Baseline: adopt frontier; hydration/route loaders supply the data.
-    syncStore.setViewCursor(answer.key, frontier);
+    syncState.setViewCursor(answer.key, frontier);
     console.debug(`[CatchupProcessor] View ${answer.key}: baseline → cursor ${frontier}`);
     return;
   }
   if (frontier <= view.cursor) return; // unchanged: skip refetches, the precision win
 
   invalidateTypes();
-  syncStore.setViewCursor(answer.key, frontier);
+  syncState.setViewCursor(answer.key, frontier);
   console.debug(`[CatchupProcessor] View ${answer.key}: frontier ${view.cursor} → ${frontier} → invalidated`);
 }
 

--- a/frontend/src/query/realtime/fetch-prioritizer.test.ts
+++ b/frontend/src/query/realtime/fetch-prioritizer.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createEntityKeys } from '~/query/basic/create-query-keys';
 import { registerEntityQueryKeys } from '~/query/basic/entity-query-registry';
 import { isSyncDeliveryTrusted, setSyncDeliveryTrusted } from '~/query/basic/sync-stale-config';
-import { useSyncStore } from '~/query/realtime/sync-store';
+import { syncStore } from '~/query/realtime/sync-store';
 
 // Mock the boundaries: fetch/invalidate, tiers, propagation, unseen recount, router.
 const fetchRangeAndPatch = vi.fn();
@@ -55,7 +55,7 @@ describe('fetch-prioritizer', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     registerEntityQueryKeys('attachment', createEntityKeys('attachment'));
-    useSyncStore.getState().reset();
+    syncStore.getState().reset();
     setSyncDeliveryTrusted(true);
     // reachedSeq Infinity = full delivery (reaches any untilSeq) unless a test overrides it.
     fetchRangeAndPatch.mockResolvedValue({ status: 'ok', items: [], reachedSeq: Number.POSITIVE_INFINITY });
@@ -77,7 +77,7 @@ describe('fetch-prioritizer', () => {
 
     expect(fetchRangeAndPatch).toHaveBeenCalledTimes(1);
     expect(fetchRangeAndPatch.mock.calls[0][3]).toBe('5,12'); // merged range
-    expect(useSyncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(12);
+    expect(syncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(12);
   });
 
   it('flushes viewing-tier channel views immediately (single events keep live behavior)', async () => {
@@ -97,11 +97,11 @@ describe('fetch-prioritizer', () => {
     await vi.advanceTimersByTimeAsync(60_000);
 
     expect(fetchRangeAndPatch).not.toHaveBeenCalled();
-    expect(useSyncStore.getState().getKnownSeq('project-9', 'attachment')).toBe(7);
+    expect(syncStore.getState().getKnownSeq('project-9', 'attachment')).toBe(7);
   });
 
   it('self-heals a small live gap by anchoring at caught-up+1', async () => {
-    useSyncStore.getState().setOrgSeq('org-1', 'attachment', 4);
+    syncStore.getState().setOrgSeq('org-1', 'attachment', 4);
     enqueueRange({ ...base, fromSeq: 6, untilSeq: 8 }); // seq 5 was missed
 
     await flushAllNow();
@@ -111,15 +111,15 @@ describe('fetch-prioritizer', () => {
 
   it('org-homed channel views (wire channelId === orgId) share ONE watermark slot with catchup', async () => {
     // Catchup advanced the org slot; the live notification carries channelId = orgId.
-    useSyncStore.getState().setOrgSeq('org-1', 'attachment', 6);
+    syncStore.getState().setOrgSeq('org-1', 'attachment', 6);
     enqueueRange({ ...base, channelId: 'org-1', fromSeq: 3, untilSeq: 9 });
 
     await flushAllNow();
 
     // Anchors at the org slot (7,9) and advances that same slot after success.
     expect(fetchRangeAndPatch.mock.calls[0][3]).toBe('7,9');
-    expect(useSyncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(9);
-    expect(useSyncStore.getState().getChannelSeq('org-1', 'org-1', 'attachment')).toBe(9);
+    expect(syncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(9);
+    expect(syncStore.getState().getChannelSeq('org-1', 'org-1', 'attachment')).toBe(9);
   });
 
   it('retries transient errors with backoff, then invalidates and advances so the range cannot loop', async () => {
@@ -132,7 +132,7 @@ describe('fetch-prioritizer', () => {
 
     expect(fetchRangeAndPatch).toHaveBeenCalledTimes(3);
     expect(invalidateEntityListForOrg).toHaveBeenCalledTimes(1);
-    expect(useSyncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(2);
+    expect(syncStore.getState().getOrgSeq('org-1', 'attachment')).toBe(2);
   });
 
   it('invalidates immediately on overflow (no retries)', async () => {
@@ -178,7 +178,7 @@ describe('fetch-prioritizer', () => {
   });
 
   it('skips ranges the client already has (untilSeq <= caught-up)', async () => {
-    useSyncStore.getState().setOrgSeq('org-1', 'attachment', 10);
+    syncStore.getState().setOrgSeq('org-1', 'attachment', 10);
     enqueueRange({ ...base, fromSeq: 8, untilSeq: 10 });
 
     await vi.advanceTimersByTimeAsync(60_000);
@@ -187,7 +187,7 @@ describe('fetch-prioritizer', () => {
   });
 
   it('covers all due channels of one org with ONE fetch and advances each to the shared bound', async () => {
-    useSyncStore.getState().setOrgSeq('org-1', 'attachment', 0);
+    syncStore.getState().setOrgSeq('org-1', 'attachment', 0);
     enqueueRange({ ...base, channelId: 'proj-a', fromSeq: 5, untilSeq: 8 });
     enqueueRange({ ...base, channelId: 'proj-b', fromSeq: 9, untilSeq: 12 });
 
@@ -197,8 +197,8 @@ describe('fetch-prioritizer', () => {
     expect(fetchRangeAndPatch).toHaveBeenCalledTimes(1);
     expect(fetchRangeAndPatch.mock.calls[0][3]).toBe('5,12');
     // Per-view advance accounting: both channels advance to the covered upper bound.
-    expect(useSyncStore.getState().getChannelSeq('org-1', 'proj-a', 'attachment')).toBe(12);
-    expect(useSyncStore.getState().getChannelSeq('org-1', 'proj-b', 'attachment')).toBe(12);
+    expect(syncStore.getState().getChannelSeq('org-1', 'proj-a', 'attachment')).toBe(12);
+    expect(syncStore.getState().getChannelSeq('org-1', 'proj-b', 'attachment')).toBe(12);
   });
 
   it('scopes the covering fetch to the channel id for a single viewed channel (no path lookup)', async () => {
@@ -238,24 +238,24 @@ describe('fetch-prioritizer', () => {
 
   it('short delivery: keeps the cursor honest, invalidates the view, and degrades sync trust', async () => {
     fetchRangeAndPatch.mockResolvedValue({ status: 'ok', items: [], reachedSeq: 0 });
-    useSyncStore.getState().setChannelSeq('org-1', 'proj-a', 'attachment', 3);
+    syncStore.getState().setChannelSeq('org-1', 'proj-a', 'attachment', 3);
     enqueueRange({ ...base, channelId: 'proj-a', fromSeq: 4, untilSeq: 7 });
 
     await flushAllNow();
 
-    expect(useSyncStore.getState().getChannelSeq('org-1', 'proj-a', 'attachment')).toBe(3); // not advanced
+    expect(syncStore.getState().getChannelSeq('org-1', 'proj-a', 'attachment')).toBe(3); // not advanced
     expect(invalidateEntityListForOrg).toHaveBeenCalled();
     expect(isSyncDeliveryTrusted()).toBe(false);
   });
 
   it('full delivery advances and stays trusted', async () => {
     fetchRangeAndPatch.mockResolvedValue({ status: 'ok', items: [{ id: 'x', seq: 7 }], reachedSeq: 7 });
-    useSyncStore.getState().setChannelSeq('org-1', 'proj-a', 'attachment', 3);
+    syncStore.getState().setChannelSeq('org-1', 'proj-a', 'attachment', 3);
     enqueueRange({ ...base, channelId: 'proj-a', fromSeq: 4, untilSeq: 7 });
 
     await flushAllNow();
 
-    expect(useSyncStore.getState().getChannelSeq('org-1', 'proj-a', 'attachment')).toBe(7);
+    expect(syncStore.getState().getChannelSeq('org-1', 'proj-a', 'attachment')).toBe(7);
     expect(isSyncDeliveryTrusted()).toBe(true);
   });
 

--- a/frontend/src/query/realtime/fetch-prioritizer.ts
+++ b/frontend/src/query/realtime/fetch-prioritizer.ts
@@ -8,7 +8,7 @@ import { queryClient } from '~/query/query-client';
 import * as cacheOps from './cache-ops';
 import { propagateEmbeddings } from './propagation';
 import { getSyncTier, isViewingChannel } from './sync-priority';
-import { useSyncStore } from './sync-store';
+import { syncStore } from './sync-store';
 import type { AppStreamNotification } from './types';
 import { resolveChannelPath } from './view-declaration';
 
@@ -73,7 +73,7 @@ export function enqueueRange(input: EnqueueInput): void {
   const tier = getSyncTier(input.entityType, input.organizationId, input.channelId);
   if (tier.min === Number.POSITIVE_INFINITY) {
     // Muted and archived scopes record the known watermark and fetch when opened.
-    useSyncStore.getState().setKnownSeq(input.channelId ?? input.organizationId, input.entityType, input.untilSeq);
+    syncStore.getState().setKnownSeq(input.channelId ?? input.organizationId, input.entityType, input.untilSeq);
     return;
   }
   enqueueWithTier(input, tier);
@@ -87,7 +87,7 @@ export function enqueueCatchupRange(input: EnqueueInput): void {
 
 function enqueueWithTier(input: EnqueueInput, tier: { min: number; max: number }): void {
   const { entityType, organizationId, tenantId, channelId, fromSeq, untilSeq, isCreate, propagation } = input;
-  const store = useSyncStore.getState();
+  const store = syncStore.getState();
   const channelViewId = channelId ?? organizationId;
 
   // Known watermark: free, recorded even for scopes we never fetch (powers catch-up-on-open).
@@ -297,7 +297,7 @@ async function flushGroup(entries: DirtyEntry[]): Promise<'ok' | 'fallback' | 'r
 }
 
 function advanceCaughtUp(entry: DirtyEntry): void {
-  const store = useSyncStore.getState();
+  const store = syncStore.getState();
   if (entry.channelId) {
     store.setChannelSeq(entry.organizationId, entry.channelId, entry.entityType, entry.untilSeq);
   } else {

--- a/frontend/src/query/realtime/stream-store.test.ts
+++ b/frontend/src/query/realtime/stream-store.test.ts
@@ -7,7 +7,7 @@ vi.mock('~/env', () => ({ isDebugMode: false }));
 vi.mock('~/lib/tracing', () => ({ reportCriticalError: vi.fn() }));
 vi.mock('~/query/basic/sync-stale-config', () => ({ setSyncStreamHealthy: vi.fn() }));
 vi.mock('~/query/realtime/sync-store', () => ({
-  useSyncStore: {
+  syncStore: {
     getState: () => ({
       cursor: null,
       setCursor: vi.fn(),
@@ -47,7 +47,7 @@ vi.mock('./tab-coordinator', () => ({
   initTabCoordinator: vi.fn(() => Promise.resolve()),
   isLeader: () => leaderControl.isLeader(),
   onNotification: vi.fn(() => () => {}),
-  useTabCoordinatorStore: { getState: () => leaderControl.getState(), subscribe: leaderControl.subscribe },
+  tabCoordinatorStore: { getState: () => leaderControl.getState(), subscribe: leaderControl.subscribe },
 }));
 vi.mock('sdk', () => ({ postAppCatchup: vi.fn() }));
 

--- a/frontend/src/query/realtime/stream-store.ts
+++ b/frontend/src/query/realtime/stream-store.ts
@@ -5,7 +5,7 @@ import { devtools } from 'zustand/middleware';
 import { isDebugMode } from '~/env';
 import { reportCriticalError } from '~/lib/tracing';
 import { setSyncStreamHealthy } from '~/query/basic/sync-stale-config';
-import { type CatchupViewRequest, useSyncStore } from '~/query/realtime/sync-store';
+import { type CatchupViewRequest, syncStore } from '~/query/realtime/sync-store';
 import { handleAppStreamNotification } from './app-stream-handler';
 import { catchupEntityTypes, processAppCatchup } from './catchup-processor';
 import {
@@ -13,7 +13,7 @@ import {
   initTabCoordinator,
   isLeader,
   onNotification,
-  useTabCoordinatorStore,
+  tabCoordinatorStore,
 } from './tab-coordinator';
 import type { AppStreamNotification, StreamState } from './types';
 import { declareViewsFromMemberships } from './view-declaration';
@@ -195,7 +195,7 @@ export class StreamManager {
       this.useStore.getState().setState('catching-up');
 
       for (let round = 0; ; round++) {
-        const currentCursor = useTabCoordination ? useSyncStore.getState().cursor : this.useStore.getState().cursor;
+        const currentCursor = useTabCoordination ? syncStore.getState().cursor : this.useStore.getState().cursor;
 
         console.debug(`[${this.name}] Fetching catchup from offset:`, currentCursor ?? 'null');
         const newCursor = await this.config.fetchAndProcessCatchup(currentCursor);
@@ -204,8 +204,8 @@ export class StreamManager {
         if (newCursor) {
           this.useStore.getState().setCursor(newCursor);
           if (useTabCoordination) {
-            useSyncStore.getState().setCursor(newCursor);
-            useSyncStore.getState().setLastSyncAt(new Date().toISOString());
+            syncStore.getState().setCursor(newCursor);
+            syncStore.getState().setLastSyncAt(new Date().toISOString());
           }
         }
 
@@ -275,7 +275,7 @@ export class StreamManager {
   private applyNotification(notification: unknown, eventId: string | undefined) {
     if (eventId) {
       this.useStore.getState().setCursor(eventId);
-      if (this.config.useTabCoordination) useSyncStore.getState().setCursor(eventId);
+      if (this.config.useTabCoordination) syncStore.getState().setCursor(eventId);
     }
     this.config.processNotification(notification);
   }
@@ -485,8 +485,8 @@ export class StreamManager {
   /** Subscribe to leader changes and reconnect when becoming leader. */
   private startLeaderReconnect() {
     if (!this.config.useTabCoordination || this.leaderUnsubscribe) return;
-    let wasLeader = useTabCoordinatorStore.getState().isLeader;
-    this.leaderUnsubscribe = useTabCoordinatorStore.subscribe((s) => {
+    let wasLeader = tabCoordinatorStore.getState().isLeader;
+    this.leaderUnsubscribe = tabCoordinatorStore.subscribe((s) => {
       if (s.isLeader && !wasLeader && !this.isConnected()) {
         console.debug(`[${this.name}] Became leader, reconnecting...`);
         this.reconnect();
@@ -584,7 +584,7 @@ export const appStreamManager = new StreamManager('AppStream', {
   fetchAndProcessCatchup: async (cursor) => {
     // Combine baseline organization views with membership-derived grant boundaries.
     declareViewsFromMemberships();
-    const views = toCatchupViews(useSyncStore.getState().getCatchupViews(catchupEntityTypes()));
+    const views = toCatchupViews(syncStore.getState().getCatchupViews(catchupEntityTypes()));
     const response = await postAppCatchup({
       body: {
         cursor: cursor ?? undefined,

--- a/frontend/src/query/realtime/sync-priority.ts
+++ b/frontend/src/query/realtime/sync-priority.ts
@@ -2,7 +2,7 @@ import type { GetMyMembershipsResponse } from 'sdk';
 import { isProduct } from 'shared';
 import { queryClient } from '~/query/query-client';
 import { isObservedChannel } from '~/query/realtime/observed-channels';
-import { useSyncStore } from '~/query/realtime/sync-store';
+import { syncStore } from '~/query/realtime/sync-store';
 import { getRouter } from '~/routes/-router-instance';
 
 /** Get the current org ID from the router's matched route context, if user is within an org layout. */
@@ -46,7 +46,7 @@ export function resolveQueryOrgTenantIds(
 /** Resolve tenantId for an organizationId. Checks sync store first (persisted, instant), then query cache. */
 export function getTenantIdForOrg(organizationId: string): string | null {
   // Sync store is persisted to localStorage, available before query cache hydration.
-  const fromStore = useSyncStore.getState().getOrgTenantId(organizationId);
+  const fromStore = syncStore.getState().getOrgTenantId(organizationId);
   if (fromStore) return fromStore;
 
   const data = queryClient.getQueryData<GetMyMembershipsResponse>(['me', 'memberships']);

--- a/frontend/src/query/realtime/sync-store.test.ts
+++ b/frontend/src/query/realtime/sync-store.test.ts
@@ -11,10 +11,10 @@ vi.stubGlobal('localStorage', {
   length: 0,
 });
 
-const { useSyncStore } = await import('./sync-store');
+const { syncStore } = await import('./sync-store');
 
 describe('sync-store declareSyncView (re-baseline rule)', () => {
-  afterEach(() => useSyncStore.getState().reset());
+  afterEach(() => syncStore.getState().reset());
 
   const base = {
     organizationId: 'org-1',
@@ -24,44 +24,44 @@ describe('sync-store declareSyncView (re-baseline rule)', () => {
   };
 
   it('keeps the cursor while the view identity is unchanged (prefix order irrelevant)', () => {
-    const store = useSyncStore.getState();
+    const store = syncStore.getState();
     store.declareSyncView('v', { ...base, prefixes: ['org-1/c1', 'org-1/c2'] });
     store.setViewCursor('v', 42);
     store.declareSyncView('v', { ...base, prefixes: ['org-1/c2', 'org-1/c1'] });
-    expect(useSyncStore.getState().getView('v')?.cursor).toBe(42);
+    expect(syncStore.getState().getView('v')?.cursor).toBe(42);
   });
 
   it('resets the cursor when the prefix set grows (new member has skipped history)', () => {
-    const store = useSyncStore.getState();
+    const store = syncStore.getState();
     store.declareSyncView('v', base);
     store.setViewCursor('v', 42);
     store.declareSyncView('v', { ...base, prefixes: ['org-1/c1', 'org-1/c9'] });
-    expect(useSyncStore.getState().getView('v')?.cursor).toBe(0);
+    expect(syncStore.getState().getView('v')?.cursor).toBe(0);
   });
 
   it('resets on depth or entity-type changes and rides the catchup request', () => {
-    const store = useSyncStore.getState();
+    const store = syncStore.getState();
     store.declareSyncView('v', base);
     store.setViewCursor('v', 42);
     store.declareSyncView('v', { ...base, depth: 'self' });
-    expect(useSyncStore.getState().getView('v')?.cursor).toBe(0);
+    expect(syncStore.getState().getView('v')?.cursor).toBe(0);
 
     store.setViewCursor('v', 7);
-    const views = useSyncStore.getState().getCatchupViews([]);
+    const views = syncStore.getState().getCatchupViews([]);
     expect(views).toEqual([{ key: 'v', ...base, depth: 'self', cursor: 7 }]);
   });
 });
 
 describe('sync-store getCatchupViews', () => {
-  afterEach(() => useSyncStore.getState().reset());
+  afterEach(() => syncStore.getState().reset());
 
   it('declares one org-prefix view per (org, entityType) with the org-slot cursor', () => {
-    const store = useSyncStore.getState();
+    const store = syncStore.getState();
     store.setOrgTenantId('org-1', 'tenant-1');
     store.setOrgSeq('org-1', 'attachment', 42);
     store.setOrgTenantId('org-2', 'tenant-2');
 
-    const views = useSyncStore.getState().getCatchupViews(['attachment']);
+    const views = syncStore.getState().getCatchupViews(['attachment']);
 
     expect(views).toEqual([
       {
@@ -76,11 +76,11 @@ describe('sync-store getCatchupViews', () => {
   });
 
   it('child-channel-view cursors never leak into the org-view cursor (they cover their subtree only)', () => {
-    const store = useSyncStore.getState();
+    const store = syncStore.getState();
     store.setOrgTenantId('org-1', 'tenant-1');
     store.setChannelSeq('org-1', 'project-9', 'attachment', 4700);
 
-    const views = useSyncStore.getState().getCatchupViews(['attachment']);
+    const views = syncStore.getState().getCatchupViews(['attachment']);
     // Org slot untouched → baseline cursor 0, despite the live child cursor.
     expect(views).toEqual([
       { key: 'org-1:attachment', organizationId: 'org-1', prefixes: ['org-1'], entityTypes: ['attachment'], cursor: 0 },
@@ -88,11 +88,11 @@ describe('sync-store getCatchupViews', () => {
   });
 
   it('org-homed live channel views (channelId === orgId) share the org slot and drive the cursor', () => {
-    const store = useSyncStore.getState();
+    const store = syncStore.getState();
     store.setOrgTenantId('org-1', 'tenant-1');
     store.setChannelSeq('org-1', 'org-1', 'attachment', 88);
 
-    const views = useSyncStore.getState().getCatchupViews(['attachment']);
+    const views = syncStore.getState().getCatchupViews(['attachment']);
     expect(views[0].cursor).toBe(88);
   });
 });

--- a/frontend/src/query/realtime/sync-store.ts
+++ b/frontend/src/query/realtime/sync-store.ts
@@ -1,6 +1,6 @@
-import { create } from 'zustand';
 import { createJSONStorage, devtools, persist } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
+import { createStore } from 'zustand/vanilla';
 import { isDebugMode } from '~/env';
 import { idbKvStorage } from '~/query/idb-kv-storage';
 
@@ -91,8 +91,8 @@ function ensureOrg(orgs: Record<string, OrgSyncState>, orgId: string, tenantId?:
   return existing;
 }
 
-/** Offline sync state: `orgs` (per-org tenantId + entity/child-context seqs), plus global `cursor`/`lastSyncAt`. */
-export const useSyncStore = create<SyncStoreState>()(
+/** Vanilla Zustand store for offline sync state: per-org sequences plus the global cursor and last-sync time. */
+export const syncStore = createStore<SyncStoreState>()(
   devtools(
     persist(
       immer((set, get) => ({
@@ -205,5 +205,5 @@ export const useSyncStore = create<SyncStoreState>()(
 
 /** Get the current cursor value (for SSE reconnect). Returns 'now' if no cursor is set. */
 export function getSyncCursor(): string {
-  return useSyncStore.getState().cursor ?? 'now';
+  return syncStore.getState().cursor ?? 'now';
 }

--- a/frontend/src/query/realtime/tab-coordinator.tsx
+++ b/frontend/src/query/realtime/tab-coordinator.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { currentSchemaVersion } from 'shared/schema-evolution';
-import { create } from 'zustand';
+import { createStore } from 'zustand/vanilla';
 import { markBundleStale } from '~/query/schema-version-guard';
 import type { AppStreamNotification } from './types';
 
@@ -22,8 +22,8 @@ interface TabCoordinatorState {
   setIsActive: (isActive: boolean) => void;
 }
 
-/** Zustand store for tab coordination state */
-export const useTabCoordinatorStore = create<TabCoordinatorState>((set) => ({
+/** Vanilla Zustand store for tab coordination state. */
+export const tabCoordinatorStore = createStore<TabCoordinatorState>((set) => ({
   isLeader: false,
   isReady: false,
   isActive: false,
@@ -72,7 +72,7 @@ export const initTabCoordinator = async (): Promise<void> => {
   if (initPromise) return initPromise;
 
   initPromise = (async () => {
-    const store = useTabCoordinatorStore.getState();
+    const store = tabCoordinatorStore.getState();
 
     // Mark coordinator as active
     store.setIsActive(true);
@@ -113,7 +113,7 @@ export const initTabCoordinator = async (): Promise<void> => {
  * the pending promotion request, so a sole tab picks the stream back up when it returns.
  */
 export const releaseTabLeadership = (): void => {
-  const store = useTabCoordinatorStore.getState();
+  const store = tabCoordinatorStore.getState();
 
   lockController?.abort();
   lockController = null;
@@ -126,7 +126,7 @@ export const releaseTabLeadership = (): void => {
 
 /** Acquire the leader lock (first tab to acquire it becomes leader); resolves once leader status is known. */
 const attemptLeaderElection = (): Promise<void> => {
-  const store = useTabCoordinatorStore.getState();
+  const store = tabCoordinatorStore.getState();
   // One controller per election: aborting it releases whichever lock this tab currently holds or
   // awaits. `ifAvailable` cannot be combined with a signal, so the callback checks it by hand.
   lockController = new AbortController();
@@ -190,7 +190,7 @@ const attemptLeaderElection = (): Promise<void> => {
  * Called by follower tabs to eventually become leader when current leader closes.
  */
 const waitForLeadership = (signal: AbortSignal): void => {
-  const store = useTabCoordinatorStore.getState();
+  const store = tabCoordinatorStore.getState();
 
   navigator.locks
     .request(leaderLockName, { signal }, async () => {
@@ -213,7 +213,7 @@ const waitForLeadership = (signal: AbortSignal): void => {
  * Handle incoming BroadcastChannel messages.
  */
 const handleBroadcastMessage = (event: MessageEvent<BroadcastMessage>): void => {
-  const store = useTabCoordinatorStore.getState();
+  const store = tabCoordinatorStore.getState();
   const message = event.data;
 
   if (message.type === 'schema-version') {
@@ -269,7 +269,7 @@ export const onNotification = (
  * Check if this tab is currently the leader.
  */
 export const isLeader = (): boolean => {
-  return useTabCoordinatorStore.getState().isLeader;
+  return tabCoordinatorStore.getState().isLeader;
 };
 
 /** Initializes multi-tab coordination. Only mounted in AppLayout. */

--- a/frontend/src/query/realtime/view-declaration.test.ts
+++ b/frontend/src/query/realtime/view-declaration.test.ts
@@ -16,7 +16,7 @@ vi.stubGlobal('localStorage', {
 const { createEntityKeys } = await import('~/query/basic/create-query-keys');
 const { registerEntityQueryKeys } = await import('~/query/basic/entity-query-registry');
 const { queryClient } = await import('~/query/query-client');
-const { useSyncStore } = await import('~/query/realtime/sync-store');
+const { syncStore } = await import('~/query/realtime/sync-store');
 const { declareViewsFromMemberships } = await import('./view-declaration');
 
 const orgMembership = (organizationId: string, role: 'admin' | 'member') => ({
@@ -35,7 +35,7 @@ const orgMembership = (organizationId: string, role: 'admin' | 'member') => ({
 describe('declareViewsFromMemberships (template equivalence)', () => {
   afterEach(() => {
     queryClient.clear();
-    useSyncStore.getState().reset();
+    syncStore.getState().reset();
   });
 
   it('derives NO registered views for org-homed template grants: catchup stays org-view-only', () => {
@@ -43,22 +43,22 @@ describe('declareViewsFromMemberships (template equivalence)', () => {
     queryClient.setQueryData(['me', 'memberships'], {
       items: [orgMembership('org-1', 'admin'), orgMembership('org-2', 'member')],
     });
-    useSyncStore.getState().setOrgTenantId('org-1', 'tenant-1');
-    useSyncStore.getState().setOrgSeq('org-1', 'attachment', 7);
+    syncStore.getState().setOrgTenantId('org-1', 'tenant-1');
+    syncStore.getState().setOrgSeq('org-1', 'attachment', 7);
 
-    const before = useSyncStore.getState().getCatchupViews(['attachment']);
+    const before = syncStore.getState().getCatchupViews(['attachment']);
     declareViewsFromMemberships();
-    const after = useSyncStore.getState().getCatchupViews(['attachment']);
+    const after = syncStore.getState().getCatchupViews(['attachment']);
 
     // Org subtree views duplicate the built-in baseline, so the registry stays empty and the
     // request is unchanged.
-    expect(useSyncStore.getState().views).toEqual({});
+    expect(syncStore.getState().views).toEqual({});
     expect(after).toEqual(before);
   });
 
   it('removes registered views whose grant disappeared', () => {
     registerEntityQueryKeys('attachment', createEntityKeys('attachment'));
-    useSyncStore.getState().declareSyncView('org-1:attachment:self', {
+    syncStore.getState().declareSyncView('org-1:attachment:self', {
       organizationId: 'org-1',
       prefixes: ['org-1/course-9'],
       entityTypes: ['attachment'],
@@ -68,12 +68,12 @@ describe('declareViewsFromMemberships (template equivalence)', () => {
 
     declareViewsFromMemberships();
 
-    expect(useSyncStore.getState().getView('org-1:attachment:self')).toBeUndefined();
+    expect(syncStore.getState().getView('org-1:attachment:self')).toBeUndefined();
   });
 
   it('handles a missing memberships cache without touching declared state', () => {
     registerEntityQueryKeys('attachment', createEntityKeys('attachment'));
     expect(() => declareViewsFromMemberships()).not.toThrow();
-    expect(useSyncStore.getState().views).toEqual({});
+    expect(syncStore.getState().views).toEqual({});
   });
 });

--- a/frontend/src/query/realtime/view-declaration.ts
+++ b/frontend/src/query/realtime/view-declaration.ts
@@ -2,7 +2,7 @@ import type { GetMyMembershipsResponse } from 'sdk';
 import { getRegisteredProductEntityTypes } from '~/query/basic/entity-query-registry';
 import { queryClient } from '~/query/query-client';
 import { deriveGrantBoundaryViews } from '~/query/realtime/views';
-import { useSyncStore } from './sync-store';
+import { syncStore } from './sync-store';
 
 /**
  * Resolve cached sub-organization channel paths through a fork registration.
@@ -41,7 +41,7 @@ export function declareViewsFromMemberships(): void {
     resolvePath: (channelType, channelId) => channelPathResolver(channelType, channelId),
   });
 
-  const store = useSyncStore.getState();
+  const store = syncStore.getState();
   const keep = new Set<string>();
   for (const view of derived) {
     // Exact org-subtree views duplicate the built-in org-view baseline.
@@ -55,7 +55,7 @@ export function declareViewsFromMemberships(): void {
     });
   }
 
-  for (const key of Object.keys(useSyncStore.getState().views)) {
+  for (const key of Object.keys(syncStore.getState().views)) {
     if (!keep.has(key)) store.removeSyncView(key);
   }
 }


### PR DESCRIPTION
## Summary

- convert the sync, seen, and tab-coordination stores from React-bound `create` to vanilla `createStore`
- rename their exports and call sites so imperative store access no longer looks like React hook usage
- update persisted-store registration and affected test mocks without changing store behavior

## Verification

- `pnpm lint`
- `pnpm --filter frontend exec vitest run --project=unit` (53 files, 375 tests)
- pre-commit `pnpm sdk && pnpm ts` across all workspaces