### PR TITLE
fix(infra): deploy-path guardrails — mint staging, per-rule drift, CI assert row, follower gate

### DIFF
--- a/infra/cli/actions/setup.ts
+++ b/infra/cli/actions/setup.ts
@@ -7,7 +7,8 @@ import { deriveInfra } from '../../lib/naming';
 import { operatorManagedRuntimeSecrets } from '../../lib/runtime-secrets';
 import { buildProviderEnv } from '../../lib/scaleway/bootstrap-scw-env';
 import { ensureDnsZone } from '../../lib/scaleway/ensure-dns-zone';
-import { ORG_PERMISSION_SETS, PROJECT_PERMISSION_SETS } from '../../lib/scaleway/permissions';
+import { CI_RULE_SHAPES } from '../../lib/scaleway/permissions';
+import { principalNames } from '../../lib/scaleway/principals';
 import { createProject, listProjects, resolveOrganizationIdFromKey } from '../../lib/scaleway/scaleway-account';
 import {
   ensureBootstrapDnsGrant,
@@ -22,7 +23,7 @@ import { changeMark, checkMark, DIVIDER, failWithHint, pc, warningMark, withSpin
 import { writeEnvVar } from '../../lib/utils/env-file';
 import { errorMessage } from '../../lib/utils/errors';
 import { infraDir } from '../../lib/utils/paths';
-import { fetchAppPermissionSetsByName } from '../../tasks/assert-vm-grants';
+import { fetchAppRulesByName } from '../../tasks/assert-vm-grants';
 import { provisionManagedKey } from '../../tasks/provision-managed-key';
 import { seedOperatorSecrets } from '../../tasks/seed-operator-secrets';
 import { setupAdminApp } from '../../tasks/setup-admin-app';
@@ -115,22 +116,40 @@ async function warnOnMissingOperatorSecrets(ctx: SetupContext): Promise<void> {
   }
 }
 
-/** Advisory-only drift check of the live CI grant against the code-defined sets. */
+/**
+ * Advisory-only drift check of the live CI grant against the code-defined
+ * rule shapes. Per-rule (sets AND condition), not a permission-set union: a
+ * union compare cannot see a rule that went missing while its sets survive on
+ * another rule, nor a condition appearing on a rule that must stay
+ * unconditioned (the disproven key-mint condition resurfacing).
+ */
 async function warnOnCiPolicyDrift(ctx: SetupContext): Promise<void> {
   try {
-    const liveSets = await fetchAppPermissionSetsByName({
+    const liveRules = await fetchAppRulesByName({
       secretKey: ctx.secretKey,
       projectId: ctx.projectId,
-      applicationName: `${ctx.appConfig.slug}-${ctx.context.environment}-ci-deploy`,
+      applicationName: principalNames(ctx.appConfig.slug, ctx.context.environment).ciDeploy,
     });
-    if (!liveSets) return;
-    const expected: string[] = [...PROJECT_PERMISSION_SETS, ...ORG_PERMISSION_SETS].sort();
-    const missing = expected.filter((s) => !liveSets.includes(s));
-    const extra = liveSets.filter((s) => !expected.includes(s));
-    if (missing.length || extra.length) {
+    if (!liveRules) return;
+    const setKey = (sets: readonly string[]): string => [...sets].sort().join(',');
+    const liveByKey = new Map(liveRules.map((rule) => [setKey(rule.permissionSets), rule]));
+    const problems: string[] = [];
+    for (const shape of CI_RULE_SHAPES) {
+      const live = liveByKey.get(setKey(shape.permissionSets));
+      if (!live) {
+        problems.push(`missing rule [${shape.id}: ${shape.permissionSets.join(', ')}]`);
+        continue;
+      }
+      if (live.condition)
+        problems.push(
+          `rule [${shape.id}] carries a condition '${live.condition}' (CI rules are unconditioned by design)`,
+        );
+      liveByKey.delete(setKey(shape.permissionSets));
+    }
+    for (const [key, rule] of liveByKey) problems.push(`unexpected rule [${rule.policyName}: ${key}]`);
+    if (problems.length > 0) {
       console.warn(
-        `  ${warningMark} CI policy permission sets have drifted from code` +
-          `${missing.length ? ` (missing: ${missing.join(', ')})` : ''}${extra.length ? ` (extra: ${extra.join(', ')})` : ''}. ` +
+        `  ${warningMark} CI policy has drifted from code: ${problems.join('; ')}. ` +
           `Re-run bootstrap and choose ${pc.italic('"Rotate keys"')} to reconcile.`,
       );
     }

--- a/infra/lib/scaleway/permissions.ts
+++ b/infra/lib/scaleway/permissions.ts
@@ -115,6 +115,26 @@ export const BOOT_PROJECT_PERMISSION_SETS = ['ContainerRegistryReadOnly', 'Objec
  */
 export const CI_KEY_MINT_PERMISSION_SETS = ['IAMApplicationManager'] as const;
 
+/**
+ * The CI policy's full per-rule shape (permission sets + scope kind), shared
+ * by the rule builder (setup-ci-key.ts) and the advisory drift check
+ * (setup.ts warnOnCiPolicyDrift) so the two cannot diverge. Every CI rule is
+ * UNCONDITIONED by design (the key-mint resource.id condition is disproven on
+ * live Scaleway — see CI_KEY_MINT_PERMISSION_SETS); a condition appearing on
+ * any CI rule is drift worth surfacing.
+ */
+export interface CiRuleShape {
+  id: 'project' | 'dns' | 'org-read' | 'key-mint';
+  scope: 'project' | 'dns-projects' | 'organization';
+  permissionSets: readonly string[];
+}
+export const CI_RULE_SHAPES: readonly CiRuleShape[] = [
+  { id: 'project', scope: 'project', permissionSets: PROJECT_PERMISSION_SETS },
+  { id: 'dns', scope: 'dns-projects', permissionSets: DNS_PERMISSION_SETS },
+  { id: 'org-read', scope: 'organization', permissionSets: ORG_SCOPED_PERMISSION_SETS },
+  { id: 'key-mint', scope: 'organization', permissionSets: CI_KEY_MINT_PERMISSION_SETS },
+];
+
 // Bootstrap-owned boundary
 
 /**

--- a/infra/tasks/assert-vm-grants.ts
+++ b/infra/tasks/assert-vm-grants.ts
@@ -143,50 +143,19 @@ async function fetchApplicationGroupIds(
 }
 
 /**
- * Union of permission set names actually granted to an application: the rules of
- * every policy whose principal is the application itself or a group it belongs to.
- * Policies bound to other principals (other applications, users, or unrelated
- * groups) are excluded, so a shared organization's policies do not leak in.
+ * Every rule (permission sets + condition) granted to an application resolved
+ * by name. Returns null when the application does not exist. Convenience
+ * wrapper (resolve org → resolve app id → collect rules) for callers that only
+ * have the deterministic `<slug>-<suffix>` name (the CLI's per-rule CI-policy
+ * drift check).
  */
-export async function fetchGrantedPermissionSets(
-  fetchImpl: FetchLike,
-  secretKey: string,
-  organizationId: string,
-  applicationId: string,
-): Promise<string[]> {
-  const groupIds = await fetchApplicationGroupIds(fetchImpl, secretKey, organizationId, applicationId);
-  const policies = await listOrganizationPolicies(fetchImpl, secretKey, organizationId);
-  const bound = policies.filter(
-    (policy) =>
-      policy.application_id === applicationId || (policy.group_id !== undefined && groupIds.has(policy.group_id)),
-  );
-  const granted = new Set<string>();
-  for (const policy of bound) {
-    const { rules = [] } = await scwGet<{ rules?: Array<{ permission_set_names?: string[] }> }>(
-      fetchImpl,
-      secretKey,
-      `${IAM_BASE}/rules?policy_id=${policy.id}&page_size=100`,
-    );
-    for (const rule of rules) {
-      for (const name of rule.permission_set_names ?? []) granted.add(name);
-    }
-  }
-  return [...granted];
-}
-
-/**
- * Sorted union of permission set names granted to an application resolved by
- * name. Returns null when the application does not exist. Convenience wrapper
- * (resolve org → resolve app id → collect sets) for callers that only have the
- * deterministic `<slug>-<suffix>` name (e.g. the CLI's CI-policy drift check).
- */
-export async function fetchAppPermissionSetsByName(opts: {
+export async function fetchAppRulesByName(opts: {
   secretKey: string;
   projectId: string;
   applicationName: string;
   organizationId?: string;
   fetchImpl?: FetchLike;
-}): Promise<string[] | null> {
+}): Promise<Array<{ policyName: string; permissionSets: string[]; condition: string }> | null> {
   const fetchImpl = resolveFetch(opts.fetchImpl);
   const organizationId = opts.organizationId ?? (await resolveOrgId(fetchImpl, opts.secretKey, opts.projectId));
   const applicationId = await resolveApplicationIdByName(
@@ -196,7 +165,7 @@ export async function fetchAppPermissionSetsByName(opts: {
     opts.applicationName,
   );
   if (!applicationId) return null;
-  return (await fetchGrantedPermissionSets(fetchImpl, opts.secretKey, organizationId, applicationId)).sort();
+  return fetchGrantedRules(fetchImpl, opts.secretKey, organizationId, applicationId);
 }
 
 /** Every rule (permission sets + condition) granted to an application across its policies. */

--- a/infra/tasks/deploy-run.test.ts
+++ b/infra/tasks/deploy-run.test.ts
@@ -25,9 +25,13 @@ async function fakeDeployEnv(opts: DeployOptions): Promise<Record<AllowedKey, st
       },
     ]),
     enabled_services_json: JSON.stringify([
-      { service: 'backend', public_url: 'https://www.cellajs.com/api' },
-      { service: 'cdc', public_url: '' },
-      { service: 'frontend', public_url: 'https://www.cellajs.com' },
+      // health_url mirrors print-deploy-env: set for LB-exposed services
+      // (including co-hosted followers), '' for internal-only ones. The
+      // version-verification step reads THESE rows, not the rollout matrices.
+      { service: 'backend', public_url: 'https://www.cellajs.com/api', health_url: 'https://www.cellajs.com/api' },
+      { service: 'cdc', public_url: '', health_url: '' },
+      { service: 'yjs', public_url: 'https://www.cellajs.com/yjs', health_url: 'https://www.cellajs.com/yjs' },
+      { service: 'frontend', public_url: 'https://www.cellajs.com', health_url: 'https://www.cellajs.com' },
     ]),
     build_images_matrix: JSON.stringify([{ service: 'backend', dockerfile: 'Dockerfile', target: 'backend' }]),
     primary_rollout_matrix: JSON.stringify([{ service: 'backend', health_url: 'https://www.cellajs.com/api' }]),
@@ -122,8 +126,10 @@ describe('runDeploy sequencing', () => {
       expect(index, `${op} missing or out of order in: ${ops.join(', ')}`).toBeGreaterThan(cursor);
       cursor = index;
     }
-    // Public version verification covers every LB-exposed service.
+    // Public version verification covers every LB-exposed service — including
+    // the co-hosted follower (yjs), which is absent from the rollout matrices.
     expect(ops.some((op) => op.startsWith('verify:') && op.endsWith('/health'))).toBe(true);
+    expect(ops).toContain('verify:https://www.cellajs.com/yjs/health');
     expect(ops).not.toContain('boot-diag');
   });
 

--- a/infra/tasks/deploy-run.ts
+++ b/infra/tasks/deploy-run.ts
@@ -291,7 +291,11 @@ export async function runDeploy(
     }
 
     await step('Verify public versions', async () => {
-      const rows: RolloutRow[] = [...JSON.parse(env.primary_rollout_matrix), ...JSON.parse(env.roll_rest_matrix)];
+      // Every LB-exposed service, not just the VM-owning rollout rows:
+      // co-hosted and collocated followers are repointed by cutover without
+      // their own version probe, so they gate here too, before the new entry
+      // files publish.
+      const rows: RolloutRow[] = JSON.parse(env.enabled_services_json);
       for (const row of rows) {
         if (!row.health_url) continue;
         const ok = await fx.verifyVersion(`${row.health_url.replace(/\/$/, '')}${healthContract.path}`, opts.sha);

--- a/infra/tasks/mint-generation-keys.test.ts
+++ b/infra/tasks/mint-generation-keys.test.ts
@@ -1,0 +1,117 @@
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSecretManagerClient } from '../lib/scaleway/scaleway-secret-manager';
+import { scwFetch, scwSend } from '../lib/scaleway/scw-fetch';
+import { mintGenerationKeys } from './mint-generation-keys';
+
+vi.mock('../lib/scaleway/scw-fetch', () => ({ scwFetch: vi.fn(), scwSend: vi.fn() }));
+vi.mock('../lib/scaleway/scaleway-secret-manager', () => ({ createSecretManagerClient: vi.fn() }));
+
+/**
+ * Ordered operation log across both mocked APIs, so the tests can assert the
+ * transactional ordering (every bundle staged before any key deletion).
+ */
+let ops: string[];
+let mintCount: number;
+let failStagingFor: string | undefined;
+
+function installMocks(): void {
+  ops = [];
+  mintCount = 0;
+  failStagingFor = undefined;
+
+  vi.mocked(scwFetch).mockImplementation(async (_auth, method, url: string) => {
+    if (method === 'GET' && url.includes('/applications?name=')) {
+      const name = decodeURIComponent(new URL(url).searchParams.get('name') ?? '');
+      return { applications: [{ id: `id-${name}`, name }] } as never;
+    }
+    if (method === 'POST' && url.endsWith('/api-keys')) {
+      mintCount += 1;
+      ops.push(`mint:${mintCount}`);
+      return { access_key: `ak-fresh-${mintCount}`, secret_key: 'sk', created_at: `2026-01-2${mintCount}` } as never;
+    }
+    if (method === 'GET' && url.includes('/api-keys?application_id=')) {
+      // Two stale keys plus the freshly-minted ones: prune must delete exactly
+      // the two oldest and keep the newest KEYS_TO_KEEP.
+      return {
+        api_keys: [
+          { access_key: 'ak-old-1', secret_key: '', created_at: '2026-01-01' },
+          { access_key: 'ak-old-2', secret_key: '', created_at: '2026-01-02' },
+          { access_key: 'ak-live', secret_key: '', created_at: '2026-01-10' },
+          { access_key: 'ak-fresh-x', secret_key: '', created_at: '2026-01-29' },
+        ],
+      } as never;
+    }
+    throw new Error(`unexpected scwFetch ${method} ${url}`);
+  });
+
+  vi.mocked(scwSend).mockImplementation(async (_auth, method, url: string) => {
+    ops.push(`${method.toLowerCase()}:${url.split('/').pop()}`);
+  });
+
+  vi.mocked(createSecretManagerClient).mockReturnValue({
+    listSecretsUnder: async () => [{ id: 'stale-bundle', name: 'handoff-stale', region: 'nl-ams' }],
+    deleteSecret: async (id: string) => {
+      ops.push(`delete-bundle:${id}`);
+    },
+    ensureSecret: async ({ name }: { name: string }) => ({ id: `bundle-${name}` }),
+    putSecretValue: async ({ secretId }: { secretId: string }) => {
+      if (failStagingFor && secretId.includes(failStagingFor)) throw new Error(`staging failed for ${secretId}`);
+      ops.push(`stage:${secretId}`);
+    },
+  } as never);
+}
+
+const outDir = mkdtempSync(join(tmpdir(), 'mint-test-'));
+
+function options(outFile: string) {
+  return {
+    slug: 'cella',
+    mode: 'production',
+    sha: 'abcdef012345',
+    region: 'nl-ams',
+    projectId: 'proj',
+    organizationId: 'org',
+    services: ['backend', 'frontend'] as const,
+    callerSecretKey: 'ci-secret',
+    outFile,
+    log: () => {},
+  };
+}
+
+beforeEach(installMocks);
+
+describe('mintGenerationKeys', () => {
+  it('stages every handoff bundle before pruning any api key', async () => {
+    const outFile = join(outDir, 'ok.json');
+    const result = await mintGenerationKeys(options(outFile));
+
+    const lastStage = ops.map((op) => op.startsWith('stage:')).lastIndexOf(true);
+    const firstKeyDelete = ops.findIndex((op) => op.startsWith('delete:ak-'));
+    expect(lastStage).toBeGreaterThanOrEqual(0);
+    expect(firstKeyDelete).toBeGreaterThan(lastStage);
+
+    expect(result.bootAccessKey).toBe('ak-fresh-1');
+    expect(Object.keys(result.handoffSecretIds)).toEqual(['backend', 'frontend']);
+    expect(JSON.parse(readFileSync(outFile, 'utf8'))).toEqual(result);
+  });
+
+  it('prunes exactly the keys beyond the newest KEYS_TO_KEEP, per app', async () => {
+    await mintGenerationKeys(options(join(outDir, 'prune.json')));
+    const keyDeletes = ops.filter((op) => op.startsWith('delete:ak-'));
+    // 3 apps (boot + 2 services) × 2 stale keys each; the newest 2 survive.
+    expect(keyDeletes).toHaveLength(6);
+    expect(new Set(keyDeletes)).toEqual(new Set(['delete:ak-old-1', 'delete:ak-old-2']));
+  });
+
+  it('a staging failure aborts with ZERO api keys pruned (old generation keeps its credentials)', async () => {
+    failStagingFor = 'handoff-frontend';
+    await expect(mintGenerationKeys(options(join(outDir, 'fail.json')))).rejects.toThrow(/staging failed/);
+    expect(ops.some((op) => op.startsWith('delete:ak-'))).toBe(false);
+    // The first service's bundle was staged before the failure — that is fine;
+    // what must not happen is key pruning.
+    expect(ops.filter((op) => op.startsWith('stage:'))).toHaveLength(1);
+  });
+});

--- a/infra/tasks/mint-generation-keys.ts
+++ b/infra/tasks/mint-generation-keys.ts
@@ -58,21 +58,30 @@ async function resolveAppId(secretKey: string, organizationId: string, name: str
   return app.id;
 }
 
-/** Mint a fresh key on the app, then prune all but the newest KEYS_TO_KEEP. */
-async function mintAndPrune(
+/** Mint a fresh key on the app. Pruning happens separately, AFTER every
+ *  handoff bundle is staged — see pruneStaleKeys. */
+async function mintKey(
   secretKey: string,
-  organizationId: string,
   projectId: string,
   appId: string,
   label: string,
   sha: string,
-  log: (msg: string) => void,
 ): Promise<ScwApiKey> {
-  const fresh = await scwFetch<ScwApiKey>({ secretKey }, 'POST', `${IAM_BASE}/api-keys`, {
+  return scwFetch<ScwApiKey>({ secretKey }, 'POST', `${IAM_BASE}/api-keys`, {
     application_id: appId,
     description: `${label} gen ${sha.slice(0, 10)}`,
     default_project_id: projectId,
   });
+}
+
+/** Delete all but the newest KEYS_TO_KEEP keys on the app. */
+async function pruneStaleKeys(
+  secretKey: string,
+  organizationId: string,
+  appId: string,
+  label: string,
+  log: (msg: string) => void,
+): Promise<void> {
   const { api_keys = [] } = await scwFetch<{ api_keys?: ScwApiKey[] }>(
     { secretKey },
     'GET',
@@ -83,7 +92,6 @@ async function mintAndPrune(
     await scwSend({ secretKey }, 'DELETE', `${IAM_BASE}/api-keys/${stale.access_key}`);
     log(`  ~ pruned ${label} key ${stale.access_key}`);
   }
-  return fresh;
 }
 
 /**
@@ -112,31 +120,28 @@ export async function mintGenerationKeys(opts: MintGenerationKeysOptions): Promi
     projectId: opts.projectId,
   });
 
+  // Resolve every app id first: a missing principal fails before anything is
+  // minted or pruned.
   const bootAppId = await resolveAppId(opts.callerSecretKey, opts.organizationId, names.boot);
-  const bootKey = await mintAndPrune(
-    opts.callerSecretKey,
-    opts.organizationId,
-    opts.projectId,
-    bootAppId,
-    names.boot,
-    opts.sha,
-    log,
-  );
+  const serviceAppIds = new Map<string, string>();
+  for (const service of opts.services) {
+    serviceAppIds.set(service, await resolveAppId(opts.callerSecretKey, opts.organizationId, names.vmService(service)));
+  }
+
+  // Transactional-ish ordering: mint and stage EVERYTHING first, prune keys
+  // LAST. A failure mid-staging then aborts with all existing keys intact —
+  // the old generation keeps hydrating/signing, and a retry re-mints cleanly.
+  // (The keep-newest-2 window can still age out the live key after repeated
+  // failed attempts within one deploy; bounded, documented, accepted.)
+  const bootKey = await mintKey(opts.callerSecretKey, opts.projectId, bootAppId, names.boot, opts.sha);
   log(`✓ minted boot key ${bootKey.access_key}`);
 
   const handoffSecretIds: Record<string, string> = {};
   for (const service of opts.services) {
     const appName = names.vmService(service);
-    const appId = await resolveAppId(opts.callerSecretKey, opts.organizationId, appName);
-    const serviceKey = await mintAndPrune(
-      opts.callerSecretKey,
-      opts.organizationId,
-      opts.projectId,
-      appId,
-      appName,
-      opts.sha,
-      log,
-    );
+    const appId = serviceAppIds.get(service);
+    if (!appId) throw new Error(`mint-generation-keys: no app id resolved for ${appName}`);
+    const serviceKey = await mintKey(opts.callerSecretKey, opts.projectId, appId, appName, opts.sha);
 
     // Prune older handoff bundles first: an unconsumed bundle from a failed
     // deploy is stale (VMs cache the key after their single read), and leaving
@@ -160,6 +165,13 @@ export async function mintGenerationKeys(opts: MintGenerationKeysOptions): Promi
     });
     handoffSecretIds[service] = bundle.id;
     log(`✓ staged handoff bundle for ${service} (${bundle.id})`);
+  }
+
+  // Every bundle is staged; only now retire stale keys.
+  await pruneStaleKeys(opts.callerSecretKey, opts.organizationId, bootAppId, names.boot, log);
+  for (const service of opts.services) {
+    const appId = serviceAppIds.get(service);
+    if (appId) await pruneStaleKeys(opts.callerSecretKey, opts.organizationId, appId, names.vmService(service), log);
   }
 
   const result: GenerationKeys = {

--- a/infra/tasks/print-deploy-env.test.ts
+++ b/infra/tasks/print-deploy-env.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   BACKEND_S3_PERMISSION_SETS,
   BOOT_PROJECT_PERMISSION_SETS,
+  CI_RULE_SHAPES,
   SERVICE_SECRET_PERMISSION_SETS,
 } from '../lib/scaleway/permissions';
 import { bootKeyCondition, serviceKeyCondition } from '../lib/scaleway/secret-paths';
@@ -52,6 +53,11 @@ describe('buildDeployEnv', () => {
           app: 'cella-production-boot',
           sets: [...BOOT_PROJECT_PERMISSION_SETS, ...SERVICE_SECRET_PERMISSION_SETS],
           condition: bootKeyCondition('cella', 'production'),
+        },
+        {
+          app: 'cella-production-ci-deploy',
+          sets: CI_RULE_SHAPES.flatMap((shape) => [...shape.permissionSets]),
+          condition: '',
         },
       ]),
       enabled_services_json: JSON.stringify([

--- a/infra/tasks/print-deploy-env.ts
+++ b/infra/tasks/print-deploy-env.ts
@@ -3,6 +3,7 @@ import { deriveInfra } from '../lib/naming';
 import {
   BACKEND_S3_PERMISSION_SETS,
   BOOT_PROJECT_PERMISSION_SETS,
+  CI_RULE_SHAPES,
   SERVICE_SECRET_PERMISSION_SETS,
 } from '../lib/scaleway/permissions';
 import { principalNames } from '../lib/scaleway/principals';
@@ -112,6 +113,15 @@ export function buildDeployEnv(appConfig: Cfg, opts: { imageTag?: string } = {})
         app: principalNames(appConfig.slug, appConfig.mode).boot,
         sets: [...BOOT_PROJECT_PERMISSION_SETS, ...SERVICE_SECRET_PERMISSION_SETS],
         condition: bootKeyCondition(appConfig.slug, appConfig.mode),
+      },
+      // The CI app asserts its own grant too: exact set union (missing sets
+      // fail deploys later and non-read-only extras are an escalation).
+      // condition '' skips the secret-condition check — CI rules are
+      // unconditioned by design (see CI_RULE_SHAPES).
+      {
+        app: principalNames(appConfig.slug, appConfig.mode).ciDeploy,
+        sets: CI_RULE_SHAPES.flatMap((shape) => [...shape.permissionSets]),
+        condition: '',
       },
     ]),
     enabled_services_json: JSON.stringify(enabledServiceRows),

--- a/infra/tasks/setup-ci-key.ts
+++ b/infra/tasks/setup-ci-key.ts
@@ -1,12 +1,7 @@
 import { syncGithubEnvironment } from '../lib/github-sync';
 import { resolveProjectId } from '../lib/scaleway/bootstrap-scw-env';
 import { resolveDnsProjectIds } from '../lib/scaleway/dns-zone-project';
-import {
-  CI_KEY_MINT_PERMISSION_SETS,
-  DNS_PERMISSION_SETS,
-  ORG_SCOPED_PERMISSION_SETS,
-  PROJECT_PERMISSION_SETS,
-} from '../lib/scaleway/permissions';
+import { CI_RULE_SHAPES } from '../lib/scaleway/permissions';
 import { type ProvisionScopedKeyOptions, provisionScopedKey, type ScopedKeyResult } from '../lib/scaleway/scaleway-iam';
 import { checkMark, DIVIDER, pc, warningMark } from '../lib/utils/cli-output';
 import { isMain } from '../lib/utils/is-main';
@@ -42,24 +37,20 @@ export async function setupCiKey(opts: SetupCiKeyOptions): Promise<CiKeyResult> 
     suffix: 'ci-deploy',
     appDescription: 'Non-human principal for GitHub Actions CI deployments',
     policyDescription: 'Least-privilege policy for CI deployments (auto-generated)',
-    buildRules: ({ projectId, organizationId }) => [
-      { permission_set_names: PROJECT_PERMISSION_SETS, project_ids: [projectId] },
-      // Separate rules per scope type (Scaleway rejects mixing them in one
-      // rule): DNS is project-scoped, IAMReadOnly is organization-scoped.
-      { permission_set_names: DNS_PERMISSION_SETS, project_ids: dnsProjectIds },
-      { permission_set_names: ORG_SCOPED_PERMISSION_SETS, organization_id: organizationId },
-      // v2: per-deploy service-key rotation. Unconditioned — the resource.id
-      // condition 403s real api-key mints on live Scaleway (disproven
-      // 2026-08-10; see CI_KEY_MINT_PERMISSION_SETS for the trade-off).
-      ...(opts.keyMintAppIds && opts.keyMintAppIds.length > 0
-        ? [
-            {
-              permission_set_names: CI_KEY_MINT_PERMISSION_SETS,
-              organization_id: organizationId,
-            },
-          ]
-        : []),
-    ],
+    // One rule per CI_RULE_SHAPES entry (separate rules per scope type:
+    // Scaleway rejects mixing scopes in one rule). The key-mint rule is
+    // unconditioned — the resource.id condition 403s real api-key mints on
+    // live Scaleway (disproven 2026-08-10; see CI_KEY_MINT_PERMISSION_SETS).
+    buildRules: ({ projectId, organizationId }) =>
+      CI_RULE_SHAPES.filter(
+        (shape) => shape.id !== 'key-mint' || (opts.keyMintAppIds && opts.keyMintAppIds.length > 0),
+      ).map((shape) =>
+        shape.scope === 'project'
+          ? { permission_set_names: [...shape.permissionSets], project_ids: [projectId] }
+          : shape.scope === 'dns-projects'
+            ? { permission_set_names: [...shape.permissionSets], project_ids: dnsProjectIds }
+            : { permission_set_names: [...shape.permissionSets], organization_id: organizationId },
+      ),
   });
 }
 


### PR DESCRIPTION
Second half of `.todos/INFRA.md` todo 2 — the deploy-path guardrails, split from #1030 so CI-critical changes get a focused review. All four items come from the archived IAM refactor backlog (items 10–12) + implementation findings (O-F4), verified still-live before implementing.

## Changes

- **mint-generation-keys is transactional-ish** (backlog #12): resolve every app id first (fail fast), mint keys and stage ALL single-access handoff bundles, prune stale keys only after every bundle is staged. Previously a mid-loop failure left some services key-pruned without a fresh bundle. Now a failure aborts with every existing key intact — the live generation keeps hydrating/signing — and a retry re-mints cleanly. First unit tests for this task (ordering across both APIs, per-app prune count, failure isolation). Known residual, documented in-code: repeated failed attempts within one deploy can still age the live key out of the keep-newest-2 window.
- **Per-rule CI drift check** (backlog #10): `warnOnCiPolicyDrift` now compares rule-by-rule (sets AND condition) against the new `CI_RULE_SHAPES` in `permissions.ts`, which `setup-ci-key` also builds its rules from — builder and checker share one source and cannot diverge. Surfaces: missing rules, unexpected rules, and any condition appearing on a CI rule (CI rules are unconditioned by design; a resurfacing key-mint condition is exactly the 2026-08-10 live/repo drift class). The union-only `fetchGrantedPermissionSets` fetcher is deleted (zero callers); `fetchAppRulesByName` replaces the wrapper. Also fixes the inline `-ci-deploy` name construction → `principalNames` (backlog #3).
- **CI-app assertion row** (backlog #11): `vm_assert_json` gains a row for the CI app itself, so the deploy's "Verify VM IAM grants" step asserts the CI key's exact set union — missing sets fail loudly with remediation instead of failing deeper, non-read-only extras are flagged as escalation. Condition-exempt (`condition: ''`) by design.
- **Follower version gate** (O-F4): "Verify public versions" now iterates every LB-exposed service from `enabled_services_json` instead of the VM-owning rollout matrices. Co-hosted (yjs/mcp) and collocated followers were repointed by cutover with no version probe until smoke — which runs *after* entry-file publish. Now every follower gates before publish. (Smoke already version-probes these same rows, so the header contract is proven.)

## Verification

644 infra tests green (3 new mint tests, deploy-run fixture extended with a follower row + assertion that it is verified); `pnpm --filter infra ts` clean; full-repo hook green. No Pulumi resources touched; behavior changes are deploy-step-internal.

Note for the next live deploy: the CI-app assert row makes grant drift deploy-fatal — if the CI policy was hand-edited at some point, the first deploy after this merge will say exactly what drifted and point at "Rotate keys".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
