### PR TITLE
fix(config): explicit .ts import extensions for Vite 8 'native' config loader

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -14,6 +14,7 @@
       "!frontend/src/routes/routeTree.gen.ts",
       "frontend/storybook/**",
       "frontend/vite/**",
+      "frontend/vite.config.ts",
       "packages/data-grid/src/**",
       "shared/**",
       "cdc/src/**",
@@ -131,6 +132,18 @@
     }
   },
   "overrides": [
+    {
+      // The vite config pulls in the whole shared/ module graph at config-load
+      // time; Vite 8's future 'native' loader requires explicit .ts extensions there.
+      "includes": ["shared/**", "frontend/vite/**", "frontend/vite.config.ts"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "useImportExtensions": "error"
+          }
+        }
+      }
+    },
     {
       // Default exports remain only where external tooling expects them.
       "includes": [

--- a/cella/migrations/20260811T0905-ts-import-extensions/README.md
+++ b/cella/migrations/20260811T0905-ts-import-extensions/README.md
@@ -1,0 +1,52 @@
+# Explicit .ts import extensions in the Vite config-load graph
+
+## What & why
+
+Vite 8 prints a ~150-line warning on every `pnpm dev`: the frontend config uses features
+unsupported by `configLoader: 'native'`, which is planned to become the default in a future
+Vite major. `frontend/vite.config.ts` imports `appConfig` from `shared`, so the entire
+`shared/` module graph is loaded at config time; the native loader (Node's built-in type
+stripping) requires fully-specified ESM imports, so extensionless relative imports become a
+hard break when the default flips. Upstream now: all relative imports in `shared/` and
+`frontend/vite/` carry explicit `.ts` extensions (~260 rewrites), directory-index imports
+name the index file (`'../shared/index.ts'`, `'./src/permissions/index.ts'`), `__dirname`
+became `import.meta.dirname` in `frontend/vite.config.ts` and the `frontend/vite/` tests,
+`allowImportingTsExtensions` moved to the root `tsconfig.json`, and a `biome.jsonc` override
+enforces `correctness/useImportExtensions` over `shared/**`, `frontend/vite/**`, and
+`frontend/vite.config.ts` (now also in Biome's `files.includes`).
+
+## Blast radius
+
+Not sync-breaking: no wire-shape change, no `clientCacheVersion` bump, no database change.
+The cost is merge surface — ~90 template-owned files change, so forks that customized
+`shared/` or `frontend/vite/` will see conflicts (take upstream, then re-run the fixer).
+After syncing, app-owned files inside those territories fail lint on extensionless relative
+imports until the codemod below runs. Apps that never touched those directories merge clean
+and need nothing beyond the sync itself.
+
+## Run
+
+The codemod is Biome's own fixer, driven by the synced `biome.jsonc` override. From the
+repo root:
+
+```sh
+pnpm biome lint --only=correctness/useImportExtensions --write --unsafe shared frontend/vite frontend/vite.config.ts   # apply
+pnpm lint:fix                                                                                                          # normalize
+```
+
+## Manual steps
+
+1. If you customized `frontend/vite.config.ts`, replace any remaining `__dirname` with
+   `import.meta.dirname` and keep the `'../shared/index.ts'` import fully specified.
+2. If a tsconfig in your app does not extend the root `tsconfig.json` but type-checks
+   `shared/` source, add `"allowImportingTsExtensions": true` to it (requires `noEmit`).
+3. Fix any directory-index imports the fixer flags but cannot resolve (rare; it rewrites
+   `'./dir'` to `'./dir/index.ts'` when the index file exists).
+
+## Verify
+
+```sh
+pnpm ts
+cd frontend && pnpm exec vite --configLoader native   # config must load under the future default (Node >= 22.18)
+pnpm check
+```

--- a/cella/migrations/manifest.json
+++ b/cella/migrations/manifest.json
@@ -406,6 +406,24 @@
         "pnpm test"
       ],
       "summary": "Settings-slot resolution moves into useChannelSettingsSections (grants, context-role pairs, overrides, stored toolsConfig); ChannelSettingsPage is a presentation-only map and a ChannelSettingsSheet reference consumer ships upstream. channelSettingsTools factory removed: spread generalToolBase/detailsToolBase/tabsToolBase/dangerToolBase(channelType, resource) and render full cards (DeleteToolCard exported; general now requires 'update'). getTools applies the section default order 50 (getSlotDescriptors stays raw for tabs); getChannelSettingsTools + ChannelSettingsToolFor removed. Surface trims: SlotToolsConfig.settings key dropped (no reader; stored config = order + hidden), PlacementOverride narrowed to hidden/order, heldContextRoles loses its unused entity-less overload; prefer requires over visibleTo (grants inherit down the ancestor chain). Backend mergeJsonbShallow util replaces inlined jsonb || merge fragments. Supersedes the channelSettingsTools guidance in 20260730T0858 step 5. No DB change, no cache bump. Arrangement UI pivots to tabs: ToolsArrangementCard deleted, TabsArrangementCard (flat data grid, row drag + visibility switches, writes toolsConfig['<channelType>.tabs']) demoed on organization settings via getNavTabCandidates (new ungated export from tab-nav); organization settings navTab now locked. toolsConfig is UI visibility only, never authorization \u2014 enforcement belongs to permissions/quotas."
+    },
+    {
+      "id": "20260811T0905-ts-import-extensions",
+      "version": "next",
+      "title": "Explicit .ts import extensions in the Vite config-load graph",
+      "kind": "manual",
+      "syncBreaking": false,
+      "clientCacheBump": false,
+      "script": null,
+      "roots": [
+        "shared",
+        "frontend/vite",
+        "frontend/vite.config.ts"
+      ],
+      "requires": [
+        "pnpm check"
+      ],
+      "summary": "Vite 8's future-default configLoader 'native' needs fully-specified ESM imports; vite.config.ts loads the whole shared/ graph at config time. All relative imports in shared/ and frontend/vite/ gain .ts extensions, directory-index imports name index.ts explicitly, __dirname becomes import.meta.dirname, allowImportingTsExtensions hoists to root tsconfig, and a biome.jsonc override enforces correctness/useImportExtensions over the territory. Codemod = Biome's own fixer (see README Run). Not sync-breaking, no cache bump, no DB."
     }
   ]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,39 +1,39 @@
+import { execSync } from 'node:child_process';
+import path from 'node:path';
 import mdx from '@mdx-js/rollup';
 import reactScan from '@react-scan/vite-plugin-react-scan';
+import babel from '@rolldown/plugin-babel';
 import terser from '@rollup/plugin-terser';
+import rehypeShiki from '@shikijs/rehype';
 import tailwindcss from '@tailwindcss/vite';
+import { tanstackRouter } from '@tanstack/router-plugin/vite';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 import react, { reactCompilerPreset } from '@vitejs/plugin-react';
-import babel from '@rolldown/plugin-babel';
-import path from 'node:path';
-import rehypeShiki from '@shikijs/rehype';
 import rehypeSlug from 'rehype-slug';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkGfm from 'remark-gfm';
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter';
 // import { visualizer } from 'rollup-plugin-visualizer';
-import { defineConfig, Plugin, type UserConfig } from 'vite';
+import { defineConfig, type Plugin, type UserConfig } from 'vite';
 import { createHtmlPlugin } from 'vite-plugin-html';
 import { VitePWA } from 'vite-plugin-pwa';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
-import { appConfig } from '../shared';
-import { tanstackRouter } from '@tanstack/router-plugin/vite';
-
-import { execSync } from 'node:child_process';
-import { sdkWatch } from './vite/sdk-watch';
-import { localesPlugin } from './vite/locales-plugin';
-import { docsFrontmatter } from './vite/docs-frontmatter';
-import { docsEditor } from './vite/docs-editor';
-import { remarkLinkRepoPaths } from './vite/remark-link-repo-paths';
+import { appConfig } from '../shared/index.ts';
+import { docsEditor } from './vite/docs-editor.ts';
+import { docsFrontmatter } from './vite/docs-frontmatter.ts';
+import { localesPlugin } from './vite/locales-plugin.ts';
+import { remarkLinkRepoPaths } from './vite/remark-link-repo-paths.ts';
+import { sdkWatch } from './vite/sdk-watch.ts';
 
 // Repo docs (cella/*.md) start with an h1 for GitHub readers, but the docs page view
 // already renders the frontmatter title as h1. Drop the leading h1 when such a file
 // is compiled as page content. Content-root files are authored without an h1.
-const remarkStripRepoDocH1 = () => (tree: { children: { type: string; depth?: number }[] }, file: { path?: string }) => {
-  if (!file.path || file.path.includes('/src/content/docs/')) return;
-  const index = tree.children.findIndex((node) => node.type === 'heading');
-  if (index !== -1 && tree.children[index].depth === 1) tree.children.splice(index, 1);
-};
+const remarkStripRepoDocH1 =
+  () => (tree: { children: { type: string; depth?: number }[] }, file: { path?: string }) => {
+    if (!file.path || file.path.includes('/src/content/docs/')) return;
+    const index = tree.children.findIndex((node) => node.type === 'heading');
+    if (index !== -1 && tree.children[index].depth === 1) tree.children.splice(index, 1);
+  };
 
 const isStorybook = process.env.STORYBOOK === 'true';
 const isDev = appConfig.mode === 'development';
