### PR TITLE
feat(frontend): visible header on tabs card + forward off disabled tabs

### DIFF
--- a/frontend/src/lib/placements.test.ts
+++ b/frontend/src/lib/placements.test.ts
@@ -1,7 +1,7 @@
 import { getModules } from 'shared/module-registry';
 import { describe, expect, it } from 'vitest';
 import { defineFrontendModule } from '~/lib/module';
-import { getTools, orderBySlotConfig, resolvePlacementList } from '~/lib/placements';
+import { getTools, isPlacementHidden, orderBySlotConfig, resolvePlacementList } from '~/lib/placements';
 
 describe('tool registry', () => {
   it('indexes module tools by slot, sorted on order with a default of 50', () => {
@@ -77,6 +77,23 @@ describe('orderBySlotConfig', () => {
   it('ignores stored ids with no matching placement', () => {
     const ordered = orderBySlotConfig(items, { order: ['removed-tool', 'b'] });
     expect(ordered.map((i) => i.id)).toEqual(['b', 'a', 'c']);
+  });
+});
+
+describe('isPlacementHidden', () => {
+  const item = { id: 'extra', label: 'c:extra', order: 50 };
+
+  it('reports channel-stored hiding, with locked immune to it', () => {
+    const slotConfig = { order: [], hidden: ['extra'] };
+    expect(isPlacementHidden('host', item, { overrides: {}, slotConfig })).toBe(true);
+    expect(isPlacementHidden('host', { ...item, locked: true }, { overrides: {}, slotConfig })).toBe(false);
+    expect(isPlacementHidden('host', item, { overrides: {} })).toBe(false);
+  });
+
+  it('reports app-override hiding even for locked placements', () => {
+    const overrides = { host: { extra: { hidden: true } } };
+    expect(isPlacementHidden('host', { ...item, locked: true }, { overrides })).toBe(true);
+    expect(isPlacementHidden('other-host', item, { overrides })).toBe(false);
   });
 });
 

--- a/frontend/src/lib/placements.ts
+++ b/frontend/src/lib/placements.ts
@@ -191,6 +191,23 @@ export interface ResolvePlacementOptions {
 }
 
 /**
+ * Whether the arrangement layers alone drop a placement from its host: an app override or the
+ * channel-stored hidden list (`locked` placements ignore the latter). Grant (`requires`) and
+ * context-role (`visibleTo`) gating are viewer conditions, not arrangement, and are deliberately
+ * excluded — this answers "is this placement disabled on the surface", e.g. to forward away from
+ * a hidden tab a viewer navigated to directly.
+ */
+export function isPlacementHidden(
+  host: string,
+  item: PlacementDescriptor,
+  options: Pick<ResolvePlacementOptions, 'slotConfig' | 'overrides'> = {},
+): boolean {
+  const { slotConfig, overrides = placementOverrides } = options;
+  if (overrides[host]?.[item.id]?.hidden) return true;
+  return !item.locked && (slotConfig?.hidden ?? []).includes(item.id);
+}
+
+/**
  * Resolves a host's final placement list: applies app overrides, channel-stored hiding, grant
  * (`requires`) and context-role (`visibleTo`) gating, then channel-stored ordering with the
  * stable `order` sort as fallback. `locked` placements ignore channel-stored hiding only.
@@ -202,11 +219,9 @@ export function resolvePlacementList<T extends PlacementDescriptor & { order: nu
 ): T[] {
   const { grants = [], pairs = [], slotConfig, overrides = placementOverrides } = options;
   const hostOverrides = overrides[host];
-  const channelHidden = new Set(slotConfig?.hidden ?? []);
 
   const adjusted = items
-    .filter((item) => !hostOverrides?.[item.id]?.hidden)
-    .filter((item) => item.locked || !channelHidden.has(item.id))
+    .filter((item) => !isPlacementHidden(host, item, { slotConfig, overrides }))
     .map((item) => {
       const order = hostOverrides?.[item.id]?.order;
       return order === undefined ? item : { ...item, order };

--- a/frontend/src/modules/common/page/tab-nav.tsx
+++ b/frontend/src/modules/common/page/tab-nav.tsx
@@ -1,5 +1,5 @@
 import type { AnyRoute } from '@tanstack/react-router';
-import { Link, type LinkComponentProps } from '@tanstack/react-router';
+import { Link, type LinkComponentProps, useNavigate, useRouterState } from '@tanstack/react-router';
 import { motion } from 'motion/react';
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,6 +9,7 @@ import { useBreakpointBelow } from '~/hooks/use-breakpoints';
 import { useMountedState } from '~/hooks/use-mounted-state';
 import {
   getSlotDescriptors,
+  isPlacementHidden,
   type PlacementDescriptor,
   type PlacementOverrides,
   resolvePlacementList,
@@ -38,6 +39,14 @@ function hasRoute<TRoutes extends Record<string, AnyRoute>>(
 
 function getChildRoutes(route: AnyRoute): AnyRoute[] {
   return Array.isArray(route.children) ? route.children : [];
+}
+
+/** Override/arrangement host key for a tabbed surface: its tabs slot id when declared, else the parent route id. */
+function getTabsHost(parentRouteId: string): string {
+  // Cast: generated FileRoutesById is a closed interface without index signature
+  const routesById = getRouter().routesById as unknown as Record<string, AnyRoute>;
+  if (!hasRoute(routesById, parentRouteId)) return parentRouteId;
+  return routesById[parentRouteId].options?.staticData?.tabsSlot ?? parentRouteId;
 }
 
 /** A resolved nav candidate: a placement descriptor plus where its tab links. */
@@ -119,9 +128,7 @@ export function resolveNavTabs(parentRouteId: string, options: ResolveNavTabsOpt
   const routesById = getRouter().routesById as unknown as Record<string, AnyRoute>;
   if (!hasRoute(routesById, parentRouteId)) return [];
 
-  const slot = routesById[parentRouteId].options?.staticData?.tabsSlot;
-  const host = slot ?? parentRouteId;
-  const resolved = resolvePlacementList(host, getNavTabCandidates(parentRouteId), {
+  const resolved = resolvePlacementList(getTabsHost(parentRouteId), getNavTabCandidates(parentRouteId), {
     grants: options.grants,
     pairs: options.pairs,
     slotConfig: options.slotConfig,
@@ -143,6 +150,34 @@ export function resolveNavTabs(parentRouteId: string, options: ResolveNavTabsOpt
  */
 export function defaultNavTabPath(parentRouteId: string, options?: ResolveNavTabsOptions): string | undefined {
   return resolveNavTabs(parentRouteId, options)[0]?.path;
+}
+
+/**
+ * Forwards off a disabled tab: when the current location sits on a tab candidate that app
+ * overrides or channel-stored arrangement hide, replace-navigates to the surface's first
+ * resolved tab. Detection uses {@link isPlacementHidden} — the arrangement layers only, never
+ * `requires`/`visibleTo` gating, whose inputs may still be loading and whose enforcement belongs
+ * to the API. No-ops when the surface resolves no tabs to forward to. {@link PageTabNav} runs
+ * this for route-derived tab bars, so every channel surface gets the forwarding without wiring.
+ */
+export function useNavTabRedirect(parentRouteId: string, options: ResolveNavTabsOptions = {}): void {
+  const navigate = useNavigate();
+  const leaf = useRouterState({ select: (state) => state.matches[state.matches.length - 1] });
+
+  // Active candidate: registry tabs match on the leaf's `$tool` param, route tabs on its path
+  const toolId = (leaf?.params as { tool?: string } | undefined)?.tool;
+  const candidates = parentRouteId ? getNavTabCandidates(parentRouteId) : [];
+  const active = toolId
+    ? candidates.find((tab) => tab.id === toolId)
+    : candidates.find((tab) => tab.path === leaf?.fullPath);
+
+  const disabled = active !== undefined && isPlacementHidden(getTabsHost(parentRouteId), active, options);
+  const target = disabled ? resolveNavTabs(parentRouteId, options)[0] : undefined;
+
+  const targetId = target?.id;
+  useEffect(() => {
+    if (target) navigate({ to: target.path, params: target.params, replace: true });
+  }, [navigate, targetId]);
 }
 
 interface Props {
@@ -190,6 +225,9 @@ export function PageTabNav({
   // Use explicit tabs or auto-generate from parent route's children
   const autoTabs = resolveNavTabs(parentRouteId ?? '', { filterTabIds, grants, pairs, slotConfig });
   const tabs = explicitTabs ?? autoTabs;
+
+  // Forward off a tab this surface has disabled (explicit tab lists opt out of route derivation)
+  useNavTabRedirect(explicitTabs ? '' : (parentRouteId ?? ''), { filterTabIds, grants, pairs, slotConfig });
 
   const layoutId = useRef(nanoid()).current;
 

--- a/frontend/src/modules/entities/tabs-arrangement-card.tsx
+++ b/frontend/src/modules/entities/tabs-arrangement-card.tsx
@@ -91,9 +91,10 @@ export function TabsArrangementCard({ entity, parentRouteId, persist }: TabsArra
     },
     {
       key: 'visible',
-      name: '',
+      name: t('c:visible'),
       width: 64,
       cellClass: 'flex items-center justify-center',
+      headerCellClass: 'text-center',
       renderCell: ({ row }) =>
         row.locked ? (
           <LockIcon className="icon-sm opacity-50" aria-label={t('c:locked')} />
@@ -111,7 +112,6 @@ export function TabsArrangementCard({ entity, parentRouteId, persist }: TabsArra
         columns={columns}
         hasNextPage={false}
         readOnly
-        hideHeader
         enableVirtualization={false}
         onRowReorder={onRowReorder}
       />

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -658,6 +658,7 @@
   "view_resource": "View {{resource}}",
   "views": "Views",
   "views_retention_hint": "Views are only tracked for items from the last 90 days.",
+  "visible": "Visible",
   "visit": "Visit",
   "waitlist": "Waitlist",
   "waitlist_request": "Join waitlist",


### PR DESCRIPTION
## What

Two changes to the tabs arrangement system, both in shared template code (`TabsArrangementCard` / `tab-nav` / `placements`) so every channel surface in forks gets them without wiring:

1. **"Visible" header on the tabs card** — the arrangement table now shows its header row with a `Visible` caption above the toggle column (new `visible` locale key). Drag-handle and label columns keep empty headers.

2. **Forward off a disabled tab** — visiting the URL of a tab that app overrides or channel-stored arrangement hide now replace-navigates to the surface's first resolved tab:
   - `isPlacementHidden(host, item, {slotConfig, overrides})` in `placements.ts` extracts the hiding rules `resolvePlacementList` already applied (app override hides even `locked`; channel-stored `hidden` never hides `locked`), keeping one source of truth.
   - `useNavTabRedirect(parentRouteId, options)` in `tab-nav.tsx` resolves the active tab candidate from router state (route tabs by path, registry tabs by the `$tool` param) and forwards when it is hidden. `PageTabNav` runs it for route-derived tab bars.

## Design notes

- Detection uses the arrangement layers only, never `requires`/`visibleTo` gating: those inputs (memberships) may still be loading and would cause spurious redirects, and permission enforcement belongs to the API.
- The settings tab is `locked`, so an admin cannot bounce themselves off the settings page by disabling it.

## Verification

- `tsgo` typecheck, biome, and 15 unit tests pass (new `isPlacementHidden` coverage added).
- Driven at runtime with Playwright against a dev session: header renders; disabling *Members* then visiting `/members` forwards to `/attachments` and the tab bar drops the entry; re-enabling restores normal rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
