### PR TITLE
fix(backend): make requests unique-signup index deploy-safe and race-safe

### DIFF
--- a/backend/drizzle/20260729191005_lonely_crystal/migration.sql
+++ b/backend/drizzle/20260729191005_lonely_crystal/migration.sql
@@ -8,4 +8,7 @@ WHERE dup."type" IN ('waitlist', 'newsletter')
   AND lower(keep."email") = lower(dup."email")
   AND keep."id" <> dup."id"
   AND (keep."created_at", keep."id") < (dup."created_at", dup."id");--> statement-breakpoint
+-- Normalize legacy casing so app-level exact-match lookups agree with the index.
+-- Safe after the dedupe: uniqueness on lower(email) already holds.
+UPDATE "requests" SET "email" = lower("email") WHERE "email" <> lower("email");--> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "requests_unique_signup_email_type" ON "requests" (lower("email"),"type") WHERE "type" in ('waitlist', 'newsletter');

--- a/backend/drizzle/20260729191005_lonely_crystal/migration.sql
+++ b/backend/drizzle/20260729191005_lonely_crystal/migration.sql
@@ -1,1 +1,11 @@
-CREATE UNIQUE INDEX "requests_unique_signup_email_type" ON "requests" (lower("email"),"type") WHERE "type" in ('waitlist', 'newsletter');
+-- Existing rows can violate the new uniqueness: the previous app-level guard matched an
+-- arbitrary row across types, and rows predating email normalization differ only in case.
+-- Deduplicate first, keeping the oldest row per (lower(email), type).
+DELETE FROM "requests" dup
+USING "requests" keep
+WHERE dup."type" IN ('waitlist', 'newsletter')
+  AND keep."type" = dup."type"
+  AND lower(keep."email") = lower(dup."email")
+  AND keep."id" <> dup."id"
+  AND (keep."created_at", keep."id") < (dup."created_at", dup."id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "requests_unique_signup_email_type" ON "requests" (lower("email"),"type") WHERE "type" in ('waitlist', 'newsletter');

--- a/backend/src/modules/requests/operations/create-request.ts
+++ b/backend/src/modules/requests/operations/create-request.ts
@@ -37,6 +37,9 @@ export async function createRequestOp(ctx: AuthContext, input: CreateRequestInpu
 
   const createdRequest = await insertRequest(ctx, { email: normalizedEmail, type, message });
 
+  // A duplicate that slipped past the check above (concurrent submit) is rejected by the unique index
+  if (!createdRequest) throw new AppError(409, 'request_exists', 'info');
+
   // Determine message content based on notification type
   let textMessage: string;
   let title: string;

--- a/backend/src/modules/requests/requests-queries.test.ts
+++ b/backend/src/modules/requests/requests-queries.test.ts
@@ -23,10 +23,10 @@ describe('request query uniqueness', () => {
     });
   });
 
-  it('enforces signup uniqueness case-insensitively at the database boundary', async () => {
+  it('swallows duplicate signups case-insensitively at the database boundary', async () => {
     await insertRequest(ctx, { email, type: 'waitlist' });
 
-    await expect(insertRequest(ctx, { email: email.toUpperCase(), type: 'waitlist' })).rejects.toThrow();
+    await expect(insertRequest(ctx, { email: email.toUpperCase(), type: 'waitlist' })).resolves.toBeUndefined();
   });
 
   it('allows repeated contact requests', async () => {

--- a/backend/src/modules/requests/requests-queries.ts
+++ b/backend/src/modules/requests/requests-queries.ts
@@ -27,13 +27,19 @@ interface InsertRequestOpts {
   message?: string | null;
 }
 
-/** Insert a request and return the created row (without tokenId). */
+/**
+ * Insert a request and return the created row (without tokenId).
+ * Returns undefined when the unique signup index (waitlist/newsletter per lower(email))
+ * rejects the row, so concurrent or case-variant duplicates surface as a duplicate
+ * signal instead of a raw constraint violation.
+ */
 export const insertRequest = async (ctx: DbContext, { email, type, message }: InsertRequestOpts) => {
   const { db } = ctx.var;
   const { tokenId, ...requestsSelect } = getColumns(requestsTable);
   const [created] = await db
     .insert(requestsTable)
     .values({ email, type, message })
+    .onConflictDoNothing()
     .returning({ ...requestsSelect });
   return created;
 };


### PR DESCRIPTION
## Why

A fork (raak) reported a failed 0.1.0 deploy: the backend cutover health gate timed out because the `MODE=migrate` one-shot failed on `requests_unique_signup_email_type` — the migration creates a unique index over existing rows, and populated databases can hold duplicates. CI never catches this because its DB is empty.

Duplicates are reachable two ways:
- the previous app-level guard fetched one arbitrary row across both unique types and only rejected on a type match, so same-type duplicates could slip through;
- rows predating email normalization differ only in case, and the index is on `lower(email)`.

## What

**Migration `20260729191005_lonely_crystal` (edited in place):**
- dedupe per `(lower(email), type)` for waitlist/newsletter before creating the index, keeping the oldest row (original signup / waitlist position);
- lowercase legacy emails afterwards so exact-match lookups agree with the index (safe post-dedupe);
- `CREATE UNIQUE INDEX IF NOT EXISTS` for idempotency.

In-place edit is safe: drizzle's migrator is timestamp-ordered, so databases that already applied it (fresh installs, CI) skip it; populated databases that haven't get the dedupe.

**Guard (`create-request.ts` / `requests-queries.ts`):**
The old flow was check-then-insert — a concurrent duplicate passed the pre-check and hit the index as a raw 23505 (500). `insertRequest` now uses `ON CONFLICT DO NOTHING`; a missing return row maps to the same `409 request_exists` as the pre-check. The index is the arbiter, the pre-check stays as a fast path.

Cross-type behavior is intentionally unchanged: one waitlist **and** one newsletter row per email are allowed, `contact` is unbounded.

## Verification

- Throwaway Postgres 16 seeded adversarially (exact dupes, case-variant dupes, same email on both lists, duplicate contact rows, plain rows): migration applies, keeps the oldest per type, leaves cross-type/contact rows intact, is idempotent on re-run, and the index then rejects new case-variant duplicates.
- `backend/src/modules/requests/requests-queries.test.ts` updated (duplicate insert now resolves `undefined` instead of throwing) and passing; vitest global setup applies the edited chain cleanly.

## Fork note

Forks carry this migration under their own generated name (raak: `20260729131117_reflective_steel_serpent`) — sync needs to apply the same SQL edit in place, not add a file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
