### PR TITLE
fix(tests): repair full-mode tests broken by worker env dedupe

### DIFF
--- a/backend/tests/health.test.ts
+++ b/backend/tests/health.test.ts
@@ -49,10 +49,8 @@ describe('Health endpoint', () => {
   it('GET /health?depth=full response has cache headers', async () => {
     const res = await fetchHealth('?depth=full');
 
-    // Only healthy/degraded (200) get cache headers
-    if (res.status === 200) {
-      expect(res.headers.get('cache-control')).toContain('max-age=10');
-    }
+    // The shared health app sets short-lived caching regardless of status
+    expect(res.headers.get('cache-control')).toContain('max-age=5');
   });
 
   it('GET /health?depth=full cdc section has expected shape', async () => {

--- a/infra/tests/unit/runtime-secrets.test.ts
+++ b/infra/tests/unit/runtime-secrets.test.ts
@@ -16,11 +16,14 @@ const { runtimeSecretsConfig } = await import('../../config/runtime-secrets.conf
 const backendEnvSource = readFileSync(resolve(__dirname, '../../../backend/src/env.ts'), 'utf-8');
 const cdcEnvSource = readFileSync(resolve(__dirname, '../../../cdc/src/env.ts'), 'utf-8');
 const yjsEnvSource = readFileSync(resolve(__dirname, '../../../yjs/src/env.ts'), 'utf-8');
+const workerEnvBaseSource = readFileSync(resolve(__dirname, '../../../shared/src/utils/worker-env.ts'), 'utf-8');
 
+// The worker env schemas extend workerEnvBase, so shared declarations (e.g.
+// DATABASE_SSL_CA) count as declared for cdc and yjs.
 const envSources = {
   backend: backendEnvSource,
-  cdc: cdcEnvSource,
-  yjs: yjsEnvSource,
+  cdc: `${workerEnvBaseSource}\n${cdcEnvSource}`,
+  yjs: `${workerEnvBaseSource}\n${yjsEnvSource}`,
 } as const;
 
 describe('runtime secret registry', () => {


### PR DESCRIPTION
## What

Repairs the two full-mode test failures blocking the release PR (#1001, [failing run](https://github.com/cellajs/cella/actions/runs/31018400641/job/92348447612)). Replaces #1012, split so the test repair and the lucide icon follow-up land as separate PRs.

- **infra `runtime-secrets.test.ts`**: #1011 deduped `DATABASE_SSL_CA` / `MAPLE_SECRET_INGEST_KEY` into the shared `workerEnvBase`, but the schema-alignment test greps each service's own `env.ts` for declarations. The test now counts `shared/src/utils/worker-env.ts` declarations for cdc/yjs, whose schemas extend the base.
- **backend `health.test.ts`**: the shared health app serves `public, max-age=5` on every status; the `depth=full` assertion still expected the old `max-age=10` (the other two assertions were already updated in #1011). Also drops the stale "only 200 gets cache headers" conditional.

Both tests are gated to full mode, so #1011's own PR never ran them — they only surfaced on the release PR.

## Verification

- `TEST_MODE=full vitest run` on both repaired files: 17/17 pass against the docker test DB.
- backend + infra typecheck green; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
