### PR TITLE
fix(infra): ignore rule drift on bootstrap-owned VM IAM policies (CI can't write IAM)

### DIFF
--- a/infra/resources/vm-iam.ts
+++ b/infra/resources/vm-iam.ts
@@ -159,9 +159,13 @@ if (!iamModelV2) {
     ],
     tags,
   }, {
-    // CI intentionally cannot write IAM policies. Keep permission rules managed,
-    // but do not let cosmetic provider/API description drift block deployments.
-    ignoreChanges: ['description'],
+    // CI cannot write IAM policies (bootstrap-owned). Ignore BOTH rules and
+    // description so a CI `pulumi up` never attempts an update it will 403 on:
+    // rules are provisioned by a privileged bootstrap/migration `up`, and the
+    // deploy's assert-vm-grants independently verifies the live grant (failing
+    // loudly on real drift). Also sidesteps the provider's condition
+    // empty-vs-unset diff asymmetry that would otherwise show a phantom ~rules.
+    ignoreChanges: ['rules', 'description'],
   }))
 } else {
   for (const svc of v2Services) {
@@ -185,7 +189,7 @@ if (!iamModelV2) {
           : []),
       ],
       tags,
-    }, { ignoreChanges: ['description'] }))
+    }, { ignoreChanges: ['rules', 'description'] }))
   }
   vmIamPolicies.push(new scaleway.iam.Policy('vm-boot-policy', {
     name: naming.resource('vm-boot-policy'),
@@ -204,7 +208,7 @@ if (!iamModelV2) {
       },
     ],
     tags,
-  }, { ignoreChanges: ['description'] }))
+  }, { ignoreChanges: ['rules', 'description'] }))
 }
 
 /** Backend service app id when it exists (REQ-20 bucket statements); undefined otherwise. */


### PR DESCRIPTION
Third and final fix for the production deploy of the IAM rewrite. The bucket policies now apply (CORS casing fixed in #990), but `vm-reader-policy` still 403'd on a phantom `~rules` diff: the bridged Scaleway provider shows an empty-vs-unset `condition` difference, and CI then tries to write the IAM policy it's structurally forbidden from writing.

Fix: extend `ignoreChanges` to `['rules','description']` on all three Pulumi-managed IAM policies (legacy vm-reader + v2 per-service + boot). Clean ownership split — **a privileged bootstrap/migration `up` writes these policies; CI only verifies them** via `assert-vm-grants` (which fails loudly on real grant drift). This is the same principle as the existing `ignoreChanges: ['description']`, extended to rules.

659 infra tests + full monorepo typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)