### PR TITLE
fix(frontend): splice blocknote-created attachments into the canonical list cache

### DIFF
--- a/frontend/src/modules/attachment/helpers/persist-attachments.ts
+++ b/frontend/src/modules/attachment/helpers/persist-attachments.ts
@@ -1,14 +1,19 @@
 import type { Attachment } from 'sdk';
 import { createAttachmentsMutationFn } from '~/modules/attachment/query-mutations';
+import { insertEntitiesIntoHome } from '~/query/basic/apply-entity-to-lists';
+import { queryClient } from '~/query/query-client';
 
 /**
- * Persist parsed BlockNote attachments under their stable client IDs through the shared mutation.
- * The imperative path preserves hook-equivalent timestamping and offline replay.
+ * Persist parsed BlockNote attachments under their stable client IDs through the shared mutation fn.
+ * The confirmed rows are spliced into the canonical home list, mirroring the create mutation's
+ * onSuccess: the own-create realtime echo only patches rows in place, so without this splice the
+ * attachment stays invisible to list consumers until the next refetch.
  */
 export async function persistAttachments(
   attachments: Attachment[],
   { tenantId, organizationId }: { tenantId: string; organizationId: string },
 ): Promise<void> {
   if (!attachments.length) return;
-  await createAttachmentsMutationFn({ tenantId, organizationId, data: attachments });
+  const result = await createAttachmentsMutationFn({ tenantId, organizationId, data: attachments });
+  insertEntitiesIntoHome(queryClient, result.data);
 }


### PR DESCRIPTION
## Problem

Uploading an image through the BlockNote editor (e.g. organization settings → details welcome text) creates an attachment that increments the unseen badge but never appears in the attachments table until an unrelated refetch (refocus/reconnect/reload).

## Cause

No backend mismatch — the list op and the unseen-count op share the identical collection-read scope, and the row is returned by a fresh list fetch. The gap is frontend cache population:

1. `persistAttachments` called `createAttachmentsMutationFn` directly, bypassing the registered create mutation — so neither the optimistic `onMutate` insert nor the confirmed `onSuccess` `insertEntitiesIntoHome` splice ever ran.
2. The compensating realtime path is deliberately suppressed for own creates: the mutation fn stamps this client's `stx.sourceId`, so the SSE echo hits the echo branch in `app-stream-handler`, which only patches rows in place and never inserts a missing row.

Net: the DB row exists (badge counts it via server recount), but the canonical home-list cache — the only source for the table's default view — never receives it.

## Fix

Mirror the create mutation's `onSuccess` in `persistAttachments`: splice the server-confirmed rows into the canonical home list with `insertEntitiesIntoHome(queryClient, result.data)`. Idempotent against later refetches (updates in place if present), and composes with echo suppression — the echo now finds the row and stamps its stx. Also drops the JSDoc claim of offline replay: a direct fn call never enters the mutation cache.

## Fork safety

Checked against raak: `persist-attachments.ts` doesn't exist there yet (the details-form media feature postdates its last sync), and every file the fix imports (`apply-entity-to-lists`, `query-client`, `query-mutations`, echo suppression in `app-stream-handler`) is byte-identical in raak. Raak's project-scoped attachment divergence travels inside each attachment item, so the helper's signature needs no fork change.

## Verification

- Frontend + full workspace typecheck, biome, SDK regen (unchanged), commitlint — all pass via hooks
- Attachment module + `apply-entity-to-lists` tests: 69 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)