### PR TITLE
feat(infra): P2 — external stores + optional app object storage

### DIFF
--- a/infra/config/stores.config.ts
+++ b/infra/config/stores.config.ts
@@ -1,5 +1,5 @@
 import { defineStores } from '../lib/stores';
-import { postgresManaged } from '../resources/stores/postgres-managed';
+import { postgresManaged } from '../resources/stores/catalog';
 
 /**
  * App-owned registry of stateful backing resources, provisioned by the deploy

--- a/infra/lib/runtime-secrets.test.ts
+++ b/infra/lib/runtime-secrets.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { databaseUrl } from '../resources/stores/database-url';
+import { none } from '../resources/stores/none';
+import { buildRuntimeSecrets, type RuntimeSecretDefinition, validateRuntimeSecrets } from './runtime-secrets';
+import { readStoreOutput, type StoreOutputs } from './stores';
+
+/** A minimal non-cella app config, the P2 external-store consumer shape. */
+const appSecrets: Record<string, Omit<RuntimeSecretDefinition, 'id'>> = {
+  adminEmail: {
+    secretName: 'admin-email',
+    description: 'Admin login',
+    envVar: 'ADMIN_EMAIL',
+    required: true,
+    valueSource: 'operator',
+    generation: 'manual',
+    services: ['api'],
+  },
+};
+const knownServices: ReadonlySet<string> = new Set(['api', 'worker']);
+
+describe('buildRuntimeSecrets with external stores (P2)', () => {
+  it('a databaseUrl registry contributes its operator secret ahead of app entries', () => {
+    const secrets = buildRuntimeSecrets({ primary: databaseUrl({ services: ['api'] }) }, appSecrets);
+    expect(secrets.map((secret) => secret.id)).toEqual(['databaseUrl', 'adminEmail']);
+    expect(secrets[0]).toMatchObject({ envVar: 'DATABASE_URL', valueSource: 'operator', generation: 'manual' });
+    expect(() => validateRuntimeSecrets(secrets, knownServices)).not.toThrow();
+  });
+
+  it('a none registry yields only the app entries', () => {
+    const secrets = buildRuntimeSecrets({ primary: none() }, appSecrets);
+    expect(secrets.map((secret) => secret.id)).toEqual(['adminEmail']);
+    expect(() => validateRuntimeSecrets(secrets, knownServices)).not.toThrow();
+  });
+
+  it('rejects a store contribution clashing with an app-config id', () => {
+    const clashing = {
+      ...appSecrets,
+      databaseUrl: { ...appSecrets.adminEmail!, secretName: 'db-url-2', envVar: 'DB_URL_2' },
+    };
+    const secrets = buildRuntimeSecrets({ primary: databaseUrl({ services: ['api'] }) }, clashing);
+    expect(() => validateRuntimeSecrets(secrets, knownServices)).toThrow(/duplicate secret id 'databaseUrl'/);
+  });
+
+  it('rejects a contribution targeting an unknown service', () => {
+    const secrets = buildRuntimeSecrets({ primary: databaseUrl({ services: ['nope'] }) }, {});
+    expect(() => validateRuntimeSecrets(secrets, knownServices)).toThrow(/unknown service 'nope'/);
+  });
+});
+
+describe('readStoreOutput (P2 primary-output contract)', () => {
+  const output = { fake: true } as unknown as StoreOutputs[string];
+
+  it('a provision-less store yields undefined for every name', () => {
+    expect(readStoreOutput({}, 'connectionStringAdmin')).toBeUndefined();
+  });
+
+  it('a provisioning store returns its outputs and throws on a missing name', () => {
+    expect(readStoreOutput({ host: output }, 'host')).toBe(output);
+    expect(() => readStoreOutput({ host: output }, 'connectionStringAdmin')).toThrow(/did not expose output/);
+  });
+});

--- a/infra/lib/runtime-secrets.ts
+++ b/infra/lib/runtime-secrets.ts
@@ -2,6 +2,7 @@ import type { ServiceName } from '../compose/compose';
 import { runtimeSecretsConfig } from '../config/runtime-secrets.config';
 import { appStores } from '../config/stores.config';
 import { serviceNames } from './services';
+import type { StoreProvisioner } from './stores';
 
 export const runtimeSecretConsumers = serviceNames;
 
@@ -57,43 +58,47 @@ export function defineRuntimeSecrets<const T extends Record<string, RuntimeSecre
   return secrets;
 }
 