@@ -69,7 +69,9 @@ const isTunneled = frontendUrl.hostname !== 'localhost';
 // when available (local/CI builds), 'unknown' otherwise (e.g. sourceless container).
 const gitSha = (() => {
   try {
-    return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+    return execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
   } catch {
     return 'unknown';
   }
@@ -91,7 +93,9 @@ const viteConfig = {
     },
     // Tunnel mode: ngrok terminates TLS and forwards plain HTTP. Accept the public
     // Host header and point HMR websockets back at the public origin.
-    ...(isTunneled ? { allowedHosts: [frontendUrl.hostname], hmr: { protocol: 'wss', host: frontendUrl.hostname, clientPort: 443 } } : {}),
+    ...(isTunneled
+      ? { allowedHosts: [frontendUrl.hostname], hmr: { protocol: 'wss', host: frontendUrl.hostname, clientPort: 443 } }
+      : {}),
     watch: {
       ignored: ['**/backend/**', '**/sdk/**'],
     },
@@ -117,7 +121,7 @@ const viteConfig = {
                 // CSP has no 'unsafe-eval', so the JavaScript regex engine is always used
                 if (/node_modules[\\/]@shikijs[\\/]engine-oniguruma[\\/]/.test(id)) return 'grammars-wasm';
                 const m = id.match(
-                  /node_modules[\\/]@shikijs[\\/](langs|langs-precompiled|themes)[\\/]dist[\\/]([\w.+-]+?)\.m?js$/
+                  /node_modules[\\/]@shikijs[\\/](langs|langs-precompiled|themes)[\\/]dist[\\/]([\w.+-]+?)\.m?js$/,
                 );
                 if (!m || m[2] === 'index') return null;
                 const variant = m[1] === 'langs-precompiled' ? 'pc-' : m[1] === 'themes' ? 'theme-' : '';
@@ -191,7 +195,7 @@ const viteConfig = {
     // Production source maps are public by choice (open-source frontend): Maple has no
     // sourcemap upload/symbolication, so public maps are what make minified stacks in error
     // events and session replays readable. Switch to 'hidden' if the frontend ever closes source.
-    sourcemap: isDev ? false : true,
+    sourcemap: !isDev,
     manifest: true,
     minify: isDev ? false : 'esbuild',
   },
@@ -229,15 +233,19 @@ const viteConfig = {
           // Autolink inline code that names a real repo file to its GitHub blob URL.
           [
             remarkLinkRepoPaths,
-            { repoRoot: path.resolve(__dirname, '..'), repoUrl: appConfig.company.githubUrl, docRoutes: repoDocRoutes },
+            {
+              repoRoot: path.resolve(import.meta.dirname, '..'),
+              repoUrl: appConfig.company.githubUrl,
+              docRoutes: repoDocRoutes,
+            },
           ],
         ],
-      // Generate GitHub-compatible heading slugs with the scroll-spy's DOM prefix.
-      // Keep aligned with frontmatter heading extraction.
+        // Generate GitHub-compatible heading slugs with the scroll-spy's DOM prefix.
+        // Keep aligned with frontmatter heading extraction.
         rehypePlugins: [
           [rehypeSlug, { prefix: 'spy-' }],
-      // Highlight Markdown at build time with dual GitHub themes selected by CSS variables.
-      // No runtime highlighter or CSP/WASM handling is required.
+          // Highlight Markdown at build time with dual GitHub themes selected by CSS variables.
+          // No runtime highlighter or CSP/WASM handling is required.
           [
             rehypeShiki,
             {
@@ -264,8 +272,8 @@ const viteConfig = {
     // serves the result at /locales/{lng}/{ns}.json in dev and emits it into the build.
     // The processed cache in .vscode/.locales-cache is also what i18n Ally reads.
     localesPlugin({
-      srcDir: path.resolve(__dirname, '../locales'),
-      outDir: path.resolve(__dirname, '../.vscode/.locales-cache'),
+      srcDir: path.resolve(import.meta.dirname, '../locales'),
+      outDir: path.resolve(import.meta.dirname, '../.vscode/.locales-cache'),
       merge: { target: 'c', sources: ['common', 'app'] },
       verbose: false,
     }),
@@ -311,8 +319,8 @@ const viteConfig = {
     // provider imports to the frontend's copies.
     dedupe: ['yjs', 'react', 'react-dom', '@mdx-js/react'],
     alias: {
-      '#json': path.resolve(__dirname, '../json'),
-      '~': path.resolve(__dirname, './src'),
+      '#json': path.resolve(import.meta.dirname, '../json'),
+      '~': path.resolve(import.meta.dirname, './src'),
     },
   },
   define: {
@@ -325,9 +333,9 @@ const viteConfig = {
         .map((key) => [key, process.env[key]]),
     ),
     // Injected into lib/sw.ts for periodic badge sync
-    '__BACKEND_URL__': JSON.stringify(appConfig.backendUrl),
+    __BACKEND_URL__: JSON.stringify(appConfig.backendUrl),
     // Release identifier for observability (lib/maple.ts serviceVersion)
-    '__APP_VERSION__': JSON.stringify(gitSha),
+    __APP_VERSION__: JSON.stringify(gitSha),
   },
 } satisfies UserConfig;
 
@@ -380,7 +388,7 @@ viteConfig.plugins?.push(
       globIgnores: ['**/grammars-*.js', '**/static/common/flags/**/*'],
       maximumFileSizeToCacheInBytes: 100 * 1024 * 1024, // 100MB
     },
-  })
+  }),
 );
 
 // Enable HTTPS only when serving https on localhost directly. Tunnel mode is https at
@@ -398,7 +406,7 @@ if (appConfig.mode === 'development' && !isStorybook) {
       scanOptions: {
         showToolbar: false,
       },
-    })
+    }),
   );
 }
 

--- a/frontend/vite/docs-editor.test.ts
+++ b/frontend/vite/docs-editor.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { parse } from 'yaml';
-import { applyFrontmatter, editDocPage, resolveSlugPath } from './docs-editor';
+import { applyFrontmatter, editDocPage, resolveSlugPath } from './docs-editor.ts';
 
 const NOW = '2026-07-07T00:00:00.000Z';
 

--- a/frontend/vite/docs-frontmatter.test.ts
+++ b/frontend/vite/docs-frontmatter.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { extractHeadings, extractStructure, pageStructure } from './docs-frontmatter';
+import { extractHeadings, extractStructure, pageStructure } from './docs-frontmatter.ts';
 
 /**
  * The extracted heading ids must match what rehype-slug (prefix: 'spy-') assigns when
@@ -68,7 +68,7 @@ describe('extractHeadings', () => {
   });
 
   it('extracts from a real repo doc (wrapper page body)', () => {
-    const source = readFileSync(path.resolve(__dirname, '../../cella/TESTING.md'), 'utf8');
+    const source = readFileSync(path.resolve(import.meta.dirname, '../../cella/TESTING.md'), 'utf8');
     const headings = extractHeadings(source, { stripLeadingH1: true });
     const ids = headings.map((h) => h.id);
     expect(ids).toContain('spy-running-tests');
@@ -170,7 +170,7 @@ describe('extractStructure sections', () => {
   });
 
   it('follows wrapper-page imports for sections (real repo doc)', () => {
-    const wrapperPath = path.resolve(__dirname, '../src/content/docs/fixture.mdx');
+    const wrapperPath = path.resolve(import.meta.dirname, '../src/content/docs/fixture.mdx');
     const wrapperSource = "import Content from '../../../../cella/TESTING.md'\n\n<Content />\n";
     const { headings, sections } = pageStructure(wrapperPath, wrapperSource);
     expect(headings.length).toBeGreaterThan(0);

--- a/frontend/vite/docs-frontmatter.ts
+++ b/frontend/vite/docs-frontmatter.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import GithubSlugger from 'github-slugger';
 import type { Plugin } from 'vite';
 import { parse } from 'yaml';
-import { createUpdatedAtResolver, type UpdatedAtResolver } from './git-updated-at';
+import { createUpdatedAtResolver, type UpdatedAtResolver } from './git-updated-at.ts';
 
 const VIRTUAL_ID = 'virtual:docs-frontmatter';
 const RESOLVED_ID = `\0${VIRTUAL_ID}`;

--- a/frontend/vite/git-updated-at.test.ts
+++ b/frontend/vite/git-updated-at.test.ts
@@ -1,12 +1,12 @@
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { createUpdatedAtResolver } from './git-updated-at';
+import { createUpdatedAtResolver } from './git-updated-at.ts';
 
 describe('createUpdatedAtResolver', () => {
-  const resolver = createUpdatedAtResolver(__dirname);
-  const existing = path.resolve(__dirname, 'docs-frontmatter.ts');
-  const alsoExisting = path.resolve(__dirname, 'git-updated-at.ts');
-  const missing = path.resolve(__dirname, 'does-not-exist.xyz');
+  const resolver = createUpdatedAtResolver(import.meta.dirname);
+  const existing = path.resolve(import.meta.dirname, 'docs-frontmatter.ts');
+  const alsoExisting = path.resolve(import.meta.dirname, 'git-updated-at.ts');
+  const missing = path.resolve(import.meta.dirname, 'does-not-exist.xyz');
 
   const asMs = (iso: string | undefined) => (iso ? Date.parse(iso) : Number.NaN);
 

--- a/frontend/vite/remark-link-repo-paths.test.ts
+++ b/frontend/vite/remark-link-repo-paths.test.ts
@@ -1,8 +1,8 @@
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { remarkLinkRepoPaths } from './remark-link-repo-paths';
+import { remarkLinkRepoPaths } from './remark-link-repo-paths.ts';
 
-const repoRoot = path.resolve(__dirname, '../..');
+const repoRoot = path.resolve(import.meta.dirname, '../..');
 const repoUrl = 'https://github.com/cellajs/cella';
 const transform = remarkLinkRepoPaths({ repoRoot, repoUrl });
 const docsTransform = remarkLinkRepoPaths({

--- a/shared/config/config.default.ts
+++ b/shared/config/config.default.ts
@@ -1,9 +1,9 @@
-import type { ConfigMode, RequiredConfig, S3ConfigInput } from '../src/config-builder/types';
-import { nonEmpty } from '../src/config-builder/utils';
-import { hierarchy } from './hierarchy-config';
+import type { ConfigMode, RequiredConfig, S3ConfigInput } from '../src/config-builder/types.ts';
+import { nonEmpty } from '../src/config-builder/utils.ts';
+import { hierarchy } from './hierarchy-config.ts';
 
 // Re-export for external consumers
-export { hierarchy, roles } from './hierarchy-config';
+export { hierarchy, roles } from './hierarchy-config.ts';
 
 export const config = {
   // Entity data model, derived from the hierarchy: the builder in hierarchy-config.ts is the

--- a/shared/config/config.development.ts
+++ b/shared/config/config.development.ts
@@ -1,5 +1,5 @@
-import type { DeepPartial } from '../src/config-builder/types';
-import type { config as _default } from './config.default';
+import type { DeepPartial } from '../src/config-builder/types.ts';
+import type { config as _default } from './config.default.ts';
 
 export const development = {
   mode: 'development',

--- a/shared/config/config.production.ts
+++ b/shared/config/config.production.ts
@@ -1,5 +1,5 @@
-import type { DeepPartial } from '../src/config-builder/types';
-import type { config as _default } from './config.default';
+import type { DeepPartial } from '../src/config-builder/types.ts';
+import type { config as _default } from './config.default.ts';
 
 export const production = {
   mode: 'production',

--- a/shared/config/config.staging.ts
+++ b/shared/config/config.staging.ts
@@ -1,5 +1,5 @@
-import type { DeepPartial } from '../src/config-builder/types';
-import type { config as _default } from './config.default';
+import type { DeepPartial } from '../src/config-builder/types.ts';
+import type { config as _default } from './config.default.ts';
 
 export const staging = {
   mode: 'staging',

--- a/shared/config/config.template.ts
+++ b/shared/config/config.template.ts
@@ -1,9 +1,9 @@
-import type { ConfigMode, RequiredConfig, S3ConfigInput } from '../src/config-builder/types';
-import { nonEmpty } from '../src/config-builder/utils';
-import { hierarchy } from './hierarchy-config';
+import type { ConfigMode, RequiredConfig, S3ConfigInput } from '../src/config-builder/types.ts';
+import { nonEmpty } from '../src/config-builder/utils.ts';
+import { hierarchy } from './hierarchy-config.ts';
 
 // Re-export for external consumers
-export { hierarchy, roles } from './hierarchy-config';
+export { hierarchy, roles } from './hierarchy-config.ts';
 
 export const config = {
   // Entity data model, derived from the hierarchy: the builder in hierarchy-config.ts is the

--- a/shared/config/config.test.ts
+++ b/shared/config/config.test.ts
@@ -1,6 +1,6 @@
-import type { DeepPartial } from '../src/config-builder/types';
-import type { config as _default } from './config.default';
-import { development } from './config.development';
+import type { DeepPartial } from '../src/config-builder/types.ts';
+import type { config as _default } from './config.default.ts';
+import { development } from './config.development.ts';
 
 /**
  * Ensure that this file does not include or use any sensitive information.

--- a/shared/config/config.tunnel.ts
+++ b/shared/config/config.tunnel.ts
@@ -1,5 +1,5 @@
-import type { DeepPartial } from '../src/config-builder/types';
-import type { config as _default } from './config.default';
+import type { DeepPartial } from '../src/config-builder/types.ts';
+import type { config as _default } from './config.default.ts';
 
 export const tunnel = {
   mode: 'tunnel',

--- a/shared/config/hierarchy-config.ts
+++ b/shared/config/hierarchy-config.ts
@@ -1,5 +1,5 @@
 // Split from config.default.ts so its types can be inferred before the config object is built.
-import { createEntityHierarchy, createRoleRegistry } from '../src/config-builder/entity-hierarchy';
+import { createEntityHierarchy, createRoleRegistry } from '../src/config-builder/entity-hierarchy.ts';
 
 /** Single source of truth for all entity roles used in memberships and permissions. */
 export const roles = createRoleRegistry(['admin', 'member'] as const);

