### PR TITLE
feat(infra)!: deploy vocabulary roll — start-first/stop-first, pathPrefix, storeOutputs

### DIFF
--- a/cella/migrations/20260812T1724-deploy-vocabulary/README.md
+++ b/cella/migrations/20260812T1724-deploy-vocabulary/README.md
@@ -1,0 +1,49 @@
+# Deploy vocabulary: start-first/stop-first, pathPrefix, storeOutputs
+
+## What & why
+
+The 2026-08 planned generation roll adopts the standard deploy vocabulary
+(Compose `deploy.update_config.order` / Traefik idioms) and retires the
+legacy names in one batch: `replacementStrategy` values `'lb-overlap'` →
+`'start-first'` and `'exclusive'` → `'stop-first'`; the service field
+`lbPathBegin` → `pathPrefix` (the Scaleway `path_begin` term stays inside the
+LB resource layer); the pinned genId fingerprint key `runMigrate` →
+`runRelease`; and the flat `db*` stack outputs (`dbConnectionStringAdmin`,
+`dbCaCertificate`, …) → the generic `storeOutputs.<storeId>.<key>` object
+(the db-exposure/seed CLI reads the primary store's entry).
+
+## Blast radius
+
+Infra-only: no app wire shape, no DB, no sync break, no clientCacheVersion
+bump. Fork files affected: `infra/config/services.config.ts` (values + field
+name) and anything fork-local reading the retired `db*` stack outputs by
+name. The fingerprint-key rename deliberately RE-ROLLS EVERY GENERATION on
+the first deploy after adoption — expect a full blue/green replacement of all
+VMs (normal cutover, no downtime by design).
+
+## Run
+
+No script — manual (three sed-able renames in one fork file):
+
+```sh
+sed -i '' "s/'lb-overlap'/'start-first'/g; s/'exclusive'/'stop-first'/g; s/lbPathBegin/pathPrefix/g" infra/config/services.config.ts
+```
+
+## Manual steps
+
+1. Grep fork-local scripts for the retired stack outputs
+   (`dbConnectionString`, `dbCaCertificate`, `dbInstanceId`, `dbHost`,
+   `dbName` as OUTPUTS — `naming.dbName` is unrelated) and switch them to
+   `pulumi stack output storeOutputs --json` → `.<primaryStoreId>.<key>`.
+2. Regenerate the compose model: `pnpm --filter infra compose:generate`.
+
+## Verify
+
+```sh
+pnpm --filter infra exec vitest run
+pnpm --filter infra ts
+pnpm check
+```
+
+First deploy after merge rolls all generations (intended); watch it complete
+one full cutover.

--- a/cella/migrations/manifest.json
+++ b/cella/migrations/manifest.json
@@ -1,429 +1,446 @@
 {
-  "schemaVersion": 1,
-  "migrations": [
-    {
-      "id": "20260722T0902-drop-entity-suffix-renames",
-      "version": "next",
-      "title": "Drop redundant Entity suffix from single-family identifiers",
-      "kind": "codemod",
-      "syncBreaking": true,
-      "clientCacheBump": false,
-      "script": "cella/migrations/20260722T0902-drop-entity-suffix-renames/drop-entity-suffix-renames.ts",
-      "roots": [
-        "backend/src",
-        "backend/tests",
-        "backend/scripts",
-        "frontend/src",
-        "shared",
-        "cdc/src",
-        "yjs/src"
-      ],
-      "requires": [
-        "pnpm sdk",
-        "pnpm check"
-      ],
-      "summary": "ChannelEntityBase->ChannelBase, ProductEntityBase->ProductBase, getValid*Entity->getValid*, EnrichedChannelEntity->EnrichedChannel, bare channelEntity->channel and the rest of the single-family Entity identifiers (48 ids + 9 files). Allow-list codemod; internal rename, no wire-shape change."
-    },
-    {
-      "id": "20260722T1906-embedding-propagation-rename",
-      "version": "next",
-      "title": "Rename embedding propagation contract to embedded/host product",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": true,
-      "script": null,
-      "roots": [
-        "backend/src",
-        "frontend/src",
-        "shared",
-        "cdc/src"
-      ],
-      "requires": [
-        "pnpm sdk",
-        "pnpm check"
-      ],
-      "summary": "PropagationHint fields sourceType->embeddedProduct, targetType->hostProduct, field->hostColumn on StreamNotification.propagation + catchup propagation; propagationTargets->hostsByEmbeddedProduct; product-type wire fields tightened to z.enum(productEntityTypes). Manual (field names too generic to codemod); apps bump clientCacheVersion."
-    },
-    {
-      "id": "20260722T2050-sonner-style-toaster-api",
-      "version": "next",
-      "title": "Adopt the Sonner-style toaster API",
-      "kind": "codemod",
-      "syncBreaking": true,
-      "clientCacheBump": false,
-      "script": "cella/migrations/20260722T2050-sonner-style-toaster-api/sonner-style-toaster-api.ts",
-      "roots": [
-        "frontend/src"
-      ],
-      "requires": [
-        "pnpm check"
-      ],
-      "summary": "Rewrite toaster(message, severity, options) calls to Sonner-style toaster.success/info/warning/error methods. TypeScript-AST codemod handles literal severities and reports dynamic calls for manual review; internal API only, no wire-shape change."
-    },
-    {
-      "id": "20260722T2105-prepared-mutation-compose",
-      "version": "next",
-      "title": "Compose prepared mutations over useMutation (drop usePreparedMutation)",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": false,
-      "script": null,
-      "roots": [
-        "frontend/src"
-      ],
-      "requires": [
-        "pnpm check"
-      ],
-      "summary": "Removed the usePreparedMutation hook; buildPreparedHandlers(mutation, prepare) stays. Mutation hooks now call useMutation directly and spread { ...mutation, ...buildPreparedHandlers(mutation, prepare) }, dropping five explicit generics and the Mutatable cast. PreparedVars/COALESCED unchanged. Frontend-only, no wire-shape change. Manual: each query.ts hook restructured (import swap + return rewrite + inline prepare input annotation)."
-    },
-    {
-      "id": "20260723T0739-hierarchy-owned-id-columns",
-      "version": "next",
-      "title": "Hierarchy-owned id-column keys and row-location API",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": false,
-      "script": null,
-      "roots": [
-        "shared",
-        "backend/src"
-      ],
-      "requires": [
-        "pnpm check"
-      ],
-      "summary": "EntityHierarchy instance owns row location: idColumnKeys/idColumnKey/idColumnName, resolve*, compute*Path, pathColumnSql, deepestAncestorSql. appConfig.entityIdColumnKeys now derives from hierarchy.idColumnKeys (replace the literal map in config.default.ts). backend pathColumnExpression removed in favor of hierarchy.pathColumnSql. No wire-shape or DB change."
-    },
-    {
-      "id": "20260723T0802-hierarchy-derived-entity-arrays",
-      "version": "next",
-      "title": "Hierarchy-derived entity arrays in config",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": false,
-      "script": null,
-      "roots": [
-        "shared"
-      ],
-      "requires": [
-        "pnpm check"
-      ],
-      "summary": "config.default.ts derives entityTypes/channelEntityTypes/productEntityTypes from the hierarchy via nonEmpty(); bidirectional config-validation checks and EntityIdColumnKeysShape removed. Apps replace their literal arrays with the derived form. No wire or DB change."
-    },
-    {
-      "id": "20260723T0814-hierarchy-instance-only-api",
-      "version": "next",
-      "title": "Hierarchy instance-only row-location API",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": false,
-      "script": null,
-      "roots": [
-        "backend/src",
-        "cdc/src",
-        "frontend/src",
-        "shared",
-        "yjs/src"
-      ],
-      "requires": [
-        "pnpm check"
-      ],
-      "summary": "Free row-location functions, entity guards (isChannelEntity/isProductEntity/getChannelRoles), and the AncestorSource/CountsHierarchy/TopologyHierarchy types are removed; the EntityHierarchy instance is the only API. Mechanical rewrite: fn(h, ...) to h.fn(...), guards to hierarchy.isChannel/isProduct/getRoles, topology params typed EntityHierarchy. No wire or DB change."
-    },
-    {
-      "id": "20260723T0822-drop-product-path-column",
-      "version": "next",
-      "title": "Drop the product tables' stored path column",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": true,
-      "script": null,
-      "roots": [
-        "backend/src",
-        "backend/drizzle",
-        "cdc/src"
-      ],
-      "requires": [
-        "pnpm generate",
-        "pnpm check"
-      ],
-      "summary": "Product rows compute their location path from ancestor id columns (hierarchy.computeProductPath) in CDC batching, move detection, and stream notifications; the stored generated column is dropped (wire: product responses lose the path field, clientCacheVersion bumped to v4-no-product-path). Channel tables keep their generated path for channel_counters ancestry."
-    },
-    {
-      "id": "20260723T0824-public-read-flag",
-      "version": "next",
-      "title": "Public read is a flag, not a mode",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": false,
-      "script": null,
-      "roots": [
-        "shared",
-        "backend/src",
-        "frontend/src"
-      ],
-      "requires": [
-        "pnpm check"
-      ],
-      "summary": "Deleted the single-member PublicReadMode union. PublicReadGrants values are now `true`, the config builder's publicRead() takes no argument, and GrantSource's public variant is { type: 'public' }. Decision logic unchanged (still the shared 'public' row condition over the row's publicAt); no wire-shape or database change. Manual: single-token edits at each call site."
-    },
-    {
-      "id": "20260723T0959-permission-vocabulary",
-      "version": "next",
-      "title": "Permission vocabulary consolidation",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": false,
-      "script": null,
-      "roots": [
-        "shared",
-        "backend/src",
-        "backend/tests",
-        "frontend/src",
-        "yjs/src"
-      ],
-      "requires": [
-        "pnpm sdk",
-        "pnpm check"
-      ],
-      "summary": "Access/Policy/Permission naming rule: AccessPolicies family -> PolicyMatrix/EntityPolicies/PolicyEntry, accessPolicies -> policyMatrix, PermissionValue/NormalizedPermissionValue -> PolicyCellInput/PolicyCell, ActionPermissionState -> CanState, resolvePermission -> resolveCan, PermissionMembership -> AccessMembership, isAllowed/enabled -> allowed, PermissionTopology removed (options.hierarchy + options.entityActions), config DSL ({ subject, contexts }) -> ({ entityType, channels }), collection scopes subChannelIds -> homeChannelIds/channelIds, AncestorScope -> IntermediateScope, permission-manager/ -> engine/, actor.ts -> access.ts. No wire-shape or DB change."
-    },
-    {
-      "id": "20260723T1237-typed-nullable-user-and-tree-rows",
-      "version": "next",
-      "title": "Nullable store user and TreeItem-constrained tree rows",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": false,
-      "script": null,
-      "roots": [
-        "frontend/src"
-      ],
-      "requires": [
-        "pnpm check"
-      ],
-      "summary": "useUserStore().user is MeUser | null (was MeUser seeded with `null as unknown as MeUser`); authenticated call sites use the new useCurrentUser()/getCurrentUser() accessors, which throw while signed out, and anything reachable signed out handles null. useTreeRows requires T extends TreeItem; buildTree is overloaded so other row shapes must pass all three accessors. Also widens getEntityPolicies/getPolicyPermissions to string and gives actorFrom/accessFrom a structural AccessContext (actorFrom now returns { anonymous: true } without a userId). Compile-time detected; no wire-shape or DB change."
-    },
-    {
-      "id": "20260723T1311-batch-presigned-urls",
-      "version": "next",
-      "title": "Batch presigned URLs replace the single presign endpoint",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": true,
-      "script": null,
-      "roots": [
-        "backend/src",
-        "frontend/src"
-      ],
-      "requires": [
-        "pnpm sdk",
-        "pnpm check"
-      ],
-      "summary": "GET /attachments/presigned-url (getPresignedUrl) -> POST /attachments/presigned-urls (getPresignedUrls): up to 50 id+variant items per call, uniform rejectedIds (no 403/404 existence oracle). Backend getPresignedUrlOp/findAttachmentById/presignedUrlQuerySchema -> getPresignedUrlsOp/findAttachmentsByIds/presignedUrlsBodySchema. Frontend getPrivateFileUrlById delegates to the presign-batch coalescer (flush window, in-flight dedupe, 1h memo); per-id denials reject with PresignRejectedError. No DB change."
-    },
-    {
-      "id": "20260723T1705-media-attachment-ref",
-      "version": "next",
-      "title": "Media blocks carry an attachment reference",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": false,
-      "script": null,
-      "roots": [
-        "frontend/src",
-        "shared",
-        "yjs/src"
-      ],
-      "requires": [
-        "pnpm check"
-      ],
-      "summary": "Media block specs (image/video/audio/file) gain an attachmentId prop via withAttachmentRef, applied to both the frontend editor schema and the yjs relay's server schema so Y.Docs round-trip it; UppyFilePanel stamps it on upload. Dead checklistGroupConfig plus checklist-group-block/render deleted, the four mediaBlockTypes copies consolidated onto the shared/blocknote export, and derive-description-core added as the shared block walk for description derivation. No wire-shape or DB change."
-    },
-    {
-      "id": "20260723T2257-deploy-engine-waves",
-      "version": "next",
-      "title": "Deploy engine: waved rollout, internal routes, one deploy command",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": false,
-      "script": null,
-      "roots": [
-        "infra",
-        ".github/workflows"
-      ],
-      "requires": [
-        "pnpm --filter infra compose:generate",
-        "pnpm check"
-      ],
-      "summary": "Two-wave rollout with concurrent cutovers and one deferred reap; single 'infra deploy' command replaces the pulumi/roll-*/publish/smoke jobs (branch-protection checks change to 'deploy'); cdc binds the backend through the LB's ACL-guarded internal route (services.config: backend internalRoute + internalHost/internalPort binding); optional INFRA_PULUMI_DRIVER=automation and INFRA_STACK_TOPOLOGY=micro knobs."
-    },
-    {
-      "id": "20260729T0922-app-product-mocks",
-      "version": "next",
-      "title": "Rename the app product mock registry",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": false,
-      "script": null,
-      "roots": [
-        "backend/src/mocks",
-        "cella.config.ts"
-      ],
-      "requires": [
-        "pnpm check"
-      ],
-      "summary": "Rename the pinned product mock registry file and export to app-product-mocks.ts and appProductMocks. Internal extension API only; no wire-shape or database change."
-    },
-    {
-      "id": "20260730T0425-boot-image-rename",
-      "version": "next",
-      "title": "Rename the boot runner image (cella-boot to infra-boot)",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": false,
-      "script": null,
-      "roots": [
-        "infra",
-        ".github/workflows"
-      ],
-      "requires": [
-        "pnpm --filter infra exec vitest run",
-        "pnpm check"
-      ],
-      "summary": "Boot runner image renamed cella-boot->infra-boot, centralized as BOOT_IMAGE_NAME in infra/lib/scaleway/boot-image.ts (build-images.ts, deploy-pipeline.yml, compute.ts). Immutable generations pin the boot image by name+sha and a digest is only pullable from its own repository, so resolveBootImage falls back to LEGACY_BOOT_IMAGE_NAMES on a 404 (threading the resolved name into cloud-init) and a pre-existing generation whose image is gone degrades to an unpinned tag instead of failing the plan. Auto-migrating: no app code changes; deploy staging first, drop 'cella-boot' from LEGACY_BOOT_IMAGE_NAMES once no environment runs a pre-rename generation. No wire-shape or DB change."
-    },
-    {
-      "id": "20260730T0624-attachment-keys-map",
-      "version": "next",
-      "title": "Attachment variant keys collapse to a single jsonb map",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": true,
-      "script": null,
-      "roots": [
-        "backend/src",
-        "backend/tests",
-        "backend/scripts",
-        "backend/drizzle",
-        "frontend/src",
-        "shared",
-        "bench/src"
-      ],
-      "requires": [
-        "pnpm generate",
-        "pnpm sdk",
-        "pnpm check"
-      ],
-      "summary": "attachments' per-variant originalKey/convertedKey/thumbnailKey/thumbnailTinyKey columns collapse into one keys jsonb map (AttachmentKeys: { original, preview?, thumbnail?, converted? }); selectVariantKey becomes keys[variant] ?? keys.original. Variant vocabulary realigned: mid-size thumbnail->preview, grid-cell thumbnail-tiny->thumbnail (attachmentVariantSchema/BlobVariant = original|preview|thumbnail|converted). Wire-breaking: clientCacheVersion bumped to v8-attachment-keys. DB: drop the four *_key columns, add keys jsonb with a jsonb_build_object backfill (thumbnail_key->preview, thumbnail_tiny_key->thumbnail). Manual: field-specific rename plus a data-preserving migration, no codemod. Apps that home attachments on a product entity keep their own taskId/projectId columns."
-    },
-    {
-      "id": "20260730T0858-frontend-module-placements",
-      "version": "next",
-      "title": "Frontend module registry and UI placements",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": false,
-      "script": null,
-      "roots": [
-        "frontend/src",
-        "cella.config.ts"
-      ],
-      "requires": [
-        "pnpm generate",
-        "pnpm sdk",
-        "pnpm check"
-      ],
-      "summary": "Frontend *-module.ts(x) files switch registerModule -> defineFrontendModule (~/lib/module); a glob composition root frontend/src/modules.ts loads them before first render. UI placements arrive with settled vocabulary: modules declare tools into slots ('${channelType}.settings', 'account.settings'); built-in settings sections are registered tools and the settings pages are pure consumers. Tools render full cards (lazy), gate on requires (grants) and visibleTo context-role pairs ('organization.admin', hierarchy-validated, matched over the ancestor chain; UI-only). Arrangement layers: manifest defaults, pinned placement-config.ts overrides, then the new organizations.tools_config jsonb (per-slot order/hidden/settings, admin Tools card, fail-closed reconciliation; locked tools immune to channel hiding). organizationSettingsSections (pinned file + type) removed. staticData.navTab typed PlacementDescriptor; system default tab derives from first visible tab. nav-buttons id special-cases move to NavItem iconSlot/badgeSlot in pinned nav-config.tsx. DB: additive tools_config column (pnpm generate); wire: additive optional toolsConfig on organization (no cache bump). Needs @cellajs/cli with the define*Module territory-scan matcher."
-    },
-    {
-      "id": "20260730T1009-owned-host-embedding",
-      "version": "next",
-      "title": "Product host FKs move to owned embeddings",
-      "kind": "manual",
-      "syncBreaking": false,
-      "clientCacheBump": false,
-      "script": null,
-      "roots": [
-        "backend/src",
-        "backend/drizzle",
-        "frontend/src",
-        "shared"
-      ],
-      "requires": [
-        "pnpm generate",
-        "pnpm sdk",
-        "pnpm check"
-      ],
-      "summary": "Child-side product-to-product host FK columns (taskId-style) are deprecated in favor of host-side id arrays registered as lifecycle 'owned' productEmbeddings. The template machinery (owned-embedding GC in the CDC worker, attachmentId media-block refs, derive-description-core collection, propagation id-array patching) already ships and activates on the first 'owned' entry. Template-side this is docs-only: apps without a host FK are unaffected; apps with one flip on their own schedule (host array + GIN, backfill from FK, drop FK and in-request cascades, own cache bump, feat!)."
-    },
-    {
-      "id": "20260730T1258-cella-config-into-cella-folder",
-      "version": "next",
-      "title": "Move cella sync files into the cella/ folder",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": false,
-      "script": null,
-      "roots": [
-        "cella.config.ts",
-        "cella.manifest.json",
-        "cella.migrations.json"
-      ],
-      "requires": [
-        "pnpm check"
-      ],
-      "summary": "Relocate cella.config.ts, cella.manifest.json and cella.migrations.json from the repo root into the cella/ folder (cella/cella.config.ts, cella/cella.manifest.json, cella/cella.migrations.json). The @cellajs/cli release with cella/-folder discovery finds them there (config loader, MANIFEST_FILE, managed-file match); run.ts reads/writes the applied-set at cella/cella.migrations.json with a read-only fallback to the old root path. Manual git mv, no codemod; sync-breaking, no wire-shape or DB change. App localPath values still resolve against the repo root and the config contents are unchanged."
-    },
-    {
-      "id": "20260731T0844-iam-model-v2",
-      "version": "next",
-      "title": "IAM model v2: per-mode/per-service principals, per-deploy keys, S3 key retirement",
-      "kind": "manual",
-      "syncBreaking": false,
-      "clientCacheBump": false,
-      "roots": [
-        "infra"
-      ],
-      "requires": [
-        "pnpm check"
-      ],
-      "summary": "Operational migration: per-mode IAM principals in a group, admin app replaces operator, per-service secret folders with resource-level conditions, per-deploy key rotation + single-access handoff, s3 managed key and s3AccessKeyId/Secret removed (backend signs with its service key; S3_* env names unchanged). Run the infra CLI 'Migrate IAM model' per environment."
-    },
-    {
-      "id": "20260804T1641-headless-settings-placements",
-      "version": "next",
-      "title": "Headless settings placements: sections hook, descriptor bases, consumers as presentation",
-      "kind": "manual",
-      "syncBreaking": true,
-      "clientCacheBump": false,
-      "script": null,
-      "roots": [
-        "frontend/src",
-        "backend/src"
-      ],
-      "requires": [
-        "pnpm check",
-        "pnpm test"
-      ],
-      "summary": "Settings-slot resolution moves into useChannelSettingsSections (grants, context-role pairs, overrides, stored toolsConfig); ChannelSettingsPage is a presentation-only map and a ChannelSettingsSheet reference consumer ships upstream. channelSettingsTools factory removed: spread generalToolBase/detailsToolBase/tabsToolBase/dangerToolBase(channelType, resource) and render full cards (DeleteToolCard exported; general now requires 'update'). getTools applies the section default order 50 (getSlotDescriptors stays raw for tabs); getChannelSettingsTools + ChannelSettingsToolFor removed. Surface trims: SlotToolsConfig.settings key dropped (no reader; stored config = order + hidden), PlacementOverride narrowed to hidden/order, heldContextRoles loses its unused entity-less overload; prefer requires over visibleTo (grants inherit down the ancestor chain). Backend mergeJsonbShallow util replaces inlined jsonb || merge fragments. Supersedes the channelSettingsTools guidance in 20260730T0858 step 5. No DB change, no cache bump. Arrangement UI pivots to tabs: ToolsArrangementCard deleted, TabsArrangementCard (flat data grid, row drag + visibility switches, writes toolsConfig['<channelType>.tabs']) demoed on organization settings via getNavTabCandidates (new ungated export from tab-nav); organization settings navTab now locked. toolsConfig is UI visibility only, never authorization \u2014 enforcement belongs to permissions/quotas."
-    },
-    {
-      "id": "20260811T0905-ts-import-extensions",
-      "version": "next",
-      "title": "Explicit .ts import extensions in the Vite config-load graph",
-      "kind": "manual",
-      "syncBreaking": false,
-      "clientCacheBump": false,
-      "script": null,
-      "roots": [
-        "shared",
-        "frontend/vite",
-        "frontend/vite.config.ts"
-      ],
-      "requires": [
-        "pnpm check"
-      ],
-      "summary": "Vite 8's future-default configLoader 'native' needs fully-specified ESM imports; vite.config.ts loads the whole shared/ graph at config time. All relative imports in shared/ and frontend/vite/ gain .ts extensions, directory-index imports name index.ts explicitly, __dirname becomes import.meta.dirname, allowImportingTsExtensions hoists to root tsconfig, and a biome.jsonc override enforces correctness/useImportExtensions over the territory. Codemod = Biome's own fixer (see README Run). Not sync-breaking, no cache bump, no DB."
-    }
-  ]
+ "schemaVersion": 1,
+ "migrations": [
+  {
+   "id": "20260722T0902-drop-entity-suffix-renames",
+   "version": "next",
+   "title": "Drop redundant Entity suffix from single-family identifiers",
+   "kind": "codemod",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": "cella/migrations/20260722T0902-drop-entity-suffix-renames/drop-entity-suffix-renames.ts",
+   "roots": [
+    "backend/src",
+    "backend/tests",
+    "backend/scripts",
+    "frontend/src",
+    "shared",
+    "cdc/src",
+    "yjs/src"
+   ],
+   "requires": [
+    "pnpm sdk",
+    "pnpm check"
+   ],
+   "summary": "ChannelEntityBase->ChannelBase, ProductEntityBase->ProductBase, getValid*Entity->getValid*, EnrichedChannelEntity->EnrichedChannel, bare channelEntity->channel and the rest of the single-family Entity identifiers (48 ids + 9 files). Allow-list codemod; internal rename, no wire-shape change."
+  },
+  {
+   "id": "20260722T1906-embedding-propagation-rename",
+   "version": "next",
+   "title": "Rename embedding propagation contract to embedded/host product",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": true,
+   "script": null,
+   "roots": [
+    "backend/src",
+    "frontend/src",
+    "shared",
+    "cdc/src"
+   ],
+   "requires": [
+    "pnpm sdk",
+    "pnpm check"
+   ],
+   "summary": "PropagationHint fields sourceType->embeddedProduct, targetType->hostProduct, field->hostColumn on StreamNotification.propagation + catchup propagation; propagationTargets->hostsByEmbeddedProduct; product-type wire fields tightened to z.enum(productEntityTypes). Manual (field names too generic to codemod); apps bump clientCacheVersion."
+  },
+  {
+   "id": "20260722T2050-sonner-style-toaster-api",
+   "version": "next",
+   "title": "Adopt the Sonner-style toaster API",
+   "kind": "codemod",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": "cella/migrations/20260722T2050-sonner-style-toaster-api/sonner-style-toaster-api.ts",
+   "roots": [
+    "frontend/src"
+   ],
+   "requires": [
+    "pnpm check"
+   ],
+   "summary": "Rewrite toaster(message, severity, options) calls to Sonner-style toaster.success/info/warning/error methods. TypeScript-AST codemod handles literal severities and reports dynamic calls for manual review; internal API only, no wire-shape change."
+  },
+  {
+   "id": "20260722T2105-prepared-mutation-compose",
+   "version": "next",
+   "title": "Compose prepared mutations over useMutation (drop usePreparedMutation)",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "frontend/src"
+   ],
+   "requires": [
+    "pnpm check"
+   ],
+   "summary": "Removed the usePreparedMutation hook; buildPreparedHandlers(mutation, prepare) stays. Mutation hooks now call useMutation directly and spread { ...mutation, ...buildPreparedHandlers(mutation, prepare) }, dropping five explicit generics and the Mutatable cast. PreparedVars/COALESCED unchanged. Frontend-only, no wire-shape change. Manual: each query.ts hook restructured (import swap + return rewrite + inline prepare input annotation)."
+  },
+  {
+   "id": "20260723T0739-hierarchy-owned-id-columns",
+   "version": "next",
+   "title": "Hierarchy-owned id-column keys and row-location API",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "shared",
+    "backend/src"
+   ],
+   "requires": [
+    "pnpm check"
+   ],
+   "summary": "EntityHierarchy instance owns row location: idColumnKeys/idColumnKey/idColumnName, resolve*, compute*Path, pathColumnSql, deepestAncestorSql. appConfig.entityIdColumnKeys now derives from hierarchy.idColumnKeys (replace the literal map in config.default.ts). backend pathColumnExpression removed in favor of hierarchy.pathColumnSql. No wire-shape or DB change."
+  },
+  {
+   "id": "20260723T0802-hierarchy-derived-entity-arrays",
+   "version": "next",
+   "title": "Hierarchy-derived entity arrays in config",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "shared"
+   ],
+   "requires": [
+    "pnpm check"
+   ],
+   "summary": "config.default.ts derives entityTypes/channelEntityTypes/productEntityTypes from the hierarchy via nonEmpty(); bidirectional config-validation checks and EntityIdColumnKeysShape removed. Apps replace their literal arrays with the derived form. No wire or DB change."
+  },
+  {
+   "id": "20260723T0814-hierarchy-instance-only-api",
+   "version": "next",
+   "title": "Hierarchy instance-only row-location API",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "backend/src",
+    "cdc/src",
+    "frontend/src",
+    "shared",
+    "yjs/src"
+   ],
+   "requires": [
+    "pnpm check"
+   ],
+   "summary": "Free row-location functions, entity guards (isChannelEntity/isProductEntity/getChannelRoles), and the AncestorSource/CountsHierarchy/TopologyHierarchy types are removed; the EntityHierarchy instance is the only API. Mechanical rewrite: fn(h, ...) to h.fn(...), guards to hierarchy.isChannel/isProduct/getRoles, topology params typed EntityHierarchy. No wire or DB change."
+  },
+  {
+   "id": "20260723T0822-drop-product-path-column",
+   "version": "next",
+   "title": "Drop the product tables' stored path column",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": true,
+   "script": null,
+   "roots": [
+    "backend/src",
+    "backend/drizzle",
+    "cdc/src"
+   ],
+   "requires": [
+    "pnpm generate",
+    "pnpm check"
+   ],
+   "summary": "Product rows compute their location path from ancestor id columns (hierarchy.computeProductPath) in CDC batching, move detection, and stream notifications; the stored generated column is dropped (wire: product responses lose the path field, clientCacheVersion bumped to v4-no-product-path). Channel tables keep their generated path for channel_counters ancestry."
+  },
+  {
+   "id": "20260723T0824-public-read-flag",
+   "version": "next",
+   "title": "Public read is a flag, not a mode",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "shared",
+    "backend/src",
+    "frontend/src"
+   ],
+   "requires": [
+    "pnpm check"
+   ],
+   "summary": "Deleted the single-member PublicReadMode union. PublicReadGrants values are now `true`, the config builder's publicRead() takes no argument, and GrantSource's public variant is { type: 'public' }. Decision logic unchanged (still the shared 'public' row condition over the row's publicAt); no wire-shape or database change. Manual: single-token edits at each call site."
+  },
+  {
+   "id": "20260723T0959-permission-vocabulary",
+   "version": "next",
+   "title": "Permission vocabulary consolidation",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "shared",
+    "backend/src",
+    "backend/tests",
+    "frontend/src",
+    "yjs/src"
+   ],
+   "requires": [
+    "pnpm sdk",
+    "pnpm check"
+   ],
+   "summary": "Access/Policy/Permission naming rule: AccessPolicies family -> PolicyMatrix/EntityPolicies/PolicyEntry, accessPolicies -> policyMatrix, PermissionValue/NormalizedPermissionValue -> PolicyCellInput/PolicyCell, ActionPermissionState -> CanState, resolvePermission -> resolveCan, PermissionMembership -> AccessMembership, isAllowed/enabled -> allowed, PermissionTopology removed (options.hierarchy + options.entityActions), config DSL ({ subject, contexts }) -> ({ entityType, channels }), collection scopes subChannelIds -> homeChannelIds/channelIds, AncestorScope -> IntermediateScope, permission-manager/ -> engine/, actor.ts -> access.ts. No wire-shape or DB change."
+  },
+  {
+   "id": "20260723T1237-typed-nullable-user-and-tree-rows",
+   "version": "next",
+   "title": "Nullable store user and TreeItem-constrained tree rows",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "frontend/src"
+   ],
+   "requires": [
+    "pnpm check"
+   ],
+   "summary": "useUserStore().user is MeUser | null (was MeUser seeded with `null as unknown as MeUser`); authenticated call sites use the new useCurrentUser()/getCurrentUser() accessors, which throw while signed out, and anything reachable signed out handles null. useTreeRows requires T extends TreeItem; buildTree is overloaded so other row shapes must pass all three accessors. Also widens getEntityPolicies/getPolicyPermissions to string and gives actorFrom/accessFrom a structural AccessContext (actorFrom now returns { anonymous: true } without a userId). Compile-time detected; no wire-shape or DB change."
+  },
+  {
+   "id": "20260723T1311-batch-presigned-urls",
+   "version": "next",
+   "title": "Batch presigned URLs replace the single presign endpoint",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": true,
+   "script": null,
+   "roots": [
+    "backend/src",
+    "frontend/src"
+   ],
+   "requires": [
+    "pnpm sdk",
+    "pnpm check"
+   ],
+   "summary": "GET /attachments/presigned-url (getPresignedUrl) -> POST /attachments/presigned-urls (getPresignedUrls): up to 50 id+variant items per call, uniform rejectedIds (no 403/404 existence oracle). Backend getPresignedUrlOp/findAttachmentById/presignedUrlQuerySchema -> getPresignedUrlsOp/findAttachmentsByIds/presignedUrlsBodySchema. Frontend getPrivateFileUrlById delegates to the presign-batch coalescer (flush window, in-flight dedupe, 1h memo); per-id denials reject with PresignRejectedError. No DB change."
+  },
+  {
+   "id": "20260723T1705-media-attachment-ref",
+   "version": "next",
+   "title": "Media blocks carry an attachment reference",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "frontend/src",
+    "shared",
+    "yjs/src"
+   ],
+   "requires": [
+    "pnpm check"
+   ],
+   "summary": "Media block specs (image/video/audio/file) gain an attachmentId prop via withAttachmentRef, applied to both the frontend editor schema and the yjs relay's server schema so Y.Docs round-trip it; UppyFilePanel stamps it on upload. Dead checklistGroupConfig plus checklist-group-block/render deleted, the four mediaBlockTypes copies consolidated onto the shared/blocknote export, and derive-description-core added as the shared block walk for description derivation. No wire-shape or DB change."
+  },
+  {
+   "id": "20260723T2257-deploy-engine-waves",
+   "version": "next",
+   "title": "Deploy engine: waved rollout, internal routes, one deploy command",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "infra",
+    ".github/workflows"
+   ],
+   "requires": [
+    "pnpm --filter infra compose:generate",
+    "pnpm check"
+   ],
+   "summary": "Two-wave rollout with concurrent cutovers and one deferred reap; single 'infra deploy' command replaces the pulumi/roll-*/publish/smoke jobs (branch-protection checks change to 'deploy'); cdc binds the backend through the LB's ACL-guarded internal route (services.config: backend internalRoute + internalHost/internalPort binding); optional INFRA_PULUMI_DRIVER=automation and INFRA_STACK_TOPOLOGY=micro knobs."
+  },
+  {
+   "id": "20260729T0922-app-product-mocks",
+   "version": "next",
+   "title": "Rename the app product mock registry",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "backend/src/mocks",
+    "cella.config.ts"
+   ],
+   "requires": [
+    "pnpm check"
+   ],
+   "summary": "Rename the pinned product mock registry file and export to app-product-mocks.ts and appProductMocks. Internal extension API only; no wire-shape or database change."
+  },
+  {
+   "id": "20260730T0425-boot-image-rename",
+   "version": "next",
+   "title": "Rename the boot runner image (cella-boot to infra-boot)",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "infra",
+    ".github/workflows"
+   ],
+   "requires": [
+    "pnpm --filter infra exec vitest run",
+    "pnpm check"
+   ],
+   "summary": "Boot runner image renamed cella-boot->infra-boot, centralized as BOOT_IMAGE_NAME in infra/lib/scaleway/boot-image.ts (build-images.ts, deploy-pipeline.yml, compute.ts). Immutable generations pin the boot image by name+sha and a digest is only pullable from its own repository, so resolveBootImage falls back to LEGACY_BOOT_IMAGE_NAMES on a 404 (threading the resolved name into cloud-init) and a pre-existing generation whose image is gone degrades to an unpinned tag instead of failing the plan. Auto-migrating: no app code changes; deploy staging first, drop 'cella-boot' from LEGACY_BOOT_IMAGE_NAMES once no environment runs a pre-rename generation. No wire-shape or DB change."
+  },
+  {
+   "id": "20260730T0624-attachment-keys-map",
+   "version": "next",
+   "title": "Attachment variant keys collapse to a single jsonb map",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": true,
+   "script": null,
+   "roots": [
+    "backend/src",
+    "backend/tests",
+    "backend/scripts",
+    "backend/drizzle",
+    "frontend/src",
+    "shared",
+    "bench/src"
+   ],
+   "requires": [
+    "pnpm generate",
+    "pnpm sdk",
+    "pnpm check"
+   ],
+   "summary": "attachments' per-variant originalKey/convertedKey/thumbnailKey/thumbnailTinyKey columns collapse into one keys jsonb map (AttachmentKeys: { original, preview?, thumbnail?, converted? }); selectVariantKey becomes keys[variant] ?? keys.original. Variant vocabulary realigned: mid-size thumbnail->preview, grid-cell thumbnail-tiny->thumbnail (attachmentVariantSchema/BlobVariant = original|preview|thumbnail|converted). Wire-breaking: clientCacheVersion bumped to v8-attachment-keys. DB: drop the four *_key columns, add keys jsonb with a jsonb_build_object backfill (thumbnail_key->preview, thumbnail_tiny_key->thumbnail). Manual: field-specific rename plus a data-preserving migration, no codemod. Apps that home attachments on a product entity keep their own taskId/projectId columns."
+  },
+  {
+   "id": "20260730T0858-frontend-module-placements",
+   "version": "next",
+   "title": "Frontend module registry and UI placements",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "frontend/src",
+    "cella.config.ts"
+   ],
+   "requires": [
+    "pnpm generate",
+    "pnpm sdk",
+    "pnpm check"
+   ],
+   "summary": "Frontend *-module.ts(x) files switch registerModule -> defineFrontendModule (~/lib/module); a glob composition root frontend/src/modules.ts loads them before first render. UI placements arrive with settled vocabulary: modules declare tools into slots ('${channelType}.settings', 'account.settings'); built-in settings sections are registered tools and the settings pages are pure consumers. Tools render full cards (lazy), gate on requires (grants) and visibleTo context-role pairs ('organization.admin', hierarchy-validated, matched over the ancestor chain; UI-only). Arrangement layers: manifest defaults, pinned placement-config.ts overrides, then the new organizations.tools_config jsonb (per-slot order/hidden/settings, admin Tools card, fail-closed reconciliation; locked tools immune to channel hiding). organizationSettingsSections (pinned file + type) removed. staticData.navTab typed PlacementDescriptor; system default tab derives from first visible tab. nav-buttons id special-cases move to NavItem iconSlot/badgeSlot in pinned nav-config.tsx. DB: additive tools_config column (pnpm generate); wire: additive optional toolsConfig on organization (no cache bump). Needs @cellajs/cli with the define*Module territory-scan matcher."
+  },
+  {
+   "id": "20260730T1009-owned-host-embedding",
+   "version": "next",
+   "title": "Product host FKs move to owned embeddings",
+   "kind": "manual",
+   "syncBreaking": false,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "backend/src",
+    "backend/drizzle",
+    "frontend/src",
+    "shared"
+   ],
+   "requires": [
+    "pnpm generate",
+    "pnpm sdk",
+    "pnpm check"
+   ],
+   "summary": "Child-side product-to-product host FK columns (taskId-style) are deprecated in favor of host-side id arrays registered as lifecycle 'owned' productEmbeddings. The template machinery (owned-embedding GC in the CDC worker, attachmentId media-block refs, derive-description-core collection, propagation id-array patching) already ships and activates on the first 'owned' entry. Template-side this is docs-only: apps without a host FK are unaffected; apps with one flip on their own schedule (host array + GIN, backfill from FK, drop FK and in-request cascades, own cache bump, feat!)."
+  },
+  {
+   "id": "20260730T1258-cella-config-into-cella-folder",
+   "version": "next",
+   "title": "Move cella sync files into the cella/ folder",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "cella.config.ts",
+    "cella.manifest.json",
+    "cella.migrations.json"
+   ],
+   "requires": [
+    "pnpm check"
+   ],
+   "summary": "Relocate cella.config.ts, cella.manifest.json and cella.migrations.json from the repo root into the cella/ folder (cella/cella.config.ts, cella/cella.manifest.json, cella/cella.migrations.json). The @cellajs/cli release with cella/-folder discovery finds them there (config loader, MANIFEST_FILE, managed-file match); run.ts reads/writes the applied-set at cella/cella.migrations.json with a read-only fallback to the old root path. Manual git mv, no codemod; sync-breaking, no wire-shape or DB change. App localPath values still resolve against the repo root and the config contents are unchanged."
+  },
+  {
+   "id": "20260731T0844-iam-model-v2",
+   "version": "next",
+   "title": "IAM model v2: per-mode/per-service principals, per-deploy keys, S3 key retirement",
+   "kind": "manual",
+   "syncBreaking": false,
+   "clientCacheBump": false,
+   "roots": [
+    "infra"
+   ],
+   "requires": [
+    "pnpm check"
+   ],
+   "summary": "Operational migration: per-mode IAM principals in a group, admin app replaces operator, per-service secret folders with resource-level conditions, per-deploy key rotation + single-access handoff, s3 managed key and s3AccessKeyId/Secret removed (backend signs with its service key; S3_* env names unchanged). Run the infra CLI 'Migrate IAM model' per environment."
+  },
+  {
+   "id": "20260804T1641-headless-settings-placements",
+   "version": "next",
+   "title": "Headless settings placements: sections hook, descriptor bases, consumers as presentation",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "frontend/src",
+    "backend/src"
+   ],
+   "requires": [
+    "pnpm check",
+    "pnpm test"
+   ],
+   "summary": "Settings-slot resolution moves into useChannelSettingsSections (grants, context-role pairs, overrides, stored toolsConfig); ChannelSettingsPage is a presentation-only map and a ChannelSettingsSheet reference consumer ships upstream. channelSettingsTools factory removed: spread generalToolBase/detailsToolBase/tabsToolBase/dangerToolBase(channelType, resource) and render full cards (DeleteToolCard exported; general now requires 'update'). getTools applies the section default order 50 (getSlotDescriptors stays raw for tabs); getChannelSettingsTools + ChannelSettingsToolFor removed. Surface trims: SlotToolsConfig.settings key dropped (no reader; stored config = order + hidden), PlacementOverride narrowed to hidden/order, heldContextRoles loses its unused entity-less overload; prefer requires over visibleTo (grants inherit down the ancestor chain). Backend mergeJsonbShallow util replaces inlined jsonb || merge fragments. Supersedes the channelSettingsTools guidance in 20260730T0858 step 5. No DB change, no cache bump. Arrangement UI pivots to tabs: ToolsArrangementCard deleted, TabsArrangementCard (flat data grid, row drag + visibility switches, writes toolsConfig['<channelType>.tabs']) demoed on organization settings via getNavTabCandidates (new ungated export from tab-nav); organization settings navTab now locked. toolsConfig is UI visibility only, never authorization \u2014 enforcement belongs to permissions/quotas."
+  },
+  {
+   "id": "20260811T0905-ts-import-extensions",
+   "version": "next",
+   "title": "Explicit .ts import extensions in the Vite config-load graph",
+   "kind": "manual",
+   "syncBreaking": false,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "shared",
+    "frontend/vite",
+    "frontend/vite.config.ts"
+   ],
+   "requires": [
+    "pnpm check"
+   ],
+   "summary": "Vite 8's future-default configLoader 'native' needs fully-specified ESM imports; vite.config.ts loads the whole shared/ graph at config time. All relative imports in shared/ and frontend/vite/ gain .ts extensions, directory-index imports name index.ts explicitly, __dirname becomes import.meta.dirname, allowImportingTsExtensions hoists to root tsconfig, and a biome.jsonc override enforces correctness/useImportExtensions over the territory. Codemod = Biome's own fixer (see README Run). Not sync-breaking, no cache bump, no DB."
+  },
+  {
+   "id": "20260812T1724-deploy-vocabulary",
+   "version": "next",
+   "title": "Deploy vocabulary: start-first/stop-first, pathPrefix, storeOutputs",
+   "kind": "manual",
+   "syncBreaking": false,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "infra"
+   ],
+   "requires": [
+    "pnpm --filter infra exec vitest run",
+    "pnpm check"
+   ],
+   "summary": "Planned generation roll: replacementStrategy values lb-overlap->start-first / exclusive->stop-first, lbPathBegin->pathPrefix (field + emitted x-service key), genId fingerprint key runMigrate->runRelease (deliberately re-rolls every generation on first deploy), flat db* stack outputs retired in favor of storeOutputs.<storeId>.<key> (db-exposure/seed CLI reads the primary store entry). Fork change is three seds in infra/config/services.config.ts plus any fork-local reader of the retired outputs; regenerate compose.gen.yml."
+  }
+ ]
 }

