### PR TITLE
ci(deploy): gate staging auto-deploy on a bootstrapped stack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,11 @@ name: Deploy
 
 # Thin trigger with three paths into one reusable pipeline (deploy-pipeline.yml):
 #   push to main      -> auto staging, so main is always mirrored on staging.
-#                        An app built from the template must bootstrap a
-#                        `staging` Environment with the SCW_* secrets before
-#                        merging to main, or this job fails.
+#                        The gate job runs it only once staging is bootstrapped:
+#                        it checks infra/Pulumi.staging.yaml for a bootstrap
+#                        marker. A fresh app has no bootstrapped staging stack, so
+#                        the push job skips cleanly (no failing CI) and the
+#                        template is safe to pull.
 #   release published -> production (gate it with a required-reviewer
 #                        Environment named `production` to make it a manual
 #                        promote; the deploy job already targets that Environment)
@@ -38,7 +40,38 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
+  # Decide whether a push to main may auto-deploy staging. The signal is a
+  # bootstrap marker in the committed infra/Pulumi.staging.yaml (written by the
+  # `pnpm infra` bootstrap). A fresh app has no bootstrapped staging stack, so
+  # staging_ready is false and the deploy job skips: no manual opt-in variable,
+  # and the template stays safe to pull. Only runs for push events; release and
+  # manual dispatch bypass it.
+  gate:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    outputs:
+      staging_ready: ${{ steps.check.outputs.staging_ready }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Detect bootstrapped staging stack
+        id: check
+        run: |
+          if grep -Eq 'infra:(bootstrapComplete|vmAccessKey|applicationId)' infra/Pulumi.staging.yaml 2>/dev/null; then
+            echo 'staging_ready=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'staging_ready=false' >> "$GITHUB_OUTPUT"
+          fi
+
   deploy:
+    needs: [gate]
+    # Release (production) and manual dispatch always run. A push runs only when
+    # the gate found a bootstrapped staging stack. `!cancelled()` keeps this job
+    # evaluating its condition even though `gate` is skipped for non-push events.
+    if: ${{ !cancelled() && (github.event_name != 'push' || needs.gate.outputs.staging_ready == 'true') }}
     uses: ./.github/workflows/deploy-pipeline.yml
     with:
       environment: ${{ inputs.environment || (github.event_name == 'push' && 'staging') || 'production' }}


### PR DESCRIPTION
## What

Makes push-to-main staging auto-deploy conditional on staging being bootstrapped, restoring the "safe to pull" property that #973 dropped when it made the deploy unconditional.

A new `gate` job greps the committed `infra/Pulumi.staging.yaml` for a bootstrap marker (`bootstrapComplete` / `vmAccessKey` / `applicationId`, the same markers `detectStackState` uses). The `deploy` job now `needs: [gate]` and runs on push only when `staging_ready == 'true'`. Release and manual dispatch bypass the gate (the `!cancelled()` guard keeps `deploy` evaluating its condition when `gate` is skipped for non-push events).

## Why

After #973, a push to main always calls the deploy pipeline. An app built from the template that has not yet bootstrapped a staging Environment fails CI on its first merge to main. The gate makes that case skip cleanly instead: no manual opt-in variable (the old `AUTO_DEPLOY_STAGING` is gone for good), and the template is safe to pull again.

## Fork safety

`create-cella` ships a companion change that strips the template's own `Pulumi.staging.yaml` on scaffold, so a fresh app starts with no bootstrapped staging stack and the gate reads false until the app runs `pnpm infra` bootstrap. Ongoing `pnpm cella` sync already lists both stack files in `ignored`, so a fork's own stack file is never clobbered.

## Behavior matrix

| event | before (#973) | after |
|---|---|---|
| push, staging bootstrapped | deploy | deploy |
| push, not bootstrapped | fail | skip cleanly |
| release published | deploy prod | deploy prod |
| workflow_dispatch | deploy chosen env | deploy chosen env |

## Validation

- `pnpm check` clean (pre-commit hook), YAML parses, no em dashes.
- Gate wiring confirmed: `gate.if` is push-only; `deploy.needs: [gate]`; `deploy.if` uses `!cancelled()` so release/dispatch still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