--- a/shared/config/permissions-config.ts
+++ b/shared/config/permissions-config.ts
@@ -1,5 +1,5 @@
-import { appConfig } from '../src/config-builder/app-config';
-import { configurePermissions } from '../src/permissions/policy-matrix';
+import { appConfig } from '../src/config-builder/app-config.ts';
+import { configurePermissions } from '../src/permissions/policy-matrix.ts';
 
 // Access policies per entity type: `1` = allowed, `0`/omitted = denied. Elevation vs. self rows,
 // product home rows, publicRead and row conditions are all explained in cella/PERMISSIONS.md.

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,10 +1,10 @@
-import { hierarchy } from './config/config.default';
+import { hierarchy } from './config/config.default.ts';
 
 // Entity hierarchy & roles
-export { hierarchy, roles } from './config/config.default';
+export { hierarchy, roles } from './config/config.default.ts';
 // App configuration
-export { appConfig } from './src/config-builder/app-config';
-export type { ConfigMode } from './src/config-builder/types';
+export { appConfig } from './src/config-builder/app-config.ts';
+export type { ConfigMode } from './src/config-builder/types.ts';
 
 // Bound guard facade: these ARE the app singleton's methods (arrow fields, so binding is
 // preserved), re-exported for the two highest-frequency checks. Everything else stays on
@@ -21,16 +21,16 @@ export type {
   ProductView,
   RoleFromRegistry,
   UserEntityView,
-} from './src/config-builder/entity-hierarchy';
+} from './src/config-builder/entity-hierarchy.ts';
 export {
   createEntityHierarchy,
   createRoleRegistry,
-} from './src/config-builder/entity-hierarchy';
+} from './src/config-builder/entity-hierarchy.ts';
 // Row location: home attribution and paths are instance methods on EntityHierarchy.
 // Only the naming rule and the pure path-string helpers remain as free exports.
-export type { ResolvedAncestor } from './src/config-builder/resolve-row-channel';
-export { entityIdColumnKey, entityIdColumnName } from './src/config-builder/resolve-row-channel';
-export { pathHomeId, pathSegments, pathStartsWith } from './src/config-builder/row-path';
+export type { ResolvedAncestor } from './src/config-builder/resolve-row-channel.ts';
+export { entityIdColumnKey, entityIdColumnName } from './src/config-builder/resolve-row-channel.ts';
+export { pathHomeId, pathSegments, pathStartsWith } from './src/config-builder/row-path.ts';
 // Config builder types
 export type {
   AppServiceEndpointConfig,
@@ -38,8 +38,15 @@ export type {
   RequiredConfig,
   S3Config,
   S3ConfigInput,
-} from './src/config-builder/types';
-export { hasKey, identityRecord, nonEmpty, recordFromKeys, typedEntries, typedKeys } from './src/config-builder/utils';
+} from './src/config-builder/types.ts';
+export {
+  hasKey,
+  identityRecord,
+  nonEmpty,
+  recordFromKeys,
+  typedEntries,
+  typedKeys,
+} from './src/config-builder/utils.ts';
 // Permissions
 export type {
   AccessMembership,
@@ -68,7 +75,7 @@ export type {
   RowConditionName,
   RowForCondition,
   SubjectForPermission,
-} from './src/permissions';
+} from './src/permissions/index.ts';
 // Permission engine (tier-neutral decision logic, shared by backend + yjs)
 export {
   type Access,
@@ -104,9 +111,9 @@ export {
   validateAncestorScope,
   validateMembership,
   validateSubject,
-} from './src/permissions';
-export { draftVisibleTo, isUnpublishedDraft } from './src/published-rows';
-export { seenWindowMs } from './src/seen-window';
+} from './src/permissions/index.ts';
+export { draftVisibleTo, isUnpublishedDraft } from './src/published-rows.ts';
+export { seenWindowMs } from './src/seen-window.ts';
 // App-derived types
 export type {
   ActivityAction,
@@ -139,9 +146,9 @@ export type {
   TrackedEventType,
   UploadTemplateId,
   UserFlags,
-} from './types';
+} from './types.ts';
 // Activity actions and event types (value exports)
-export { actionToVerb, activityActions, activityVerbs, isValidEventType, trackedEventTypes } from './types';
+export { actionToVerb, activityActions, activityVerbs, isValidEventType, trackedEventTypes } from './types.ts';
 
 // Side-effect import: compile-time validation that config matches hierarchy
-import './src/config-builder/config-validation';
+import './src/config-builder/config-validation.ts';

--- a/shared/scripts/check-app-vocabulary.test.ts
+++ b/shared/scripts/check-app-vocabulary.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { findAppVocabularyFindings } from './check-app-vocabulary';
+import { findAppVocabularyFindings } from './check-app-vocabulary.ts';
 
 const legacyTerm = ['fo', 'rk'].join('');
 

--- a/shared/scripts/check-doc-style.test.ts
+++ b/shared/scripts/check-doc-style.test.ts
@@ -4,7 +4,7 @@ import {
   findDocStyleViolations,
   formatAgentVocabularyFinding,
   formatDocStyleViolation,
-} from './check-doc-style';
+} from './check-doc-style.ts';
 
 const singular = ['invar', 'iant'].join('');
 const plural = `${singular}s`;

--- a/shared/scripts/check-lenses.ts
+++ b/shared/scripts/check-lenses.ts
@@ -8,9 +8,9 @@ import { execFileSync } from 'node:child_process';
 import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { appConfig } from '../index';
-import { deltaRenameMap } from '../src/schema-evolution/define';
-import { lenses } from '../src/schema-evolution/lens-list';
+import { appConfig } from '../index.ts';
+import { deltaRenameMap } from '../src/schema-evolution/define.ts';
+import { lenses } from '../src/schema-evolution/lens-list.ts';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const lensDir = join(here, '..', 'src', 'schema-evolution');

--- a/shared/scripts/wait-backend.ts
+++ b/shared/scripts/wait-backend.ts
@@ -3,7 +3,7 @@
  *
  * @see README.md
  */
-import { waitForBackend } from '../src/utils/wait-for-backend';
+import { waitForBackend } from '../src/utils/wait-for-backend.ts';
 
 const args = process.argv.slice(2);
 let interval = 1000;

