### PR TITLE
fix(infra): tolerate migration-owned privilege drift on managed postgres

### DIFF
--- a/infra/resources/stores/postgres-managed.ts
+++ b/infra/resources/stores/postgres-managed.ts
@@ -226,24 +226,37 @@ export function postgresManaged(config: PostgresManagedConfig = {}): StoreProvis
         region,
       });
 
-      // Privileges: each role gets 'all' on the database (fine-grained table
-      // permissions are enforced by the RLS migration, not Scaleway-level grants)
+      // Privileges: each role gets 'all' on the database at creation; the
+      // effective grants are owned by the role/RLS migrations from then on
+      // (their REVOKEs make Scaleway read the privilege back as 'custom').
+      // ignoreChanges keeps a refreshed state from arming an enforcement of
+      // 'all' that would clobber migration-owned grants — and that CI cannot
+      // execute anyway (RelationalDatabasesReadOnly), which would fail the
+      // deploy (seen live 2026-08-10 after the IAM v2 reconcile refresh).
 
-      new scaleway.databases.Privilege('admin-privilege', {
-        instanceId: instance.id,
-        databaseName: database.name,
-        userName: adminUser.name,
-        permission: 'all',
-        region,
-      });
+      new scaleway.databases.Privilege(
+        'admin-privilege',
+        {
+          instanceId: instance.id,
+          databaseName: database.name,
+          userName: adminUser.name,
+          permission: 'all',
+          region,
+        },
+        { ignoreChanges: ['permission'] },
+      );
 
-      new scaleway.databases.Privilege('runtime-privilege', {
-        instanceId: instance.id,
-        databaseName: database.name,
-        userName: runtimeUser.name,
-        permission: 'all',
-        region,
-      });
+      new scaleway.databases.Privilege(
+        'runtime-privilege',
+        {
+          instanceId: instance.id,
+          databaseName: database.name,
+          userName: runtimeUser.name,
+          permission: 'all',
+          region,
+        },
+        { ignoreChanges: ['permission'] },
+      );
 
       // The instance is created with a privateNetwork block, so this only trips if
       // Scaleway ever returns an instance without one, fail with a real error


### PR DESCRIPTION
Time-sensitive follow-up to the IAM v2 reconcile (plan doc §6b ops block, executed tonight): the state refresh imported live reality into Pulumi state, including `runtime-privilege` reading back `custom` (the role/RLS migrations' REVOKEs) against the program's `all`. Without this tolerance, **the next production deploy fails** — CI's plain `pulumi up` sees the diff and attempts an RDB privilege write its key cannot make (`RelationalDatabasesReadOnly`), and a privileged up would clobber migration-owned grants.

`ignoreChanges: ['permission']` on both privilege resources, same pattern as the #991/#993 drift tolerances; `all` stays as the creation-time baseline, migrations own the grants from then on. Comment documents the provenance.

Ops-block results (all done tonight, read-back verified): vm-backend-policy recreated canonically via targeted up (state reconciled), full state refresh as the admin principal (its designed purpose — bootstrap keys can't even read the policy-protected buckets), stray generation keys self-cleaned by rotation, admin-403 mystery SOLVED (the key had been rotated away by a migrate re-run 30s after minting; S3 reports dead credentials as 403 — recovery path works fine), and the refresh surfaced that the apex `cellajs.com` → `www` 301 ACL was missing live; restored via targeted up and verified.

Verification: infra vitest 654 passed, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)