### PR TITLE
fix(frontend): build onboarding steps lazily to avoid i18n module-load crash

### DIFF
--- a/frontend/src/modules/home/onboarding/footer.tsx
+++ b/frontend/src/modules/home/onboarding/footer.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDialoger } from '~/modules/common/dialoger/use-dialoger';
 import { useStepper } from '~/modules/common/stepper/stepper';
-import { onboardingSteps } from '~/modules/home/onboarding/onboarding-config';
+import { getOnboardingSteps } from '~/modules/home/onboarding/onboarding-config';
 import { SkipOrganization } from '~/modules/home/onboarding/skip-organization';
 import type { OnboardingStates } from '~/modules/home/onboarding/steps';
 import { Button } from '~/modules/ui/button';
@@ -29,7 +29,7 @@ export function StepperFooter({ setOnboardingState }: StepperFooterProps) {
   // Ask to confirm
   const skipStep = (e: { preventDefault: () => void }) => {
     e.preventDefault();
-    if (onboardingSteps[activeStep].id === 'organization') {
+    if (getOnboardingSteps()[activeStep].id === 'organization') {
       useDialoger.getState().create(<SkipOrganization setOnboardingState={setOnboardingState} />, {
         id: 'skip-org-creation',
         triggerRef: skipButtonRef,

--- a/frontend/src/modules/home/onboarding/onboarding-config.ts
+++ b/frontend/src/modules/home/onboarding/onboarding-config.ts
@@ -2,15 +2,23 @@ import i18n from 'i18next';
 import type { StepItem } from '~/modules/common/stepper/types';
 
 /**
- * Ordered list of onboarding steps shown by the welcome stepper.
- * All steps are optional so users can skip ahead at any point.
+ * Ordered onboarding steps shown by the welcome stepper. All steps are optional
+ * so users can skip ahead at any point.
+ *
+ * Built lazily (a function, not a module-scope const) because the labels call
+ * `i18n.t(...)`: evaluating those at module load — before i18next has
+ * initialized its namespaces — returns `undefined`, and
+ * `i18n.t('c:organization').toLowerCase()` then throws and white-screens the
+ * app. Call this at render time, when i18next is ready.
  */
-export const onboardingSteps: StepItem[] = [
-  { id: 'profile', label: i18n.t('c:tune_profile'), optional: true },
-  {
-    id: 'organization',
-    label: i18n.t('c:create_resource', { resource: i18n.t('c:organization').toLowerCase() }),
-    optional: true,
-  },
-  { id: 'invitation', label: i18n.t('c:invite_others'), optional: true },
-];
+export function getOnboardingSteps(): StepItem[] {
+  return [
+    { id: 'profile', label: i18n.t('c:tune_profile'), optional: true },
+    {
+      id: 'organization',
+      label: i18n.t('c:create_resource', { resource: i18n.t('c:organization').toLowerCase() }),
+      optional: true,
+    },
+    { id: 'invitation', label: i18n.t('c:invite_others'), optional: true },
+  ];
+}

--- a/frontend/src/modules/home/onboarding/steps.tsx
+++ b/frontend/src/modules/home/onboarding/steps.tsx
@@ -7,7 +7,7 @@ import { useMountedState } from '~/hooks/use-mounted-state';
 import type { CallbackArgs } from '~/modules/common/data-table/types';
 import { Step, Stepper } from '~/modules/common/stepper/stepper';
 import { StepperFooter } from '~/modules/home/onboarding/footer';
-import { onboardingSteps } from '~/modules/home/onboarding/onboarding-config';
+import { getOnboardingSteps } from '~/modules/home/onboarding/onboarding-config';
 import { WelcomeText } from '~/modules/home/onboarding/welcome-text';
 import { CreateOrganizationForm } from '~/modules/organization/create-organization-form';
 import { organizationsListQueryOptions } from '~/modules/organization/query';
@@ -49,7 +49,10 @@ export function Onboarding({
 
   // Lock steps at mount: if user already has orgs, show only profile step.
   // Don't shrink mid-flow when an org is created during onboarding.
-  const [steps] = useState(() => (hasOrganizations ? [onboardingSteps[0]] : onboardingSteps));
+  const [steps] = useState(() => {
+    const allSteps = getOnboardingSteps();
+    return hasOrganizations ? [allSteps[0]] : allSteps;
+  });
 
   return (
     <div className="flex min-h-[90vh] flex-col items-center sm:min-h-screen">


### PR DESCRIPTION
Production white-screened after the deploy with `Cannot read properties of undefined (reading 'toLowerCase')` at `onboarding-config.ts:12`.

Root cause: `onboardingSteps` was a top-level `export const` calling `i18n.t()` at **module-load** time. When the home chunk evaluates before i18next has initialized its namespaces, `i18n.t('c:organization')` returns `undefined` and `.toLowerCase()` throws. (A genuinely missing key returns the key string, which wouldn't crash — so this is purely an init-timing bug, latent on main and surfaced now that production ships this frontend.)

Fix: convert to `getOnboardingSteps()`, evaluated at render time (steps `useState` initializer, footer skip handler) when i18next is ready. `onboarding-config` was the only module-scope `i18n.t()` offender (menu-config / update-row calls are all inside functions). Behavior otherwise unchanged; frontend typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)