### PR TITLE
fix(backend): include committed tree hash in openapi cache fingerprint

### DIFF
--- a/backend/scripts/generate-openapi.ts
+++ b/backend/scripts/generate-openapi.ts
@@ -15,16 +15,26 @@ const OPENAPI_RELEVANT_PATHS = [
   'src/',
 ];
 
-/** Get hash of git diff for relevant backend paths */
-function getGitDiffHash(): string | null {
+/** Fingerprint of committed content plus uncommitted diff for relevant backend paths */
+function getGitFingerprint(): string | null {
   try {
+    const cwd = resolve(import.meta.dirname, '..');
+    const hash = createHash('sha256');
+    // Committed tree hash per path: a diff against HEAD alone misses commits
+    // arriving via pull/merge (clean tree before and after, same empty diff),
+    // which left a stale cache in place until --force. `./` keeps the path
+    // relative to backend/, matching OPENAPI_RELEVANT_PATHS.
+    for (const path of OPENAPI_RELEVANT_PATHS) {
+      const tree = execSync(`git rev-parse HEAD:./${path.replace(/\/$/, '')}`, { cwd, encoding: 'utf-8' });
+      hash.update(tree);
+    }
     const paths = OPENAPI_RELEVANT_PATHS.join(' ');
     const diff = execSync(`git diff --no-color HEAD -- ${paths}`, {
-      cwd: resolve(import.meta.dirname, '..'),
+      cwd,
       encoding: 'utf-8',
       maxBuffer: 10 * 1024 * 1024, // 10MB buffer for large diffs
     });
-    return createHash('sha256').update(diff).digest('hex').slice(0, 16);
+    return hash.update(diff).digest('hex').slice(0, 16);
   } catch {
     // Git not available or not a git repo - always regenerate
     return null;
@@ -49,7 +59,7 @@ function canSkipGeneration(): { skip: boolean; reason: string; hash: string | nu
     return { skip: false, reason: 'force flag', hash: null };
   }
 
-  const currentHash = getGitDiffHash();
+  const currentHash = getGitFingerprint();
   if (currentHash === null) {
     return { skip: false, reason: 'git not available', hash: null };
   }


### PR DESCRIPTION
## What

`backend/scripts/generate-openapi.ts` skip-detection now fingerprints the **committed tree** of the relevant paths (`git rev-parse HEAD:./src`, cwd-relative from `backend/`) in addition to the uncommitted diff. The manifest key stays `diffHash`; existing manifests regenerate once because the fingerprint format changed.

## The bug

The skip check hashed only `git diff HEAD -- src/`, i.e. uncommitted changes. Commits that arrive with a clean working tree (pull, merge, checkout) leave that diff empty before and after, so the hash never changes and the generator skips forever on a stale `openapi.cache.json`.

Concrete failure (raak, 2026-07-31): after pulling a `feat!` that renamed a Task field, `pnpm sdk` kept reporting "OpenAPI generation skipped — no changes" and regenerated the SDK from a week-old cache, resurrecting the pre-rename wire shape. The committed `sdk/gen` and the freshly "regenerated" one disagreed, and `pnpm check` failed in frontend files that were correct. Only `--force` recovered.

This inverts the file's own stated invariant ("false positives are safe, false negatives are not"): the diff-only hash produced a false negative on the most common repo operation, pulling main.

## The fix

Hash `git rev-parse HEAD:<path>` for each relevant path (the tree object id of the committed content) together with the uncommitted diff. Any pulled or merged change under `backend/src` changes the tree id, so the cache regenerates; false positives remain safe.

## Test plan

- `pnpm check` clean at the repo root.
- Functional, in a worktree: run once (generates), run again (skips, "no changes"), commit a whitespace edit under `backend/src` with a clean tree afterwards, run again: regenerates ("files changed") where the old logic skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
