### PR TITLE
fix(infra): correctness batch — apex derivation, teardown lock, engine gate, redis posture

### DIFF
--- a/infra/cli/actions/teardown.ts
+++ b/infra/cli/actions/teardown.ts
@@ -99,14 +99,19 @@ export async function runTeardown(context: InfraContext): Promise<void> {
   });
 
   // --refresh first so the destroy plan matches live state (a stale local view
-  // of generations/LB must not orphan real resources).
-  console.info(pc.dim('\n→ pulumi destroy --refresh (this may take several minutes)…'));
-  const destroy = spawnSync('pulumi', ['destroy', '--refresh', '--yes', '--stack', targetStack], {
-    cwd: infraDir,
-    env,
-    stdio: 'inherit',
-  });
-  await stackLock.release();
+  // of generations/LB must not orphan real resources). The lock releases in a
+  // finally so a throw between acquire and release cannot strand it until TTL.
+  let destroy: ReturnType<typeof spawnSync>;
+  try {
+    console.info(pc.dim('\n→ pulumi destroy --refresh (this may take several minutes)…'));
+    destroy = spawnSync('pulumi', ['destroy', '--refresh', '--yes', '--stack', targetStack], {
+      cwd: infraDir,
+      env,
+      stdio: 'inherit',
+    });
+  } finally {
+    await stackLock.release();
+  }
   if (destroy.status !== 0) {
     console.error(
       `\n${warningMark} pulumi destroy exited ${destroy.status}. Common causes: protected resources (lift 'protect' in code for a real teardown), ` +

--- a/infra/lib/runtime-secrets.ts
+++ b/infra/lib/runtime-secrets.ts
@@ -57,9 +57,9 @@ export function defineRuntimeSecrets<const T extends Record<string, RuntimeSecre
   return secrets;
 }
 
-// Store-owned declarations come first, in store-registry order: cella's
-// database secrets historically led the app config, and the per-consumer union
-// order is genId-fingerprinted, so the merge position is deliberate.
+// Store-owned declarations come first, in store-registry order: database
+// secrets historically led the app config, and the per-consumer union order
+// is genId-fingerprinted, so the merge position is deliberate.
 const storeContributions: RuntimeSecretDefinition[] = Object.values(appStores).flatMap((store) =>
   (store.secrets?.() ?? []).map((contribution) => ({
     id: contribution.id,

--- a/infra/package.json
+++ b/infra/package.json
@@ -33,6 +33,7 @@
     "compose:generate": "tsx compose/synth.ts",
     "compose:check": "tsx compose/synth.ts --check",
     "smoke": "tsx tasks/smoke.ts",
+    "engine-gate": "bash scripts/engine-gate.sh",
     "ts": "cd .. && tsgo -p infra/tsconfig.json --pretty",
     "tsperf": "rm -rf tsconfig.tsbuildinfo && tsgo --noEmit --extendedDiagnostics"
   },

--- a/infra/resources/loadbalancer.ts
+++ b/infra/resources/loadbalancer.ts
@@ -42,7 +42,9 @@ function provisionLoadBalancer(): LoadBalancerOutputs {
     );
   }
 
-  const appHost = serviceHost('frontend');
+  // The default-route service owns the app host (S14 pattern: derive, never
+  // name a service literal in the engine).
+  const appHost = serviceHost(defaultService.slug);
   // Zone-apex resources (apex A record, apex cert, apex-to-www redirect) belong
   // to exactly ONE stack per zone: the one serving `www.<zone>`. A staging
   // stack on the shared zone (staging.<zone>) must never manage the apex, or

--- a/infra/resources/stores/redis-managed.test.ts
+++ b/infra/resources/stores/redis-managed.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { redisManaged } from './redis-managed';
+
+const base = { version: '7.0.5', nodeType: 'RED1-MICRO' };
+
+describe('redisManaged store', () => {
+  it('contributes url + ca secrets when consumers are declared (tls on by default)', () => {
+    const secrets = redisManaged({ ...base, secretConsumers: { url: ['api'], ca: ['api'] } }).secrets?.() ?? [];
+    expect(secrets.map((s) => s.id)).toEqual(['redisUrl', 'redisSslCa']);
+    expect(secrets[0]).toMatchObject({ envVar: 'REDIS_URL', valueSource: 'pulumi', required: true });
+  });
+
+  it('omits the ca contribution when tls is disabled', () => {
+    const secrets = redisManaged({ ...base, tls: false, secretConsumers: { url: ['api'] } }).secrets?.() ?? [];
+    expect(secrets.map((s) => s.id)).toEqual(['redisUrl']);
+  });
+
+  it('declares no secrets without consumers', () => {
+    expect(redisManaged(base).secrets?.()).toEqual([]);
+  });
+
+  it('validate refuses ca consumers with tls disabled (would silently emit no CA secret)', () => {
+    const store = redisManaged({ ...base, tls: false, secretConsumers: { url: ['api'], ca: ['api'] } });
+    expect(() => store.validate?.()).toThrow(/tls is disabled/);
+  });
+
+  it('validate passes for the default TLS posture', () => {
+    const store = redisManaged({ ...base, secretConsumers: { url: ['api'], ca: ['api'] } });
+    expect(() => store.validate?.()).not.toThrow();
+  });
+});

--- a/infra/resources/stores/redis-managed.ts
+++ b/infra/resources/stores/redis-managed.ts
@@ -13,6 +13,13 @@ export interface RedisManagedConfig {
   /** Terminate connections with TLS (rediss scheme). Defaults to true. */
   tls?: boolean;
   /**
+   * Permit a public cluster endpoint. Off by default: the provider-formatted
+   * `connectionString` prefers a public endpoint when one exists, so an
+   * unnoticed public network would silently switch the emitted REDIS_URL from
+   * private to internet-reachable.
+   */
+  allowPublicEndpoint?: boolean;
+  /**
    * Services that consume the connection URL (and, with TLS, the cluster CA)
    * as runtime secrets. When set, the store owns the secret declarations.
    */
@@ -33,6 +40,14 @@ export function redisManaged(config: RedisManagedConfig): StoreProvisioner {
 
   return {
     kind: 'redis-managed',
+
+    validate(): void {
+      if (!tls && config.secretConsumers?.ca?.length) {
+        throw new Error(
+          'redisManaged: secretConsumers.ca declared but tls is disabled — no CA secret would be emitted. Enable tls or drop the ca consumers.',
+        );
+      }
+    },
 
     secrets(): StoreSecretContribution[] {
       const consumers = config.secretConsumers;
@@ -86,16 +101,27 @@ export function redisManaged(config: RedisManagedConfig): StoreProvisioner {
         { protect: isProduction },
       );
 
+      // Provider-formatted URI for the first reachable endpoint; rediss scheme
+      // when TLS is enabled, userinfo included. Posture guard: the provider
+      // prefers a public endpoint when one exists, so fail the deploy rather
+      // than silently emit an internet-reachable REDIS_URL (O-F5).
+      const connectionString = cluster.publicNetwork.apply((publicNetwork) => {
+        if (!config.allowPublicEndpoint && (publicNetwork?.ips?.length ?? 0) > 0) {
+          throw new Error(
+            'redisManaged: the cluster has a public endpoint but allowPublicEndpoint is not set — the emitted REDIS_URL would prefer it. Opt in explicitly or remove the public network.',
+          );
+        }
+        return cluster.connectionString;
+      });
+
       return {
         outputs: {
           clusterId: cluster.id,
-          // Provider-formatted URI for the first reachable endpoint; rediss
-          // scheme when TLS is enabled, userinfo included.
-          connectionString: cluster.connectionString,
+          connectionString,
           certificate: cluster.certificate,
         },
         secretValues: {
-          redisUrl: cluster.connectionString,
+          redisUrl: connectionString,
           ...(tls
             ? {
                 // Base64-encode the multiline CA for line-based `.env.runtime`

--- a/infra/scripts/engine-gate.sh
+++ b/infra/scripts/engine-gate.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Engine-purity gate (.todos/INFRA.md): the deploy engine — resources/,
+# compose/, lib/, boot/src/ — must not contain app knowledge. Refined per
+# P-F1 so it can actually go green: case-sensitive \bMODE\b (lowercase "mode"
+# is a legitimate engine concept), the quoted literal '/health' (import paths
+# and prose don't count), and service(Url|Host) called with a literal service
+# name. Tests and build artifacts are excluded. One blessed pin is allowlisted:
+# the runMigrate genId fingerprint key (P-F2 — fingerprint object keys are
+# hashed into every live genId; renaming it re-rolls every generation).
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+PATTERNS=(
+  '[cC]ella'
+  '\bMODE\b'
+  "'/health'"
+  'service(Url|Host)\(.?(frontend|backend|cdc|yjs|mcp)'
+  '\bmigrate\b'
+)
+ALLOW='resources/generations\.ts:[0-9]+:.*runMigrate'
+
+violations=0
+for pattern in "${PATTERNS[@]}"; do
+  hits=$(grep -rEn "$pattern" resources compose lib boot/src \
+    --include='*.ts' --exclude='*.test.ts' | grep -Ev "$ALLOW" || true)
+  if [ -n "$hits" ]; then
+    echo "── pattern: $pattern"
+    echo "$hits"
+    echo
+    violations=1
+  fi
+done
+
+if [ "$violations" -eq 0 ]; then
+  echo "engine gate: clean"
+else
+  echo "engine gate: violations above — engine code must not know the app (see .todos/INFRA.md)"
+  exit 1
+fi


### PR DESCRIPTION
First half of `.todos/INFRA.md` todo 2 (cheap correctness batch) — the operator-facing items. The deploy-path half (mint-generation-keys stage-then-prune, per-rule drift compare, CI-app assert row, follower version-gate) follows as its own PR so CI-critical changes get a focused review. Independent of #1028 (branched off main, no file overlap).

## Changes

- **S23 — apex derivation**: `resources/loadbalancer.ts` derived the app host from the `'frontend'` literal; now from the `lbRoute: 'default'` service (the S14 pattern). Byte-identical for cella. `legacyBaseNames` stays — it pins shipped Pulumi URNs.
- **Teardown lock**: `stackLock.release()` now runs in a `finally`; a throw between acquire and release no longer strands the lock until TTL.
- **Engine gate, executable**: the doc-only purity grep becomes `pnpm --filter infra engine-gate` (P-F1 refinements: case-sensitive `\bMODE\b`, quoted `'/health'`, `service(Url|Host)\(` with a literal name, tests/artifacts excluded, `runMigrate` genId pin allowlisted per P-F2). After this PR the only residue is the `cella-infra` IAM branding pair — the parked decision (INFRA.md todo 6).
- **redisManaged posture (O-F5)**: new `validate()` refuses `secretConsumers.ca` with `tls: false` (that combination silently emitted no CA secret), and the emitted connection string now fails the deploy if the cluster has a public endpoint without `allowPublicEndpoint` — the provider prefers public endpoints, so this would otherwise silently switch `REDIS_URL` to internet-reachable. First real user of the store-plugin `validate()` op. (+5 unit tests; store is still unwired, so cella is unaffected.)

## Verification

`pnpm --filter infra ts` clean; 659 infra tests green; engine-gate output verified by hand (3 hits before the comment fix, 2 branding hits remain by design); full-repo hook (biome, typescript, commitlint) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
