### PR TITLE
docs: deprecate child-side product host FKs in favor of owned embeddings

### DIFF
--- a/cella/AGENTS.md
+++ b/cella/AGENTS.md
@@ -107,6 +107,28 @@ The permission system in `backend/src/permissions/` provides: the `checkAccess*`
 - **Schema evolution (lenses)**: breaking wire-shape changes to product entities ship as append-only lens modules in `shared/src/schema-evolution/`; never edit a shipped module. Until the first lens ships, bump `appConfig.clientCacheVersion` in the same PR as any breaking change to a cached entity's wire shape (`schema-bust-gate` CI enforces this). Playbook: [Schema evolution](/docs/page/architecture/schema-evolution).
 - **Lens seams (new entity modules)**: build update bodies with `createUpdateSchema(entityType, shape)`, create bodies with `widenBodySchema(entityType, schema)`, resolve updates via `resolveUpdateOps(entityType, …)`, and map create items through `normalizeCreateItem(entityType, item)`. These carry the lens widening/normalization; skipping them breaks version tolerance for that entity.
 
+## Cross-product references
+
+Relationships between products are data, never permission indirection (permissions and public
+read always flow through the hierarchy's channel columns). Exactly two mechanisms are sanctioned
+for product-to-product references:
+
+1. **`productEmbeddings` host id arrays**: the host product's table carries an id array column,
+   declared in `appConfig.productEmbeddings`. The generic machinery (CDC embedding cleanup,
+   owned-embedding GC, ref counters, SSE propagation hints, client cache patching) is
+   config-driven; apps extend the registry, the engine code never changes. `lifecycle: 'shared'`
+   (default) means embedded rows live independently and dead references are stripped from hosts;
+   `lifecycle: 'owned'` means the union of host arrays is the row's reason to exist and the CDC
+   worker soft-deletes rows no live host references.
+2. **The mutation bus** (`defineBackendModule` + `onMutation`/`dispatchMutation`): for lifecycle
+   side effects an embedding cannot express, e.g. seeding rows on `project.created` or
+   propagating config edits. Handlers run synchronously, optionally inside the write transaction.
+
+A child-side host FK (a nullable `<host>Id` column on one product pointing at another) is
+deprecated: it is invisible to sync views, CDC, propagation hints, and counters, and it forces
+app edits inside template-owned modules. See
+`cella/migrations/20260730T1009-owned-host-embedding/` for the conversion guide.
+
 ## Coding patterns
 
 - **Entities**: `ChannelEntityType` (has memberships) and `ProductEntityType` (content-related). See `cella/ARCHITECTURE.md`.

--- a/cella/migrations/20260730T1009-owned-host-embedding/README.md
+++ b/cella/migrations/20260730T1009-owned-host-embedding/README.md
@@ -1,0 +1,66 @@
+# Product host FKs move to owned embeddings
+
+## What & why
+
+The child-side host FK pattern for product-to-product ownership (a nullable `<host>Id` column on
+one product row pointing at another product, e.g. `attachments.taskId`) is deprecated in favor of
+a host-side id array registered in `appConfig.productEmbeddings` with `lifecycle: 'owned'`. A
+child-side FK is invisible to every generic layer (sync view declarations, CDC embedding cleanup,
+SSE propagation hints, counters, client cache patching) and forces the fork to edit
+template-owned module files, which is exactly where sync friction concentrates.
+
+The template already ships everything the flip needs: the `lifecycle: 'shared' | 'owned'`
+discriminant on `productEmbeddings` (`shared/src/config-builder/types.ts`), the CDC worker's
+owned-embedding GC (`cdc/src/utils/owned-embedding-gc.ts`, host-side dispatch in
+`cdc/src/pipeline/process-events.ts`), the `attachmentId` media-block reference prop
+(`withAttachmentRef` in `shared/utils/blocknote-schema-configs`, see
+`20260723T1705-media-attachment-ref`), the shared description walk with attachment-id collection
+(`shared/utils/derive-description-core`), and id-array handling in the client propagation patcher
+(`frontend/src/query/realtime/propagation.ts`). Registering an `owned` entry activates the GC;
+with no entry it stays inert.
+
+## Blast radius
+
+The template itself changes nothing here: no DB change, no wire change, no `clientCacheVersion`
+bump upstream. An app that never added a product-to-product host FK is unaffected. An app that
+did (the `taskId`-style column this guide targets) performs a sync-breaking flip on its own side,
+with its own DB migration and its own cache bump or lens, at a moment of its choosing.
+
+## Run
+
+No script, manual.
+
+## Manual steps
+
+1. Add the host array to the HOST product's table (app-owned): a `uuid().array().notNull()`
+   column with `'{}'::uuid[]` default plus a GIN index (the GC refcount check reads it).
+2. Register the embedding in the app config:
+   `{ embeddedProduct: '<child>', hostProduct: '<host>', hostColumn: '<column>', lifecycle: 'owned' }`.
+3. Derive the array from the app's linkage source. For description-hosted media, collect
+   `attachmentId` block props via `countDescriptionBlocks` on create/update and narrow the
+   candidate ids to live in-org child rows inside the write transaction.
+4. In the same drizzle migration: backfill the host arrays from the legacy FK
+   (`array_agg` over the child table grouped by the FK, excluding soft-deleted rows), then drop
+   the FK column and its index.
+5. Delete the FK-based lifecycle code: the delete-cascade query and any `onMutation` handler that
+   soft-deleted child rows in-request. The CDC GC now owns deletion: hosts surrendering ids (array
+   shrink or host soft-delete) trigger a refcount check, and orphans are soft-deleted
+   asynchronously. Expect tombstone latency to move from in-request to CDC latency.
+6. Remove the FK from the child's create body schema, create operation, mocks, and any client
+   upload flow that stamped it; the reference now rides the host-side derivation source.
+7. Ship the wire change per the schema-evolution playbook: the host entity gains the array field
+   and the child loses the FK, so bump `clientCacheVersion` (or ship a lens) in the same PR and
+   title it `feat!:`.
+
+## Verify
+
+```sh
+pnpm generate
+pnpm sdk
+pnpm check
+pnpm --filter cdc-worker exec vitest run src/tests/owned-embedding-gc.test.ts
+```
+
+Then verify at runtime: removing an embedded reference (or deleting the host) tombstones the
+orphaned child row via CDC within a few seconds, and child rows never referenced by any host
+array are left untouched.

--- a/cella/migrations/manifest.json
+++ b/cella/migrations/manifest.json
@@ -336,6 +336,27 @@
       "summary": "Frontend *-module.ts(x) files switch registerModule -> defineFrontendModule (~/lib/module); a glob composition root frontend/src/modules.ts loads them before first render. UI placements arrive with settled vocabulary: modules declare tools into slots ('${channelType}.settings', 'account.settings'); built-in settings sections are registered tools and the settings pages are pure consumers. Tools render full cards (lazy), gate on requires (grants) and visibleTo context-role pairs ('organization.admin', hierarchy-validated, matched over the ancestor chain; UI-only). Arrangement layers: manifest defaults, pinned placement-config.ts overrides, then the new organizations.tools_config jsonb (per-slot order/hidden/settings, admin Tools card, fail-closed reconciliation; locked tools immune to channel hiding). organizationSettingsSections (pinned file + type) removed. staticData.navTab typed PlacementDescriptor; system default tab derives from first visible tab. nav-buttons id special-cases move to NavItem iconSlot/badgeSlot in pinned nav-config.tsx. DB: additive tools_config column (pnpm generate); wire: additive optional toolsConfig on organization (no cache bump). Needs @cellajs/cli with the define*Module territory-scan matcher."
     },
     {
+      "id": "20260730T1009-owned-host-embedding",
+      "version": "next",
+      "title": "Product host FKs move to owned embeddings",
+      "kind": "manual",
+      "syncBreaking": false,
+      "clientCacheBump": false,
+      "script": null,
+      "roots": [
+        "backend/src",
+        "backend/drizzle",
+        "frontend/src",
+        "shared"
+      ],
+      "requires": [
+        "pnpm generate",
+        "pnpm sdk",
+        "pnpm check"
+      ],
+      "summary": "Child-side product-to-product host FK columns (taskId-style) are deprecated in favor of host-side id arrays registered as lifecycle 'owned' productEmbeddings. The template machinery (owned-embedding GC in the CDC worker, attachmentId media-block refs, derive-description-core collection, propagation id-array patching) already ships and activates on the first 'owned' entry. Template-side this is docs-only: apps without a host FK are unaffected; apps with one flip on their own schedule (host array + GIN, backfill from FK, drop FK and in-request cascades, own cache bump, feat!)."
+    },
+    {
       "id": "20260730T1258-cella-config-into-cella-folder",
       "version": "next",
       "title": "Move cella sync files into the cella/ folder",


### PR DESCRIPTION
## What

Adds the missing docs half of the owned-embedding lifecycle work (#960):

- **`cella/migrations/20260730T1009-owned-host-embedding/`**: manual migration with the full conversion guide for apps that carry a child-side product-to-product host FK (a nullable `<host>Id` column, `attachments.taskId`-style): host array + GIN index, backfill from the FK, drop the FK and in-request cascades, register the `lifecycle: 'owned'` embedding, ship the wire change with a cache bump or lens.
- **`cella/migrations/manifest.json`**: the matching entry (`kind: manual`, `syncBreaking: false`, `version: next`), inserted in chronological position.
- **`cella/AGENTS.md`**: a `## Cross-product references` section naming the two sanctioned mechanisms for product-to-product references (`productEmbeddings` host id arrays and the mutation bus) and deprecating the child-side host FK, which is invisible to sync views, CDC, propagation hints, and counters.

## Why

The engine side already shipped in #960 (`lifecycle: 'shared' | 'owned'`, CDC owned-embedding GC, `withAttachmentRef`, `derive-description-core`, id-array propagation patching) and stays inert until an app registers an `owned` entry. What was missing is the guidance telling apps the FK pattern is deprecated and how to flip. The guide was authored and applied in raak (cellajs/raak#94, `attachment.taskId` → `tasks.attachments`), so the steps are proven against a real conversion.

Template-side this is docs-only: no code, no DB change, no wire change, not sync-breaking. All file paths cited in the README were verified to exist on current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)