-// Store-owned declarations come first, in store-registry order: database
-// secrets historically led the app config, and the per-consumer union order
-// is genId-fingerprinted, so the merge position is deliberate.
-const storeContributions: RuntimeSecretDefinition[] = Object.values(appStores).flatMap((store) =>
-  (store.secrets?.() ?? []).map((contribution) => ({
-    id: contribution.id,
-    secretName: contribution.secretName,
-    description: contribution.description,
-    envVar: contribution.envVar,
-    required: contribution.required,
-    valueSource: contribution.valueSource,
-    generation: 'manual' as const,
-    services: contribution.services,
-  })),
-);
+/**
+ * Pure merge of a store registry's secret contributions with an app's
+ * `runtime-secrets.config.ts` entries. Store-owned declarations come first,
+ * in store-registry order: database secrets historically led the app config,
+ * and the per-consumer union order is genId-fingerprinted, so the merge
+ * position is deliberate. Extracted (rather than inlined on the module-level
+ * registry) so a non-postgres registry — external `databaseUrl`, `none` — is
+ * testable without swapping the app config.
+ */
+export function buildRuntimeSecrets(
+  stores: Record<string, Pick<StoreProvisioner, 'secrets'>>,
+  appSecrets: Record<string, Omit<RuntimeSecretDefinition, 'id'>>,
+): RuntimeSecretDefinition[] {
+  const storeContributions: RuntimeSecretDefinition[] = Object.values(stores).flatMap((store) =>
+    (store.secrets?.() ?? []).map((contribution) => ({
+      id: contribution.id,
+      secretName: contribution.secretName,
+      description: contribution.description,
+      envVar: contribution.envVar,
+      required: contribution.required,
+      valueSource: contribution.valueSource,
+      generation: 'manual' as const,
+      services: contribution.services,
+    })),
+  );
+  return [...storeContributions, ...Object.entries(appSecrets).map(([id, definition]) => ({ id, ...definition }))];
+}
 
 /**
- * Flattened, ordered runtime secret definitions: store contributions followed
- * by the app's `runtime-secrets.config.ts` entries.
+ * Fail fast on an app misconfiguration, preventing a missing container at
+ * deploy time or a missing variable at runtime. Covers store contributions
+ * and app-config entries alike (including cross-source clashes).
  */
