### PR TITLE
fix(frontend): mobile viewport height strategy

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/static/common/icons/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/static/common/icons/favicon-16x16.png">
   <link rel="icon" href="/static/common/icons/favicon.svg" type="image/svg+xml">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
   <title>
     <%= title %>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -16,6 +16,7 @@ import { reportReactError } from '~/lib/maple';
 import { AppRouter } from '~/modules/common/app/app-router';
 import { QueryClientProvider } from '~/query/provider';
 import { initFaviconBadge } from '~/utils/init-favicon-badge';
+import { initViewportObserver } from '~/utils/viewport-observer';
 
 // Configure the SDK client with runtime settings (credentials, error handling, etc.)
 client.setConfig(createClientConfig());
@@ -26,6 +27,8 @@ if (!root) throw new Error('Root element not found');
 renderAscii();
 
 initFaviconBadge(appConfig.mode);
+
+initViewportObserver();
 
 // In dev server mode, unregister any lingering service workers left by `pnpm offline`.
 // `import.meta.env.DEV` is true only for the Vite dev server, not for `vite preview`.

--- a/frontend/src/modules/attachment/dialog/attachment-dialog.tsx
+++ b/frontend/src/modules/attachment/dialog/attachment-dialog.tsx
@@ -71,7 +71,7 @@ export function AttachmentDialog() {
   const blocking = isLoading || awaitingContext || awaitingGroup || isFetchingSingle;
   if (blocking && !hasRenderedRef.current) {
     return (
-      <div className="flex h-screen items-center justify-center">
+      <div className="flex h-dvh items-center justify-center">
         <Spinner className="h-12 w-12" />
       </div>
     );
@@ -97,7 +97,7 @@ export function AttachmentDialog() {
   // Success state - show carousel with resolved attachments
   hasRenderedRef.current = true;
   return (
-    <div className="relative -z-1 flex h-screen grow flex-wrap justify-center p-2">
+    <div className="relative -z-1 flex h-dvh grow flex-wrap justify-center p-2">
       <AttachmentsCarousel items={resolvedItems} isDialog itemIndex={itemIndex} saveInSearchParams />
     </div>
   );

--- a/frontend/src/modules/attachment/dialog/params.ts
+++ b/frontend/src/modules/attachment/dialog/params.ts
@@ -11,7 +11,7 @@ const ATTACHMENT_DIALOG_EXTRA_PARAMS = ['groupId'] as const;
 export const attachmentDialogClassName = 'min-w-full h-dvh max-h-dvh border-0 p-0 rounded-none flex flex-col mt-0';
 
 /** Wrapper the carousel is mounted in, identical for both dialog entry points. */
-export const attachmentDialogContentClassName = 'relative -z-1 flex h-screen grow flex-wrap justify-center p-2';
+export const attachmentDialogContentClassName = 'relative -z-1 flex h-dvh grow flex-wrap justify-center p-2';
 
 /** Search-param patch that opens the dialog on `attachmentId`. */
 export function openAttachmentDialogSearch(attachmentId: string, groupId?: string | null) {

--- a/frontend/src/modules/auth/auth-layout.tsx
+++ b/frontend/src/modules/auth/auth-layout.tsx
@@ -23,7 +23,7 @@ export function AuthLayout() {
     <div
       data-started={hasStarted}
       data-waited={hasWaited}
-      className="group rich-gradient container flex min-h-[90vh] flex-col items-center before:fixed after:fixed sm:min-h-screen"
+      className="group rich-gradient container flex min-h-[90svh] flex-col items-center before:fixed after:fixed sm:min-h-svh"
     >
       {/* Render bg animation */}
       <Suspense fallback={<div className="fixed top-0 left-0 h-full w-full bg-loading-placeholder" />}>

--- a/frontend/src/modules/auth/sign-out.tsx
+++ b/frontend/src/modules/auth/sign-out.tsx
@@ -38,5 +38,5 @@ export function SignOut() {
     handleSignOut();
   }, []);
 
-  return <ContentPlaceholder className="h-screen" icon={HeartIcon} title="c:signing_out" />;
+  return <ContentPlaceholder className="h-svh" icon={HeartIcon} title="c:signing_out" />;
 }

--- a/frontend/src/modules/common/app/app-content.tsx
+++ b/frontend/src/modules/common/app/app-content.tsx
@@ -23,7 +23,7 @@ export function AppContent() {
     >
       <div
         id="app-content"
-        className="relative flex min-h-svh min-w-0 flex-1 flex-col max-sm:min-h-[calc(100svh-4rem)]"
+        className="relative flex min-h-svh min-w-0 flex-1 flex-col max-sm:min-h-[calc(100svh-4rem-env(safe-area-inset-bottom,0px))]"
       >
         <main id="app-content-inner" className="flex flex-1 flex-col focus:outline-none" aria-label="Main Content">
           <FocusTarget target="content" />

--- a/frontend/src/modules/common/app/app-layout.tsx
+++ b/frontend/src/modules/common/app/app-layout.tsx
@@ -16,7 +16,7 @@ import { TabCoordinator } from '~/query/realtime/tab-coordinator';
 
 function AppLayout() {
   return (
-    <div id="appLayout" className="in-[.floating-nav]:mb-0 max-sm:mb-16">
+    <div id="appLayout" className="in-[.floating-nav]:mb-0 max-sm:mb-[calc(4rem+env(safe-area-inset-bottom,0px))]">
       <ErrorBoundary
         fallbackRender={({ error, resetErrorBoundary }) => (
           <ErrorNotice error={error as ErrorNoticeError} boundary="root" resetErrorBoundary={resetErrorBoundary} />

--- a/frontend/src/modules/common/board/board-layout.tsx
+++ b/frontend/src/modules/common/board/board-layout.tsx
@@ -206,7 +206,7 @@ export function BoardLayout({
   return (
     <ScrollArea
       className={cn(
-        'transition sm:h-[calc(100vh-var(--board-offset-sm))] md:h-[calc(100vh-var(--board-offset-md))]',
+        'transition sm:h-[calc(100dvh-var(--board-offset-sm))] md:h-[calc(100dvh-var(--board-offset-md))]',
         className,
       )}
       viewportClassName="overflow-y-hidden! overscroll-y-auto"

--- a/frontend/src/modules/common/board/board-panel.tsx
+++ b/frontend/src/modules/common/board/board-panel.tsx
@@ -61,7 +61,7 @@ export function BoardPanelBody({
         'group/panel relative flex max-w-full flex-1 shrink-0 snap-center flex-col rounded-b-none bg-transparent opacity-100 sm:border',
         // Highlight border when an ancestor wrapper is marked as a drop-target hover (see board-panel.tsx)
         'group-data-[highlighted=true]/paneldrop:border-primary',
-        !windowScroll && 'sm:h-[calc(100vh-var(--board-panel-offset))]',
+        !windowScroll && 'sm:h-[calc(100dvh-var(--board-panel-offset))]',
         hasSelection && 'is-selected',
         className,
       )}

--- a/frontend/src/modules/common/data-grid/cell-renderers/render-enum-select.tsx
+++ b/frontend/src/modules/common/data-grid/cell-renderers/render-enum-select.tsx
@@ -90,7 +90,7 @@ export function RenderEnumSelect<TRow extends { id: string }, TValue extends str
       <>
         <span ref={probeRef} aria-hidden className="hidden" />
         <Drawer open onOpenChange={handleOpenChange}>
-          <DrawerContent className="max-h-[70vh]">
+          <DrawerContent className="max-h-[70dvh]">
             <DrawerHeader className="p-0">
               <span className="sr-only">
                 <DrawerTitle>Choose</DrawerTitle>

--- a/frontend/src/modules/common/dropdowner/drawer.tsx
+++ b/frontend/src/modules/common/dropdowner/drawer.tsx
@@ -19,7 +19,7 @@ export function DropdownerDrawer({ dropdown }: { dropdown: InternalDropdown }) {
 
   return (
     <Drawer key={id} open={true} onOpenChange={onOpenChange}>
-      <DrawerContent id={String(id)} className="max-h-[70vh]">
+      <DrawerContent id={String(id)} className="max-h-[70dvh]">
         <DrawerHeader data-overlay="dropdown" className="p-0">
           <span className="sr-only">
             <DrawerTitle>Choose</DrawerTitle>

--- a/frontend/src/modules/common/error-notice.tsx
+++ b/frontend/src/modules/common/error-notice.tsx
@@ -59,7 +59,7 @@ export function ErrorNotice({ error, children, resetErrorBoundary, boundary, hom
   return (
     <>
       {boundary === 'root' && <Dialoger />}
-      <div className="error-notice container flex min-h-[calc(100vh-10rem)] flex-col items-center">
+      <div className="error-notice container flex min-h-[calc(100svh-10rem)] flex-col items-center">
         <div className="mx-auto my-auto">
           <Card className="mt-8 w-[80vw] max-w-[80vw] border-none bg-transparent sm:w-160">
             <CardHeader className="p-0 text-center">

--- a/frontend/src/modules/common/focus-view.tsx
+++ b/frontend/src/modules/common/focus-view.tsx
@@ -57,7 +57,7 @@ export function FocusViewContainer({ children, className = '', disabled }: Focus
   return (
     <div
       className={cn(
-        'focus-view-container container flex min-h-screen flex-col gap-2 pt-3',
+        'focus-view-container container flex min-h-svh flex-col gap-2 pt-3',
         className,
         isActive ? 'focused min-h-full w-full min-w-full max-w-none' : '',
       )}

--- a/frontend/src/modules/common/scroll-reset.tsx
+++ b/frontend/src/modules/common/scroll-reset.tsx
@@ -22,7 +22,7 @@ export function ScrollReset({ children }: { children: ReactNode }) {
   return (
     <ScrollResetContext.Provider value={scrollToReset}>
       <div ref={ref} className="h-0" aria-hidden />
-      <div className="min-h-screen">{children}</div>
+      <div className="min-h-svh">{children}</div>
     </ScrollResetContext.Provider>
   );
 }

--- a/frontend/src/modules/common/sheeter/sheet.tsx
+++ b/frontend/src/modules/common/sheeter/sheet.tsx
@@ -106,7 +106,8 @@ export function SheeterSheet({ sheet }: { sheet: InternalSheet }) {
           <AnimatePresence mode="popLayout" initial={false}>
             <motion.div
               key={contentKey}
-              className="flex flex-1 flex-col"
+              // h-full keeps the height definite so sheet content can resolve min-h-full against it
+              className="flex h-full flex-1 flex-col"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -20 }}

--- a/frontend/src/modules/common/sheeter/sheet.tsx
+++ b/frontend/src/modules/common/sheeter/sheet.tsx
@@ -106,8 +106,7 @@ export function SheeterSheet({ sheet }: { sheet: InternalSheet }) {
           <AnimatePresence mode="popLayout" initial={false}>
             <motion.div
               key={contentKey}
-              // h-full keeps the height definite so sheet content can resolve min-h-full against it
-              className="flex h-full flex-1 flex-col"
+              className="flex flex-1 flex-col"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -20 }}

--- a/frontend/src/modules/common/stories/scroll-spy.stories.tsx
+++ b/frontend/src/modules/common/stories/scroll-spy.stories.tsx
@@ -235,7 +235,7 @@ const ScrollSpyPage = ({
   label?: string;
   showTests?: boolean;
 }) => (
-  <div className="min-h-screen bg-background text-foreground">
+  <div className="min-h-svh bg-background text-foreground">
     {/* Sticky header */}
     <div className="sticky top-0 z-10 border-b bg-background/95 p-3 backdrop-blur">
       <h1 className="font-semibold text-base">{label ?? 'Scroll Spy Test'}</h1>
@@ -246,7 +246,7 @@ const ScrollSpyPage = ({
 
     <div className="flex">
       {/* Sidebar */}
-      <div className="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-64 shrink-0 overflow-y-auto border-r p-4 md:block">
+      <div className="sticky top-14 hidden h-[calc(100dvh-3.5rem)] w-64 shrink-0 overflow-y-auto border-r p-4 md:block">
         <Sidebar withRouter={withRouter} />
         {showTests && (
           <div className="mt-4">

--- a/frontend/src/modules/docs/sidebar/docs-sidebar.tsx
+++ b/frontend/src/modules/docs/sidebar/docs-sidebar.tsx
@@ -44,7 +44,7 @@ export function DocsSidebar({ tags }: DocsSidebarProps) {
   };
 
   return (
-    <SidebarContent className="min-h-full flex-none overflow-visible bg-card pt-2 pb-24">
+    <SidebarContent className="min-h-dvh flex-none overflow-visible bg-card pt-2 pb-24">
       <div aria-hidden="true" className="sticky top-0 z-20 -mb-4 h-2 shrink-0 bg-card" data-slot="sticky-mask" />
 
       <div className="my-2 flex items-center gap-2 px-4 pt-2">

--- a/frontend/src/modules/docs/sidebar/docs-sidebar.tsx
+++ b/frontend/src/modules/docs/sidebar/docs-sidebar.tsx
@@ -44,7 +44,7 @@ export function DocsSidebar({ tags }: DocsSidebarProps) {
   };
 
   return (
-    <SidebarContent className="min-h-screen flex-none overflow-visible bg-card pt-2 pb-24">
+    <SidebarContent className="min-h-full flex-none overflow-visible bg-card pt-2 pb-24">
       <div aria-hidden="true" className="sticky top-0 z-20 -mb-4 h-2 shrink-0 bg-card" data-slot="sticky-mask" />
 
       <div className="my-2 flex items-center gap-2 px-4 pt-2">

--- a/frontend/src/modules/home/onboarding/completed.tsx
+++ b/frontend/src/modules/home/onboarding/completed.tsx
@@ -38,7 +38,7 @@ export function OnboardingCompleted() {
   }, [mutate, setSectionsDefault, hasOrganization, orgQuery.isFetching]);
 
   return (
-    <div className="relative z-1 mx-auto flex h-screen min-w-full max-w-3xl flex-col items-center justify-center space-y-6 p-4 text-center">
+    <div className="relative z-1 mx-auto flex h-svh min-w-full max-w-3xl flex-col items-center justify-center space-y-6 p-4 text-center">
       {isExploding && <Confetti fire />}
 
       {user.userFlags.finishedOnboarding && (

--- a/frontend/src/modules/home/onboarding/steps.tsx
+++ b/frontend/src/modules/home/onboarding/steps.tsx
@@ -55,7 +55,7 @@ export function Onboarding({
   });
 
   return (
-    <div className="flex min-h-[90vh] flex-col items-center sm:min-h-screen">
+    <div className="flex min-h-[90svh] flex-col items-center sm:min-h-svh">
       <div className="mt-auto mb-auto w-full">
         {onboarding === 'start' && <WelcomeText onboardingToStepper={() => setOnboardingState('stepper')} />}
         {onboarding === 'stepper' && (

--- a/frontend/src/modules/home/welcome-page.tsx
+++ b/frontend/src/modules/home/welcome-page.tsx
@@ -31,7 +31,7 @@ function WelcomePage() {
       <Dialog open={onboarding !== 'completed'} onOpenChange={onOpenChange} defaultOpen={true}>
         <DialogContent
           aria-describedby={undefined}
-          className="mt-0 flex h-screen max-h-none min-w-full flex-col overflow-y-auto rounded-none border-0 bg-background/75 p-0 max-sm:max-h-dvh"
+          className="mt-0 flex h-dvh max-h-none min-w-full flex-col overflow-y-auto rounded-none border-0 bg-background/75 p-0"
         >
           <span className="sr-only">
             <DialogTitle>Welcome</DialogTitle>

--- a/frontend/src/modules/marketing/accessibility-page.tsx
+++ b/frontend/src/modules/marketing/accessibility-page.tsx
@@ -7,7 +7,7 @@ export function AccessibilityPage() {
   return (
     <MarketingLayout title={t('c:accessibility')}>
       <section className="bg-background py-16">
-        <div className="mx-auto min-h-screen max-w-3xl px-4 md:px-8">
+        <div className="mx-auto min-h-svh max-w-3xl px-4 md:px-8">
           <p>Accessibility statement here</p>
         </div>
       </section>

--- a/frontend/src/modules/marketing/legal/legal-page.tsx
+++ b/frontend/src/modules/marketing/legal/legal-page.tsx
@@ -52,7 +52,7 @@ export function LegalPage() {
         </div>
 
         {/* Main legal content */}
-        <div className="flex min-h-screen flex-col gap-8 md:w-[75%]">
+        <div className="flex min-h-svh flex-col gap-8 md:w-[75%]">
           {subjects.map(({ id }) => {
             const isActive = id === currentSubject;
             const Component = legalConfig[id].component;
@@ -60,7 +60,7 @@ export function LegalPage() {
               isActive && (
                 <div
                   key={id}
-                  className="prose dark:prose-invert mb-40 min-h-screen max-w-full bg-background px-4 pt-4 text-foreground antialiased md:px-8 lg:mx-auto lg:max-w-4xl"
+                  className="prose dark:prose-invert mb-40 min-h-svh max-w-full bg-background px-4 pt-4 text-foreground antialiased md:px-8 lg:mx-auto lg:max-w-4xl"
                 >
                   <h2 className="pt-8 pb-4 font-bold text-2xl">{t(legalConfig[id].label)}</h2>
                   <Component />

--- a/frontend/src/modules/navigation/account-sheet.tsx
+++ b/frontend/src/modules/navigation/account-sheet.tsx
@@ -80,7 +80,7 @@ export function AccountSheet() {
   }, []);
 
   return (
-    <div ref={buttonWrapper} className="group/menu flex min-h-full w-full flex-col bg-card">
+    <div ref={buttonWrapper} className="group/menu flex min-h-dvh w-full flex-col bg-card">
       <FocusTarget target="sheet" />
       <div className="flex items-center justify-between px-3 pt-3">
         <h2 className="p-2 font-semibold text-base">{t('c:account')}</h2>

--- a/frontend/src/modules/navigation/account-sheet.tsx
+++ b/frontend/src/modules/navigation/account-sheet.tsx
@@ -80,7 +80,7 @@ export function AccountSheet() {
   }, []);
 
   return (
-    <div ref={buttonWrapper} className="group/menu flex min-h-screen w-full flex-col bg-card">
+    <div ref={buttonWrapper} className="group/menu flex min-h-full w-full flex-col bg-card">
       <FocusTarget target="sheet" />
       <div className="flex items-center justify-between px-3 pt-3">
         <h2 className="p-2 font-semibold text-base">{t('c:account')}</h2>

--- a/frontend/src/modules/navigation/bottom-bar-nav.tsx
+++ b/frontend/src/modules/navigation/bottom-bar-nav.tsx
@@ -31,7 +31,7 @@ export function BottomBarNav({ triggerNavItem }: BottomBarNavProps) {
     <nav
       id="bottom-bar-nav"
       data-started={hasStarted}
-      className="fixed bottom-0 z-100 flex w-full flex-row justify-between bg-sidebar shadow-xs transition-transform ease-out group-[.focus-view]/body:hidden group-[.selection-active]/body:translate-y-full data-[started=false]:translate-y-full"
+      className="fixed bottom-0 z-100 flex w-full flex-row justify-between bg-sidebar pb-[env(safe-area-inset-bottom,0px)] shadow-xs transition-transform ease-out group-[.focus-view]/body:hidden group-[.selection-active]/body:translate-y-full data-[started=false]:translate-y-full"
     >
       <ul className="flex w-full flex-row justify-between p-1 px-2">
         {getBaseNavItems().map((navItem: NavItem, index: number) => {

--- a/frontend/src/modules/navigation/floating-nav/button.tsx
+++ b/frontend/src/modules/navigation/floating-nav/button.tsx
@@ -41,7 +41,7 @@ export function FloatingNavButton({
       variant="secondary"
       onClick={onClick}
       className={cn(
-        'fixed bottom-4 z-105 flex h-14 w-14 transform items-center justify-center rounded-full bg-secondary opacity-100 shadow-xl transition-all duration-300 ease-in-out hover:bg-secondary active:scale-95 data-[direction=right]:right-4 data-[direction=left]:left-4',
+        'fixed bottom-[calc(1rem+var(--bottom-inset,0px))] z-105 flex h-14 w-14 transform items-center justify-center rounded-full bg-secondary opacity-100 shadow-xl transition-all duration-300 ease-in-out hover:bg-secondary active:scale-95 data-[direction=right]:right-4 data-[direction=left]:left-4',
         // Animate out while the floating selection action bar is shown
         'group-[.selection-active]/body:pointer-events-none group-[.selection-active]/body:-bottom-12 group-[.selection-active]/body:scale-50 group-[.selection-active]/body:opacity-0',
         className,

--- a/frontend/src/modules/navigation/menu-sheet/menu-sheet.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/menu-sheet.tsx
@@ -80,7 +80,7 @@ export function MenuSheet() {
     .filter((el) => el !== null);
 
   return (
-    <div className="group/menu flex min-h-full w-full flex-col bg-card">
+    <div className="group/menu flex min-h-dvh w-full flex-col bg-card">
       <FocusTarget target="sheet" />
 
       <MenuSheetHeader />

--- a/frontend/src/modules/navigation/menu-sheet/menu-sheet.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/menu-sheet.tsx
@@ -80,7 +80,7 @@ export function MenuSheet() {
     .filter((el) => el !== null);
 
   return (
-    <div className="group/menu flex min-h-screen w-full flex-col bg-card">
+    <div className="group/menu flex min-h-full w-full flex-col bg-card">
       <FocusTarget target="sheet" />
 
       <MenuSheetHeader />

--- a/frontend/src/modules/navigation/menu-sheet/sheet-panel.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/sheet-panel.tsx
@@ -106,7 +106,7 @@ export function MenuSheetPanels() {
       <FocusTrap active={hasOpenPanel} disableInactive={false}>
         <div
           className={cn(
-            'flex flex-col gap-1 border-t border-dashed bg-card px-3 py-2',
+            'flex flex-col gap-1 border-t border-dashed bg-card px-3 pt-2 pb-[calc(0.5rem+env(safe-area-inset-bottom,0px))]',
             hasOpenPanel && 'max-h-dvh overflow-y-auto rounded-t-md shadow-lg',
           )}
         >

--- a/frontend/src/styling/tailwind.css
+++ b/frontend/src/styling/tailwind.css
@@ -281,6 +281,13 @@
 }
 
 @layer base {
+  /* Bottom inset for fixed-to-bottom UI: layout-viewport bottom hidden behind the on-screen
+     keyboard or overlaying browser chrome (--vv-bottom, see viewport-observer.ts) + device
+     safe area (home indicator, requires viewport-fit=cover). */
+  :root {
+    --bottom-inset: calc(var(--vv-bottom, 0px) + env(safe-area-inset-bottom, 0px));
+  }
+
   /* For small screens we enlarge all elements by using rem everywhere, and then simply increase font-size */
   html {
     @apply font-sans overscroll-none max-sm:text-[18px];

--- a/frontend/src/utils/viewport-observer.ts
+++ b/frontend/src/utils/viewport-observer.ts
@@ -1,0 +1,32 @@
+/**
+ * Track the visual viewport and write how much of the layout viewport is hidden at the
+ * bottom (on-screen keyboard, overlaying browser chrome in webviews, URL bar transitions)
+ * to `--vv-bottom` on <html>. Fixed-to-bottom UI consumes it through `--bottom-inset`
+ * (tailwind.css) so it stays visible when `position: fixed` and the visible viewport disagree.
+ *
+ * JS writes, CSS reads: no React state, no re-renders.
+ */
+export const initViewportObserver = () => {
+  const viewport = window.visualViewport;
+  if (!viewport) return;
+
+  let rafId = 0;
+  let lastHidden = -1;
+
+  const update = () => {
+    rafId = 0;
+    const hidden = Math.max(0, Math.round(window.innerHeight - viewport.height - viewport.offsetTop));
+    if (hidden === lastHidden) return;
+    lastHidden = hidden;
+    document.documentElement.style.setProperty('--vv-bottom', `${hidden}px`);
+  };
+
+  const schedule = () => {
+    if (!rafId) rafId = requestAnimationFrame(update);
+  };
+
+  viewport.addEventListener('resize', schedule);
+  viewport.addEventListener('scroll', schedule);
+  window.addEventListener('orientationchange', schedule);
+  update();
+};


### PR DESCRIPTION
## Problem

Two mobile symptoms, one theme: heights referencing the wrong viewport.

1. **Sheet bottom panels off-screen** — menu/account/docs-sidebar sheet content used `min-h-screen` (`100vh` = the *largest* possible viewport, browser UI collapsed). The sheet popup is `fixed inset-y-0`, which is the *actual* visible viewport, so with the URL bar expanded the content ran ~60–100px past the sheet and the Preferences/Info panel buttons landed below the fold.
2. **Floating nav button falling off-screen** — `position: fixed` anchors to the layout viewport, which diverges from what's visible during URL-bar transitions, with the on-screen keyboard open (iOS + Android `resizes-visual` default), and in webviews with overlaying chrome. No CSS unit fixes fixed-element *positioning*.

## Strategy (three rules)

| Case | Rule |
|---|---|
| Viewport-tall fixed overlays (sheets, fullscreen dialogs, drawers) | `dvh` (`min-h-dvh` / `h-dvh` / `max-h-[70dvh]`) — tracks the current viewport |
| Page-level min-heights | `svh` — always fully visible, no resize jank |
| Fixed-to-bottom UI | offset by `--bottom-inset` = `--vv-bottom` (visualViewport observer) + `env(safe-area-inset-bottom)` |

`vh` remains only for intentional scroll-padding overshoot (`70vh`). `h-screen`/`min-h-screen`/`100vh` are now at zero occurrences in `frontend/src`.

## Changes

- **`viewport-observer.ts`** (new, ~30 lines): one global `visualViewport` listener writes the hidden-bottom gap to `--vv-bottom` on `<html>`. JS writes, CSS reads — no React state, no re-renders. `tailwind.css` composes `--bottom-inset` from it plus safe-area.
- **`viewport-fit=cover`** added to the meta tag; bottom bar, sheet bottom panels, and app-layout clearances take `env(safe-area-inset-bottom)` padding (a nav bar should stay *behind* the keyboard, so only the floating button consumes the full inset).
- **Sheets**: `min-h-screen` → `min-h-dvh` (menu, account, docs sidebar). First attempt was `min-h-full`, but the percentage chain through the sheet's ScrollArea flex internals capped the wrapper on desktop and failed to stretch short content — `dvh` equals the popup height by construction (see commit history).
- **Sweep**: remaining `h-screen`/`100vh` sites → `svh`/`dvh` per the rules above (~15 sites incl. welcome dialog, auth layout, attachment dialog, board layout, mobile drawers).

## Verified

Playwright against the dev server at 390×844 (mobile emulation) and 1280×800, authed session: 18/18 checks — account sheet stretches to exactly sheet height with panels hugging the visible bottom (previously 604px content + panels mid-air), menu sheet grows with tall content, docs FAB visible with `calc` resolving, `--vv-bottom` written, no page errors; screenshots checked visually. Keyboard/URL-bar divergence can't be emulated headlessly — the observer degrades to `0px` (today's behavior) when layout and visual viewports agree; worth a quick check on a real device.

## Follow-up candidates

- A `check-frontend-style` rule banning `h-screen|min-h-screen|100vh` outside an allowlist, so the convention survives fork syncs.
- A short "which height unit when" section in the frontend docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
