### PR TITLE
fix(infra): keep DB-exposure state out of the committed stack config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ frontend/stats.html
 .devcontainer/
 
 # Cella
+# DB exposure overlay: apply-time copy of the stack config carrying the
+# public-endpoint keys, written by the infra CLI expose/seed flows.
+infra/Pulumi.*.exposure.yaml
 *storybook.log
 storybook-static
 .locales-cache

--- a/infra/Pulumi.production.yaml
+++ b/infra/Pulumi.production.yaml
@@ -1,6 +1,3 @@
 encryptionsalt: v1:OB3eX2/Cavo=:v1:zUWCmiHoqAtbw5w9:nUhV6Y7FbTkk7Ok5ad1LipqvR6L/4Q==
 config:
   infra:bootstrapComplete: "2026-06-20T05:30:28.418Z"
-  infra:dbPublicEndpoint: "true"
-  infra:dbPublicAcl:
-    secure: v1:4NElyxWQQyAOU1sV:M4U73BkOH3C/S++nm+PjP4ErxBjZboNntKU2f7IXjA==

--- a/infra/cli/actions/db-exposure.ts
+++ b/infra/cli/actions/db-exposure.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import { writeFileSync } from 'node:fs'
+import { copyFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { confirm, input } from '@inquirer/prompts'
@@ -18,10 +18,37 @@ import { parseAclInput } from './db-exposure-acl'
 import { pc, checkMark, crossMark, warningMark } from '../../lib/utils/cli-output'
 
 // Pulumi config keys consumed by resources/stores/postgres-managed.ts and the outputs it exports.
-const DB_ENDPOINT_KEY = 'infra:dbPublicEndpoint'
-const DB_ACL_KEY = 'infra:dbPublicAcl'
+export const DB_ENDPOINT_KEY = 'infra:dbPublicEndpoint'
+export const DB_ACL_KEY = 'infra:dbPublicAcl'
 const PUBLIC_DSN_OUTPUT = 'dbConnectionStringAdminPublic'
 const DB_CA_OUTPUT = 'dbCaCertificate'
+
+/**
+ * Gitignored per-environment stack config overlay that carries the DB-exposure
+ * keys. Exposure converges run `pulumi up --config-file` with this file, so the
+ * committed `Pulumi.<env>.yaml` never records an open endpoint and any normal
+ * deploy (CI uses the committed file) converges the endpoint closed again.
+ */
+export function exposureOverlayPath(environment: string): string {
+  return join(infraDir, `Pulumi.${environment}.exposure.yaml`)
+}
+
+/**
+ * Create the exposure overlay as a copy of the committed stack config (the copy
+ * carries `encryptionsalt`, so secret config encrypts with the same passphrase).
+ * Returns the overlay path; while the file exists it also marks the endpoint as
+ * exposure-managed for the CLI menu.
+ */
+export function writeExposureOverlay(stackPath: string, environment: string): string {
+  const overlayPath = exposureOverlayPath(environment)
+  copyFileSync(stackPath, overlayPath)
+  return overlayPath
+}
+
+/** Delete the exposure overlay after a successful close of the endpoint. */
+export function removeExposureOverlay(environment: string): void {
+  rmSync(exposureOverlayPath(environment), { force: true })
+}
 
 /** Detect the operator's current public IPv4 via a well-known echo service. */
 export async function detectPublicIp(): Promise<string | undefined> {
@@ -35,9 +62,10 @@ export async function detectPublicIp(): Promise<string | undefined> {
   }
 }
 
-/** Set one stack config key, exiting on failure. `secret` encrypts the value. */
-export function pulumiConfigSet(env: NodeJS.ProcessEnv, stack: string, key: string, value: string, opts: { secret?: boolean } = {}): void {
-  const args = ['config', 'set', ...(opts.secret ? ['--secret'] : []), key, value, '--stack', stack]
+/** Set one stack config key, exiting on failure. `secret` encrypts the value;
+ *  `configFile` targets an alternate stack config file (the exposure overlay). */
+export function pulumiConfigSet(env: NodeJS.ProcessEnv, stack: string, key: string, value: string, opts: { secret?: boolean; configFile?: string } = {}): void {
+  const args = ['config', 'set', ...(opts.secret ? ['--secret'] : []), key, value, '--stack', stack, ...(opts.configFile ? ['--config-file', opts.configFile] : [])]
   const result = spawnSync('pulumi', args, { cwd: infraDir, env, stdio: 'inherit' })
   if (result.status !== 0) {
     console.error(`${crossMark} pulumi config set ${key} failed (exit ${result.status}).`)
@@ -80,14 +108,16 @@ export function writeDbCaFile(env: NodeJS.ProcessEnv, stack: string, environment
  * The privileged bootstrap-key converge shared by expose/unexpose: acquire keys
  * and the stack lock, adopt any orphaned IAM/secret state, reconcile rollout
  * config from live state (so a local `up` cannot revert compute to a stale
- * generation), apply the caller's config mutation, then run `pulumi up`. Returns
- * the provider env and stack so the caller can read outputs after the lock is
- * released. Exits the process on any hard failure.
+ * generation), apply the caller's config mutation, then run `pulumi up`.
+ * `prepare` may return an alternate stack config file (the exposure overlay)
+ * that the `up` then runs with; returning undefined converges the committed
+ * config. Returns the provider env and stack so the caller can read outputs
+ * after the lock is released. Exits the process on any hard failure.
  */
 export async function convergePublicEndpoint(
   context: InfraContext,
   operation: string,
-  mutate: (env: NodeJS.ProcessEnv, stack: string) => void,
+  prepare: (env: NodeJS.ProcessEnv, stack: string) => string | undefined,
 ): Promise<{ env: NodeJS.ProcessEnv; stack: string }> {
   if (context.state !== 'bootstrapped') {
     console.error(`${warningMark} This action requires a fully bootstrapped stack (state=${context.state}). Run Resume first.`)
@@ -130,10 +160,10 @@ export async function convergePublicEndpoint(
     process.exit(sync.status ?? 1)
   }
 
-  mutate(env, stack)
+  const configFile = prepare(env, stack)
 
   while (true) {
-    const { code, output } = await runPulumiUpWithHint(stack, infraDir, env)
+    const { code, output } = await runPulumiUpWithHint(stack, infraDir, env, configFile)
     if (code === 0) break
     const orphans = parseOrphanedDeletes(output)
     if (orphans.length > 0 && (await confirm({ message: `Prune ${orphans.length} stale state entr${orphans.length === 1 ? 'y' : 'ies'} and retry?`, default: true }))) {
@@ -188,7 +218,8 @@ export async function runExposeDatabase(context: InfraContext): Promise<void> {
 
   console.warn(
     `\n${pc.yellow(pc.bold('⚠  This opens an internet-reachable database endpoint'))}, restricted to: ${pc.cyan(acl)}.\n` +
-      `  ${pc.dim('The stack config file records the endpoint as enabled — do not commit it. Run "Stop public DB exposure" when done.')}\n`,
+      `  ${pc.dim(`Exposure lives only in the gitignored overlay Pulumi.${context.environment}.exposure.yaml; the committed stack config stays clean,`)}\n` +
+      `  ${pc.dim('so the next CI deploy converges the endpoint closed. Run "Stop public DB exposure" when done sooner.')}\n`,
   )
   if (!(await confirm({ message: 'Proceed with exposing the database?', default: false }))) {
     console.info('Aborted; no changes made.')
@@ -196,10 +227,12 @@ export async function runExposeDatabase(context: InfraContext): Promise<void> {
   }
 
   const { env, stack } = await convergePublicEndpoint(context, 'expose-db', (e, s) => {
-    pulumiConfigSet(e, s, DB_ENDPOINT_KEY, 'true')
+    const overlay = writeExposureOverlay(context.stackPath, context.environment)
+    pulumiConfigSet(e, s, DB_ENDPOINT_KEY, 'true', { configFile: overlay })
     // Encrypt the ACL: it records the operator's source IP and should not sit in
-    // plaintext in the committed stack config.
-    pulumiConfigSet(e, s, DB_ACL_KEY, acl, { secret: true })
+    // plaintext in the overlay either.
+    pulumiConfigSet(e, s, DB_ACL_KEY, acl, { secret: true, configFile: overlay })
+    return overlay
   })
 
   const dsn = readPublicDsn(env, stack)
@@ -231,9 +264,15 @@ export async function runUnexposeDatabase(context: InfraContext): Promise<void> 
   }
 
   const { env, stack } = await convergePublicEndpoint(context, 'unexpose-db', (e, s) => {
-    pulumiConfigSet(e, s, DB_ENDPOINT_KEY, 'false')
-    pulumiConfigRm(e, s, DB_ACL_KEY)
+    // Compat: stacks that predate the overlay recorded the exposure keys in the
+    // committed stack config; remove them so the plain converge closes the
+    // endpoint. Overlay-based exposure needs no config change here: converging
+    // the committed file (which lacks the keys) is the close.
+    if (context.stackYaml?.includes(DB_ENDPOINT_KEY)) pulumiConfigRm(e, s, DB_ENDPOINT_KEY)
+    if (context.stackYaml?.includes(DB_ACL_KEY)) pulumiConfigRm(e, s, DB_ACL_KEY)
+    return undefined
   })
+  removeExposureOverlay(context.environment)
 
   const dsn = readPublicDsn(env, stack)
   if (dsn) {

--- a/infra/cli/actions/seed-db.ts
+++ b/infra/cli/actions/seed-db.ts
@@ -4,10 +4,18 @@ import { confirm } from '@inquirer/prompts'
 import { pc, checkMark, crossMark, warningMark } from '../../lib/utils/cli-output'
 import { infraDir } from '../../lib/utils/paths'
 import type { InfraContext } from '../shared'
-import { convergePublicEndpoint, detectPublicIp, pulumiConfigRm, pulumiConfigSet, readDbCa, readPublicDsn } from './db-exposure'
-
-const DB_ENDPOINT_KEY = 'infra:dbPublicEndpoint'
-const DB_ACL_KEY = 'infra:dbPublicAcl'
+import {
+  DB_ACL_KEY,
+  DB_ENDPOINT_KEY,
+  convergePublicEndpoint,
+  detectPublicIp,
+  pulumiConfigRm,
+  pulumiConfigSet,
+  readDbCa,
+  readPublicDsn,
+  removeExposureOverlay,
+  writeExposureOverlay,
+} from './db-exposure'
 
 /**
  * One guarded flow for demo data on a non-production environment: temporarily
@@ -33,8 +41,12 @@ export async function runSeedDatabase(context: InfraContext): Promise<void> {
   }
 
   const { env, stack } = await convergePublicEndpoint(context, 'seed-db', (e, s) => {
-    pulumiConfigSet(e, s, DB_ENDPOINT_KEY, 'true')
-    pulumiConfigSet(e, s, DB_ACL_KEY, `${detected}/32`, { secret: true })
+    // Exposure keys go into the gitignored overlay, never the committed stack
+    // config; see db-exposure.ts.
+    const overlay = writeExposureOverlay(context.stackPath, context.environment)
+    pulumiConfigSet(e, s, DB_ENDPOINT_KEY, 'true', { configFile: overlay })
+    pulumiConfigSet(e, s, DB_ACL_KEY, `${detected}/32`, { secret: true, configFile: overlay })
+    return overlay
   })
 
   try {
@@ -58,10 +70,16 @@ export async function runSeedDatabase(context: InfraContext): Promise<void> {
   } finally {
     console.info(pc.dim('\n-> Closing the public endpoint...\n'))
     const closed = await convergePublicEndpoint(context, 'unseed-db', (e, s) => {
-      pulumiConfigSet(e, s, DB_ENDPOINT_KEY, 'false')
-      pulumiConfigRm(e, s, DB_ACL_KEY)
+      // Compat cleanup for stacks that predate the overlay; converging the
+      // committed (key-free) config is what closes the endpoint.
+      if (context.stackYaml?.includes(DB_ENDPOINT_KEY)) pulumiConfigRm(e, s, DB_ENDPOINT_KEY)
+      if (context.stackYaml?.includes(DB_ACL_KEY)) pulumiConfigRm(e, s, DB_ACL_KEY)
+      return undefined
     }).then(
-      () => true,
+      () => {
+        removeExposureOverlay(context.environment)
+        return true
+      },
       (err) => {
         console.error(`${warningMark} closing the endpoint failed: ${err instanceof Error ? err.message : String(err)}`)
         return false

--- a/infra/cli/infra-cli.ts
+++ b/infra/cli/infra-cli.ts
@@ -8,7 +8,7 @@ import { infraDir } from '../lib/utils/paths'
 import { runApply } from './actions/apply'
 import { runPreview } from './actions/preview'
 import { runResetDatabase } from './actions/reset-database'
-import { runExposeDatabase, runUnexposeDatabase } from './actions/db-exposure'
+import { exposureOverlayPath, runExposeDatabase, runUnexposeDatabase } from './actions/db-exposure'
 import { runSeedDatabase } from './actions/seed-db'
 import { runRotatePassphrase } from './actions/rotate-passphrase'
 import { runSecrets } from './actions/secrets'
@@ -199,7 +199,11 @@ async function chooseStackAction(): Promise<Exclude<CliMode, 'status'> | 'back'>
 }
 
 async function chooseAction(ctx: InfraContext): Promise<Exclude<CliMode, 'status'>> {
-  const dbExposed = detectDbPublicEndpoint(ctx.stackYaml)
+  // Exposure state lives in the gitignored overlay; the committed stack yaml is
+  // only consulted for stacks that predate the overlay flow.
+  const overlayPath = exposureOverlayPath(ctx.environment)
+  const overlayYaml = existsSync(overlayPath) ? readFileSync(overlayPath, 'utf8') : undefined
+  const dbExposed = detectDbPublicEndpoint(overlayYaml ?? ctx.stackYaml)
   const { runStatus } = await import('../tasks/status')
   while (true) {
     const category = await select<'status' | 'database' | 'keys' | 'stack'>({

--- a/infra/lib/stack/bootstrap-stack-state.ts
+++ b/infra/lib/stack/bootstrap-stack-state.ts
@@ -54,11 +54,12 @@ export function detectComputeDeferred(yamlText?: string): string | undefined {
 }
 
 /**
- * Detect whether the local stack config opts the database into a public
- * endpoint (`infra:dbPublicEndpoint: "true"`), the state the expose/unexpose
- * flow toggles. Read from the committed/local yaml, so it drives the menu's
- * status-aware label without any I/O. The converge itself is idempotent, so a
- * stale read only mislabels the menu, never misacts. Pure.
+ * Detect whether a stack config text opts the database into a public endpoint
+ * (`infra:dbPublicEndpoint: "true"`), the state the expose/unexpose flow
+ * toggles. Callers pass the gitignored exposure overlay when present, falling
+ * back to the committed yaml for stacks that predate the overlay. The converge
+ * itself is idempotent, so a stale read only mislabels the menu, never misacts.
+ * Pure.
  */
 export function detectDbPublicEndpoint(yamlText?: string): boolean {
   return yamlText ? /(?:^|\n)\s*infra:dbPublicEndpoint:\s*["']?true/.test(yamlText) : false

--- a/infra/lib/stack/pulumi-up.ts
+++ b/infra/lib/stack/pulumi-up.ts
@@ -65,13 +65,16 @@ export interface PulumiUpResult {
 }
 
 /** Runs `pulumi up --stack <s> --yes --non-interactive` in `cwd` with `env`.
- *  On non-zero exit, prints a permission hint when stderr indicates one. */
-export async function runPulumiUpWithHint(stack: string, cwd: string, env: NodeJS.ProcessEnv): Promise<PulumiUpResult> {
-  console.info(`\n→ pulumi up (base infra)\n  $ pulumi up --stack ${stack} --yes --non-interactive`)
+ *  `configFile` swaps the stack config for an alternate file (`--config-file`),
+ *  used by the DB-exposure overlay. On non-zero exit, prints a permission hint
+ *  when stderr indicates one. */
+export async function runPulumiUpWithHint(stack: string, cwd: string, env: NodeJS.ProcessEnv, configFile?: string): Promise<PulumiUpResult> {
+  const configFileArgs = configFile ? ['--config-file', configFile] : []
+  console.info(`\n→ pulumi up (base infra)\n  $ pulumi up --stack ${stack} --yes --non-interactive${configFileArgs.map((a) => ` ${a}`).join('')}`)
   // stdout is teed, not inherited, so the Diagnostics section reaches
   // parseOrphanedDeletes; with --non-interactive pulumi already uses the plain
   // (non-TTY) display, so piping does not change what the operator sees.
-  const child = spawn('pulumi', ['up', '--stack', stack, '--yes', '--non-interactive'], {
+  const child = spawn('pulumi', ['up', '--stack', stack, '--yes', '--non-interactive', ...configFileArgs], {
     cwd,
     env,
     stdio: ['inherit', 'pipe', 'pipe'],

--- a/infra/tests/unit/no-unexpected-public.test.ts
+++ b/infra/tests/unit/no-unexpected-public.test.ts
@@ -73,6 +73,24 @@ describe('no-unexpected-public sweep', () => {
     }
   })
 
+  // Exposure keys must only ever live in the gitignored Pulumi.<env>.exposure.yaml
+  // overlay (written by the expose/seed flows): a committed key would make every
+  // CI deploy re-converge the public endpoint open.
+  it('no committed stack config records DB-exposure keys', () => {
+    const infraRoot = resolve(__dirname, '../..')
+    const offenders: string[] = []
+    for (const file of readdirSync(infraRoot)) {
+      if (!/^Pulumi\..+\.yaml$/.test(file) || file.endsWith('.exposure.yaml')) continue
+      const src = readFileSync(resolve(infraRoot, file), 'utf-8')
+      if (/dbPublicEndpoint:\s*["']?true/.test(src) || /dbPublicAcl/.test(src)) offenders.push(file)
+    }
+    expect(
+      offenders,
+      `DB-exposure keys found in committed stack config: ${offenders.join(', ')}. ` +
+        'Run "Stop public DB exposure" (infra CLI) and remove the keys; exposure belongs in the gitignored overlay.',
+    ).toEqual([])
+  })
+
   it('does not flag pristine surface — sanity check the scanner itself runs', () => {
     // If PATTERNS array got accidentally emptied, this test catches it.
     expect(PATTERNS.length).toBeGreaterThan(0)


### PR DESCRIPTION
## Problem

`infra expose-db` / `seed-db` record `infra:dbPublicEndpoint` + `infra:dbPublicAcl` in `Pulumi.<env>.yaml`, and #936 committed that state for production. CI deploys run `pulumi up` against the committed file, so **every production deploy since July 21 has re-converged the public DB endpoint open**, pinned to the operator ACL, despite the flow's own "do not commit it" warning.

## Fix: apply-time exposure overlay

Exposure config now never touches the committed stack file. The expose/seed converge copies `Pulumi.<env>.yaml` to a gitignored `Pulumi.<env>.exposure.yaml` (the copy carries `encryptionsalt`, so the secret ACL encrypts with the same passphrase), sets the two keys there, and runs `pulumi up --config-file` with the overlay.

Properties:
- The repo never records an open endpoint.
- Any normal deploy uses the committed (key-free) config, so it **automatically converges the endpoint closed**: exposure has a deploy-bounded lifetime and is fail-safe by default. This is a deliberate behavior change: a mid-exposure deploy closes the endpoint under the operator.
- "Stop public DB exposure" converges the committed config and deletes the overlay; it still removes old-style keys from stacks that predate the overlay.
- The CLI menu reads exposure state from the overlay file, with the committed yaml as compat fallback.

## Also in this PR

- `Pulumi.production.yaml`: the committed exposure keys are removed. The next production deploy closes the currently open endpoint; run "Stop public DB exposure" for an immediate close.
- `no-unexpected-public.test.ts` gains a backstop: any committed `Pulumi.*.yaml` recording the exposure keys fails the suite (this test alone would have caught #936).
- `.gitignore`: `infra/Pulumi.*.exposure.yaml`.

## Verification

- `pnpm --filter infra exec vitest run`: 638 passed (includes the new backstop test, which fails without the `Pulumi.production.yaml` cleanup).
- `pnpm check` at the repo root: clean.
- `pulumi up --config-file` and `pulumi config set --config-file` verified supported (CLI v3.253.0; deploy pipeline pins 3.236.0 which also has the flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
