### PR TITLE
fix(infra): union folded services into the singleVM host's secret-path grant

### DIFF
--- a/infra/lib/scaleway/vm-reader-secret.ts
+++ b/infra/lib/scaleway/vm-reader-secret.ts
@@ -66,12 +66,15 @@ export function handoffFolderPath(slug: string, mode: string): string {
 }
 
 /**
- * Condition for ONE service application: its own folder + shared. Narrower
+ * Condition for one service application: its folder(s) + shared. Narrower
  * than {@link vmSecretCondition} (the single-app P2 grant), which unions all
- * services.
+ * services. Pass the full secret scope (lib/services.ts secretScopeSlugs) —
+ * for the singleVM host that includes the folded co-hosted/collocated
+ * services, whose secrets hydrate on the host VM.
  */
-export function serviceKeyCondition(slug: string, mode: string, service: string): string {
-  return [serviceSecretPath(slug, mode, service), sharedSecretPath(slug, mode)]
+export function serviceKeyCondition(slug: string, mode: string, services: string | readonly string[]): string {
+  const scope = typeof services === 'string' ? [services] : services;
+  return [...scope.map((service) => serviceSecretPath(slug, mode, service)), sharedSecretPath(slug, mode)]
     .map((path) => `resource.name.startsWith("${path}")`)
     .join(' || ');
 }

--- a/infra/lib/services.ts
+++ b/infra/lib/services.ts
@@ -89,6 +89,28 @@ export function collocatedServices(
   return collocated;
 }
 
+/**
+ * Service slugs whose secret folders a service's VMs must be able to read: the
+ * service itself, plus — for the singleVM host — every co-hosted worker and
+ * collocated container folded onto it. Their runtime secrets union onto the
+ * host VM (resources/generations.ts secretConsumersFor), so the host's
+ * secret-path grant must union identically or hydration 403s on the folded
+ * services' secrets.
+ */
+export function secretScopeSlugs(
+  serviceConfig: Record<string, EngineServiceEndpoint>,
+  singleVM: boolean,
+  service: ServiceName,
+): readonly ServiceName[] {
+  const host = deployedServices(serviceConfig, singleVM).find((s) => s.primaryRollout)?.slug;
+  if (!singleVM || service !== host) return [service];
+  return [
+    service,
+    ...coHostedServices(serviceConfig, singleVM).map((s) => s.slug),
+    ...collocatedServices(serviceConfig, singleVM).map((s) => s.slug),
+  ];
+}
+
 /** A public service's resolved endpoint, derived from appConfig by the registry. */
 export interface ServiceEndpoint {
   slug: ServiceName;

--- a/infra/resources/vm-iam.ts
+++ b/infra/resources/vm-iam.ts
@@ -12,7 +12,7 @@ import {
 } from '../lib/scaleway/permissions';
 import { principalNames } from '../lib/scaleway/principals';
 import { bootKeyCondition, serviceKeyCondition } from '../lib/scaleway/vm-reader-secret';
-import { deployedServices } from '../lib/services';
+import { deployedServices, secretScopeSlugs } from '../lib/services';
 import { mode, naming, organizationId, projectId, tags } from '../pulumi-context';
 
 const names = principalNames(appConfig.slug, mode);
@@ -198,7 +198,11 @@ if (!iamModelV2) {
             {
               permissionSetNames: [...SERVICE_SECRET_PERMISSION_SETS],
               projectIds: [projectId],
-              condition: serviceKeyCondition(naming.slug, mode, svc.slug),
+              condition: serviceKeyCondition(
+                naming.slug,
+                mode,
+                secretScopeSlugs(appConfig.services, appConfig.singleVM ?? false, svc.slug),
+              ),
             },
             ...(isBackend
               ? [

--- a/infra/tasks/print-deploy-env.ts
+++ b/infra/tasks/print-deploy-env.ts
@@ -7,7 +7,7 @@ import {
 } from '../lib/scaleway/permissions';
 import { principalNames } from '../lib/scaleway/principals';
 import { bootKeyCondition, serviceKeyCondition, vmSecretCondition } from '../lib/scaleway/vm-reader-secret';
-import { deployedServices, enabledServices, serviceEndpoints, serviceNames } from '../lib/services';
+import { deployedServices, enabledServices, secretScopeSlugs, serviceEndpoints, serviceNames } from '../lib/services';
 import { isMain } from '../lib/utils/is-main';
 import { getFlag } from './args';
 
@@ -112,7 +112,11 @@ export function buildDeployEnv(appConfig: Cfg, opts: { imageTag?: string } = {})
       ...deployedServices(appConfig.services, appConfig.singleVM ?? false).map((svc) => ({
         app: principalNames(appConfig.slug, appConfig.mode).vmService(svc.slug),
         sets: [...SERVICE_SECRET_PERMISSION_SETS, ...(svc.s3Access ? BACKEND_S3_PERMISSION_SETS : [])],
-        condition: serviceKeyCondition(appConfig.slug, appConfig.mode, svc.slug),
+        condition: serviceKeyCondition(
+          appConfig.slug,
+          appConfig.mode,
+          secretScopeSlugs(appConfig.services, appConfig.singleVM ?? false, svc.slug),
+        ),
       })),
       {
         app: principalNames(appConfig.slug, appConfig.mode).boot,


### PR DESCRIPTION
Second finding from the cella-prod IAM v2 migration: under singleVM the host VM hydrates every co-hosted worker's and collocated container's runtime secrets, but the v2 per-service secret condition only allowed the host's own folder + shared — so the first v2 deploy died at `hydrate-runtime-secrets: DATABASE_CDC_URL: 403` (the secret lives under `/cella-production/cdc/`). Cutover never switched; prod kept serving on the old generation.

New `secretScopeSlugs` helper mirrors `generations.ts secretConsumersFor`'s union; the vm-iam policy condition and print-deploy-env's assertion row both consume it, so producer and checker stay string-equal. Raak (multi-VM) never exercises this path — cella is the first singleVM stack through v2.

Rollout note: `vm-backend-policy` has `ignoreChanges: ['rules']`, so after merge the live policy must be deleted and recreated by a privileged apply (runbook §4b in .todos/IAM_V2_MIGRATION_PLAN.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)