### PR TITLE
fix(frontend): truthful lucide size attrs and icon-lg on menu-sheet buttons

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -47,7 +47,12 @@ ReactDOM.createRoot(root, {
 }).render(
   <StrictMode>
     <Themer />
-    <LucideProvider strokeWidth={appConfig.theme.strokeWidth}>
+    {/* size="1rem" keeps the emitted width/height attributes truthful: they mirror the
+        `:where(svg.lucide)` CSS default instead of lucide's misleading px 24. Sizing itself
+        stays class-based (icon-* utilities); classes override both the rule and the attrs.
+        The cast bridges a lucide-react typing gap: LucideConfig narrows size to number,
+        while the icons consuming the context accept LucideProps' string | number. */}
+    <LucideProvider size={'1rem' as unknown as number} strokeWidth={appConfig.theme.strokeWidth}>
       <QueryClientProvider>
         <AppRouter />
       </QueryClientProvider>

--- a/frontend/src/modules/navigation/menu-sheet/section-archive-button.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/section-archive-button.tsx
@@ -30,7 +30,7 @@ export function SectionArchiveButton({
         className="group focus-effect w-full bg-transparent p-0 shadow-none ring-inset ring-offset-0 transition duration-300 hover:bg-accent/50 hover:text-accent-foreground group-data-[submenu=true]/archived:h-8"
       >
         <div className="flex w-12 items-center justify-center py-2">
-          <ArchiveIcon className="ml-2 items-center opacity-75" />
+          <ArchiveIcon className="icon-lg ml-2 items-center opacity-75" />
         </div>
         <div className="grow truncate p-2 pl-2 text-left opacity-75">
           <span className="text-sm group-data-[submenu=true]/archived:text-xs">{t('c:archived')}</span>

--- a/frontend/src/modules/navigation/menu-sheet/section-button.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/section-button.tsx
@@ -91,7 +91,7 @@ export function MenuSectionButton({
                     size="icon"
                     onClick={() => toggleIsEditing()}
                   >
-                    <Settings2Icon />
+                    <Settings2Icon className="icon-lg" />
                   </Button>
                 </TooltipButton>
               </motion.div>
@@ -117,7 +117,7 @@ export function MenuSectionButton({
                     size="icon"
                     onClick={() => handleCreateAction(createButtonRef)}
                   >
-                    <PlusIcon />
+                    <PlusIcon className="icon-lg" />
                   </Button>
                 </TooltipButton>
               </motion.div>


### PR DESCRIPTION
## What

Split out of #1012 (icon follow-up to the icon-conventions sweep, separate from the CI test repair in the sibling PR).

- `LucideProvider` now emits `size="1rem"` so svg width/height attributes mirror the `:where(svg.lucide)` CSS default instead of lucide's misleading 24px. A commented cast bridges a lucide-react typing gap: `LucideConfig` narrows `size` to `number`, while the icons consuming the context accept `LucideProps`' `string | number`.
- Menu-sheet section buttons (`Settings2Icon`, `PlusIcon`, `ArchiveIcon`) get explicit `icon-lg` to keep their previous size.

## Verification

- Frontend typecheck: the `size="1rem"` type error is resolved by the cast; only the 7 pre-existing main errors remain (locales import + placements.test), untouched here.
- Biome clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
