### PR TITLE
chore(infra): run staging single-VM (co-host cdc in the backend)

### DIFF
--- a/shared/config/config.staging.ts
+++ b/shared/config/config.staging.ts
@@ -13,4 +13,8 @@ export const staging = {
   backendAuthUrl: 'https://staging.cellajs.com/api/auth',
   yjsUrl: 'wss://staging.cellajs.com/yjs',
   mcpUrl: 'https://staging.cellajs.com/mcp',
+
+  // Staging runs single-VM: the backend co-hosts every enabled worker in-process,
+  // so cdc folds into the backend VM. Keeps staging at two VMs (backend + frontend).
+  singleVM: true,
 } satisfies DeepPartial<typeof _default>;


### PR DESCRIPTION
## What

Sets `singleVM: true` for the **staging** deploy in [config.staging.ts](shared/config/config.staging.ts). Production is untouched (`config.production.ts` keeps the default `singleVM: false`).

## Why

`cdc` already declares `coHosted: true` in the infra service registry ([services.config.ts](infra/config/services.config.ts)), but nothing folded it in because `singleVM` was globally `false`. Turning it on for staging lets the backend co-host cdc in-process.

## Effect on staging topology

Enabled staging services: `backend`, `cdc`, `frontend` (yjs/mcp disabled). Under `singleVM`:

| | own VM | folded into backend |
|---|---|---|
| before | backend, cdc, frontend | — |
| after | backend, frontend | cdc |

Staging goes from **3 VMs → 2**. The backend VM inherits cdc's `exclusive` replacement strategy (cdc holds the single Postgres replication slot), so staging's backend cuts over exclusively instead of lb-overlap — already handled in the deploy engine.

## Validation

- `pnpm check` clean (SDK regen + full typecheck + lint + comment/vocabulary gates).
- Infra suite: 72 files / 637 tests pass.
- Topology derived directly from `deployedServices`/`coHostedServices` for `APP_MODE=staging` confirms `cdc` moves to co-hosted and only `backend`+`frontend` keep their own VMs.

## Deploy test

Merging to main auto-deploys staging (per [deploy.yml](.github/workflows/deploy.yml), gated by the push-to-main staging opt-in variable), which builds fresh images from this commit so the running backend actually co-hosts cdc. That is the intended "does it deploy" check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)