### PR TITLE
fix(infra): prefer AWS_* credentials for the control-store read

### DIFF
--- a/infra/resources/control.ts
+++ b/infra/resources/control.ts
@@ -6,8 +6,12 @@ import { errorMessage } from '../lib/utils/errors'
 async function loadControlState(): Promise<ControlState> {
   if (process.env.VITEST) return emptyControlState()
 
-  const accessKey = process.env.SCW_ACCESS_KEY ?? process.env.AWS_ACCESS_KEY_ID
-  const secretKey = process.env.SCW_SECRET_KEY ?? process.env.AWS_SECRET_ACCESS_KEY
+  // AWS_* first: they are the state-backend S3 credentials, and Scaleway's S3
+  // gateway only honors project-scoped ObjectStorage grants, which an
+  // API-capable SCW_* identity may lack. Normal deploys set both pairs to the
+  // same key, so the order only matters for split-identity operator runs.
+  const accessKey = process.env.AWS_ACCESS_KEY_ID ?? process.env.SCW_ACCESS_KEY
+  const secretKey = process.env.AWS_SECRET_ACCESS_KEY ?? process.env.SCW_SECRET_KEY
   if (!accessKey || !secretKey) {
     pulumi.log.warn('control-store: no S3 credentials in env; rollout state defaults to first-provision values')
     return emptyControlState()


### PR DESCRIPTION
## What

`loadControlState` in `infra/resources/control.ts` now prefers `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` over `SCW_ACCESS_KEY`/`SCW_SECRET_KEY` when reading the rollout control object from the state bucket.

## Why

The control object lives in the Pulumi state bucket, and Scaleway's S3 gateway only honors **project-scoped** ObjectStorage grants: an org-wide `ObjectStorageFullAccess` rule (for example on an `AllProductsFullAccess` provisioning identity) is not accepted by the S3 API, even for keys whose `default_project_id` matches the bucket's project.

This surfaced during a production database recovery: the run needed a split-identity setup where `SCW_*` held an API-capable provisioning key (provider resources, IPAM lookup in `loadbalancer.ts`) and `AWS_*` held the ObjectStorage-scoped operator key that the state backend already uses. With `SCW_*` preferred, the control-store read failed with `Access Denied` and aborted the plan, even though the process had working S3 credentials in `AWS_*` the whole time.

`AWS_*` are by definition the credentials that can reach the state bucket (`pulumi login s3://...` uses them), so they are the right first choice for a reader of that same bucket.

## Behavior change

None for normal deploys: `deploy-run.ts` derives `AWS_* ??= SCW_*`, so both pairs hold the same key and the preference order is invisible. The order only matters when an operator deliberately splits identities.

## Test plan

- `pnpm check` clean at the repo root.
- Exercised in a real split-identity recovery run (raak production, 2026-07-31): control-store read succeeded with `AWS_*` = operator key while `SCW_*` held a provisioning key without S3 access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