--- a/shared/src/config-builder.ts
+++ b/shared/src/config-builder.ts
@@ -1,3 +1,3 @@
 // Public barrel for the config-builder module (see ./config-builder/).
 // Kept as a flat file so `shared/config-builder` resolves via the `./*` -> `./src/*.ts` export.
-export * from './config-builder/index';
+export * from './config-builder/index.ts';

--- a/shared/src/config-builder/app-config.test.ts
+++ b/shared/src/config-builder/app-config.test.ts
@@ -10,7 +10,7 @@ afterEach(() => {
 async function loadAppConfig(env: Record<string, string>) {
   vi.resetModules();
   process.env = { ...originalEnv, ...env };
-  return (await import('./app-config')).appConfig;
+  return (await import('./app-config.ts')).appConfig;
 }
 
 describe('appConfig service endpoints', () => {

--- a/shared/src/config-builder/app-config.ts
+++ b/shared/src/config-builder/app-config.ts
@@ -1,11 +1,11 @@
-import { config as _default } from '../../config/config.default';
-import { development } from '../../config/config.development';
-import { production } from '../../config/config.production';
-import { staging } from '../../config/config.staging';
-import { test } from '../../config/config.test';
-import { tunnel } from '../../config/config.tunnel';
-import type { S3Config } from './types';
-import { mergeDeep } from './utils';
+import { config as _default } from '../../config/config.default.ts';
+import { development } from '../../config/config.development.ts';
+import { production } from '../../config/config.production.ts';
+import { staging } from '../../config/config.staging.ts';
+import { test } from '../../config/config.test.ts';
+import { tunnel } from '../../config/config.tunnel.ts';
+import type { S3Config } from './types.ts';
+import { mergeDeep } from './utils.ts';
 
 type Config = Omit<typeof _default, 's3'> & { s3: S3Config };
 const configModes = { development, tunnel, staging, production, test } satisfies Record<Config['mode'], unknown>;

--- a/shared/src/config-builder/config-validation.ts
+++ b/shared/src/config-builder/config-validation.ts
@@ -1,7 +1,7 @@
-import { policyMatrix } from '../../config/permissions-config';
-import { getEntityPolicies, isRowCondition } from '../permissions';
-import { appConfig } from './app-config';
-import type { RequiredConfig } from './types';
+import { policyMatrix } from '../../config/permissions-config.ts';
+import { getEntityPolicies, isRowCondition } from '../permissions/index.ts';
+import { appConfig } from './app-config.ts';
+import type { RequiredConfig } from './types.ts';
 
 // Validate that Config satisfies RequiredConfig (compile-time only).
 type Config = typeof appConfig;

--- a/shared/src/config-builder/entity-hierarchy.ts
+++ b/shared/src/config-builder/entity-hierarchy.ts
@@ -5,14 +5,14 @@ import {
   type ResolvedAncestor,
   resolveDeepestAncestorId,
   resolveNonNullAncestors,
-} from './resolve-row-channel';
+} from './resolve-row-channel.ts';
 import {
   computeAncestorPath,
   computeChannelPath,
   computeProductPath,
   deepestAncestorSql,
   pathColumnSql,
-} from './row-path';
+} from './row-path.ts';
 
 // Role Registry
 function buildRoleMap<T extends readonly string[]>(roleNames: T): { readonly [K in T[number]]: K } {

--- a/shared/src/config-builder/index.ts
+++ b/shared/src/config-builder/index.ts
@@ -7,15 +7,15 @@ export type {
   ProductView,
   RoleFromRegistry,
   UserEntityView,
-} from './entity-hierarchy';
+} from './entity-hierarchy.ts';
 export {
   createEntityHierarchy,
   createRoleRegistry,
-} from './entity-hierarchy';
+} from './entity-hierarchy.ts';
 // Row location: home attribution and paths are instance methods on EntityHierarchy.
-export type { ResolvedAncestor } from './resolve-row-channel';
-export { entityIdColumnKey, entityIdColumnName } from './resolve-row-channel';
-export { pathHomeId, pathSegments, pathStartsWith } from './row-path';
+export type { ResolvedAncestor } from './resolve-row-channel.ts';
+export { entityIdColumnKey, entityIdColumnName } from './resolve-row-channel.ts';
+export { pathHomeId, pathSegments, pathStartsWith } from './row-path.ts';
 // Config types
 export type {
   BaseAuthStrategies,
@@ -34,6 +34,6 @@ export type {
   ThemeNavigationConfig,
   TotpConfig,
   UppyRestrictionsConfig,
-} from './types';
+} from './types.ts';
 // Utility functions
-export { hasKey, identityRecord, mergeDeep, nonEmpty, recordFromKeys } from './utils';
+export { hasKey, identityRecord, mergeDeep, nonEmpty, recordFromKeys } from './utils.ts';

--- a/shared/src/config-builder/resolve-row-channel.ts
+++ b/shared/src/config-builder/resolve-row-channel.ts
@@ -1,4 +1,4 @@
-import { toColumnName } from '../permissions/schema-naming';
+import { toColumnName } from '../permissions/schema-naming.ts';
 
 /** Minimal hierarchy surface needed for attribution: lets tests inject a synthetic hierarchy. */
 export interface AncestorSource {

--- a/shared/src/config-builder/row-path.ts
+++ b/shared/src/config-builder/row-path.ts
@@ -1,4 +1,4 @@
-import { type AncestorSource, entityIdColumnKey, entityIdColumnName } from './resolve-row-channel';
+import { type AncestorSource, entityIdColumnKey, entityIdColumnName } from './resolve-row-channel.ts';
 
 /**
  * Builds a root-first path from populated ancestor IDs, optionally appending a channel row's ID.

--- a/shared/src/config-builder/tests/entity-hierarchy.test.ts
+++ b/shared/src/config-builder/tests/entity-hierarchy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createEntityHierarchy, createRoleRegistry } from '../entity-hierarchy';
+import { createEntityHierarchy, createRoleRegistry } from '../entity-hierarchy.ts';
 
 describe('EntityHierarchyBuilder', () => {
   const roles = createRoleRegistry(['admin', 'member', 'guest'] as const);

--- a/shared/src/config-builder/tests/resolve-row-channel.test.ts
+++ b/shared/src/config-builder/tests/resolve-row-channel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { makeDeepHierarchy } from '../../testing/deep-fixture';
+import { makeDeepHierarchy } from '../../testing/deep-fixture.ts';
 
 /**
  * Variable-depth `item` rows attach at any depth; raak/cella configs cannot exhibit this

--- a/shared/src/config-builder/tests/row-path.test.ts
+++ b/shared/src/config-builder/tests/row-path.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { deepHierarchy } from '../../testing/deep-fixture';
-import { pathHomeId, pathSegments, pathStartsWith } from '../row-path';
+import { deepHierarchy } from '../../testing/deep-fixture.ts';
+import { pathHomeId, pathSegments, pathStartsWith } from '../row-path.ts';
 
 /**
  * The path rule must stay equivalent to the deepest-non-null-ancestor rule

--- a/shared/src/config-builder/utils.ts
+++ b/shared/src/config-builder/utils.ts
@@ -1,4 +1,4 @@
-import type { DeepPartial } from './types';
+import type { DeepPartial } from './types.ts';
 
 function isObject(item: object) {
   return item && typeof item === 'object' && !Array.isArray(item);

--- a/shared/src/health-app.test.ts
+++ b/shared/src/health-app.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createHealthApp } from './health-app';
+import { createHealthApp } from './health-app.ts';
 
 const app = createHealthApp({
   version: 'sha-123',

--- a/shared/src/otel.test.ts
+++ b/shared/src/otel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createOtelSDK } from './otel';
+import { createOtelSDK } from './otel.ts';
 
 describe('createOtelSDK', () => {
   it('creates meterProvider without Maple key', () => {

--- a/shared/src/otel.ts
+++ b/shared/src/otel.ts
@@ -10,7 +10,7 @@ import { PeriodicExportingMetricReader, MeterProvider as SdkMeterProvider } from
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import type { SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
-import { appConfig } from './config-builder/app-config';
+import { appConfig } from './config-builder/app-config.ts';
 
 const MAPLE_INGEST_BASE = 'https://ingest.maple.dev/v1';
 const MAPLE_DISABLED_MSG = '[otel] MAPLE_SECRET_INGEST_KEY not set — skipping Maple.dev';

--- a/shared/src/permissions/action-helpers.test.ts
+++ b/shared/src/permissions/action-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isUnconditionalCan, resolveCan } from './action-helpers';
+import { isUnconditionalCan, resolveCan } from './action-helpers.ts';
 
 describe('resolveCan', () => {
   // --- Pass cases: permission should be granted ---

--- a/shared/src/permissions/action-helpers.ts
+++ b/shared/src/permissions/action-helpers.ts
@@ -1,7 +1,7 @@
-import type { EntityActionType } from '../../types';
-import { appConfig } from '../config-builder/app-config';
-import { recordFromKeys } from '../config-builder/utils';
-import type { CanState } from './types';
+import type { EntityActionType } from '../../types.ts';
+import { appConfig } from '../config-builder/app-config.ts';
+import { recordFromKeys } from '../config-builder/utils.ts';
+import type { CanState } from './types.ts';
 
 /**
  * Creates a typed record mapping each entity action to a value.

--- a/shared/src/permissions/build-subject.ts
+++ b/shared/src/permissions/build-subject.ts
@@ -1,9 +1,9 @@
-import { hierarchy } from '../../config/hierarchy-config';
-import type { ChannelEntityType, ProductEntityType } from '../../types';
-import { appConfig } from '../config-builder/app-config';
-import { generateId } from '../utils/entity-id';
-import type { AncestorChannelIds, ChannelIdColumns, SubjectForPermission } from './engine/types';
-import { validateAncestorScope } from './validate-ancestor-scope';
+import { hierarchy } from '../../config/hierarchy-config.ts';
+import type { ChannelEntityType, ProductEntityType } from '../../types.ts';
+import { appConfig } from '../config-builder/app-config.ts';
+import { generateId } from '../utils/entity-id.ts';
+import type { AncestorChannelIds, ChannelIdColumns, SubjectForPermission } from './engine/types.ts';
+import { validateAncestorScope } from './validate-ancestor-scope.ts';
 
 /**
  * Builds a permission subject from database-shaped ancestor ID columns, ignoring unrelated

--- a/shared/src/permissions/check-access.ts
+++ b/shared/src/permissions/check-access.ts
@@ -1,13 +1,13 @@
-import { elevatedRoles, policyMatrix, publicReadGrants } from '../../config/permissions-config';
-import type { EntityActionType } from '../../types';
-import { getAllDecisions } from './engine/check';
-import { type EngineAccess, getDecisionsForAccesses } from './engine/resolve-access';
+import { elevatedRoles, policyMatrix, publicReadGrants } from '../../config/permissions-config.ts';
+import type { EntityActionType } from '../../types.ts';
+import { getAllDecisions } from './engine/check.ts';
+import { type EngineAccess, getDecisionsForAccesses } from './engine/resolve-access.ts';
 import type {
   AccessMembership,
   PermissionCheckOptions,
   PermissionDecision,
   SubjectForPermission,
-} from './engine/types';
+} from './engine/types.ts';
 
 /**
  * Explicit authenticated or anonymous actor used by SQL permission predicates.

--- a/shared/src/permissions/compute-can.test.ts
+++ b/shared/src/permissions/compute-can.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { computeWideCan, configureWidePermissions, wideMembership, wideOverrides } from '../testing/wide-fixture';
-import { computeCan } from './compute-can';
+import { computeWideCan, configureWidePermissions, wideMembership, wideOverrides } from '../testing/wide-fixture.ts';
+import { computeCan } from './compute-can.ts';
 
 // Policies with 'own' permission for attachment update/delete, plus project-scoped grants
 // (attachment guest-read, task member-update) used by the wider coverage below.

--- a/shared/src/permissions/compute-can.ts
+++ b/shared/src/permissions/compute-can.ts
@@ -1,10 +1,10 @@
-import type { ChannelEntityType, EntityActionType, EntityRole, EntityType } from '../../types';
-import { recordFromKeys } from '../config-builder/utils';
-import { allActionsDenied } from './action-helpers';
-import { type HierarchyOverrides, resolveHierarchy } from './engine/resolve-hierarchy';
-import { getEntityPolicies, getPolicyPermissions } from './policy-matrix';
-import { isRowCondition } from './row-conditions';
-import type { CanState, PolicyMatrix } from './types';
+import type { ChannelEntityType, EntityActionType, EntityRole, EntityType } from '../../types.ts';
+import { recordFromKeys } from '../config-builder/utils.ts';
+import { allActionsDenied } from './action-helpers.ts';
+import { type HierarchyOverrides, resolveHierarchy } from './engine/resolve-hierarchy.ts';
+import { getEntityPolicies, getPolicyPermissions } from './policy-matrix.ts';
+import { isRowCondition } from './row-conditions.ts';
+import type { CanState, PolicyMatrix } from './types.ts';
 
 /**
  * Per-action permission state for one entity type. Three-valued to carry row conditions to the UI:

--- a/shared/src/permissions/engine/check.perf.test.ts
+++ b/shared/src/permissions/engine/check.perf.test.ts
@@ -1,8 +1,8 @@
 import { appConfig, type ChannelEntityType, type EntityRole } from 'shared';
 import { describe, expect, it } from 'vitest';
-import { configurePolicyMatrix } from '../../testing/policies';
-import { getAllDecisions } from './check';
-import type { SubjectForPermission } from './types';
+import { configurePolicyMatrix } from '../../testing/policies.ts';
+import { getAllDecisions } from './check.ts';
+import type { SubjectForPermission } from './types.ts';
 
 /** Minimal test membership matching MembershipBaseModel structure */
 type TestMembership = {

--- a/shared/src/permissions/engine/check.ts
+++ b/shared/src/permissions/engine/check.ts
@@ -1,10 +1,10 @@
-import type { ChannelEntityType, EntityActionType, ProductEntityType } from '../../../types';
-import { allActionsAllowed, createActionRecord } from '../action-helpers';
-import type { PublicReadGrants } from '../public-read';
-import { type ConditionActor, isRowCondition, matchesRowCondition, type RowForCondition } from '../row-conditions';
-import type { EntityActionPermissions, PolicyMatrix } from '../types';
-import { formatBatchPermissionSummary, formatPermissionDecision } from './format';
-import { resolveHierarchy } from './resolve-hierarchy';
+import type { ChannelEntityType, EntityActionType, ProductEntityType } from '../../../types.ts';
+import { allActionsAllowed, createActionRecord } from '../action-helpers.ts';
+import type { PublicReadGrants } from '../public-read.ts';
+import { type ConditionActor, isRowCondition, matchesRowCondition, type RowForCondition } from '../row-conditions.ts';
+import type { EntityActionPermissions, PolicyMatrix } from '../types.ts';
+import { formatBatchPermissionSummary, formatPermissionDecision } from './format.ts';
+import { resolveHierarchy } from './resolve-hierarchy.ts';
 import type {
   AccessMembership,
   ActionAttribution,
@@ -12,8 +12,8 @@ import type {
   PermissionDecision,
   ResolvedChannelIds,
   SubjectForPermission,
-} from './types';
-import { validateMembership, validateSubject } from './validation';
+} from './types.ts';
+import { validateMembership, validateSubject } from './validation.ts';
 
 /** Memberships keyed by `${channelType}:${channelId}`. */
 export type MembershipIndex<T extends AccessMembership> = Map<string, T[]>;

--- a/shared/src/permissions/engine/format.ts
+++ b/shared/src/permissions/engine/format.ts
@@ -1,7 +1,7 @@
-import type { EntityActionType } from '../../../types';
-import { appConfig } from '../../config-builder/app-config';
-import { createActionRecord } from '../action-helpers';
-import type { AccessMembership, GrantSource, PermissionDecision } from './types';
+import type { EntityActionType } from '../../../types.ts';
+import { appConfig } from '../../config-builder/app-config.ts';
+import { createActionRecord } from '../action-helpers.ts';
+import type { AccessMembership, GrantSource, PermissionDecision } from './types.ts';
 
 const formatGrant = (g: GrantSource): string => {
   if (g.type === 'membership') return `${g.channelType}:${g.channelId}/${g.role}`;

--- a/shared/src/permissions/engine/index.test.ts
+++ b/shared/src/permissions/engine/index.test.ts
@@ -1,8 +1,8 @@
 import { hierarchy } from 'shared';
 import { describe, expect, it } from 'vitest';
-import { configureWidePermissions, wideMembership, wideOverrides, wideSubject } from '../../testing/wide-fixture';
-import { getAllDecisions } from './check';
-import type { SubjectForPermission } from './types';
+import { configureWidePermissions, wideMembership, wideOverrides, wideSubject } from '../../testing/wide-fixture.ts';
+import { getAllDecisions } from './check.ts';
+import type { SubjectForPermission } from './types.ts';
 
 const organizationSubject = (id: string): SubjectForPermission =>
   wideSubject({ entityType: 'organization', id, channelIds: {} });

--- a/shared/src/permissions/engine/index.ts
+++ b/shared/src/permissions/engine/index.ts
@@ -1,5 +1,5 @@
-export { getAllDecisions } from './check';
-export { formatBatchPermissionSummary, formatPermissionDecision } from './format';
+export { getAllDecisions } from './check.ts';
+export { formatBatchPermissionSummary, formatPermissionDecision } from './format.ts';
 export type {
   AccessMembership,
   ActionAttribution,
@@ -10,5 +10,5 @@ export type {
   PermissionDecision,
   ResolvedChannelIds,
   SubjectForPermission,
-} from './types';
-export { validateMembership, validateSubject } from './validation';
+} from './types.ts';
+export { validateMembership, validateSubject } from './validation.ts';

--- a/shared/src/permissions/engine/resolve-access.test.ts
+++ b/shared/src/permissions/engine/resolve-access.test.ts
@@ -7,10 +7,10 @@ import {
   wideMembership,
   wideOverrides,
   wideSubject,
-} from '../../testing/wide-fixture';
-import { getAllDecisions } from './check';
-import { type EngineAccess, getDecisionsForAccesses } from './resolve-access';
-import type { AccessMembership, SubjectForPermission } from './types';
+} from '../../testing/wide-fixture.ts';
+import { getAllDecisions } from './check.ts';
+import { type EngineAccess, getDecisionsForAccesses } from './resolve-access.ts';
+import type { AccessMembership, SubjectForPermission } from './types.ts';
 
 /**
  * THE guarantee that lets `checkAccess` collapse accesses into classes: for every access,

--- a/shared/src/permissions/engine/resolve-access.ts
+++ b/shared/src/permissions/engine/resolve-access.ts
@@ -1,11 +1,11 @@
-import type { ChannelEntityType } from '../../../types';
-import { allActionsDenied, createActionRecord } from '../action-helpers';
-import { isRowCondition, matchesRowCondition, type RowConditionName, type RowForCondition } from '../row-conditions';
-import type { PolicyMatrix } from '../types';
-import { buildPolicyIndex, checkWithIndices, getMembershipIndex, getSubjectChannelId } from './check';
-import { resolveHierarchy } from './resolve-hierarchy';
-import type { AccessMembership, PermissionCheckOptions, PermissionDecision, SubjectForPermission } from './types';
-import { validateSubject } from './validation';
+import type { ChannelEntityType } from '../../../types.ts';
+import { allActionsDenied, createActionRecord } from '../action-helpers.ts';
+import { isRowCondition, matchesRowCondition, type RowConditionName, type RowForCondition } from '../row-conditions.ts';
+import type { PolicyMatrix } from '../types.ts';
+import { buildPolicyIndex, checkWithIndices, getMembershipIndex, getSubjectChannelId } from './check.ts';
+import { resolveHierarchy } from './resolve-hierarchy.ts';
+import type { AccessMembership, PermissionCheckOptions, PermissionDecision, SubjectForPermission } from './types.ts';
+import { validateSubject } from './validation.ts';
 
 /**
  * One actor's inputs to a decision, engine-shaped: the memberships plus the two actor

--- a/shared/src/permissions/engine/resolve-hierarchy.ts
+++ b/shared/src/permissions/engine/resolve-hierarchy.ts
@@ -1,7 +1,7 @@
-import { hierarchy as appHierarchy } from '../../../config/hierarchy-config';
-import type { ChannelEntityType, EntityActionType } from '../../../types';
-import { appConfig } from '../../config-builder/app-config';
-import type { EntityHierarchy } from '../../config-builder/entity-hierarchy';
+import { hierarchy as appHierarchy } from '../../../config/hierarchy-config.ts';
+import type { ChannelEntityType, EntityActionType } from '../../../types.ts';
+import { appConfig } from '../../config-builder/app-config.ts';
+import type { EntityHierarchy } from '../../config-builder/entity-hierarchy.ts';
 
 /** Optional hierarchy and action overrides let tests exercise the engine outside app config. */
 export interface HierarchyOverrides {

--- a/shared/src/permissions/engine/types.ts
+++ b/shared/src/permissions/engine/types.ts
@@ -4,9 +4,9 @@ import type {
   EntityIdColumns,
   EntityRole,
   ProductEntityType,
-} from '../../../types';
-import type { EntityHierarchy } from '../../config-builder/entity-hierarchy';
-import type { PublicReadGrants } from '../public-read';
+} from '../../../types.ts';
+import type { EntityHierarchy } from '../../config-builder/entity-hierarchy.ts';
+import type { PublicReadGrants } from '../public-read.ts';
 
 /** Database-shaped channel ID columns, such as `organizationId`. */
 export type ChannelIdColumns = EntityIdColumns<ChannelEntityType, string | null>;

--- a/shared/src/permissions/engine/validation.ts
+++ b/shared/src/permissions/engine/validation.ts
@@ -1,6 +1,6 @@
-import { hierarchy } from '../../../config/hierarchy-config';
-import type { EntityHierarchy } from '../../config-builder/entity-hierarchy';
-import type { AccessMembership, SubjectForPermission } from './types';
+import { hierarchy } from '../../../config/hierarchy-config.ts';
+import type { EntityHierarchy } from '../../config-builder/entity-hierarchy.ts';
+import type { AccessMembership, SubjectForPermission } from './types.ts';
 
 /**
  * Validates a subject has required fields for permission checking. `entityGuards` defaults to

--- a/shared/src/permissions/index.ts
+++ b/shared/src/permissions/index.ts
@@ -1,12 +1,12 @@
-export { elevatedRoles, policyMatrix, publicReadGrants } from '../../config/permissions-config';
+export { elevatedRoles, policyMatrix, publicReadGrants } from '../../config/permissions-config.ts';
 export {
   allActionsAllowed,
   allActionsDenied,
   createActionRecord,
   isUnconditionalCan,
   resolveCan,
-} from './action-helpers';
-export { buildSubject, buildSubjectFromEntity } from './build-subject';
+} from './action-helpers.ts';
+export { buildSubject, buildSubjectFromEntity } from './build-subject.ts';
 export {
   type Access,
   type Actor,
@@ -16,14 +16,14 @@ export {
   checkAccessBatch,
   checkAccessFanout,
   type PermissionResult,
-} from './check-access';
-export type { EntityCanMap } from './compute-can';
-export { computeCan } from './compute-can';
+} from './check-access.ts';
+export type { EntityCanMap } from './compute-can.ts';
+export { computeCan } from './compute-can.ts';
 // Permission engine (tier-neutral decision logic)
-export { getAllDecisions } from './engine/check';
-export { formatBatchPermissionSummary, formatPermissionDecision } from './engine/format';
-export { type EngineAccess, getDecisionsForAccesses, type ResolveAccessOptions } from './engine/resolve-access';
-export type { HierarchyOverrides } from './engine/resolve-hierarchy';
+export { getAllDecisions } from './engine/check.ts';
+export { formatBatchPermissionSummary, formatPermissionDecision } from './engine/format.ts';
+export { type EngineAccess, getDecisionsForAccesses, type ResolveAccessOptions } from './engine/resolve-access.ts';
+export type { HierarchyOverrides } from './engine/resolve-hierarchy.ts';
 export type {
   AccessMembership,
   ActionAttribution,
@@ -34,16 +34,16 @@ export type {
   PermissionDecision,
   ResolvedChannelIds,
   SubjectForPermission,
-} from './engine/types';
-export { validateMembership, validateSubject } from './engine/validation';
-export { MissingScopeError } from './missing-scope-error';
-export type { PermissionsConfigResult } from './policy-matrix';
+} from './engine/types.ts';
+export { validateMembership, validateSubject } from './engine/validation.ts';
+export { MissingScopeError } from './missing-scope-error.ts';
+export type { PermissionsConfigResult } from './policy-matrix.ts';
 // `configurePolicyMatrix` is test-only; it lives at `shared/testing/policies`, not on this barrel.
-export { configurePermissions, getEntityPolicies, getPolicyPermissions } from './policy-matrix';
-export type { PublicReadGrants } from './public-read';
-export type { ConditionActor, RowConditionName, RowForCondition } from './row-conditions';
-export { isRowCondition, matchesRowCondition } from './row-conditions';
-export { toColumnName, toTableName } from './schema-naming';
+export { configurePermissions, getEntityPolicies, getPolicyPermissions } from './policy-matrix.ts';
+export type { PublicReadGrants } from './public-read.ts';
+export type { ConditionActor, RowConditionName, RowForCondition } from './row-conditions.ts';
+export { isRowCondition, matchesRowCondition } from './row-conditions.ts';
+export { toColumnName, toTableName } from './schema-naming.ts';
 export type {
   CanState,
   ChannelPolicyBuilder,
@@ -55,5 +55,5 @@ export type {
   PolicyConfiguration,
   PolicyEntry,
   PolicyMatrix,
-} from './types';
-export { validateAncestorScope } from './validate-ancestor-scope';
+} from './types.ts';
+export { validateAncestorScope } from './validate-ancestor-scope.ts';

--- a/shared/src/permissions/missing-scope-error.ts
+++ b/shared/src/permissions/missing-scope-error.ts
@@ -1,4 +1,4 @@
-import type { ChannelEntityType, ProductEntityType } from '../../types';
+import type { ChannelEntityType, ProductEntityType } from '../../types.ts';
 
 /**
  * Thrown by `validateAncestorScope` when a required ancestor channel ID is missing (`undefined`).

--- a/shared/src/permissions/policy-defaults.test.ts
+++ b/shared/src/permissions/policy-defaults.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import type { EntityType } from '../../types';
-import { wideEntityTypes, wideMembership, wideOverrides, wideSubject } from '../testing/wide-fixture';
-import { getAllDecisions } from './engine';
-import { configurePermissions } from './policy-matrix';
-import type { PolicyCallback } from './types';
+import type { EntityType } from '../../types.ts';
+import { wideEntityTypes, wideMembership, wideOverrides, wideSubject } from '../testing/wide-fixture.ts';
+import { getAllDecisions } from './engine/index.ts';
+import { configurePermissions } from './policy-matrix.ts';
+import type { PolicyCallback } from './types.ts';
 
 describe('missing policy rows', () => {
   it('denies every action instead of requiring explicit all-zero rows', () => {

--- a/shared/src/permissions/policy-matrix.ts
+++ b/shared/src/permissions/policy-matrix.ts
@@ -1,7 +1,7 @@
-import type { ChannelEntityType, EntityActionType, EntityType, ProductEntityType } from '../../types';
-import { type HierarchyOverrides, resolveHierarchy } from './engine/resolve-hierarchy';
-import type { PublicReadGrants } from './public-read';
-import { isRowCondition } from './row-conditions';
+import type { ChannelEntityType, EntityActionType, EntityType, ProductEntityType } from '../../types.ts';
+import { type HierarchyOverrides, resolveHierarchy } from './engine/resolve-hierarchy.ts';
+import type { PublicReadGrants } from './public-read.ts';
+import { isRowCondition } from './row-conditions.ts';
 import type {
   ChannelPolicyBuilder,
   EntityActionPermissions,
@@ -11,7 +11,7 @@ import type {
   PolicyConfiguration,
   PolicyEntry,
   PolicyMatrix,
-} from './types';
+} from './types.ts';
 
 /**
  * Creates a channel policy builder for fluent role-permission configuration.

--- a/shared/src/permissions/public-read.test.ts
+++ b/shared/src/permissions/public-read.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { configureWidePermissions, wideOverrides, widePublicGrants, wideSubject } from '../testing/wide-fixture';
-import { getAllDecisions } from './engine/check';
-import type { SubjectForPermission } from './engine/types';
-import { matchesRowCondition } from './row-conditions';
+import { configureWidePermissions, wideOverrides, widePublicGrants, wideSubject } from '../testing/wide-fixture.ts';
+import { getAllDecisions } from './engine/check.ts';
+import type { SubjectForPermission } from './engine/types.ts';
+import { matchesRowCondition } from './row-conditions.ts';
 
 /**
  * Verifies membership-independent public reads from the row's own `publicAt` across the wide

--- a/shared/src/permissions/public-read.ts
+++ b/shared/src/permissions/public-read.ts
@@ -1,4 +1,4 @@
-import type { ChannelEntityType, ProductEntityType } from '../../types';
+import type { ChannelEntityType, ProductEntityType } from '../../types.ts';
 
 /**
  * Per-subject public read opt-in, keyed by entity type. A present key grants actor-independent

--- a/shared/src/permissions/schema-naming.ts
+++ b/shared/src/permissions/schema-naming.ts
@@ -1,4 +1,4 @@
-import type { EntityType } from '../../types';
+import type { EntityType } from '../../types.ts';
 
 /**
  * Naming conventions shared by the backend (drizzle source of truth) and the standalone yjs

--- a/shared/src/permissions/types.ts
+++ b/shared/src/permissions/types.ts
@@ -1,5 +1,5 @@
-import type { ChannelEntityType, EntityActionType, EntityRole, EntityType, ProductEntityType } from '../../types';
-import type { RowConditionName } from './row-conditions';
+import type { ChannelEntityType, EntityActionType, EntityRole, EntityType, ProductEntityType } from '../../types.ts';
+import type { RowConditionName } from './row-conditions.ts';
 
 /**
  * Policy cell value the engine and downstream consumers read. A cell is the config literal

--- a/shared/src/permissions/validate-ancestor-scope.ts
+++ b/shared/src/permissions/validate-ancestor-scope.ts
@@ -1,7 +1,7 @@
-import { hierarchy } from '../../config/hierarchy-config';
-import { appConfig } from '../config-builder/app-config';
-import type { SubjectForPermission } from './engine/types';
-import { MissingScopeError } from './missing-scope-error';
+import { hierarchy } from '../../config/hierarchy-config.ts';
+import { appConfig } from '../config-builder/app-config.ts';
+import type { SubjectForPermission } from './engine/types.ts';
+import { MissingScopeError } from './missing-scope-error.ts';
 
 /**
  * Validates that every ancestor ID is present. `null` marks an unused ancestor; `undefined`

--- a/shared/src/pino.ts
+++ b/shared/src/pino.ts
@@ -1,7 +1,7 @@
 import { trace } from '@opentelemetry/api';
 import pino from 'pino';
-import type { Severity } from '../types';
-import { appConfig } from './config-builder/app-config';
+import type { Severity } from '../types.ts';
+import { appConfig } from './config-builder/app-config.ts';
 
 export type { Logger } from 'pino';
 

--- a/shared/src/published-rows.test.ts
+++ b/shared/src/published-rows.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { draftVisibleTo, isUnpublishedDraft } from './published-rows';
+import { draftVisibleTo, isUnpublishedDraft } from './published-rows.ts';
 
 describe('isUnpublishedDraft', () => {
   it('is true only for an explicit null publishedAt', () => {

--- a/shared/src/schema-evolution.ts
+++ b/shared/src/schema-evolution.ts
@@ -1,3 +1,3 @@
 // Public barrel for the schema-evolution module (see ./schema-evolution/).
 // Kept as a flat file so `shared/schema-evolution` resolves via the `./*` -> `./src/*.ts` export.
-export * from './schema-evolution/index';
+export * from './schema-evolution/index.ts';

--- a/shared/src/schema-evolution/define.ts
+++ b/shared/src/schema-evolution/define.ts
@@ -1,4 +1,4 @@
-import type { ChannelEntityType, ProductEntityType } from '../../types';
+import type { ChannelEntityType, ProductEntityType } from '../../types.ts';
 
 /**
  * Entity types lenses can target. Product entities get the full artifact set

--- a/shared/src/schema-evolution/engine.ts
+++ b/shared/src/schema-evolution/engine.ts
@@ -1,13 +1,13 @@
 import { createRegistry, type Registry, type RegistryHooks } from 'dobajs';
-import { schemaEvolutionPolicy, type UnknownFieldHandling } from './config';
+import { schemaEvolutionPolicy, type UnknownFieldHandling } from './config.ts';
 import {
   deltaRenameMap,
   type LensContext,
   type LensDefinition,
   type LensEntityType,
   resolveAddDefault,
-} from './define';
-import { lenses } from './lens-list';
+} from './define.ts';
+import { lenses } from './lens-list.ts';
 
 /** Re-exported doba type so telemetry consumers don't import dobajs directly. */
 export type { RegistryHooks } from 'dobajs';

--- a/shared/src/schema-evolution/index.ts
+++ b/shared/src/schema-evolution/index.ts
@@ -4,7 +4,7 @@
  * @see README.md
  */
 
-export { schemaEvolutionPolicy, type UnknownFieldHandling } from './config';
+export { schemaEvolutionPolicy, type UnknownFieldHandling } from './config.ts';
 export type {
   AddDelta,
   DropDelta,
@@ -17,9 +17,9 @@ export type {
   RenameDelta,
   RetypeDelta,
   SetRenameDelta,
-} from './define';
-export { defineLens, LENS_FORMAT_VERSION, resolveAddDefault } from './define';
-export type { NormalizeOpsOptions, RegistryHooks } from './engine';
+} from './define.ts';
+export { defineLens, LENS_FORMAT_VERSION, resolveAddDefault } from './define.ts';
+export type { NormalizeOpsOptions, RegistryHooks } from './engine.ts';
 export {
   configureLensTelemetry,
   currentSchemaVersion,
@@ -30,5 +30,5 @@ export {
   resetLensEngine,
   versionNodeFor,
   widenedOpsKeyMap,
-} from './engine';
-export { lenses } from './lens-list';
+} from './engine.ts';
+export { lenses } from './lens-list.ts';

--- a/shared/src/schema-evolution/lens-list.ts
+++ b/shared/src/schema-evolution/lens-list.ts
@@ -1,4 +1,4 @@
-import type { LensDefinition } from './define';
+import type { LensDefinition } from './define.ts';
 
 // ── Ordered lens modules (append new imports at the end) ──
 // example:

--- a/shared/src/schema-evolution/tests/engine-empty.test.ts
+++ b/shared/src/schema-evolution/tests/engine-empty.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { defineLens, LENS_FORMAT_VERSION } from '../define';
-import { currentSchemaVersion, migrateCachedEntity, normalizeOps } from '../engine';
+import { defineLens, LENS_FORMAT_VERSION } from '../define.ts';
+import { currentSchemaVersion, migrateCachedEntity, normalizeOps } from '../engine.ts';
 
 // No mock here: exercises the real (empty) lens list shipped in lens-list.ts.
 // Every runtime touch point must be a safe passthrough until a lens is appended.

--- a/shared/src/schema-evolution/tests/engine.test.ts
+++ b/shared/src/schema-evolution/tests/engine.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ProductEntityType } from '../../../types';
-import { defineLens } from '../define';
+import type { ProductEntityType } from '../../../types.ts';
+import { defineLens } from '../define.ts';
 
 // Synthetic second entity; lenses are injected via the mock below
 const DOC = 'doc' as ProductEntityType;
@@ -42,7 +42,7 @@ import {
   resetLensEngine,
   versionNodeFor,
   widenedOpsKeyMap,
-} from '../engine';
+} from '../engine.ts';
 
 beforeEach(() => resetLensEngine());
 

--- a/shared/src/testing/deep-fixture.ts
+++ b/shared/src/testing/deep-fixture.ts
@@ -1,7 +1,7 @@
-import type { EntityType } from '../../types';
-import { createEntityHierarchy, createRoleRegistry } from '../config-builder/entity-hierarchy';
-import type { HierarchyOverrides, PolicyCellInput, PolicyMatrix } from '../permissions';
-import { configurePolicyMatrix } from '../permissions/policy-matrix';
+import type { EntityType } from '../../types.ts';
+import { createEntityHierarchy, createRoleRegistry } from '../config-builder/entity-hierarchy.ts';
+import type { HierarchyOverrides, PolicyCellInput, PolicyMatrix } from '../permissions/index.ts';
+import { configurePolicyMatrix } from '../permissions/policy-matrix.ts';
 
 // Deep synthetic hierarchy (projectcampus-shaped): 4 channel levels with an `item` product whose
 // rows attach at any depth, typed independently of any app config. Path, home-resolution,

--- a/shared/src/testing/entity-hierarchy.ts
+++ b/shared/src/testing/entity-hierarchy.ts
@@ -1,7 +1,7 @@
-import { hierarchy } from '../../config/config.default';
-import type { ChannelEntityType, EntityIdColumnKey, EntityType } from '../../types';
-import { appConfig } from '../config-builder/app-config';
-import { toColumnName, toTableName } from '../permissions';
+import { hierarchy } from '../../config/config.default.ts';
+import type { ChannelEntityType, EntityIdColumnKey, EntityType } from '../../types.ts';
+import { appConfig } from '../config-builder/app-config.ts';
+import { toColumnName, toTableName } from '../permissions/index.ts';
 
 export interface TestChannelColumn {
   channelType: ChannelEntityType;

--- a/shared/src/testing/pino.ts
+++ b/shared/src/testing/pino.ts
@@ -1,4 +1,4 @@
-import type { Log } from '../pino';
+import type { Log } from '../pino.ts';
 
 export type MockLog<TMock> = Record<keyof Log, TMock>;
 

--- a/shared/src/testing/policies.ts
+++ b/shared/src/testing/policies.ts
@@ -1,2 +1,2 @@
 /** Test-only policy configuration without completeness validation. Not part of the public barrel. */
-export { configurePolicyMatrix } from '../permissions/policy-matrix';
+export { configurePolicyMatrix } from '../permissions/policy-matrix.ts';

--- a/shared/src/testing/wide-fixture.test.ts
+++ b/shared/src/testing/wide-fixture.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { getAllDecisions } from '../permissions';
-import { configureWidePermissions, wideHierarchy, wideMembership, wideOverrides, wideSubject } from './wide-fixture';
+import { getAllDecisions } from '../permissions/index.ts';
+import { configureWidePermissions, wideHierarchy, wideMembership, wideOverrides, wideSubject } from './wide-fixture.ts';
 
 /**
  * Smoke test for the wide fixture kit: proves the hierarchy-override seam drives the engine over the

--- a/shared/src/testing/wide-fixture.ts
+++ b/shared/src/testing/wide-fixture.ts
@@ -1,5 +1,5 @@
-import type { EntityActionType, EntityType } from '../../types';
-import { createEntityHierarchy, createRoleRegistry } from '../config-builder/entity-hierarchy';
+import type { EntityActionType, EntityType } from '../../types.ts';
+import { createEntityHierarchy, createRoleRegistry } from '../config-builder/entity-hierarchy.ts';
 import {
   type AccessMembership,
   type CanState,
@@ -12,7 +12,7 @@ import {
   type PolicyMatrix,
   type PublicReadGrants,
   type SubjectForPermission,
-} from '../permissions';
+} from '../permissions/index.ts';
 
 // Wide entity/role vocabulary typed independently of any app config so the tests that
 // use these names compile in every app (an app whose real config lacks `project` still builds).

--- a/shared/src/tools-config.ts
+++ b/shared/src/tools-config.ts
@@ -1,4 +1,4 @@
-import type { ChannelEntityType, EntityRole } from '../types';
+import type { ChannelEntityType, EntityRole } from '../types.ts';
 
 /**
  * A context-role pair: a membership role qualified by the channel type that holds it. Tools use

--- a/shared/src/tracing.ts
+++ b/shared/src/tracing.ts
@@ -1,3 +1,3 @@
 // Public barrel for the tracing module (see ./tracing/).
 // Kept as a flat file so `shared/tracing` resolves via the `./*` -> `./src/*.ts` export.
-export * from './tracing/tracing';
+export * from './tracing/tracing.ts';

--- a/shared/src/tracing/span-store-processor.test.ts
+++ b/shared/src/tracing/span-store-processor.test.ts
@@ -1,8 +1,8 @@
 import { SpanStatusCode } from '@opentelemetry/api';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { describe, expect, it, vi } from 'vitest';
-import { createSpanStoreProcessor } from './span-store-processor';
-import { createSpanStore } from './tracing';
+import { createSpanStoreProcessor } from './span-store-processor.ts';
+import { createSpanStore } from './tracing.ts';
 
 /** Build a minimal ReadableSpan mock for testing. */
 function mockReadableSpan(

--- a/shared/src/tracing/span-store-processor.ts
+++ b/shared/src/tracing/span-store-processor.ts
@@ -1,6 +1,6 @@
 import type { Context } from '@opentelemetry/api';
 import type { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base';
-import type { SpanData, SpanStore } from './tracing';
+import type { SpanData, SpanStore } from './tracing.ts';
 
 export interface SpanStoreProcessorOptions {
   /** SpanStore to push completed spans into. */

--- a/shared/src/tracing/tracing.test.ts
+++ b/shared/src/tracing/tracing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { activityAttrs, cdcAttrs, computeSpanStats, createSpanStore, eventAttrs, type SpanData } from './tracing';
+import { activityAttrs, cdcAttrs, computeSpanStats, createSpanStore, eventAttrs, type SpanData } from './tracing.ts';
 
 function makeSpan(overrides: Partial<SpanData> = {}): SpanData {
   return {

--- a/shared/src/tracing/tracing.ts
+++ b/shared/src/tracing/tracing.ts
@@ -1,7 +1,7 @@
-import type { EntityType } from '../../types';
+import type { EntityType } from '../../types.ts';
 
-export * from './span-names';
-export { createSpanStoreProcessor, type SpanStoreProcessorOptions } from './span-store-processor';
+export * from './span-names.ts';
+export { createSpanStoreProcessor, type SpanStoreProcessorOptions } from './span-store-processor.ts';
 
 // Types
 /** Span status aligned with OTel conventions. */

--- a/shared/src/utils/derive-description-core.test.ts
+++ b/shared/src/utils/derive-description-core.test.ts
@@ -4,7 +4,7 @@ import {
   countDescriptionBlocks,
   type DescriptionBlock,
   findSummarySource,
-} from './derive-description-core';
+} from './derive-description-core.ts';
 
 const paragraph = (text: string): DescriptionBlock => ({
   type: 'paragraph',

--- a/shared/src/utils/derive-description-core.ts
+++ b/shared/src/utils/derive-description-core.ts
@@ -1,4 +1,4 @@
-import { mediaBlockTypes } from './text-from-block';
+import { mediaBlockTypes } from './text-from-block.ts';
 
 /** Loose block shape for parsed description JSON, tolerant of custom block types. */
 export type DescriptionBlock = {

--- a/shared/src/utils/display-order.test.ts
+++ b/shared/src/utils/display-order.test.ts
@@ -6,7 +6,7 @@ import {
   getOrderBetween,
   getRelativeOrder,
   orderGap,
-} from './display-order';
+} from './display-order.ts';
 
 describe('getOrderBetween', () => {
   it('returns defaultOrder when both bounds are undefined', () => {

--- a/shared/src/utils/is-cdn-url.ts
+++ b/shared/src/utils/is-cdn-url.ts
@@ -1,4 +1,4 @@
-import { appConfig } from '../config-builder/app-config';
+import { appConfig } from '../config-builder/app-config.ts';
 
 /**
  * Validate if a URL is a CDN URL. Its valid if it starts with the public CDN or private CDN URL.

--- a/shared/src/utils/text-from-block.test.ts
+++ b/shared/src/utils/text-from-block.test.ts
@@ -1,6 +1,6 @@
 import type { Block } from '@blocknote/core';
 import { describe, expect, it } from 'vitest';
-import { getSearchableTextFromBlock, getSearchableTextFromUrl } from './text-from-block';
+import { getSearchableTextFromBlock, getSearchableTextFromUrl } from './text-from-block.ts';
 
 describe('getSearchableTextFromUrl', () => {
   it('extracts host and path tokens but skips query strings and fragments', () => {

--- a/shared/src/utils/validate-block-media-urls.ts
+++ b/shared/src/utils/validate-block-media-urls.ts
@@ -1,6 +1,6 @@
-import { appConfig } from '../config-builder/app-config';
-import { isCDNUrl } from './is-cdn-url';
-import { mediaBlockTypes } from './text-from-block';
+import { appConfig } from '../config-builder/app-config.ts';
+import { isCDNUrl } from './is-cdn-url.ts';
+import { mediaBlockTypes } from './text-from-block.ts';
 
 const isAllowedDomain = (url: string, domains: string[]): boolean => {
   try {

--- a/shared/src/utils/wait-for-backend.ts
+++ b/shared/src/utils/wait-for-backend.ts
@@ -1,5 +1,5 @@
-import { appConfig } from '../config-builder/app-config';
-import { sleep } from './sleep';
+import { appConfig } from '../config-builder/app-config.ts';
+import { sleep } from './sleep.ts';
 
 /**
  * Wait for the backend health endpoint to be available.

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,5 +1,5 @@
-import type { hierarchy, roles } from './config/config.default';
-import { appConfig } from './src/config-builder/app-config';
+import type { hierarchy, roles } from './config/config.default.ts';
+import { appConfig } from './src/config-builder/app-config.ts';
 
 // Entity types
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,10 @@
     /* Bundler mode */
     "jsx": "react-jsx",
     "moduleResolution": "Bundler",
+    // Relative imports in shared/ and frontend/vite/ carry explicit .ts
+    // extensions (Vite 8 'native' config loader). Any program that pulls in
+    // shared source needs this, so it lives at the root.
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Problem

Since Vite 8, every `pnpm dev` prints a ~150-line warning: the frontend config uses features unsupported by `configLoader: 'native'`, which is planned to become the **default** in a future Vite major — a warning today, a hard config-load failure later. Because `frontend/vite.config.ts` imports `appConfig` from `../shared` (workspace source), Vite traverses the entire `shared/` module graph at config-load time and flags every extensionless import in it.

Reported via fork feedback; all claims verified against main (5 `__dirname` uses, ~260 extensionless relative imports, 2 directory-index imports).

## Changes

- **~260 import rewrites**: explicit `.ts` extensions on all relative imports in `shared/` and `frontend/vite/`, applied mechanically via Biome's `useImportExtensions` fixer (which also resolved the directory-index imports to `'../shared/index.ts'` / `'./src/permissions/index.ts'`).
- **`__dirname` → `import.meta.dirname`** in `frontend/vite.config.ts` and the `frontend/vite/` test files.
- **`allowImportingTsExtensions` hoisted to root `tsconfig.json`** — 6 of 10 package tsconfigs already set it locally; hoisting covers the missing `infra`/`sdk`/`frontend` programs (all of which type-check `shared` source) and any future package.
- **Enforcement**: `biome.jsonc` override enables `correctness/useImportExtensions` over `shared/**`, `frontend/vite/**`, and `frontend/vite.config.ts` (the config file is now in Biome's `files.includes` — it was previously unlinted), so `lint:fix` maintains the invariant going forward.
- **Fork migration**: `cella/migrations/20260811T0905-ts-import-extensions/` + manifest entry. Not sync-breaking (no wire-shape change, no cache bump, no DB); the codemod for app-owned files is the same Biome fixer invocation.

## Verification

- Default loader: the configLoader warning is **gone** (`vite dev` startup clean).
- Future default: `vite --configLoader native` **loads the config and serves** (Node 24).
- `pnpm ts` clean across all 10 workspaces; shared tests 249/249, `frontend/vite` node tests 42/42; `pnpm sdk` → generated SDK unchanged; `lens:check` OK. Pre-commit gate (biome + sdk + ts + commitlint) passed.

## Follow-up (separate repo)

`create-cella`'s `generateEnvConfigs` string-templates the `config.<mode>.ts` import lines ([constants.ts:121](https://github.com/cellajs/create-cella/blob/main/src/constants.ts)) — needs the matching `.ts`-extension update or freshly generated forks will fail the new lint rule. Companion PR incoming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)