### PR TITLE
refactor(infra): smoke derives URLs by role + boot service-key tests

### DIFF
--- a/infra/boot/src/service-key.test.ts
+++ b/infra/boot/src/service-key.test.ts
@@ -1,0 +1,66 @@
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { fetchServiceKey } from './service-key';
+
+const dir = mkdtempSync(join(tmpdir(), 'service-key-'));
+const pair = { accessKey: 'SCWAK', secretKey: 'sk' };
+const bundleResponse = () =>
+  new Response(JSON.stringify({ data: Buffer.from(JSON.stringify(pair), 'utf-8').toString('base64') }), {
+    status: 200,
+  });
+
+function options(cacheFile: string, fetchImpl: (url: string, init?: RequestInit) => Promise<Response>) {
+  return {
+    handoff: { secretId: 'sec-1', cacheFile },
+    bootSecretKey: 'boot-secret',
+    region: 'nl-ams',
+    fetchImpl: fetchImpl as never,
+  };
+}
+
+describe('fetchServiceKey (single-access handoff)', () => {
+  it('first boot fetches the bundle once, persists it 0600, and returns the pair', async () => {
+    const cacheFile = join(dir, 'first-boot.json');
+    let fetches = 0;
+    const result = await fetchServiceKey(
+      options(cacheFile, async () => {
+        fetches += 1;
+        return bundleResponse();
+      }),
+    );
+    expect(result).toEqual(pair);
+    expect(fetches).toBe(1);
+    expect(JSON.parse(readFileSync(cacheFile, 'utf-8'))).toEqual(pair);
+    expect(statSync(cacheFile).mode & 0o777).toBe(0o600);
+  });
+
+  it('reboots are cache-first: the network is never touched', async () => {
+    const cacheFile = join(dir, 'reboot.json');
+    writeFileSync(cacheFile, JSON.stringify(pair));
+    const result = await fetchServiceKey(
+      options(cacheFile, async () => {
+        throw new Error('network must not be reached on a cached boot');
+      }),
+    );
+    expect(result).toEqual(pair);
+  });
+
+  it('a failed fetch with NO cache is the interception security signal, not a retryable error', async () => {
+    const cacheFile = join(dir, 'consumed.json');
+    await expect(
+      fetchServiceKey(options(cacheFile, async () => new Response('gone', { status: 404 }))),
+    ).rejects.toThrow(/SECURITY: service-key handoff fetch failed \(404\)/);
+  });
+
+  it('rejects a malformed bundle payload', async () => {
+    const cacheFile = join(dir, 'malformed.json');
+    const badBundle = new Response(JSON.stringify({ data: Buffer.from('{"nope":true}', 'utf-8').toString('base64') }), {
+      status: 200,
+    });
+    await expect(fetchServiceKey(options(cacheFile, async () => badBundle))).rejects.toThrow(
+      /does not contain \{accessKey, secretKey\}/,
+    );
+  });
+});

