### PR TITLE
fix(infra): IAM v2 migration prep — state-identity override, key-mint fix, worker health probes

### DIFF
--- a/cdc/src/index.ts
+++ b/cdc/src/index.ts
@@ -35,7 +35,9 @@ export async function runCdcWorker(): Promise<void> {
     },
   });
 
-  const healthServer = serve({ fetch: healthApp.fetch, port: env.CDC_HEALTH_PORT }, () => {
+  // hostname doubles as the Host fallback for the LB's host-less HTTP/1.0 health
+  // probe: without it @hono/node-server rejects the probe with 400 Missing host header.
+  const healthServer = serve({ fetch: healthApp.fetch, hostname: '0.0.0.0', port: env.CDC_HEALTH_PORT }, () => {
     log.info(`CDC health server listening on port ${env.CDC_HEALTH_PORT}`);
   });
 

--- a/infra/Pulumi.production.yaml
+++ b/infra/Pulumi.production.yaml
@@ -1,3 +1,4 @@
 encryptionsalt: v1:OB3eX2/Cavo=:v1:zUWCmiHoqAtbw5w9:nUhV6Y7FbTkk7Ok5ad1LipqvR6L/4Q==
 config:
   infra:bootstrapComplete: "2026-06-20T05:30:28.418Z"
+  infra:iamModel: v2

--- a/infra/cli/actions/apply.ts
+++ b/infra/cli/actions/apply.ts
@@ -3,7 +3,7 @@ import { confirm } from '@inquirer/prompts';
 import { deriveInfra } from '../../lib/naming';
 import { adoptOrphanedPolicy } from '../../lib/scaleway/adopt-orphaned-policy';
 import { adoptOrphanedSecrets } from '../../lib/scaleway/adopt-orphaned-secrets';
-import { buildProviderEnv } from '../../lib/scaleway/bootstrap-scw-env';
+import { buildProviderEnv, stateKeyOverrideFromEnv } from '../../lib/scaleway/bootstrap-scw-env';
 import { resolveOrganizationId } from '../../lib/scaleway/scaleway-iam';
 import { parseOrphanedDeletes, pruneOrphanedDeletes, runPulumiUpWithHint } from '../../lib/stack/pulumi-up';
 import { pc, warningMark } from '../../lib/utils/cli-output';
@@ -62,17 +62,25 @@ export async function runApply(context: InfraContext): Promise<void> {
     `${pc.yellow(pc.bold('\u26A0  Keep this run in the foreground.'))} ${pc.dim('If it is interrupted, re-run "Apply infra change" to converge.')}`,
   );
 
-  const applyEnv = buildProviderEnv(infraDir, { accessKey: bootAccess, secretKey: bootSecret, projectId, passphrase });
+  const stateOverride = stateKeyOverrideFromEnv();
+  const applyEnv = buildProviderEnv(infraDir, {
+    accessKey: bootAccess,
+    secretKey: bootSecret,
+    projectId,
+    passphrase,
+    ...stateOverride,
+  });
 
   const { appConfig } = context;
   pulumiLoginAndSelect(infraDir, applyEnv, appConfig, targetStack);
 
   // Lock the stack through the control bucket to exclude concurrent operators and CI.
   // Exit paths release it; abandoned locks expire or can be cleared with "Unlock".
+  // The lock object lives in the state bucket, so the state-identity override applies.
   const stackLock = await acquireStackLockOrExit({
     appConfig,
-    accessKey: bootAccess,
-    secretKey: bootSecret,
+    accessKey: stateOverride.stateAccessKey ?? bootAccess,
+    secretKey: stateOverride.stateSecretKey ?? bootSecret,
     stack: targetStack,
     operation: 'apply',
   });

--- a/infra/cli/actions/migrate-iam.ts
+++ b/infra/cli/actions/migrate-iam.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 import { confirm, select } from '@inquirer/prompts';
 import { syncGithubEnvironment } from '../../lib/github-sync';
 import { deriveInfra } from '../../lib/naming';
-import { buildProviderEnv } from '../../lib/scaleway/bootstrap-scw-env';
+import { buildProviderEnv, stateKeyOverrideFromEnv } from '../../lib/scaleway/bootstrap-scw-env';
 import { principalNames } from '../../lib/scaleway/principals';
 import {
   deleteApplicationCascade,
@@ -124,6 +124,7 @@ export async function runMigrateIam(context: InfraContext): Promise<void> {
     projectId: context.projectId,
     passphrase,
     organizationId,
+    ...stateKeyOverrideFromEnv(),
   });
 
   console.info(`\n→ Admin app (${names.admin})`);

--- a/infra/lib/scaleway/bootstrap-scw-env.ts
+++ b/infra/lib/scaleway/bootstrap-scw-env.ts
@@ -40,6 +40,22 @@ export interface ProviderEnvInput {
 }
 
 /**
+ * State-backend credential override from `SCW_STATE_ACCESS_KEY` /
+ * `SCW_STATE_SECRET_KEY`, for split-identity runs: the state-bucket policy is
+ * deny-by-default and admits only the CI and admin principals, so a
+ * bootstrap-key run 403s on `pulumi login` unless an admitted key (e.g. an
+ * ephemeral operator/admin key) is supplied for the `AWS_*` side.
+ */
+export function stateKeyOverrideFromEnv(): Pick<ProviderEnvInput, 'stateAccessKey' | 'stateSecretKey'> {
+  const stateAccessKey = process.env.SCW_STATE_ACCESS_KEY?.trim() || undefined;
+  const stateSecretKey = process.env.SCW_STATE_SECRET_KEY?.trim() || undefined;
+  if (!!stateAccessKey !== !!stateSecretKey) {
+    throw new Error('SCW_STATE_ACCESS_KEY and SCW_STATE_SECRET_KEY must be set together');
+  }
+  return { stateAccessKey, stateSecretKey };
+}
+
+/**
  * Builds a child environment with explicit Scaleway, S3-state, and Pulumi credentials.
  * It inherits process utilities but overrides credential variables and disables local
  * Scaleway profiles so operator configuration cannot shadow the supplied identity.

--- a/infra/lib/scaleway/permissions.ts
+++ b/infra/lib/scaleway/permissions.ts
@@ -112,18 +112,18 @@ export const BACKEND_S3_PERMISSION_SETS = [
 export const BOOT_PROJECT_PERMISSION_SETS = ['ContainerRegistryReadOnly', 'ObjectStorageObjectsWrite'] as const;
 
 /**
- * The CI key-mint grant (D3, live-validated 2026-07-31): IAMApplicationManager
- * conditioned to `resource.id in [<service/boot app ids>]` lets CI rotate
- * those apps' API keys every deploy while creating apps/policies stays denied
- * (create carries no matching resource.id). The escalation firewall holds.
- * STRICT condition: no `!has(resource.id)` escape, listing stays denied.
+ * The CI key-mint grant (D3): IAMApplicationManager, unconditioned. The
+ * former `resource.id in [<app ids>]` condition is disproven on live
+ * Scaleway (probe 2026-08-10: api-key POST on a LISTED app id → 403; the
+ * api-key request carries no `resource.id` for the condition to match) —
+ * raak's live rule has run unconditioned since its migration and its repo
+ * condition was live/repo drift, not validation. Documented widening: CI can
+ * manage applications/api-keys org-wide; the remaining firewall is the
+ * absent IAMPolicyManager (CI cannot grant permissions). Re-narrow when the
+ * condition vocabulary can address an api-key's parent application
+ * (IAM_PRIVILEGE_RETHINK).
  */
 export const CI_KEY_MINT_PERMISSION_SETS = ['IAMApplicationManager'] as const;
-
-/** CEL condition for the CI key-mint rule. */
-export function ciKeyMintCondition(appIds: readonly string[]): string {
-  return `resource.id in [${appIds.map((id) => `"${id}"`).join(', ')}]`;
-}
 
 // Bootstrap-owned boundary
 

--- a/infra/lib/stack/control-store.ts
+++ b/infra/lib/stack/control-store.ts
@@ -281,16 +281,20 @@ export interface ControlContext {
 /**
  * Resolve the control-object context for a fully-qualified stack from the
  * environment: sets APP_MODE from the stack's short name (so `shared`'s
- * appConfig resolves the right mode), builds the S3 client from SCW_* (or
- * AWS_*) credentials, and derives bucket + keys. Returns null (with a warning)
+ * appConfig resolves the right mode), builds the S3 client from AWS_* (or
+ * SCW_*) credentials, and derives bucket + keys. Returns null (with a warning)
  * when no credentials are present; the caller then skips control-store writes.
+ * AWS-first: the control object lives in the state bucket, whose
+ * deny-by-default policy admits the state-backend identity (what AWS_*
+ * carries on split-identity runs), not necessarily the SCW provider key.
  */
 export async function controlContextForStack(
   stack: string,
   log: (msg: string) => void = console.warn,
 ): Promise<ControlContext | null> {
-  const accessKey = process.env.SCW_ACCESS_KEY ?? process.env.AWS_ACCESS_KEY_ID;
-  const secretKey = process.env.SCW_SECRET_KEY ?? process.env.AWS_SECRET_ACCESS_KEY;
+  const fromAws = !!(process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY);
+  const accessKey = fromAws ? process.env.AWS_ACCESS_KEY_ID : process.env.SCW_ACCESS_KEY;
+  const secretKey = fromAws ? process.env.AWS_SECRET_ACCESS_KEY : process.env.SCW_SECRET_KEY;
   if (!accessKey || !secretKey) {
     log('control-store: no S3 credentials (SCW_* or AWS_*); cannot read/write rollout state');
     return null;

--- a/infra/tasks/setup-ci-key.ts
+++ b/infra/tasks/setup-ci-key.ts
@@ -3,7 +3,6 @@ import { resolveProjectId } from '../lib/scaleway/bootstrap-scw-env';
 import { resolveDnsProjectIds } from '../lib/scaleway/dns-zone-project';
 import {
   CI_KEY_MINT_PERMISSION_SETS,
-  ciKeyMintCondition,
   DNS_PERMISSION_SETS,
   ORG_SCOPED_PERMISSION_SETS,
   PROJECT_PERMISSION_SETS,
@@ -18,9 +17,11 @@ export interface SetupCiKeyOptions extends ProvisionScopedKeyOptions {
   /** Deploy mode; per-mode CI apps keep staging/production keys independent. */
   mode: string;
   /**
-   * Service + boot application ids (v2 model): adds the conditioned
-   * IAMApplicationManager rule so CI can rotate exactly those apps' keys per
-   * deploy, and nothing else (creates carry no matching resource.id).
+   * Service + boot application ids (v2 model): presence adds the key-mint
+   * rule so CI can rotate service keys per deploy. The ids intentionally no
+   * longer narrow the rule (see CI_KEY_MINT_PERMISSION_SETS for why and the
+   * trade-off); they remain declared as the intended scope for a future
+   * re-narrowing.
    */
   keyMintAppIds?: readonly string[];
 }
@@ -47,16 +48,14 @@ export async function setupCiKey(opts: SetupCiKeyOptions): Promise<CiKeyResult> 
       // rule): DNS is project-scoped, IAMReadOnly is organization-scoped.
       { permission_set_names: DNS_PERMISSION_SETS, project_ids: dnsProjectIds },
       { permission_set_names: ORG_SCOPED_PERMISSION_SETS, organization_id: organizationId },
-      // v2: per-deploy service-key rotation. STRICTLY conditioned to the
-      // known app ids (live-validated: mint on target ALLOW, mint elsewhere /
-      // create app / create policy DENY). Set via PUT /rules by the API layer;
-      // read back + asserted by warnOnCiPolicyDrift and assert-vm-grants.
+      // v2: per-deploy service-key rotation. Unconditioned — the resource.id
+      // condition 403s real api-key mints on live Scaleway (disproven
+      // 2026-08-10; see CI_KEY_MINT_PERMISSION_SETS for the trade-off).
       ...(opts.keyMintAppIds && opts.keyMintAppIds.length > 0
         ? [
             {
               permission_set_names: CI_KEY_MINT_PERMISSION_SETS,
               organization_id: organizationId,
-              condition: ciKeyMintCondition(opts.keyMintAppIds),
             },
           ]
         : []),

--- a/yjs/src/server/ws-server.ts
+++ b/yjs/src/server/ws-server.ts
@@ -50,7 +50,9 @@ function buildHttpApp(): Hono {
 
 export function startWsServer(): void {
   // serve() uses node:http's createServer by default, so the upgrade event is available.
-  const server = serve({ fetch: buildHttpApp().fetch, port: env.YJS_PORT }, () => {
+  // hostname doubles as the Host fallback for the LB's host-less HTTP/1.0 health
+  // probe: without it @hono/node-server rejects the probe with 400 Missing host header.
+  const server = serve({ fetch: buildHttpApp().fetch, hostname: '0.0.0.0', port: env.YJS_PORT }, () => {
     log.info('Yjs WebSocket server listening', { port: env.YJS_PORT });
   }) as Server;
   httpServer = server;


### PR DESCRIPTION
Lands the code side of the cella-prod IAM v2 migration (ritual executed 2026-08-10, runbook in .todos/IAM_V2_MIGRATION_PLAN.md):

- **State-identity override (raak #109, ported 1:1)**: `stateKeyOverrideFromEnv` + threading through `apply`/`migrate-iam` + AWS-first `controlContextForStack` — the state-bucket policy is deny-by-default, so bootstrap-key runs 403 without a split identity. Verified live during the migration.
- **Unconditioned CI key-mint rule**: the `resource.id in [...]` CEL condition never matches api-key POSTs on live Scaleway (probed: mint on a listed app → 403). Raak's live rule already runs unconditioned — its repo shape was uncommitted console drift. Trade-off documented at `CI_KEY_MINT_PERMISSION_SETS`; post-fix probe: mint on service app → 200, cleaned up.
- **`hostname: '0.0.0.0'` on cdc + yjs serve()** (raak #115 class): the LB health probe is host-less HTTP/1.0; matters during the v2 deploy's VM re-roll.
- **`Pulumi.production.yaml`: `infra:iamModel: v2`** — the privileged apply has already converged live (+vm-backend/vm-boot policies, 5 bucket policies flipped, legacy vm-reader-policy deleted, 0 errors); merging this makes CI take the v2 deploy path.

Merge = first v2 deploy (mints generation keys, re-rolls the VM onto the handoff flow). Legacy principal cleanup follows after that deploy is verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
