### PR TITLE
fix(tests): repair full-mode tests broken by worker env dedupe

### DIFF
--- a/backend/tests/health.test.ts
+++ b/backend/tests/health.test.ts
@@ -49,10 +49,8 @@ describe('Health endpoint', () => {
   it('GET /health?depth=full response has cache headers', async () => {
     const res = await fetchHealth('?depth=full');
 
-    // Only healthy/degraded (200) get cache headers
-    if (res.status === 200) {
-      expect(res.headers.get('cache-control')).toContain('max-age=10');
-    }
+    // The shared health app sets short-lived caching regardless of status
+    expect(res.headers.get('cache-control')).toContain('max-age=5');
   });
 
   it('GET /health?depth=full cdc section has expected shape', async () => {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -47,7 +47,12 @@ ReactDOM.createRoot(root, {
 }).render(
   <StrictMode>
     <Themer />
-    <LucideProvider strokeWidth={appConfig.theme.strokeWidth}>
+    {/* size="1rem" keeps the emitted width/height attributes truthful: they mirror the
+        `:where(svg.lucide)` CSS default instead of lucide's misleading px 24. Sizing itself
+        stays class-based (icon-* utilities); classes override both the rule and the attrs.
+        The cast bridges a lucide-react typing gap: LucideConfig narrows size to number,
+        while the icons consuming the context accept LucideProps' string | number. */}
+    <LucideProvider size={'1rem' as unknown as number} strokeWidth={appConfig.theme.strokeWidth}>
       <QueryClientProvider>
         <AppRouter />
       </QueryClientProvider>

--- a/frontend/src/modules/navigation/menu-sheet/section-archive-button.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/section-archive-button.tsx
@@ -30,7 +30,7 @@ export function SectionArchiveButton({
         className="group focus-effect w-full bg-transparent p-0 shadow-none ring-inset ring-offset-0 transition duration-300 hover:bg-accent/50 hover:text-accent-foreground group-data-[submenu=true]/archived:h-8"
       >
         <div className="flex w-12 items-center justify-center py-2">
-          <ArchiveIcon className="ml-2 items-center opacity-75" />
+          <ArchiveIcon className="icon-lg ml-2 items-center opacity-75" />
         </div>
         <div className="grow truncate p-2 pl-2 text-left opacity-75">
           <span className="text-sm group-data-[submenu=true]/archived:text-xs">{t('c:archived')}</span>

--- a/frontend/src/modules/navigation/menu-sheet/section-button.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/section-button.tsx
@@ -91,7 +91,7 @@ export function MenuSectionButton({
                     size="icon"
                     onClick={() => toggleIsEditing()}
                   >
-                    <Settings2Icon />
+                    <Settings2Icon className="icon-lg" />
                   </Button>
                 </TooltipButton>
               </motion.div>
@@ -117,7 +117,7 @@ export function MenuSectionButton({
                     size="icon"
                     onClick={() => handleCreateAction(createButtonRef)}
                   >
-                    <PlusIcon />
+                    <PlusIcon className="icon-lg" />
                   </Button>
                 </TooltipButton>
               </motion.div>

--- a/infra/tests/unit/runtime-secrets.test.ts
+++ b/infra/tests/unit/runtime-secrets.test.ts
@@ -16,11 +16,14 @@ const { runtimeSecretsConfig } = await import('../../config/runtime-secrets.conf
 const backendEnvSource = readFileSync(resolve(__dirname, '../../../backend/src/env.ts'), 'utf-8');
 const cdcEnvSource = readFileSync(resolve(__dirname, '../../../cdc/src/env.ts'), 'utf-8');
 const yjsEnvSource = readFileSync(resolve(__dirname, '../../../yjs/src/env.ts'), 'utf-8');
+const workerEnvBaseSource = readFileSync(resolve(__dirname, '../../../shared/src/utils/worker-env.ts'), 'utf-8');
 
+// The worker env schemas extend workerEnvBase, so shared declarations (e.g.
+// DATABASE_SSL_CA) count as declared for cdc and yjs.
 const envSources = {
   backend: backendEnvSource,
-  cdc: cdcEnvSource,
-  yjs: yjsEnvSource,
+  cdc: `${workerEnvBaseSource}\n${cdcEnvSource}`,
+  yjs: `${workerEnvBaseSource}\n${yjsEnvSource}`,
 } as const;
 
 describe('runtime secret registry', () => {


### PR DESCRIPTION
## What

Repairs the two full-mode test failures blocking the release PR (#1001, [failing run](https://github.com/cellajs/cella/actions/runs/31018400641/job/92348447612)), plus bundles the pending lucide icon-size follow-up.

### Full-mode test repairs (fallout from #1011)

- **infra `runtime-secrets.test.ts`**: #1011 deduped `DATABASE_SSL_CA` / `MAPLE_SECRET_INGEST_KEY` into the shared `workerEnvBase`, but the schema-alignment test greps each service's own `env.ts` for declarations. The test now counts `shared/src/utils/worker-env.ts` declarations for cdc/yjs, whose schemas extend the base.
- **backend `health.test.ts`**: the shared health app serves `public, max-age=5` on every status; the `depth=full` assertion still expected the old `max-age=10` (the other two assertions were already updated in #1011). Also drops the stale "only 200 gets cache headers" conditional.

Both tests are gated to full mode, so #1011's own PR never ran them — they only surfaced on the release PR.

### Lucide icon sizing follow-up

- `LucideProvider` emits `size="1rem"` so svg width/height attributes mirror the `:where(svg.lucide)` CSS default instead of lucide's misleading 24px (cast bridges lucide-react's too-narrow `LucideConfig.size: number`; icons accept `string | number`).
- Menu-sheet section buttons get explicit `icon-lg` to keep their previous size.

## Verification

- `TEST_MODE=full vitest run` on both repaired files: 17/17 pass against the docker test DB.
- backend + infra typecheck green; biome clean on all changed files.
- Frontend typecheck has 7 pre-existing errors on main (locales import + placements.test), untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)