### PR TITLE
fix(infra): repair full-mode tests broken by lint consolidation

### DIFF
--- a/infra/tests/unit/loadbalancer.test.ts
+++ b/infra/tests/unit/loadbalancer.test.ts
@@ -23,7 +23,7 @@ describe('loadbalancer module — registry-driven wiring', () => {
   });
 
   it('issues a Lets Encrypt certificate per DNS record, gated on public propagation', () => {
-    expect(src).toMatch(/new scaleway\.loadbalancers\.Certificate\(`\$\{base\}-cert`/);
+    expect(src).toMatch(/new scaleway\.loadbalancers\.Certificate\(\s*`\$\{base\}-cert`/);
     expect(src).toMatch(/commonName:\s*host/);
     // Cert creation waits for the record to answer publicly (not merely exist),
     // and the frontend attach waits for the cert to be `ready`. Both via the
@@ -35,7 +35,7 @@ describe('loadbalancer module — registry-driven wiring', () => {
   });
 
   it('creates one LB backend per exposed service on its declared port', () => {
-    expect(src).toMatch(/new scaleway\.loadbalancers\.Backend\(`\$\{service\.slug\}-lb-backend`/);
+    expect(src).toMatch(/new scaleway\.loadbalancers\.Backend\(\s*`\$\{service\.slug\}-lb-backend`/);
     expect(src).toMatch(/forwardPort:\s*service\.healthPort/);
     expect(src).toMatch(/serverIps:\s*serviceGenerationIps\(service\.slug\)/);
   });
@@ -121,7 +121,7 @@ describe('loadbalancer module — internal routes', () => {
   });
 
   it('gives internal traffic its own pool with WebSocket-grade timeouts and session kill on mark-down', () => {
-    expect(src).toMatch(/new scaleway\.loadbalancers\.Backend\(`\$\{service\.slug\}-internal-lb-backend`/);
+    expect(src).toMatch(/new scaleway\.loadbalancers\.Backend\(\s*`\$\{service\.slug\}-internal-lb-backend`/);
     expect(src).toMatch(/onMarkedDownAction: 'shutdown_sessions'/);
     // The internal pool block carries its own 1h timeouts (not lbWebsockets-gated).
     const internalBlock = src.match(/internal-lb-backend[\s\S]*?ignoreChanges: \['serverIps'\]/)?.[0] ?? '';

--- a/infra/tests/unit/managed-keys.test.ts
+++ b/infra/tests/unit/managed-keys.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { managedKeysConfig } from '../../config/managed-keys.config';
 import { defineManagedKeys, managedKeyById, managedKeys } from '../../lib/managed-keys';
 import { runtimeSecrets } from '../../lib/runtime-secrets';
+
+// The config module and lib/managed-keys form an import cycle (config imports the
+// define helper, lib derives the registry from config), so the cycle must be entered
+// from the lib side. A static import sorts alphabetically ahead of the lib imports.
+const { managedKeysConfig } = await import('../../config/managed-keys.config');
 
 describe('managed key registry', () => {
   it('derives managedKeys from the app config, keyed by id, preserving order', () => {

--- a/infra/tests/unit/runtime-secrets.test.ts
+++ b/infra/tests/unit/runtime-secrets.test.ts
@@ -1,13 +1,17 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { runtimeSecretsConfig } from '../../config/runtime-secrets.config';
 import {
   defineRuntimeSecrets,
   runtimeSecretConsumers,
   runtimeSecrets,
   runtimeSecretsForConsumer,
 } from '../../lib/runtime-secrets';
+
+// The config module and lib/runtime-secrets form an import cycle (config imports the
+// define helper, lib derives the registry from config), so the cycle must be entered
+// from the lib side. A static import sorts alphabetically ahead of the lib import.
+const { runtimeSecretsConfig } = await import('../../config/runtime-secrets.config');
 
 const backendEnvSource = readFileSync(resolve(__dirname, '../../../backend/src/env.ts'), 'utf-8');
 const cdcEnvSource = readFileSync(resolve(__dirname, '../../../cdc/src/env.ts'), 'utf-8');


### PR DESCRIPTION
Unblocks the 0.8.1 release: the heavy `test` gate on the release-please PR ([failing run](https://github.com/cellajs/cella/actions/runs/30990648788/job/92255705442?pr=1001)) fails on three infra test files, all broken by the biome consolidation in #1000. Feature-PR CI never caught it because the full test suite only runs on the release PR.

Two distinct breakages, both formatting-only in origin:

- **Import cycle entered from the wrong side** (`managed-keys.test.ts`, `runtime-secrets.test.ts`): biome's import sorting placed the `config/*.config` import ahead of the `lib/*` import. Those module pairs are circular (config imports the `define*` helper from lib; lib derives the registry from config), so evaluating config first leaves the config binding uninitialized when lib runs `Object.entries()` → `TypeError: Cannot convert undefined or null to object` at load time. The tests now import lib statically and load the config via a top-level `await import()`, which the import organizer leaves in place — verified `biome check` applies no fixes.
- **Same-line regexes vs. reformatting** (`loadbalancer.test.ts`): the reformat moved constructor name arguments onto their own line; the three source-pinning regexes now allow `\s*` after the opening paren.

No production code changes. Verified: full infra suite passes in both default and `TEST_MODE=full` (75 files, 660 tests), tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)