--- a/infra/cli/actions/db-exposure.ts
+++ b/infra/cli/actions/db-exposure.ts
@@ -3,6 +3,7 @@ import { copyFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { confirm, input } from '@inquirer/prompts';
+import { appStores } from '../../config/stores.config';
 import { pulumiConfigRm, pulumiConfigSet } from '../../lib/stack/pulumi-up';
 import { checkMark, crossMark, pc, warningMark } from '../../lib/utils/cli-output';
 import { infraDir } from '../../lib/utils/paths';
@@ -14,8 +15,11 @@ import { printRevokeReminder, runPrivilegedConverge } from './privileged-converg
 // Pulumi config keys consumed by resources/stores/postgres-managed.ts and the outputs it exports.
 export const DB_ENDPOINT_KEY = 'infra:dbPublicEndpoint';
 export const DB_ACL_KEY = 'infra:dbPublicAcl';
-const PUBLIC_DSN_OUTPUT = 'dbConnectionStringAdminPublic';
-const DB_CA_OUTPUT = 'dbCaCertificate';
+// Keys within the primary store's entry of the `storeOutputs` stack output
+// (the flat db* outputs were retired in the 2026-08 planned break).
+const PUBLIC_DSN_OUTPUT = 'connectionStringAdminPublic';
+const DB_CA_OUTPUT = 'caCertificate';
+const PRIMARY_STORE_ID = Object.keys(appStores)[0] ?? 'primary';
 
 /**
  * Gitignored per-environment stack config overlay that carries the DB-exposure
@@ -56,24 +60,30 @@ export async function detectPublicIp(): Promise<string | undefined> {
   }
 }
 
-/** Read a (secret) stack output as raw text; empty when absent or unreadable. */
-function readSecretOutput(env: NodeJS.ProcessEnv, stack: string, name: string): string {
-  const result = spawnSync('pulumi', ['stack', 'output', name, '--show-secrets', '--stack', stack], {
-    cwd: infraDir,
-    env,
-    encoding: 'utf8',
-  });
-  return result.status === 0 ? (result.stdout ?? '').trim() : '';
+/** Read one key of the primary store's `storeOutputs` entry; empty when absent or unreadable. */
+function readPrimaryStoreOutput(env: NodeJS.ProcessEnv, stack: string, key: string): string {
+  const result = spawnSync(
+    'pulumi',
+    ['stack', 'output', 'storeOutputs', '--show-secrets', '--json', '--stack', stack],
+    { cwd: infraDir, env, encoding: 'utf8' },
+  );
+  if (result.status !== 0) return '';
+  try {
+    const parsed = JSON.parse(result.stdout ?? '{}') as Record<string, Record<string, string> | undefined>;
+    return (parsed?.[PRIMARY_STORE_ID]?.[key] ?? '').trim();
+  } catch {
+    return '';
+  }
 }
 
-/** Read the public admin DSN stack output (empty when the endpoint is disabled). */
+/** Read the public admin DSN store output (empty when the endpoint is disabled). */
 export function readPublicDsn(env: NodeJS.ProcessEnv, stack: string): string {
-  return readSecretOutput(env, stack, PUBLIC_DSN_OUTPUT);
+  return readPrimaryStoreOutput(env, stack, PUBLIC_DSN_OUTPUT);
 }
 
-/** Read the database instance CA certificate stack output (PEM; empty when unavailable). */
+/** Read the database instance CA certificate store output (PEM; empty when unavailable). */
 export function readDbCa(env: NodeJS.ProcessEnv, stack: string): string {
-  return readSecretOutput(env, stack, DB_CA_OUTPUT);
+  return readPrimaryStoreOutput(env, stack, DB_CA_OUTPUT);
 }
 
 /**

--- a/infra/compose.gen.yml
+++ b/infra/compose.gen.yml
@@ -39,7 +39,7 @@ services:
       healthTimeoutSeconds: 240
       healthExpectStatus: 204
       runRelease: true
-      replacementStrategy: lb-overlap
+      replacementStrategy: start-first
       drainSeconds: 10
       instanceType:
         production: DEV1-S
@@ -47,7 +47,7 @@ services:
       primaryRollout: true
       drainPolicy: requests
       lbRoute: path
-      lbPathBegin: /api
+      pathPrefix: /api
       internalRoute: true
       dockerfile: Dockerfile
       target: backend
@@ -95,7 +95,7 @@ services:
       healthTimeoutSeconds: 90
       healthExpectStatus: 204
       runRelease: false
-      replacementStrategy: exclusive
+      replacementStrategy: stop-first
       drainSeconds: 0
       instanceType: DEV1-S
       dockerfile: Dockerfile
@@ -131,12 +131,12 @@ services:
       healthTimeoutSeconds: 90
       healthExpectStatus: 204
       runRelease: false
-      replacementStrategy: lb-overlap
+      replacementStrategy: start-first
       drainSeconds: 5
       instanceType: DEV1-S
       drainPolicy: reconnect
       lbRoute: path
-      lbPathBegin: /yjs
+      pathPrefix: /yjs
       lbWebsockets: true
       dockerfile: Dockerfile
       target: yjs
@@ -172,12 +172,12 @@ services:
       healthTimeoutSeconds: 240
       healthExpectStatus: 204
       runRelease: false
-      replacementStrategy: lb-overlap
+      replacementStrategy: start-first
       drainSeconds: 10
       instanceType: DEV1-S
       drainPolicy: requests
       lbRoute: path
-      lbPathBegin: /mcp
+      pathPrefix: /mcp
       reusesImageOf: backend
       coHosted: true
       bindings:
@@ -204,7 +204,7 @@ services:
       healthTimeoutSeconds: 90
       healthExpectStatus: 200
       runRelease: false
-      replacementStrategy: lb-overlap
+      replacementStrategy: start-first
       drainSeconds: 0
       instanceType: DEV1-S
       drainPolicy: requests

--- a/infra/compose/infrastructure.ts
+++ b/infra/compose/infrastructure.ts
@@ -5,30 +5,28 @@ import type { AppServiceConfig, AppServices, ComposeFile, ComposeService, Health
 export function defineServices<const T extends AppServices>(services: T): T {
   const seenPrefixes = new Map<string, string>();
   for (const [slug, cfg] of Object.entries(services)) {
-    const prefix = cfg.lbPathBegin;
+    const prefix = cfg.pathPrefix;
     if (prefix === undefined) {
       // A path-routed service is reachable ONLY through its path route.
       if (cfg.lbRoute === 'path')
-        throw new Error(
-          `services config: '${slug}' has lbRoute 'path' but no lbPathBegin — nothing would route to it.`,
-        );
+        throw new Error(`services config: '${slug}' has lbRoute 'path' but no pathPrefix — nothing would route to it.`);
       continue;
     }
     // The LB matches the raw path-begin string, so a malformed prefix silently
     // routes wrong traffic, so validation fails during synth/plan.
     if (!cfg.lbRoute)
       throw new Error(
-        `services config: '${slug}' declares lbPathBegin without lbRoute — an internal-only service has no LB backend to route to.`,
+        `services config: '${slug}' declares pathPrefix without lbRoute — an internal-only service has no LB backend to route to.`,
       );
     if (!/^\/[a-z0-9-]+$/.test(prefix)) {
       throw new Error(
-        `services config: '${slug}' lbPathBegin '${prefix}' must be a single lowercase path segment starting with '/' and no trailing slash (e.g. '/api').`,
+        `services config: '${slug}' pathPrefix '${prefix}' must be a single lowercase path segment starting with '/' and no trailing slash (e.g. '/api').`,
       );
     }
     const owner = seenPrefixes.get(prefix);
     if (owner)
       throw new Error(
-        `services config: lbPathBegin '${prefix}' declared by both '${owner}' and '${slug}' — path prefixes must be unique.`,
+        `services config: pathPrefix '${prefix}' declared by both '${owner}' and '${slug}' — path prefixes must be unique.`,
       );
     seenPrefixes.set(prefix, slug);
   }
@@ -68,7 +66,7 @@ function metaFrom(slug: string, cfg: AppServiceConfig): ServiceMeta {
   if (cfg.primaryRollout) meta.primaryRollout = true;
   if (cfg.drainPolicy) meta.drainPolicy = cfg.drainPolicy;
   if (cfg.lbRoute) meta.lbRoute = cfg.lbRoute;
-  if (cfg.lbPathBegin) meta.lbPathBegin = cfg.lbPathBegin;
+  if (cfg.pathPrefix) meta.pathPrefix = cfg.pathPrefix;
   if (cfg.lbWebsockets) meta.lbWebsockets = true;
   if (cfg.internalRoute) meta.internalRoute = true;
   if (cfg.reusesImageOf) meta.reusesImageOf = cfg.reusesImageOf;

--- a/infra/compose/types.ts
+++ b/infra/compose/types.ts
@@ -2,9 +2,9 @@ import type { Environment } from '../lib/stack/bootstrap-stack-state';
 
 /**
  * VM cutover strategy: `lb-overlap` health-gates and drains overlapping generations;
- * `exclusive` releases a singleton resource before replacement starts.
+ * `stop-first` releases a singleton resource before replacement starts.
  */
-export type ReplacementStrategy = 'lb-overlap' | 'exclusive';
+export type ReplacementStrategy = 'start-first' | 'stop-first';
 
 /**
  * How the old generation is drained off the LB when it is de-registered:
@@ -27,7 +27,7 @@ export type LbRoute = 'default' | 'host' | 'path';
  * The service must serve under the same leading-slash, no-trailing-slash prefix; required for
  * path-routed services.
  */
-export type LbPathBegin = `/${string}`;
+export type PathPrefix = `/${string}`;
 
 /** A service's VM size: one type for all modes, or a per-mode map. */
 export type ServiceInstanceType = string | Partial<Record<Environment, string>>;
@@ -73,23 +73,23 @@ export interface ServiceMeta {
   /** Deploy this service before the rest of the VM fleet. At most one enabled service may set this. */
   primaryRollout?: boolean;
   /**
-   * How this service's VM generation is cut over on a deploy. `'lb-overlap'`
+   * How this service's VM generation is cut over on a deploy. `'start-first'`
    * for LB-exposed services (overlap two generations behind the LB);
-   * `'exclusive'` for the singleton-slot cdc worker.
+   * `'stop-first'` for the singleton-slot cdc worker.
    */
   replacementStrategy: ReplacementStrategy;
   /**
    * How the old generation drains off the LB. `'requests'` (HTTP, finish
    * in-flight) or `'reconnect'` (WebSocket, clients re-dial). Omit for the
-   * LB-less `exclusive` worker.
+   * LB-less `stop-first` worker.
    */
   drainPolicy?: DrainPolicy;
   /** Drain window (seconds) the cutover waits after the old generation is de-registered; 0 for none. */
   drainSeconds: number;
   /** Public LB exposure; absent = internal-only. */
   lbRoute?: LbRoute;
-  /** Path-prefix route on the shared HTTPS frontend (same-origin migration); see LbPathBegin. */
-  lbPathBegin?: LbPathBegin;
+  /** Path-prefix route on the shared HTTPS frontend (same-origin migration); see PathPrefix. */
+  pathPrefix?: PathPrefix;
   /** Long-lived LB timeouts (1h server/tunnel) for WebSocket services. */
   lbWebsockets?: boolean;
   /** Private ACL-guarded LB frontend giving in-network consumers a stable, cutover-following address. */
@@ -183,8 +183,8 @@ export interface AppServiceConfig {
    */
   healthExpectStatus?: number;
   /**
-   * How this service's VM generation is replaced on a deploy. `'lb-overlap'`
-   * is for LB-exposed services; `'exclusive'` is for the singleton-slot cdc
+   * How this service's VM generation is replaced on a deploy. `'start-first'`
+   * is for LB-exposed services; `'stop-first'` is for the singleton-slot cdc
    * worker, which cannot overlap because only one process can consume its
    * PostgreSQL replication slot.
    */
@@ -198,7 +198,7 @@ export interface AppServiceConfig {
   primaryRollout?: boolean;
   /**
    * How the old generation drains off the LB when de-registered. `'requests'`
-   * (HTTP) or `'reconnect'` (WebSocket). Omit for the LB-less `exclusive` worker.
+   * (HTTP) or `'reconnect'` (WebSocket). Omit for the LB-less `stop-first` worker.
    */
   drainPolicy?: DrainPolicy;
   /** Drain window (seconds) the cutover waits after the old generation is de-registered; defaults to 0. */
@@ -212,9 +212,9 @@ export interface AppServiceConfig {
   /**
    * Additionally route `<prefix>` path-begins on the shared HTTPS frontend to
    * this service (same-origin migration, e.g. '/api'). Only meaningful with
-   * `lbRoute`; see LbPathBegin for the exact matching/stripping semantics.
+   * `lbRoute`; see PathPrefix for the exact matching/stripping semantics.
    */
-  lbPathBegin?: LbPathBegin;
+  pathPrefix?: PathPrefix;
   /**
    * Keep LB connections long-lived (1h server/tunnel timeouts) for services
    * speaking WebSockets through the LB (yjs). Only meaningful with `lbRoute`.

--- a/infra/config/services.config.ts
+++ b/infra/config/services.config.ts
@@ -20,7 +20,7 @@ export const appServices = defineServices({
     // companion runs at the new generation's boot (expand-before-cutover): it
     // applies migrations via MODE=migrate, and the app block is told not to
     // migrate on its own boot.
-    replacementStrategy: 'lb-overlap',
+    replacementStrategy: 'start-first',
     drainPolicy: 'requests',
     release: { env: { MODE: 'migrate' }, appEnv: { RUN_MIGRATIONS_ON_BOOT: 'false' } },
     primaryRollout: true,
@@ -28,7 +28,7 @@ export const appServices = defineServices({
     // Same-origin: reached at https://<app-host>/api/... via an LB path-begin
     // route; the backend self-mounts '/api' (no LB stripping).
     lbRoute: 'path',
-    lbPathBegin: '/api',
+    pathPrefix: '/api',
     // Private ACL-guarded LB frontend: in-network consumers (cdc) dial a stable
     // address that follows every cutover.
     internalRoute: true,
@@ -53,7 +53,7 @@ export const appServices = defineServices({
     startPeriod: '10s',
     // CDC must cut over exclusively because it owns one PostgreSQL replication slot.
     // It is internal-only and reached through the private network.
-    replacementStrategy: 'exclusive',
+    replacementStrategy: 'stop-first',
     instanceType: 'DEV1-S',
     // singleVM: fold into the backend process in-process (holds the same slot).
     coHosted: true,
@@ -80,7 +80,7 @@ export const appServices = defineServices({
     healthExpectStatus: 204,
     healthTimeoutSeconds: 90,
     startPeriod: '10s',
-    replacementStrategy: 'lb-overlap',
+    replacementStrategy: 'start-first',
     // WebSocket clients reconnect to the new generation and resync from durable
     // CRDT state while sessions close during drain.
     drainPolicy: 'reconnect',
@@ -88,7 +88,7 @@ export const appServices = defineServices({
     // Same-origin: reached at wss://<app-host>/yjs/... via an LB path-begin
     // route; the yjs server accepts the unstripped prefix.
     lbRoute: 'path',
-    lbPathBegin: '/yjs',
+    pathPrefix: '/yjs',
     // WebSocket service: LB keeps connections open for up to an hour.
     lbWebsockets: true,
     // Only deployed when appConfig.services.yjs.enabled is true.
@@ -107,7 +107,7 @@ export const appServices = defineServices({
     healthExpectStatus: 204,
     healthTimeoutSeconds: 240,
     startPeriod: '15s',
-    replacementStrategy: 'lb-overlap',
+    replacementStrategy: 'start-first',
     drainPolicy: 'requests',
     drainSeconds: 10,
     // Reuses the backend image at the same SHA; CI builds no separate mcp image.
@@ -115,7 +115,7 @@ export const appServices = defineServices({
     // Same-origin: reached at https://<app-host>/mcp/... via an LB path-begin
     // route; the shared base app self-mounts '/mcp'.
     lbRoute: 'path',
-    lbPathBegin: '/mcp',
+    pathPrefix: '/mcp',
     // Only deployed when appConfig.services.mcp.enabled is true.
     instanceType: 'DEV1-S',
     // singleVM: fold into the backend process (LB still routes to the host VM).
@@ -141,7 +141,7 @@ export const appServices = defineServices({
     port: 80,
     healthTimeoutSeconds: 90,
     startPeriod: '10s',
-    replacementStrategy: 'lb-overlap',
+    replacementStrategy: 'start-first',
     drainPolicy: 'requests',
     // The app origin: the LB's fallback backend. Everything no path route
     // matches (/api, /yjs, /mcp) lands on the SPA proxy.

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -22,14 +22,9 @@ export const privateUploadsBucketName = program.privateUploadsBucketName;
 export const privateUploadsBucketEndpoint = program.privateUploadsBucketEndpoint;
 export const bootDiagBucketName = program.bootDiagBucketName;
 export const bootDiagBucketEndpoint = program.bootDiagBucketEndpoint;
-export const dbInstanceId = program.dbInstanceId;
-export const dbName = program.dbName;
-export const dbHost = program.dbHost;
-export const dbConnectionStringAdmin = program.dbConnectionStringAdmin;
-export const dbConnectionStringRuntime = program.dbConnectionStringRuntime;
-export const dbConnectionStringCdc = program.dbConnectionStringCdc;
-export const dbConnectionStringAdminPublic = program.dbConnectionStringAdminPublic;
-export const dbCaCertificate = program.dbCaCertificate;
+// Generic per-store outputs (S11): `storeOutputs.<storeId>.<key>`. The flat
+// db* outputs were retired in the 2026-08 planned break.
+export const storeOutputs = program.storeOutputs;
 export const computeInstances = program.computeInstances;
 export const computeGenerationMetadata = program.computeGenerationMetadata;
 export const serviceDomainUrls = program.serviceDomainUrls;

--- a/infra/lib/runtime-secrets.test.ts
+++ b/infra/lib/runtime-secrets.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import { databaseUrl } from '../resources/stores/database-url';
 import { none } from '../resources/stores/none';
 import { buildRuntimeSecrets, type RuntimeSecretDefinition, validateRuntimeSecrets } from './runtime-secrets';
-import { readStoreOutput, type StoreOutputs } from './stores';
 
 /** A minimal non-cella app config, the P2 external-store consumer shape. */
 const appSecrets: Record<string, Omit<RuntimeSecretDefinition, 'id'>> = {
@@ -44,18 +43,5 @@ describe('buildRuntimeSecrets with external stores (P2)', () => {
   it('rejects a contribution targeting an unknown service', () => {
     const secrets = buildRuntimeSecrets({ primary: databaseUrl({ services: ['nope'] }) }, {});
     expect(() => validateRuntimeSecrets(secrets, knownServices)).toThrow(/unknown service 'nope'/);
-  });
-});
-
-describe('readStoreOutput (P2 primary-output contract)', () => {
-  const output = { fake: true } as unknown as StoreOutputs[string];
-
-  it('a provision-less store yields undefined for every name', () => {
-    expect(readStoreOutput({}, 'connectionStringAdmin')).toBeUndefined();
-  });
-
-  it('a provisioning store returns its outputs and throws on a missing name', () => {
-    expect(readStoreOutput({ host: output }, 'host')).toBe(output);
-    expect(() => readStoreOutput({ host: output }, 'connectionStringAdmin')).toThrow(/did not expose output/);
   });
 });

--- a/infra/lib/stores.ts
+++ b/infra/lib/stores.ts
@@ -116,19 +116,3 @@ export interface StoreProvisioner {
 export function defineStores<const T extends Record<string, StoreProvisioner>>(stores: T): T {
   return stores;
 }
-
-/**
- * Read a named output from a store's outputs under the P2 contract: a
- * provision-less store (external URL / none — no outputs at all) yields
- * undefined for every name, and the caller substitutes an empty export; a
- * PROVISIONING store must expose every requested name — a missing key there
- * is a store bug (or a typo at the call site), so it throws loudly. Full
- * store-agnostic output namespacing (`store.<id>.<key>`) is the P3/P4 fix;
- * this rule only makes provision-less primaries loadable.
- */
-export function readStoreOutput(outputs: StoreOutputs, name: string): pulumi.Output<string> | undefined {
-  const value = outputs[name];
-  if (value !== undefined) return value;
-  if (Object.keys(outputs).length === 0) return undefined;
-  throw new Error(`store: provisioning store did not expose output '${name}'`);
-}

--- a/infra/resources/generations.ts
+++ b/infra/resources/generations.ts
@@ -17,7 +17,7 @@ export const enabled = deployedServices(appConfig.services, appConfig.singleVM);
 
 // Workers folded into the host backend process under singleVM. Empty in the
 // normal split-VM deploy. Their runtime secrets are unioned onto the host VM and
-// an `exclusive` one among them forces the host to cut over exclusively.
+// a `stop-first` one among them forces the host to cut over stop-first.
 export const coHosted = coHostedServices(appConfig.services, appConfig.singleVM);
 
 // Containers the boot runner starts on the host VM next to the host container
@@ -36,17 +36,17 @@ export function secretConsumersFor(svc: ServiceDefinition): RuntimeSecretConsume
 }
 
 /**
- * Resolves the VM replacement strategy. A single-VM host containing an exclusive worker
- * must also cut over exclusively to avoid concurrent replication-slot consumers.
+ * Resolves the VM replacement strategy. A single-VM host containing a stop-first worker
+ * must also cut over stop-first to avoid concurrent replication-slot consumers.
  * The level-triggered load-balancer reconciler then repairs traffic onto the replacement.
  */
 export function effectiveStrategy(svc: ServiceDefinition): ServiceDefinition['replacementStrategy'] {
   if (
     appConfig.singleVM &&
     svc.slug === hostSlug &&
-    [...coHosted, ...collocated].some((s) => s.replacementStrategy === 'exclusive')
+    [...coHosted, ...collocated].some((s) => s.replacementStrategy === 'stop-first')
   ) {
-    return 'exclusive';
+    return 'stop-first';
   }
   return svc.replacementStrategy;
 }
@@ -80,11 +80,13 @@ function serviceFingerprint(svc: ServiceDefinition): unknown {
   return {
     slug: svc.slug,
     port: svc.healthPort,
-    // Fingerprint key pinned to its original name: the key itself is hashed
-    // into every live genId, so renaming it would re-roll every generation.
-    runMigrate: svc.runRelease ?? false,
-    // Only fold in the strategy when singleVM changes it (host co-hosting an
-    // exclusive worker). Keeps the split-VM fingerprint byte-stable so this
+    // Renamed from the pinned legacy `runMigrate` key in the 2026-08 planned
+    // generation roll (fingerprint keys are hashed into every genId, so this
+    // rename deliberately re-rolls all generations, together with the
+    // start-first/stop-first vocabulary).
+    runRelease: svc.runRelease ?? false,
+    // Only fold in the strategy when singleVM changes it (host co-hosting a
+    // stop-first worker). Keeps the split-VM fingerprint byte-stable so this
     // feature doesn't churn every existing service's genId.
     ...(effectiveStrategy(svc) !== svc.replacementStrategy ? { singleVmStrategy: effectiveStrategy(svc) } : {}),
     bindings: svc.bindings ?? {},
@@ -97,7 +99,7 @@ function serviceFingerprint(svc: ServiceDefinition): unknown {
 
 /**
  * The live and pending content-addressed generations for a service. Selection
- * (exclusive collapse, first-provision fallback) lives in
+ * (stop-first collapse, first-provision fallback) lives in
  * lib/select-generations.ts as a pure function; single-VM hosts inherit
  * exclusivity when they own the replication slot in-process. Old generations
  * are reaped after promotion; rollback uses a revert and redeploy.
@@ -105,7 +107,7 @@ function serviceFingerprint(svc: ServiceDefinition): unknown {
 export function activeGenerations(svc: ServiceDefinition): Generation[] {
   const fingerprint = serviceFingerprint(svc);
   return selectGenerations(controlState.rollout[svc.slug], {
-    exclusive: effectiveStrategy(svc) === 'exclusive',
+    exclusive: effectiveStrategy(svc) === 'stop-first',
     genIdFor: (sha) => deriveGenId(sha, fingerprint),
   });
 }

--- a/infra/resources/loadbalancer.ts
+++ b/infra/resources/loadbalancer.ts
@@ -337,11 +337,11 @@ function provisionLoadBalancer(): LoadBalancerOutputs {
   // Same-origin path routes preserve their prefix and otherwise fall through to the app backend.
   // Scaleway routes match one criterion, so service prefixes are registry-declared and validated.
   for (const service of lbServices) {
-    if (!service.lbPathBegin) continue;
+    if (!service.pathPrefix) continue;
     new scaleway.loadbalancers.Route(`${baseName(service.slug)}-path-route`, {
       frontendId: httpsFrontend.id,
       backendId: backends.get(service.slug)!.id,
-      matchPathBegin: service.lbPathBegin,
+      matchPathBegin: service.pathPrefix,
     });
   }
 

--- a/infra/resources/program.ts
+++ b/infra/resources/program.ts
@@ -1,5 +1,3 @@
-import * as pulumi from '@pulumi/pulumi';
-import { readStoreOutput } from '../lib/stores';
 import * as storage from './storage';
 import './dns';
 import * as compute from './compute';
@@ -11,17 +9,6 @@ import './state-bucket-policy';
 import './vm-iam';
 import { mode, naming, region } from '../pulumi-context';
 import * as lb from './loadbalancer';
-
-/**
- * Read a named output from the primary store. A provisioning store (postgres)
- * must expose the full db contract — a missing key throws. A provision-less
- * primary (external `databaseUrl`, `none`) has no outputs at all, so every
- * `db*` export becomes an empty string and consumers (db-exposure CLI, seed)
- * treat the feature as unavailable.
- */
-function primaryStoreOutput(name: string): pulumi.Output<string> {
-  return readStoreOutput(stores.primaryStoreOutputs, name) ?? pulumi.output('');
-}
 
 // The whole deployment program: one stack per mode, long-lived base resources
 // plus the content-addressed generation VMs.
@@ -46,19 +33,10 @@ export const privateUploadsBucketEndpoint = storage.privateUploadsBucketEndpoint
 export const bootDiagBucketName = storage.bootDiagBucketName;
 export const bootDiagBucketEndpoint = storage.bootDiagBucketEndpoint;
 
-// S11: generic store outputs, `storeOutputs.<storeId>.<key>`. Additive — the
-// flat db* exports below stay as the primary store's aliases (db-exposure and
-// seed read them by name) until a planned break retires them.
+// S11: generic store outputs, `storeOutputs.<storeId>.<key>`. The flat db*
+// exports were retired in the 2026-08 planned break: the db-exposure/seed
+// CLI reads the primary store's keys out of this object.
 export const storeOutputs = stores.allStoreOutputs;
-
-export const dbInstanceId = primaryStoreOutput('instanceId');
-export const dbName = primaryStoreOutput('databaseName');
-export const dbHost = primaryStoreOutput('host');
-export const dbConnectionStringAdmin = primaryStoreOutput('connectionStringAdmin');
-export const dbConnectionStringRuntime = primaryStoreOutput('connectionStringRuntime');
-export const dbConnectionStringCdc = primaryStoreOutput('connectionStringCdc');
-export const dbConnectionStringAdminPublic = primaryStoreOutput('connectionStringAdminPublic');
-export const dbCaCertificate = primaryStoreOutput('caCertificate');
 
 export const computeInstances = compute.computeInstances.map((i) => i.name);
 export const computeGenerationMetadata = compute.computeGenerationMetadata;

--- a/infra/resources/stores/index.ts
+++ b/infra/resources/stores/index.ts
@@ -36,8 +36,8 @@ export const primaryStoreOutputs: StoreOutputs = results[0]?.[1].outputs ?? {};
 /**
  * Every store's outputs, keyed by store id (S11 generic namespacing: the
  * stack exports these as one `storeOutputs` object, `<storeId>.<key>`). The
- * legacy flat `db*` exports remain as the primary store's aliases for the
- * db-exposure CLI; consumers of non-primary or non-postgres stores read this.
+ * db-exposure/seed CLI reads the primary store's keys from here; the flat
+ * db* aliases were retired in the 2026-08 planned break.
  */
 export const allStoreOutputs: Record<string, StoreOutputs> = Object.fromEntries(
   results.map(([id, provisioned]) => [id, provisioned.outputs]),

--- a/infra/scripts/engine-gate.sh
+++ b/infra/scripts/engine-gate.sh
@@ -4,9 +4,8 @@
 # P-F1 so it can actually go green: case-sensitive \bMODE\b (lowercase "mode"
 # is a legitimate engine concept), the quoted literal '/health' (import paths
 # and prose don't count), and service(Url|Host) called with a literal service
-# name. Tests and build artifacts are excluded. One blessed pin is allowlisted:
-# the runMigrate genId fingerprint key (P-F2 — fingerprint object keys are
-# hashed into every live genId; renaming it re-rolls every generation).
+# name. Tests and build artifacts are excluded. (The former runMigrate genId
+# pin was retired in the 2026-08 planned generation roll — no allowlist left.)
 set -uo pipefail
 cd "$(dirname "$0")/.."
 
@@ -17,12 +16,10 @@ PATTERNS=(
   'service(Url|Host)\(.?(frontend|backend|cdc|yjs|mcp)'
   '\bmigrate\b'
 )
-ALLOW='resources/generations\.ts:[0-9]+:.*runMigrate'
-
 violations=0
 for pattern in "${PATTERNS[@]}"; do
   hits=$(grep -rEn "$pattern" resources compose lib boot/src \
-    --include='*.ts' --exclude='*.test.ts' | grep -Ev "$ALLOW" || true)
+    --include='*.ts' --exclude='*.test.ts' || true)
   if [ -n "$hits" ]; then
     echo "── pattern: $pattern"
     echo "$hits"

--- a/infra/tasks/cutover.test.ts
+++ b/infra/tasks/cutover.test.ts
@@ -20,11 +20,11 @@ function recordingSetServers(): { fn: SetServersFn; calls: string[][] } {
 
 const getOldServers: GetServersFn = async () => ['10.0.0.4'];
 
-/** A minimal lb-overlap plan with overridable effects. */
+/** A minimal start-first plan with overridable effects. */
 function lbPlan(overrides: Partial<CutoverPlan> = {}): CutoverPlan {
   return {
     service: 'backend',
-    strategy: 'lb-overlap',
+    strategy: 'start-first',
     drainPolicy: 'requests',
     oldIps: ['10.0.0.4'],
     newIps: ['10.0.0.9'],
@@ -46,7 +46,7 @@ describe('contractBackend', () => {
   });
 });
 
-describe('sequenceCutover — lb-overlap', () => {
+describe('sequenceCutover — start-first', () => {
   it('expands [old,new] before contracting to [new]', async () => {
     const lb = recordingSetServers();
     const res = await sequenceCutover(lbPlan({ setServers: lb.fn }));
@@ -164,7 +164,7 @@ describe('sequenceCutover — lb-overlap', () => {
     expect(slept).toBe(false);
   });
 
-  it('throws if a lb-overlap plan has no setServers effect', async () => {
+  it('throws if a start-first plan has no setServers effect', async () => {
     await expect(sequenceCutover(lbPlan({ setServers: undefined }))).rejects.toThrow(/requires a setServers effect/);
   });
 });
@@ -175,7 +175,7 @@ describe('sequenceCutover — exclusive (cdc)', () => {
     const order: string[] = [];
     const res = await sequenceCutover({
       service: 'cdc',
-      strategy: 'exclusive',
+      strategy: 'stop-first',
       oldIps: [],
       newIps: [],
       drainSeconds: 0,
@@ -195,7 +195,7 @@ describe('sequenceCutover — exclusive (cdc)', () => {
   it('aborts (unhealthy) when the new generation never comes up', async () => {
     const res = await sequenceCutover({
       service: 'cdc',
-      strategy: 'exclusive',
+      strategy: 'stop-first',
       oldIps: [],
       newIps: [],
       drainSeconds: 0,

--- a/infra/tasks/cutover.ts
+++ b/infra/tasks/cutover.ts
@@ -77,7 +77,7 @@ export async function sequenceCutover(plan: CutoverPlan): Promise<CutoverResult>
     log(`[cutover ${plan.service}] ${step}`);
   };
 
-  if (plan.strategy === 'exclusive') {
+  if (plan.strategy === 'stop-first') {
     // cdc: no LB, no overlap. The new worker is warm and idle-contending for the
     // slot; the old worker must release it first (deploy-service.ts destroys the
     // old generation and re-gates health after this returns).
@@ -243,8 +243,8 @@ if (isMain(import.meta.url)) {
     process.stderr.write('Required: --service, --sha, --strategy, --health-url\n');
     process.exit(2);
   }
-  if (strategy !== 'lb-overlap' && strategy !== 'exclusive') {
-    process.stderr.write(`Unknown --strategy '${strategy}' (expected lb-overlap | exclusive)\n`);
+  if (strategy !== 'start-first' && strategy !== 'stop-first') {
+    process.stderr.write(`Unknown --strategy '${strategy}' (expected start-first | stop-first)\n`);
     process.exit(2);
   }
   if (drainPolicyRaw !== 'requests' && drainPolicyRaw !== 'reconnect') {
@@ -266,7 +266,7 @@ if (isMain(import.meta.url)) {
   // flags are read (and checked) exactly once.
   let setServers: SetServersFn | undefined;
   let getServers: GetServersFn | undefined;
-  if (strategy === 'lb-overlap') {
+  if (strategy === 'start-first') {
     const zone = getFlag(argv, '--lb-zone');
     const backendId = getFlag(argv, '--backend-id');
     if (!zone || !backendId || !secretKey) {

--- a/infra/tasks/deploy-rollout.test.ts
+++ b/infra/tasks/deploy-rollout.test.ts
@@ -43,14 +43,14 @@ describe('buildWavedPlan', () => {
     });
     expect(plan.primary).toMatchObject({
       service: 'backend',
-      strategy: 'lb-overlap',
+      strategy: 'start-first',
       drainSeconds: 10,
       healthUrl: 'https://api/health',
     });
-    expect(plan.rest[0]).toMatchObject({ service: 'cdc', strategy: 'exclusive' });
+    expect(plan.rest[0]).toMatchObject({ service: 'cdc', strategy: 'stop-first' });
     expect(plan.rest[1]).toMatchObject({
       service: 'frontend',
-      strategy: 'lb-overlap',
+      strategy: 'start-first',
       healthUrl: 'https://app/health',
     });
   });

--- a/infra/tasks/rollout-plans.test.ts
+++ b/infra/tasks/rollout-plans.test.ts
@@ -11,7 +11,7 @@ describe('planForService', () => {
     const plan = planForService('backend', 'https://www.cellajs.com/api');
     expect(plan).toMatchObject({
       service: 'backend',
-      strategy: 'lb-overlap',
+      strategy: 'start-first',
       drainPolicy: 'requests',
       drainSeconds: 10,
       healthUrl: 'https://www.cellajs.com/api/health',
@@ -22,7 +22,7 @@ describe('planForService', () => {
 
   it('builds an exclusive plan without LB requirements', () => {
     const plan = planForService('cdc');
-    expect(plan.strategy).toBe('exclusive');
+    expect(plan.strategy).toBe('stop-first');
     expect(plan.healthUrl).toBeUndefined();
   });
 

--- a/infra/tasks/rollout-plans.ts
+++ b/infra/tasks/rollout-plans.ts
@@ -28,7 +28,7 @@ export function planForService(serviceFlag: string, healthUrl?: string): Rollout
     healthUrl: normalizeHealthUrl(healthUrl),
   };
 
-  if (definition.replacementStrategy !== 'exclusive') {
+  if (definition.replacementStrategy !== 'stop-first') {
     if (!definition.lbRoute)
       throw new Error(`Service '${service}' is not exclusive and has no LB route; no deploy path is defined.`);
     if (!plan.healthUrl) throw new Error(`Service '${service}' has no health URL.`);

--- a/infra/tasks/rollout.test.ts
+++ b/infra/tasks/rollout.test.ts
@@ -86,15 +86,15 @@ function makeFake(opts: FakeOptions) {
 
 const backendPlan: RolloutServicePlan = {
   service: 'backend',
-  strategy: 'lb-overlap',
+  strategy: 'start-first',
   drainPolicy: 'requests',
   drainSeconds: 10,
   healthUrl: 'https://api/health',
 };
-const cdcPlan: RolloutServicePlan = { service: 'cdc', strategy: 'exclusive', drainSeconds: 0 };
+const cdcPlan: RolloutServicePlan = { service: 'cdc', strategy: 'stop-first', drainSeconds: 0 };
 const frontendPlan: RolloutServicePlan = {
   service: 'frontend',
-  strategy: 'lb-overlap',
+  strategy: 'start-first',
   drainPolicy: 'requests',
   drainSeconds: 0,
   healthUrl: 'https://app/health',

--- a/infra/tasks/rollout.ts
+++ b/infra/tasks/rollout.ts
@@ -10,7 +10,7 @@ export interface RolloutServicePlan {
   strategy: ReplacementStrategy;
   drainPolicy?: DrainPolicy;
   drainSeconds: number;
-  /** Public health URL; required for lb-overlap services. */
+  /** Public health URL; required for start-first services. */
   healthUrl?: string;
   /** Co-hosted worker slugs (singleVM) whose LB backends follow this VM. */
   repointBackendKeys?: string[];
@@ -78,7 +78,7 @@ export async function activateService(
   const current = await rt.currentRollout(service);
   const target = resolvePendingGen(generations, service, sha, current?.active?.id);
 
-  if (plan.strategy === 'exclusive') {
+  if (plan.strategy === 'stop-first') {
     // cdc: no LB, no overlap. The stack update provisioned only the new
     // generation (the old one is replaced/destroyed in the same update); the new
     // worker reports healthy once it acquires the slot the old one releases.
@@ -105,7 +105,7 @@ export async function activateService(
   const healthUrl = plan.healthUrl;
   const cutover = await sequenceCutover({
     service,
-    strategy: 'lb-overlap',
+    strategy: 'start-first',
     drainPolicy: plan.drainPolicy,
     oldIps,
     newIps: [target.privateIp],
@@ -157,9 +157,9 @@ export async function runWavedRollout(plan: WavedRolloutPlan, rt: RolloutRuntime
   const { sha } = plan;
 
   // LB backend ids are only defined (and only needed) when a wave contains an
-  // lb-overlap service; exclusive-only waves skip the stack-output read.
+  // start-first service; stop-first-only waves skip the stack-output read.
   const backendIdsFor = async (wave: RolloutServicePlan[]): Promise<Record<string, string>> =>
-    wave.some((item) => item.strategy !== 'exclusive' || (item.repointBackendKeys?.length ?? 0) > 0)
+    wave.some((item) => item.strategy !== 'stop-first' || (item.repointBackendKeys?.length ?? 0) > 0)
       ? rt.readLbBackendIds()
       : {};
 

--- a/infra/tests/unit/loadbalancer.test.ts
+++ b/infra/tests/unit/loadbalancer.test.ts
@@ -69,12 +69,12 @@ describe('loadbalancer module — registry-driven wiring', () => {
     expect(src).toMatch(/matchHostHeader:\s*serviceHost\(service\.slug\)/);
   });
 
-  it('adds a path-begin route for every lbPathBegin service (same-origin migration)', () => {
+  it('adds a path-begin route for every pathPrefix service (same-origin migration)', () => {
     // Registry-driven like the host routes: the prefix comes from the service
     // declaration, never hardcoded per service, and targets the same backend.
-    expect(src).toMatch(/if \(!service\.lbPathBegin\) continue/);
+    expect(src).toMatch(/if \(!service\.pathPrefix\) continue/);
     expect(src).toMatch(/new scaleway\.loadbalancers\.Route\(`\$\{baseName\(service\.slug\)\}-path-route`/);
-    expect(src).toMatch(/matchPathBegin:\s*service\.lbPathBegin/);
+    expect(src).toMatch(/matchPathBegin:\s*service\.pathPrefix/);
     expect(src).not.toMatch(/matchPathBegin:\s*'/);
   });
 

--- a/infra/tests/unit/path-prefix.test.ts
+++ b/infra/tests/unit/path-prefix.test.ts
@@ -2,44 +2,44 @@ import { describe, expect, it } from 'vitest';
 import { defineServices } from '../../compose/infrastructure';
 import { appServices } from '../../config/services.config';
 
-/** Minimal valid service entry to hang lbPathBegin variations on. */
+/** Minimal valid service entry to hang pathPrefix variations on. */
 const base = {
   image: 'r/x:latest',
   port: 4000,
   healthTimeoutSeconds: 60,
   startPeriod: '10s',
-  replacementStrategy: 'lb-overlap',
+  replacementStrategy: 'start-first',
   instanceType: 'DEV1-S',
 } as const;
 
-// lbPathBegin feeds the LB's raw matchPathBegin string; a malformed or
+// pathPrefix feeds the LB's raw matchPathBegin string; a malformed or
 // duplicated prefix silently misroutes traffic, so defineServices rejects it
 // at synth/plan time.
-describe('lbPathBegin registry validation', () => {
+describe('pathPrefix registry validation', () => {
   it('accepts a single lowercase segment with a leading slash', () => {
-    expect(() => defineServices({ a: { ...base, lbRoute: 'default', lbPathBegin: '/api' } })).not.toThrow();
+    expect(() => defineServices({ a: { ...base, lbRoute: 'default', pathPrefix: '/api' } })).not.toThrow();
   });
 
   it('rejects a prefix on an internal-only service (no lbRoute → no LB backend)', () => {
-    expect(() => defineServices({ a: { ...base, lbPathBegin: '/api' } })).toThrow(/without lbRoute/);
+    expect(() => defineServices({ a: { ...base, pathPrefix: '/api' } })).toThrow(/without lbRoute/);
   });
 
   it("rejects lbRoute 'path' without a prefix (nothing would route to it)", () => {
-    expect(() => defineServices({ a: { ...base, lbRoute: 'path' } })).toThrow(/no lbPathBegin/);
+    expect(() => defineServices({ a: { ...base, lbRoute: 'path' } })).toThrow(/no pathPrefix/);
   });
 
   it('rejects trailing slashes, nested segments, and uppercase', () => {
     for (const bad of ['/api/', '/api/v1', '/API', 'api']) {
       // @ts-expect-error: 'api' (no leading slash) is also a type error; the rest fail at runtime
-      expect(() => defineServices({ a: { ...base, lbRoute: 'default', lbPathBegin: bad } })).toThrow(/lbPathBegin/);
+      expect(() => defineServices({ a: { ...base, lbRoute: 'default', pathPrefix: bad } })).toThrow(/pathPrefix/);
     }
   });
 
   it('rejects two services claiming the same prefix', () => {
     expect(() =>
       defineServices({
-        a: { ...base, lbRoute: 'default', lbPathBegin: '/api' },
-        b: { ...base, lbRoute: 'host', lbPathBegin: '/api' },
+        a: { ...base, lbRoute: 'default', pathPrefix: '/api' },
+        b: { ...base, lbRoute: 'host', pathPrefix: '/api' },
       }),
     ).toThrow(/unique/);
   });
@@ -47,10 +47,10 @@ describe('lbPathBegin registry validation', () => {
 
 describe('shipped registry declares the same-origin prefixes', () => {
   it('backend, yjs, and mcp carry their path prefixes; cdc and frontend stay off', () => {
-    expect(appServices.backend.lbPathBegin).toBe('/api');
-    expect(appServices.yjs.lbPathBegin).toBe('/yjs');
-    expect(appServices.mcp.lbPathBegin).toBe('/mcp');
-    expect('lbPathBegin' in appServices.cdc).toBe(false);
-    expect('lbPathBegin' in appServices.frontend).toBe(false);
+    expect(appServices.backend.pathPrefix).toBe('/api');
+    expect(appServices.yjs.pathPrefix).toBe('/yjs');
+    expect(appServices.mcp.pathPrefix).toBe('/mcp');
+    expect('pathPrefix' in appServices.cdc).toBe(false);
+    expect('pathPrefix' in appServices.frontend).toBe(false);
   });
 });


### PR DESCRIPTION
The **planned generation roll** — everything that has been waiting for "a phase that accepts a roll", landed in one batch so the fleet re-rolls once, not four times.

## Renames
- `replacementStrategy` values: `'lb-overlap'` → `'start-first'`, `'exclusive'` → `'stop-first'` (the Compose `deploy.update_config.order` vocabulary from the standards-alignment table).
- `lbPathBegin` → `pathPrefix` (field + emitted `x-service` key); the Scaleway `path_begin` matcher term stays inside the LB resource layer only.
- genId fingerprint key `runMigrate` → `runRelease`: retires the last engine-gate allowlist entry (the gate script now has none).

## Retirement: flat `db*` stack outputs → `storeOutputs.<storeId>.<key>`
The eight `db*` outputs are gone; the db-exposure/seed CLI now reads the primary store's entry out of the generic `storeOutputs` object (primary id derived from the store registry). **Bonus catch:** `index.ts` (the actual Pulumi entry) never re-exported `storeOutputs`, so #1036's S11 export was program-internal only and never a real stack output — the retirement forced the fix. `readStoreOutput` and the provision-less alias contract are deleted with the aliases they served.

## Deploy expectations — read before merging
**The first deploy after this merge re-rolls EVERY generation** (fingerprint key + strategy values are hashed into each genId). That is the point of the batch: one full blue/green replacement of all VMs via the normal cutover, no downtime by design. Watch that deploy complete one full cutover; nothing else should change (LB routes/certs/buckets untouched — `pathPrefix` only renames the registry field, not the Scaleway matcher).

## Fork migration
`cella/migrations/20260812T1724-deploy-vocabulary/` (manual): three seds in `infra/config/services.config.ts`, a grep for fork-local readers of the retired outputs, compose regen. Raak adoption named per convention.

## Verification
All 76 infra test files green after the rename sweep (cutover/rollout/plans/compose tests renamed with the vocabulary), typecheck clean, `compose.gen.yml` regenerated, engine gate residue unchanged (branding pair only — now with zero allowlist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
