### PR TITLE
fix(deploy): drop deleted locales/package.json from Dockerfile manifests stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,6 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY backend/package.json ./backend/
 COPY shared/package.json ./shared/
 COPY sdk/package.json ./sdk/
-COPY locales/package.json ./locales/
 COPY cdc/package.json ./cdc/
 COPY yjs/package.json ./yjs/
 COPY patches/ ./patches/


### PR DESCRIPTION
## Problem

The [v0.8.1 deploy run](https://github.com/cellajs/cella/actions/runs/31075810861) failed in the **backend** and **cdc** image builds:

```
ERROR: failed to compute cache key: "/locales/package.json": not found
```

#1008 removed locales as a workspace package (deleted `locales/package.json` and `locales/index.ts`), but the shared `manifests` stage — parent of every service build — still copied the manifest. Docker images are only built by the deploy workflow, so the breakage surfaced at release time instead of PR CI. Prod is still on the previous release.

## Fix

Delete the stale `COPY locales/package.json ./locales/` line. The remaining `COPY locales/ ./locales/` lines in the builder stages stay: the directory still exists and `backend/src/lib/i18n-locales.ts` bundles its JSON at build time.

## Verification

Built locally from this branch with real exit codes checked:
- `docker build --target backend` → exit 0
- `docker build --target cdc` → exit 0

Merging to main triggers the deploy workflow (push trigger), so this unblocks prod without cutting 0.8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)