--- a/infra/tasks/deploy-run.ts
+++ b/infra/tasks/deploy-run.ts
@@ -319,6 +319,11 @@ export async function runDeploy(
         opts.sha,
         '--services-json',
         env.enabled_services_json,
+        // The primary-rollout service owns smoke's aggregate-health/OpenAPI
+        // checks; derived from the rollout matrix, no service-name literal.
+        ...((JSON.parse(env.primary_rollout_matrix) as RolloutRow[])[0]
+          ? ['--primary', (JSON.parse(env.primary_rollout_matrix) as RolloutRow[])[0]!.service]
+          : []),
         // A provided-but-unreadable --dist is a hard failure in smoke, so a
         // frontend-less registry omits it instead of pointing at nothing.
         ...(env.frontend_bucket ? ['--dist', resolve(distDir, 'index.html')] : []),

--- a/infra/tasks/smoke.test.ts
+++ b/infra/tasks/smoke.test.ts
@@ -147,8 +147,8 @@ describe('runSmoke', () => {
 
   it('passes every check against a healthy deployment', async () => {
     const results = await runSmoke({
-      frontendUrl: 'https://app',
-      backendUrl: 'https://api',
+      defaultRouteUrl: 'https://app',
+      primaryUrl: 'https://api',
       expectedSha: SHA,
       get: healthyGet,
     });
@@ -158,8 +158,8 @@ describe('runSmoke', () => {
 
   it('asserts the served bundle references the freshly built hash when expectedAsset is set', async () => {
     const pass = await runSmoke({
-      frontendUrl: 'https://app',
-      backendUrl: 'https://api',
+      defaultRouteUrl: 'https://app',
+      primaryUrl: 'https://api',
       expectedSha: SHA,
       expectedAsset: '/assets/index-abc123.js',
       get: healthyGet,
@@ -167,8 +167,8 @@ describe('runSmoke', () => {
     expect(pass.find((r) => r.name === 'index.html references freshly built bundle')?.ok).toBe(true);
 
     const stale = await runSmoke({
-      frontendUrl: 'https://app',
-      backendUrl: 'https://api',
+      defaultRouteUrl: 'https://app',
+      primaryUrl: 'https://api',
       expectedSha: SHA,
       expectedAsset: '/assets/index-OLD.js',
       get: healthyGet,
@@ -180,8 +180,8 @@ describe('runSmoke', () => {
 
   it('checks deployed SHA for every public service in the rollout matrix', async () => {
     const results = await runSmoke({
-      frontendUrl: 'https://app',
-      backendUrl: 'https://api',
+      defaultRouteUrl: 'https://app',
+      primaryUrl: 'https://api',
       expectedSha: SHA,
       services: [
         { service: 'backend', health_url: 'https://api' },
@@ -200,9 +200,14 @@ describe('runSmoke', () => {
       url === 'https://api/health'
         ? Promise.resolve(res({ status: 204, headers: new Headers({ 'x-app-version': 'old9999' }) }))
         : healthyGet(url);
-    const results = await runSmoke({ frontendUrl: 'https://app', backendUrl: 'https://api', expectedSha: SHA, get });
+    const results = await runSmoke({
+      defaultRouteUrl: 'https://app',
+      primaryUrl: 'https://api',
+      expectedSha: SHA,
+      get,
+    });
 
-    const sha = results.find((r) => r.name === 'backend reports deployed SHA');
+    const sha = results.find((r) => r.name === 'primary reports deployed SHA');
     expect(sha?.ok).toBe(false);
     expect(sha?.detail).toContain('old9999');
     // The other five still ran and passed.
@@ -214,7 +219,12 @@ describe('runSmoke', () => {
       url === 'https://app/'
         ? Promise.resolve(res({ body: HASHED_HTML, headers: secureHeaders({}, ['X-Frame-Options']) }))
         : healthyGet(url);
-    const results = await runSmoke({ frontendUrl: 'https://app', backendUrl: 'https://api', expectedSha: SHA, get });
+    const results = await runSmoke({
+      defaultRouteUrl: 'https://app',
+      primaryUrl: 'https://api',
+      expectedSha: SHA,
+      get,
+    });
 
     const sec = results.find((r) => r.name === 'security headers present');
     expect(sec?.ok).toBe(false);
@@ -224,9 +234,14 @@ describe('runSmoke', () => {
   it('captures a thrown fetch error as a failed check', async () => {
     const get = (url: string) =>
       url.endsWith('/openapi.json') ? Promise.reject(new Error('ECONNREFUSED')) : healthyGet(url);
-    const results = await runSmoke({ frontendUrl: 'https://app', backendUrl: 'https://api', expectedSha: SHA, get });
+    const results = await runSmoke({
+      defaultRouteUrl: 'https://app',
+      primaryUrl: 'https://api',
+      expectedSha: SHA,
+      get,
+    });
 
-    const api = results.find((r) => r.name === 'backend /openapi.json reachable');
+    const api = results.find((r) => r.name === 'primary /openapi.json reachable');
     expect(api?.ok).toBe(false);
     expect(api?.detail).toBe('ECONNREFUSED');
   });
@@ -234,8 +249,13 @@ describe('runSmoke', () => {
   it('flags a non-ok openapi response', async () => {
     const get = (url: string) =>
       url.endsWith('/openapi.json') ? Promise.resolve(res({ status: 404, ok: false })) : healthyGet(url);
-    const results = await runSmoke({ frontendUrl: 'https://app', backendUrl: 'https://api', expectedSha: SHA, get });
-    expect(results.find((r) => r.name === 'backend /openapi.json reachable')?.ok).toBe(false);
+    const results = await runSmoke({
+      defaultRouteUrl: 'https://app',
+      primaryUrl: 'https://api',
+      expectedSha: SHA,
+      get,
+    });
+    expect(results.find((r) => r.name === 'primary /openapi.json reachable')?.ok).toBe(false);
   });
 
   it('retries the component check and passes once the cdc worker reconnects', async () => {
@@ -257,15 +277,15 @@ describe('runSmoke', () => {
     };
     const sleep = vi.fn().mockResolvedValue(undefined);
     const results = await runSmoke({
-      frontendUrl: 'https://app',
-      backendUrl: 'https://api',
+      defaultRouteUrl: 'https://app',
+      primaryUrl: 'https://api',
       expectedSha: SHA,
       get,
       sleep,
       componentsRetryDelayMs: 1,
     });
 
-    expect(results.find((r) => r.name === 'backend components healthy')?.ok).toBe(true);
+    expect(results.find((r) => r.name === 'primary components healthy')?.ok).toBe(true);
     expect(depthFullCalls).toBe(3);
     expect(sleep).toHaveBeenCalledTimes(2);
   });
@@ -285,8 +305,8 @@ describe('runSmoke', () => {
     };
     const sleep = vi.fn().mockResolvedValue(undefined);
     const results = await runSmoke({
-      frontendUrl: 'https://app',
-      backendUrl: 'https://api',
+      defaultRouteUrl: 'https://app',
+      primaryUrl: 'https://api',
       expectedSha: SHA,
       get,
       sleep,
@@ -294,7 +314,7 @@ describe('runSmoke', () => {
       componentsRetryDelayMs: 1,
     });
 
-    const components = results.find((r) => r.name === 'backend components healthy');
+    const components = results.find((r) => r.name === 'primary components healthy');
     expect(components?.ok).toBe(false);
     expect(components?.detail).toContain('cdc=unhealthy(worker_disconnected)');
     expect(depthFullCalls).toBe(3);
@@ -305,8 +325,8 @@ describe('runSmoke', () => {
 describe('parseArgs', () => {
   it('parses the required flags with a default timeout', () => {
     expect(parseArgs(['--frontend', 'https://app', '--backend', 'https://api', '--sha', SHA])).toEqual({
-      frontendUrl: 'https://app',
-      backendUrl: 'https://api',
+      defaultRouteUrl: 'https://app',
+      primaryUrl: 'https://api',
       sha: SHA,
       services: undefined,
       timeoutMs: 10000,
@@ -327,15 +347,22 @@ describe('parseArgs', () => {
     ]);
   });
 
-  it('derives frontend and backend URLs from services-json', () => {
+  it('derives the URLs from services-json by ROLE (lb_route/--primary), not by service name', () => {
     const matrix = JSON.stringify([
-      { service: 'backend', public_url: 'https://api', health_url: 'https://api' },
-      { service: 'frontend', public_url: 'https://app', health_url: 'https://app' },
+      { service: 'api', public_url: 'https://api', health_url: 'https://api', lb_route: 'path' },
+      { service: 'web', public_url: 'https://app', health_url: 'https://app', lb_route: 'default' },
     ]);
-    expect(parseArgs(['--sha', SHA, '--services-json', matrix])).toMatchObject({
-      frontendUrl: 'https://app',
-      backendUrl: 'https://api',
+    expect(parseArgs(['--sha', SHA, '--services-json', matrix, '--primary', 'api'])).toMatchObject({
+      defaultRouteUrl: 'https://app',
+      primaryUrl: 'https://api',
     });
+    // Without --primary: the first non-default-route service with a health URL.
+    expect(parseArgs(['--sha', SHA, '--services-json', matrix])).toMatchObject({ primaryUrl: 'https://api' });
+    // Frontend-less matrix: no defaultRouteUrl, checks 1/4/5 will skip.
+    const apiOnly = JSON.stringify([
+      { service: 'api', public_url: 'https://api', health_url: 'https://api', lb_route: 'path' },
+    ]);
+    expect(parseArgs(['--sha', SHA, '--services-json', apiOnly]).defaultRouteUrl).toBeUndefined();
   });
 
   it('honours an explicit --timeout', () => {
@@ -367,10 +394,9 @@ describe('parseArgs', () => {
   });
 
   it.each([
-    ['--backend', 'https://api', '--sha', SHA],
     ['--frontend', 'https://app', '--sha', SHA],
     ['--frontend', 'https://app', '--backend', 'https://api'],
-  ])('throws when a required flag is missing', (...argv) => {
+  ])('throws when the primary URL or sha is missing', (...argv) => {
     expect(() => parseArgs(argv)).toThrow(/Usage:/);
   });
 });

--- a/infra/tasks/smoke.ts
+++ b/infra/tasks/smoke.ts
@@ -117,8 +117,12 @@ export function createFetchGet(timeoutMs: number): HttpGet {
 }
 
 export interface SmokeOptions {
-  frontendUrl: string;
-  backendUrl: string;
+  /** Public URL of the default-route (browser) service; absent for a
+   *  frontend-less registry — the SPA/security-header checks then skip. */
+  defaultRouteUrl?: string;
+  /** Public URL of the primary-rollout service (the API that serves the
+   *  aggregate /health?depth=full and /openapi.json). */
+  primaryUrl: string;
   expectedSha: string;
   /** Enabled rollout services; public services carry health_url, internal-only services have ''. */
   services?: readonly SmokeService[];
@@ -157,7 +161,7 @@ export interface SmokeResult {
 
 /** Run all smoke checks, collecting every result (no short-circuit). */
 export async function runSmoke(opts: SmokeOptions): Promise<SmokeResult[]> {
-  const { frontendUrl, backendUrl, expectedSha, get } = opts;
+  const { defaultRouteUrl, primaryUrl, expectedSha, get } = opts;
   const sleep = opts.sleep ?? defaultSleep;
   const componentsRetryAttempts = opts.componentsRetryAttempts ?? COMPONENTS_RETRY_ATTEMPTS;
   const componentsRetryDelayMs = opts.componentsRetryDelayMs ?? COMPONENTS_RETRY_DELAY_MS;
@@ -174,32 +178,34 @@ export async function runSmoke(opts: SmokeOptions): Promise<SmokeResult[]> {
     }
   };
 
-  // 1. Require the exact local entry hash when available, otherwise any hashed frontend asset.
-  await check(
-    opts.expectedAsset ? 'index.html references freshly built bundle' : 'index.html references hashed asset',
-    async () => {
-      const res = await get(`${frontendUrl}/`);
-      const matched = opts.expectedAsset ? res.body.includes(opts.expectedAsset) : hasHashedAsset(res.body);
-      // Detail mirrors the branch that actually failed: a bad status, or a 200
-      // whose HTML lacks the expected (or any) hashed entry asset.
-      const detail = !res.ok
-        ? `status=${res.status}`
-        : opts.expectedAsset
-          ? `served does not reference ${opts.expectedAsset}`
-          : 'no hashed entry asset found in served index.html';
-      return { ok: res.ok && matched, detail };
-    },
-  );
+  // 1. Require the exact local entry hash when available, otherwise any hashed
+  // entry asset. Skipped (with 4 and 5) when no default-route service exists.
+  if (defaultRouteUrl)
+    await check(
+      opts.expectedAsset ? 'index.html references freshly built bundle' : 'index.html references hashed asset',
+      async () => {
+        const res = await get(`${defaultRouteUrl}/`);
+        const matched = opts.expectedAsset ? res.body.includes(opts.expectedAsset) : hasHashedAsset(res.body);
+        // Detail mirrors the branch that actually failed: a bad status, or a 200
+        // whose HTML lacks the expected (or any) hashed entry asset.
+        const detail = !res.ok
+          ? `status=${res.status}`
+          : opts.expectedAsset
+            ? `served does not reference ${opts.expectedAsset}`
+            : 'no hashed entry asset found in served index.html';
+        return { ok: res.ok && matched, detail };
+      },
+    );
 
-  // 2. Backend OpenAPI spec is reachable.
-  await check('backend /openapi.json reachable', async () => {
-    const res = await get(`${backendUrl}/openapi.json`);
+  // 2. Primary service OpenAPI spec is reachable.
+  await check('primary /openapi.json reachable', async () => {
+    const res = await get(`${primaryUrl}/openapi.json`);
     return { ok: res.ok, detail: `status=${res.status}` };
   });
 
   // 3. Public services report the deployed release SHA. Internal-only services
-  // (cdc) have no health_url and are covered by the aggregate backend health.
-  const publicServices = (opts.services ?? [{ service: 'backend', health_url: backendUrl }]).filter(
+  // have no health_url and are covered by the aggregate primary health.
+  const publicServices = (opts.services ?? [{ service: 'primary', health_url: primaryUrl }]).filter(
     (service) => service.health_url,
   );
   for (const service of publicServices) {
@@ -214,26 +220,29 @@ export async function runSmoke(opts: SmokeOptions): Promise<SmokeResult[]> {
   }
 
   // 4. SPA route fallback returns an HTML document.
-  await check('SPA fallback returns HTML', async () => {
-    const res = await get(`${frontendUrl}/__smoke_${Date.now()}`);
-    return { ok: res.ok && isHtmlDocument(res.body), detail: `status=${res.status}` };
-  });
+  if (defaultRouteUrl)
+    await check('SPA fallback returns HTML', async () => {
+      const res = await get(`${defaultRouteUrl}/__smoke_${Date.now()}`);
+      return { ok: res.ok && isHtmlDocument(res.body), detail: `status=${res.status}` };
+    });
 
-  // 5. Frontend security headers are present.
-  await check('security headers present', async () => {
-    const res = await get(`${frontendUrl}/`);
-    const missing = missingSecurityHeaders(res.headers);
-    return { ok: missing.length === 0, detail: `missing: ${missing.join(', ')}` };
-  });
+  // 5. Default-route security headers are present.
+  if (defaultRouteUrl)
+    await check('security headers present', async () => {
+      const res = await get(`${defaultRouteUrl}/`);
+      const missing = missingSecurityHeaders(res.headers);
+      return { ok: missing.length === 0, detail: `missing: ${missing.join(', ')}` };
+    });
 
-  // 6. Retry aggregate health across one CDC reconnect interval after rollout.
-  // Pass on the first clean read; persistent component failures exhaust the budget.
-  await check('backend components healthy', async () => {
+  // 6. Retry aggregate health across one worker reconnect interval after
+  // rollout. Pass on the first clean read; persistent component failures
+  // exhaust the budget.
+  await check('primary components healthy', async () => {
     let lastDetail = 'no response';
     const healthy = await pollUntil(
       async () => {
         try {
-          const res = await get(`${backendUrl}${healthContract.path}?depth=full`);
+          const res = await get(`${primaryUrl}${healthContract.path}?depth=full`);
           if (!res.ok) {
             lastDetail = `status=${res.status}`;
             return undefined;
@@ -255,8 +264,8 @@ export async function runSmoke(opts: SmokeOptions): Promise<SmokeResult[]> {
 }
 
 interface CliArgs {
-  frontendUrl: string;
-  backendUrl: string;
+  defaultRouteUrl?: string;
+  primaryUrl: string;
   sha: string;
   services?: SmokeService[];
   /** Path to the freshly built local index.html for deriving the expected bundle hash. */
@@ -264,28 +273,39 @@ interface CliArgs {
   timeoutMs: number;
 }
 
-export function parseServicesJson(raw: string): Array<SmokeService & { public_url?: string }> {
-  return parseServiceRows(raw, '--services-json', { required: ['service', 'health_url'], optional: ['public_url'] });
+export function parseServicesJson(raw: string): Array<SmokeService & { public_url?: string; lb_route?: string }> {
+  return parseServiceRows(raw, '--services-json', {
+    required: ['service', 'health_url'],
+    optional: ['public_url', 'lb_route'],
+  });
 }
 
 /** Parse `--key value` flags. Exported for testing. */
 export function parseArgs(argv: string[]): CliArgs {
   const servicesRaw = getFlag(argv, '--services-json');
   const services = servicesRaw ? parseServicesJson(servicesRaw) : undefined;
-  const frontendUrl =
-    getFlag(argv, '--frontend') ?? services?.find((service) => service.service === 'frontend')?.public_url;
-  const backendUrl =
-    getFlag(argv, '--backend') ?? services?.find((service) => service.service === 'backend')?.public_url;
+  // Roles, not names (S9): the default-route service owns the browser checks;
+  // the primary service (named via --primary, passed by the deploy from its
+  // rollout matrix) owns the aggregate health + OpenAPI checks. Fallback for
+  // standalone runs without --primary: the first non-default-route service
+  // with a health URL.
+  const defaultRouteRow = services?.find((service) => service.lb_route === 'default');
+  const primarySlug = getFlag(argv, '--primary');
+  const primaryRow = primarySlug
+    ? services?.find((service) => service.service === primarySlug)
+    : services?.find((service) => service.health_url && service.lb_route !== 'default');
+  const defaultRouteUrl = getFlag(argv, '--frontend') ?? defaultRouteRow?.public_url;
+  const primaryUrl = getFlag(argv, '--backend') ?? primaryRow?.public_url;
   const sha = getFlag(argv, '--sha');
-  if (!frontendUrl || !backendUrl || !sha) {
+  if (!primaryUrl || !sha) {
     throw new Error(
-      'Usage: smoke.ts --frontend <url> --backend <url> --sha <git-sha> [--services-json <json>] [--timeout ms]',
+      'Usage: smoke.ts [--frontend <url>] --backend <url> | --primary <slug> --sha <git-sha> [--services-json <json>] [--timeout ms]',
     );
   }
   const timeoutRaw = getFlag(argv, '--timeout');
   return {
-    frontendUrl,
-    backendUrl,
+    ...(defaultRouteUrl ? { defaultRouteUrl } : {}),
+    primaryUrl,
     sha,
     services,
     dist: getFlag(argv, '--dist'),
@@ -319,8 +339,8 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   const args = parseArgs(argv);
   const expectedAsset = resolveExpectedAsset(args.dist);
   const results = await runSmoke({
-    frontendUrl: args.frontendUrl,
-    backendUrl: args.backendUrl,
+    defaultRouteUrl: args.defaultRouteUrl,
+    primaryUrl: args.primaryUrl,
     expectedSha: args.sha,
     services: args.services,
     expectedAsset,


### PR DESCRIPTION
Point-2 batch (independent of #1038 — branched off main, no file overlap with the vocabulary roll).

## smoke de-cella (S9, the widened version)
The `frontend`/`backend` NAME coupling ran through smoke's whole option surface; it is now role derivation:
- The **default-route** service (`lb_route: 'default'` from services-json, or `--frontend` override) owns the browser checks (index/bundle, SPA fallback, security headers) — **skipped entirely for a frontend-less registry**, matching P2b's deploy gating.
- The **primary-rollout** service owns the aggregate `/health?depth=full` and `/openapi.json` checks. The deploy passes `--primary <slug>` derived from its rollout matrix; standalone runs fall back to the first non-default-route service with a health URL. `--backend` stays as an explicit override.
- No service-name literal remains in the smoke path (including the old `{service:'backend'}` fallback row). Tests ported to the role vocabulary, plus a new frontend-less derivation case.

## boot service-key tests
First tests for `fetchServiceKey` — the credential-guarding path the IAM backlog flagged as the highest-value untested code: cache-first reboot (network never touched), 0600 persistence, the consumed-bundle SECURITY signal, malformed-bundle rejection.

## Verification
659 infra tests green (77 files), typecheck clean, hook green.

**Not in this PR** (still queued in INFRA.md todo 10): the iam-client consolidation and the DEPLOYMENT.md/README doc sweeps — the doc sweep deliberately waits for #1038 so it documents the post-rename vocabulary once, not twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