-export const runtimeSecrets: RuntimeSecretDefinition[] = [
-  ...storeContributions,
-  ...Object.entries(runtimeSecretsConfig).map(([id, definition]) => ({
-    id,
-    ...definition,
-  })),
-];
-
-// Fail fast at load time on an app misconfiguration, preventing a missing
-// container at deploy time or a missing variable at runtime. Covers store
-// contributions and app-config entries alike (including cross-source clashes).
-{
-  const knownServices = new Set<string>(serviceNames);
+export function validateRuntimeSecrets(
+  secrets: readonly RuntimeSecretDefinition[],
+  knownServices: ReadonlySet<string>,
+): void {
   const seenIds = new Set<string>();
   const seenEnvVars = new Set<string>();
   const seenSecretNames = new Set<string>();
-  for (const secret of runtimeSecrets) {
+  for (const secret of secrets) {
     if (seenIds.has(secret.id)) {
       throw new Error(
         `runtime-secrets: duplicate secret id '${secret.id}' — a store contribution clashes with another store or the app config.`,
@@ -122,6 +127,14 @@ export const runtimeSecrets: RuntimeSecretDefinition[] = [
     seenSecretNames.add(secret.secretName);
   }
 }
+
+/**
+ * Flattened, ordered runtime secret definitions for THIS app: store
+ * contributions followed by the `runtime-secrets.config.ts` entries,
+ * validated at load time.
+ */
+export const runtimeSecrets: RuntimeSecretDefinition[] = buildRuntimeSecrets(appStores, runtimeSecretsConfig);
+validateRuntimeSecrets(runtimeSecrets, new Set<string>(serviceNames));
 
 export const operatorManagedRuntimeSecrets: RuntimeSecretDefinition[] = runtimeSecrets.filter(
   (secret) => secret.valueSource === 'operator',

--- a/infra/lib/services.test.ts
+++ b/infra/lib/services.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { coHostedServices, collocatedServices, deployedServices, enabledServices, services } from './services';
+import {
+  appStorageNeeds,
+  coHostedServices,
+  collocatedServices,
+  deployedServices,
+  enabledServices,
+  type ServiceDefinition,
+  services,
+} from './services';
 
 const allOn = { yjs: { enabled: true }, mcp: { enabled: true } };
 const allOff = { yjs: { enabled: false }, mcp: { enabled: false } };
@@ -95,5 +103,25 @@ describe('service registry — lbRoute contract', () => {
     expect(services.find((s) => s.slug === 'yjs')).not.toHaveProperty('enabled');
     expect(services.find((s) => s.slug === 'mcp')).not.toHaveProperty('enabled');
     expect(services.find((s) => s.slug === 'backend')).not.toHaveProperty('enabled');
+  });
+});
+
+describe('appStorageNeeds (P2 optional app storage)', () => {
+  const svc = (partial: { slug: string; lbRoute?: string; s3Access?: boolean }) =>
+    partial as unknown as ServiceDefinition;
+
+  it("cella's registry needs everything: SPA bucket, upload buckets, browser origin", () => {
+    const needs = appStorageNeeds(services);
+    expect(needs).toEqual({ spaBucket: true, uploadBuckets: true, browserOriginSlug: 'frontend' });
+  });
+
+  it('a frontend-less API+worker registry needs no app buckets at all', () => {
+    const needs = appStorageNeeds([svc({ slug: 'api', lbRoute: 'path' }), svc({ slug: 'worker' })]);
+    expect(needs).toEqual({ spaBucket: false, uploadBuckets: false, browserOriginSlug: undefined });
+  });
+
+  it('an s3Access service without a browser app gets upload buckets but no CORS origin', () => {
+    const needs = appStorageNeeds([svc({ slug: 'api', lbRoute: 'path', s3Access: true })]);
+    expect(needs).toEqual({ spaBucket: false, uploadBuckets: true, browserOriginSlug: undefined });
   });
 });

--- a/infra/lib/services.ts
+++ b/infra/lib/services.ts
@@ -111,6 +111,28 @@ export function secretScopeSlugs(
   ];
 }
 
+/**
+ * Which app-owned object storage the service registry implies (P2). The SPA
+ * bucket follows the default-route service; the upload buckets follow any
+ * service that signs S3 requests (`s3Access`); browser CORS on the upload
+ * buckets exists only when both do. Engine-owned buckets (Pulumi state,
+ * boot-diag) are unconditional and not represented here. A registry with no
+ * default route and no s3Access service provisions NO app buckets — the
+ * frontend-less consumer scenario.
+ */
+export function appStorageNeeds(definitions: readonly ServiceDefinition[]): {
+  spaBucket: boolean;
+  uploadBuckets: boolean;
+  browserOriginSlug?: ServiceName;
+} {
+  const browserOriginSlug = definitions.find((s) => s.lbRoute === 'default')?.slug;
+  return {
+    spaBucket: browserOriginSlug !== undefined,
+    uploadBuckets: definitions.some((s) => s.s3Access),
+    browserOriginSlug,
+  };
+}
+
 /** A public service's resolved endpoint, derived from appConfig by the registry. */
 export interface ServiceEndpoint {
   slug: ServiceName;

--- a/infra/lib/stores.ts
+++ b/infra/lib/stores.ts
@@ -116,3 +116,19 @@ export interface StoreProvisioner {
 export function defineStores<const T extends Record<string, StoreProvisioner>>(stores: T): T {
   return stores;
 }
+
+/**
+ * Read a named output from a store's outputs under the P2 contract: a
+ * provision-less store (external URL / none — no outputs at all) yields
+ * undefined for every name, and the caller substitutes an empty export; a
+ * PROVISIONING store must expose every requested name — a missing key there
+ * is a store bug (or a typo at the call site), so it throws loudly. Full
+ * store-agnostic output namespacing (`store.<id>.<key>`) is the P3/P4 fix;
+ * this rule only makes provision-less primaries loadable.
+ */
+export function readStoreOutput(outputs: StoreOutputs, name: string): pulumi.Output<string> | undefined {
+  const value = outputs[name];
+  if (value !== undefined) return value;
+  if (Object.keys(outputs).length === 0) return undefined;
+  throw new Error(`store: provisioning store did not expose output '${name}'`);
+}

--- a/infra/resources/program.ts
+++ b/infra/resources/program.ts
@@ -1,4 +1,5 @@
-import type * as pulumi from '@pulumi/pulumi';
+import * as pulumi from '@pulumi/pulumi';
+import { readStoreOutput } from '../lib/stores';
 import * as storage from './storage';
 import './dns';
 import * as compute from './compute';
@@ -11,11 +12,15 @@ import './vm-iam';
 import { mode, naming, region } from '../pulumi-context';
 import * as lb from './loadbalancer';
 
-/** Read a named output from the primary store, failing loudly if it is absent. */
+/**
+ * Read a named output from the primary store. A provisioning store (postgres)
+ * must expose the full db contract — a missing key throws. A provision-less
+ * primary (external `databaseUrl`, `none`) has no outputs at all, so every
+ * `db*` export becomes an empty string and consumers (db-exposure CLI, seed)
+ * treat the feature as unavailable.
+ */
 function primaryStoreOutput(name: string): pulumi.Output<string> {
-  const value = stores.primaryStoreOutputs[name];
-  if (value === undefined) throw new Error(`program: primary store did not expose output '${name}'`);
-  return value;
+  return readStoreOutput(stores.primaryStoreOutputs, name) ?? pulumi.output('');
 }
 
 // The whole deployment program: one stack per mode, long-lived base resources

--- a/infra/resources/storage.ts
+++ b/infra/resources/storage.ts
@@ -1,16 +1,27 @@
 import * as pulumi from '@pulumi/pulumi';
 import * as scaleway from '@pulumiverse/scaleway';
 import { sizing } from '../config/sizing';
-import { services } from '../lib/services';
+import { appStorageNeeds, services } from '../lib/services';
 import { isProduction, naming, region, serviceUrl, tagsAsMap } from '../pulumi-context';
 import { adminApplicationId, backendServiceApplicationId, bootApplicationId, ciDeployApplicationId } from './vm-iam';
 
-// The browser app origin allowed to call the upload buckets: the service that
-// owns the LB's default route (the SPA), resolved without naming a service.
-const browserOriginSlug = services.find((s) => s.lbRoute === 'default')?.slug;
-if (!browserOriginSlug)
-  throw new Error('storage: no service owns the LB default route — cannot resolve the browser origin for bucket CORS.');
-const browserOrigin = serviceUrl(browserOriginSlug);
+// App-owned buckets follow the service registry (P2): the SPA bucket needs a
+// default-route service, the upload buckets need an s3Access service, and the
+// browser CORS origin is the default-route service's URL when both exist. A
+// frontend-less registry provisions no app buckets at all; the engine-owned
+// boot-diag bucket below is unconditional.
+const needs = appStorageNeeds(services);
+const browserOrigin = needs.browserOriginSlug ? serviceUrl(needs.browserOriginSlug) : undefined;
+const uploadCorsRules = browserOrigin
+  ? [
+      {
+        allowedHeaders: ['*'],
+        allowedMethods: ['GET', 'PUT', 'POST'],
+        allowedOrigins: [browserOrigin],
+        maxAgeSeconds: 3600,
+      },
+    ]
+  : undefined;
 
 /**
  * Admin application S3 access on the CI-scoped bucket policies, so a human key
@@ -121,160 +132,162 @@ const uploadsSignerAccess = (bucketName: pulumi.Input<string>) =>
 // Root entry files stay outside this lifecycle prefix.
 const assetRetentionDays = sizing.assetRetentionDays;
 
-// Frontend static files bucket (website hosting)
+// Frontend static files bucket (website hosting); only when a default-route
+// service exists to serve it.
 
-const frontendBucket = new scaleway.object.Bucket(
-  'frontend-bucket',
-  {
-    name: naming.frontendBucket,
-    region,
-    tags: tagsAsMap,
-    forceDestroy: !isProduction,
-    versioning: { enabled: true },
-    lifecycleRules: [
+const frontendBucket = needs.spaBucket
+  ? new scaleway.object.Bucket(
+      'frontend-bucket',
       {
-        // Versioned expiration creates delete markers, so purge noncurrent objects bucket-wide
-        // after 30 days and remove markers once no versions remain.
-        id: 'cleanup-old-versions',
-        enabled: true,
-        noncurrentVersionExpiration: { noncurrentDays: 30 },
-        expiration: { expiredObjectDeleteMarker: true },
+        name: naming.frontendBucket,
+        region,
+        tags: tagsAsMap,
+        forceDestroy: !isProduction,
+        versioning: { enabled: true },
+        lifecycleRules: [
+          {
+            // Versioned expiration creates delete markers, so purge noncurrent objects bucket-wide
+            // after 30 days and remove markers once no versions remain.
+            id: 'cleanup-old-versions',
+            enabled: true,
+            noncurrentVersionExpiration: { noncurrentDays: 30 },
+            expiration: { expiredObjectDeleteMarker: true },
+          },
+          {
+            // Expire immutable chunks after the open-tab window; rollback reuploads identical hashes.
+            // Versioning creates a marker here, while the old-version rule performs deletion.
+            id: 'expire-stale-assets',
+            enabled: true,
+            expiration: { days: assetRetentionDays },
+            prefix: 'assets/',
+          },
+        ],
       },
-      {
-        // Expire immutable chunks after the open-tab window; rollback reuploads identical hashes.
-        // Versioning creates a marker here, while the old-version rule performs deletion.
-        id: 'expire-stale-assets',
-        enabled: true,
-        expiration: { days: assetRetentionDays },
-        prefix: 'assets/',
-      },
-    ],
-  },
-  { protect: isProduction },
-);
+      { protect: isProduction },
+    )
+  : undefined;
 
 // Public read via bucket policy only: the SPA is served by the Caddy frontend
 // VMs proxying the S3 REST endpoint (with their own index.html fallback), so
 // no S3 website hosting configuration is needed.
-new scaleway.object.BucketPolicy('frontend-policy', {
-  bucket: frontendBucket.name,
-  region,
-  policy: pulumi.jsonStringify({
-    Version: '2023-04-17',
-    Statement: adminAccess(frontendBucket.name).apply((admin) => [
-      {
-        Sid: 'PublicRead',
-        Effect: 'Allow',
-        Principal: '*',
-        Action: ['s3:GetObject'],
-        Resource: [pulumi.interpolate`${frontendBucket.name}/*`],
-      },
-      deployAccess(frontendBucket.name),
-      ...admin,
-    ]),
-  }),
-});
-
-// Public uploads bucket (user-uploaded public assets)
-
-const publicUploadsBucket = new scaleway.object.Bucket('public-uploads-bucket', {
-  name: naming.publicBucket,
-  region,
-  tags: tagsAsMap,
-  forceDestroy: !isProduction,
-  // User uploads are irreplaceable: versioning + a noncurrent-expiry window is
-  // the backup floor (REQ-14). Overwrites/deletes are recoverable for 30
-  // days, and the CI statement below cannot delete versions.
-  versioning: { enabled: true },
-  lifecycleRules: [
-    {
-      id: 'cleanup-old-versions',
-      enabled: true,
-      noncurrentVersionExpiration: { noncurrentDays: 30 },
-      expiration: { expiredObjectDeleteMarker: true },
-    },
-  ],
-  corsRules: [
-    {
-      allowedHeaders: ['*'],
-      allowedMethods: ['GET', 'PUT', 'POST'],
-      allowedOrigins: [browserOrigin],
-      maxAgeSeconds: 3600,
-    },
-  ],
-});
-
-// Public read access for public uploads
-new scaleway.object.BucketPolicy('public-uploads-policy', {
-  bucket: publicUploadsBucket.name,
-  region,
-  policy: pulumi.jsonStringify({
-    Version: '2023-04-17',
-    Statement: pulumi
-      .all([adminAccess(publicUploadsBucket.name), uploadsSignerAccess(publicUploadsBucket.name)])
-      .apply(([admin, signers]) => [
+if (frontendBucket) {
+  new scaleway.object.BucketPolicy('frontend-policy', {
+    bucket: frontendBucket.name,
+    region,
+    policy: pulumi.jsonStringify({
+      Version: '2023-04-17',
+      Statement: adminAccess(frontendBucket.name).apply((admin) => [
         {
           Sid: 'PublicRead',
           Effect: 'Allow',
           Principal: '*',
           Action: ['s3:GetObject'],
-          Resource: [pulumi.interpolate`${publicUploadsBucket.name}/*`],
+          Resource: [pulumi.interpolate`${frontendBucket.name}/*`],
         },
-        deployAccessNoVersionDelete(publicUploadsBucket.name),
+        deployAccess(frontendBucket.name),
         ...admin,
-        ...signers,
       ]),
-  }),
-});
+    }),
+  });
+}
+
+// Public uploads bucket (user-uploaded public assets); only when a service
+// signs S3 uploads (s3Access).
+
+const publicUploadsBucket = needs.uploadBuckets
+  ? new scaleway.object.Bucket('public-uploads-bucket', {
+      name: naming.publicBucket,
+      region,
+      tags: tagsAsMap,
+      forceDestroy: !isProduction,
+      // User uploads are irreplaceable: versioning + a noncurrent-expiry window is
+      // the backup floor (REQ-14). Overwrites/deletes are recoverable for 30
+      // days, and the CI statement below cannot delete versions.
+      versioning: { enabled: true },
+      lifecycleRules: [
+        {
+          id: 'cleanup-old-versions',
+          enabled: true,
+          noncurrentVersionExpiration: { noncurrentDays: 30 },
+          expiration: { expiredObjectDeleteMarker: true },
+        },
+      ],
+      // Browser direct upload needs the SPA origin; a registry without a
+      // default-route service uploads server-side only, no CORS.
+      ...(uploadCorsRules ? { corsRules: uploadCorsRules } : {}),
+    })
+  : undefined;
+
+// Public read access for public uploads
+if (publicUploadsBucket) {
+  new scaleway.object.BucketPolicy('public-uploads-policy', {
+    bucket: publicUploadsBucket.name,
+    region,
+    policy: pulumi.jsonStringify({
+      Version: '2023-04-17',
+      Statement: pulumi
+        .all([adminAccess(publicUploadsBucket.name), uploadsSignerAccess(publicUploadsBucket.name)])
+        .apply(([admin, signers]) => [
+          {
+            Sid: 'PublicRead',
+            Effect: 'Allow',
+            Principal: '*',
+            Action: ['s3:GetObject'],
+            Resource: [pulumi.interpolate`${publicUploadsBucket.name}/*`],
+          },
+          deployAccessNoVersionDelete(publicUploadsBucket.name),
+          ...admin,
+          ...signers,
+        ]),
+    }),
+  });
+}
 
 // Private uploads bucket (user-uploaded private assets, signed URL access)
 
-const privateUploadsBucket = new scaleway.object.Bucket(
-  'private-uploads-bucket',
-  {
-    name: naming.privateBucket,
-    region,
-    tags: tagsAsMap,
-    forceDestroy: !isProduction,
-    // Same backup floor as public uploads (REQ-14). This bucket stays
-    // policy-less (signed URLs only), so version protection here is IAM-side
-    // only until P3 adds the per-service backend statement.
-    versioning: { enabled: true },
-    lifecycleRules: [
+const privateUploadsBucket = needs.uploadBuckets
+  ? new scaleway.object.Bucket(
+      'private-uploads-bucket',
       {
-        id: 'cleanup-old-versions',
-        enabled: true,
-        noncurrentVersionExpiration: { noncurrentDays: 30 },
-        expiration: { expiredObjectDeleteMarker: true },
+        name: naming.privateBucket,
+        region,
+        tags: tagsAsMap,
+        forceDestroy: !isProduction,
+        // Same backup floor as public uploads (REQ-14). This bucket stays
+        // policy-less (signed URLs only), so version protection here is IAM-side
+        // only until P3 adds the per-service backend statement.
+        versioning: { enabled: true },
+        lifecycleRules: [
+          {
+            id: 'cleanup-old-versions',
+            enabled: true,
+            noncurrentVersionExpiration: { noncurrentDays: 30 },
+            expiration: { expiredObjectDeleteMarker: true },
+          },
+        ],
+        ...(uploadCorsRules ? { corsRules: uploadCorsRules } : {}),
       },
-    ],
-    corsRules: [
-      {
-        allowedHeaders: ['*'],
-        allowedMethods: ['GET', 'PUT', 'POST'],
-        allowedOrigins: [browserOrigin],
-        maxAgeSeconds: 3600,
-      },
-    ],
-  },
-  { protect: isProduction },
-);
+      { protect: isProduction },
+    )
+  : undefined;
 
 /**
  * Deny-by-default policy on the private bucket (P3): no public statement, signed URLs only.
  * Admits the upload signer (backend service app), CI without version deletes (REQ-14),
  * and the admin app; any other key, including a compromised VM boot key or another service's key, is denied.
  */
-new scaleway.object.BucketPolicy('private-uploads-policy', {
-  bucket: privateUploadsBucket.name,
-  region,
-  policy: pulumi.jsonStringify({
-    Version: '2023-04-17',
-    Statement: pulumi
-      .all([adminAccess(privateUploadsBucket.name), uploadsSignerAccess(privateUploadsBucket.name)])
-      .apply(([admin, signers]) => [deployAccessNoVersionDelete(privateUploadsBucket.name), ...admin, ...signers]),
-  }),
-});
+if (privateUploadsBucket) {
+  new scaleway.object.BucketPolicy('private-uploads-policy', {
+    bucket: privateUploadsBucket.name,
+    region,
+    policy: pulumi.jsonStringify({
+      Version: '2023-04-17',
+      Statement: pulumi
+        .all([adminAccess(privateUploadsBucket.name), uploadsSignerAccess(privateUploadsBucket.name)])
+        .apply(([admin, signers]) => [deployAccessNoVersionDelete(privateUploadsBucket.name), ...admin, ...signers]),
+    }),
+  });
+}
 
 // Boot diagnostics bucket (VM write-only diagnostics channel)
 
@@ -322,25 +335,26 @@ new scaleway.object.BucketPolicy('boot-diag-policy', {
   }),
 });
 
-// Exports
+// Exports. Skipped buckets export empty strings, matching the provision-less
+// primary-store contract in resources/program.ts.
 
 /** Frontend bucket name */
-export const frontendBucketName = frontendBucket.name;
+export const frontendBucketName = frontendBucket?.name ?? pulumi.output('');
 
 /** Frontend bucket S3 endpoint */
-export const frontendBucketEndpoint = frontendBucket.endpoint;
+export const frontendBucketEndpoint = frontendBucket?.endpoint ?? pulumi.output('');
 
 /** Public uploads bucket name */
-export const publicUploadsBucketName = publicUploadsBucket.name;
+export const publicUploadsBucketName = publicUploadsBucket?.name ?? pulumi.output('');
 
 /** Public uploads bucket S3 endpoint */
-export const publicUploadsBucketEndpoint = publicUploadsBucket.endpoint;
+export const publicUploadsBucketEndpoint = publicUploadsBucket?.endpoint ?? pulumi.output('');
 
 /** Private uploads bucket name */
-export const privateUploadsBucketName = privateUploadsBucket.name;
+export const privateUploadsBucketName = privateUploadsBucket?.name ?? pulumi.output('');
 
 /** Private uploads bucket S3 endpoint */
-export const privateUploadsBucketEndpoint = privateUploadsBucket.endpoint;
+export const privateUploadsBucketEndpoint = privateUploadsBucket?.endpoint ?? pulumi.output('');
 
 /** Boot diagnostics bucket name */
 export const bootDiagBucketName = bootDiagBucket.name;

--- a/infra/resources/stores/catalog.ts
+++ b/infra/resources/stores/catalog.ts
@@ -1,0 +1,12 @@
+/**
+ * The store-plugin catalog: every provisioner factory an app's
+ * `config/stores.config.ts` can register, re-exported from one
+ * side-effect-free module. Import factories from HERE, never from
+ * `./index` — importing the index provisions the registered stores, which
+ * must only happen inside the Pulumi program.
+ */
+export { databaseUrl } from './database-url';
+export { externalUrl, mongoUrl, redisUrl } from './external-url';
+export { none } from './none';
+export { postgresManaged } from './postgres-managed';
+export { redisManaged } from './redis-managed';

--- a/infra/tasks/deploy-run.test.ts
+++ b/infra/tasks/deploy-run.test.ts
@@ -141,6 +141,17 @@ describe('runDeploy sequencing', () => {
     expect(ops.at(-1)).toBe('task:stack-lock:release');
   });
 
+  it('a frontend-less registry (empty frontend_bucket) skips build, asset upload, and entry publish', async () => {
+    const { fx, ops } = makeFake();
+    const frontendless = async (opts: DeployOptions) => ({ ...(await fakeDeployEnv(opts)), frontend_bucket: '' });
+    await runDeploy({ ...baseOpts, distDir: undefined as unknown as string }, fx, frontendless);
+    expect(ops).not.toContain('exec:pnpm:--filter');
+    expect(ops).not.toContain('upload-assets');
+    expect(ops).not.toContain('publish-entry');
+    expect(ops).toContain('task:smoke');
+    expect(ops.at(-1)).toBe('task:stack-lock:release');
+  });
+
   it('fails before publishing when a service does not serve the expected version', async () => {
     const { fx, ops } = makeFake({ verifyFails: true });
     await expect(runDeploy(baseOpts, fx, fakeDeployEnv)).rejects.toThrow(/does not serve/);

--- a/infra/tasks/deploy-run.ts
+++ b/infra/tasks/deploy-run.ts
@@ -207,6 +207,8 @@ export async function runDeploy(
       );
     })();
     const frontendReady = (async () => {
+      // No SPA bucket (frontend-less registry): nothing to build or upload.
+      if (!env.frontend_bucket) return;
       if (!opts.distDir) {
         await step('Build frontend', () =>
           fx.exec('pnpm', ['--filter', 'frontend', 'build'], {
@@ -304,18 +306,22 @@ export async function runDeploy(
     });
 
     // Strictly after rollout verification: users only load the new entry
-    // files once every service already serves the new release.
-    await step('Publish frontend entry files', () =>
-      fx.publishEntryFiles({ distDir, bucket: env.frontend_bucket, region: env.region }),
-    );
+    // files once every service already serves the new release. Skipped for a
+    // frontend-less registry (no SPA bucket).
+    if (env.frontend_bucket) {
+      await step('Publish frontend entry files', () =>
+        fx.publishEntryFiles({ distDir, bucket: env.frontend_bucket, region: env.region }),
+      );
+    }
     await step('Smoke tests', () =>
       fx.task('smoke', [
         '--sha',
         opts.sha,
         '--services-json',
         env.enabled_services_json,
-        '--dist',
-        resolve(distDir, 'index.html'),
+        // A provided-but-unreadable --dist is a hard failure in smoke, so a
+        // frontend-less registry omits it instead of pointing at nothing.
+        ...(env.frontend_bucket ? ['--dist', resolve(distDir, 'index.html')] : []),
       ]),
     );
   } catch (err) {

--- a/infra/tasks/print-deploy-env.ts
+++ b/infra/tasks/print-deploy-env.ts
@@ -8,7 +8,13 @@ import {
 } from '../lib/scaleway/permissions';
 import { principalNames } from '../lib/scaleway/principals';
 import { bootKeyCondition, serviceKeyCondition } from '../lib/scaleway/secret-paths';
-import { deployedServices, enabledServices, secretScopeSlugs, serviceEndpoints } from '../lib/services';
+import {
+  appStorageNeeds,
+  deployedServices,
+  enabledServices,
+  secretScopeSlugs,
+  serviceEndpoints,
+} from '../lib/services';
 import { isMain } from '../lib/utils/is-main';
 import { getFlag } from './args';
 
@@ -93,7 +99,9 @@ export function buildDeployEnv(appConfig: Cfg, opts: { imageTag?: string } = {})
     pulumi_stack: appConfig.mode,
     region: appConfig.s3.region,
     registry_ns: naming.registryNamespace,
-    frontend_bucket: naming.frontendBucket,
+    // Empty when the registry implies no SPA bucket (frontend-less app); the
+    // deploy skips asset upload + entry publish on ''.
+    frontend_bucket: appStorageNeeds(enabled).spaBucket ? naming.frontendBucket : '',
     state_bucket: naming.pulumiStateBucket,
     // One assertion row per principal (exact sets + exact condition, built by
     // the same shared builders the Pulumi program uses so the deploy's


### PR DESCRIPTION
Phase **P2** of `.todos/INFRA.md`, both halves (plan recorded there). Cella's resources and Pulumi URNs are byte-identical throughout — every conditional resolves to "provision" on this repo.

## Commit 1 — P2a: wire external stores (`databaseUrl` / `none`)

The store-secret merge in `lib/runtime-secrets.ts` turned out to be **already fully store-generic**; the actual gaps were:

1. **Provision-less primaries crashed `pulumi up`** — `resources/program.ts` threw for any missing primary-store output. New contract (`lib/stores.ts` `readStoreOutput`): a store with **no** outputs yields empty `db*` exports (db-exposure/seed report the feature unavailable — correct for BYO-Neon); a **provisioning** store must still expose the full contract, keeping the typo protection. Generic `store.<id>.<key>` namespacing stays P3/P4 (S11).
2. **No side-effect-free import surface** — `stores/index.ts` provisions on import. New `resources/stores/catalog.ts` re-exports every factory; `stores.config.ts` consumes it as the reference example.
3. **The merge was untestable** — extracted pure `buildRuntimeSecrets`/`validateRuntimeSecrets` with first tests proving a `databaseUrl`/`none` registry merges, orders ahead of app entries, and trips the validations.

## Commit 2 — P2b: optional app object storage (frontend-less apps can deploy)

`resources/storage.ts` previously provisioned the SPA + upload buckets unconditionally and **threw** without a default-route service. It now derives needs from the registry (`appStorageNeeds` in `lib/services.ts`): SPA bucket ⇐ default-route service exists; upload buckets ⇐ any `s3Access` service; browser CORS ⇐ both. Skipped buckets export empty strings (same contract as provision-less stores); the engine-owned state and boot-diag buckets stay unconditional.

Deploy side: `print-deploy-env` emits `frontend_bucket=''` when the registry implies no SPA bucket, and the deploy then skips frontend build, asset upload, entry publish, and omits smoke's `--dist` (a provided-but-unreadable dist is a hard smoke failure by design).

## Verification

657 infra tests green (+13 across both commits: external-store merge, `readStoreOutput` contract, `appStorageNeeds` derivations, a frontend-less `runDeploy` sequencing test). Typecheck + hook green per commit. Engine gate residue unchanged (only the parked `cella-infra` branding pair).

Because storage.ts restructured resource declarations into conditionals (same names, args, options), the reviewer-facing safety claim is: **cella's `pulumi preview` must show an empty diff** — worth confirming on the next release deploy or a manual preview before/at merge.

Deliberately out of scope (tracked in INFRA.md): `spaSite()`/`objectStorage()` preset packaging (P-pkg), store-owned secret values (P3), ops-menu derivation (P4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
