### PR TITLE
fix(deploy): stop freezing stable-named /static files behind immutable caches

### DIFF
--- a/frontend/src/lib/sw.ts
+++ b/frontend/src/lib/sw.ts
@@ -40,7 +40,9 @@ const serwist = new Serwist({
   runtimeCaching: [
     {
       // Cache runtime docs data after its first visit so the section works offline.
-      // Stale-while-revalidate refreshes these non-content-hashed files after each deploy.
+      // These files keep stable names with per-release content; the app appends a
+      // ?v=<sha> param to their fetches, so each release keys fresh cache entries
+      // while stale-while-revalidate serves them stale-first within a release.
       matcher: ({ url }) =>
         url.origin === self.location.origin &&
         (url.pathname.startsWith('/static/docs.gen/') || url.pathname === '/static/openapi.json'),

--- a/frontend/src/modules/docs/helpers/extract-types.ts
+++ b/frontend/src/modules/docs/helpers/extract-types.ts
@@ -1,5 +1,6 @@
 import { queryOptions } from '@tanstack/react-query';
 import { appConfig } from 'shared';
+import { versionedUrl } from '~/modules/docs/query';
 
 export type DefinitionIndex = Map<string, string>;
 
@@ -64,7 +65,7 @@ function buildIndex(content: string): DefinitionIndex {
 export const zodIndexQueryOptions = queryOptions({
   queryKey: ['docs', 'zod-index'],
   queryFn: async () => {
-    const res = await fetch(`${appConfig.frontendUrl}/static/zod.gen.ts`);
+    const res = await fetch(versionedUrl(`${appConfig.frontendUrl}/static/zod.gen.ts`));
     return buildIndex(await res.text());
   },
   staleTime: Number.POSITIVE_INFINITY,
@@ -77,7 +78,7 @@ export const zodIndexQueryOptions = queryOptions({
 export const typesIndexQueryOptions = queryOptions({
   queryKey: ['docs', 'types-index'],
   queryFn: async () => {
-    const res = await fetch(`${appConfig.frontendUrl}/static/types.gen.ts`);
+    const res = await fetch(versionedUrl(`${appConfig.frontendUrl}/static/types.gen.ts`));
     return buildIndex(await res.text());
   },
   staleTime: Number.POSITIVE_INFINITY,

--- a/frontend/src/modules/docs/query.ts
+++ b/frontend/src/modules/docs/query.ts
@@ -9,12 +9,19 @@ import type {
   GenTagSummary,
 } from '~/modules/docs/types';
 
+/**
+ * Append the build SHA to a /static URL. These files keep stable names with
+ * per-release content, so the param rolls browser HTTP and service worker
+ * caches over on each release.
+ */
+export const versionedUrl = (url: string) => `${url}?v=${__APP_VERSION__}`;
+
 /** Base URL for docs JSON files served at /static/docs.gen (generated into sdk/gen, copied by Vite) */
 const docsBaseUrl = `${appConfig.frontendUrl}/static/docs.gen`;
 
 /** Fetch JSON with Content-Type validation (guards against SPA HTML fallback responses). */
 async function fetchJson<T>(url: string): Promise<T> {
-  const response = await fetch(url);
+  const response = await fetch(versionedUrl(url));
   if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
   const contentType = response.headers.get('content-type');
   if (!contentType?.includes('application/json')) {
@@ -23,8 +30,10 @@ async function fetchJson<T>(url: string): Promise<T> {
   return response.json() as Promise<T>;
 }
 
-/** OpenAPI spec URL in public/static */
-export const openApiUrl = `${appConfig.frontendUrl}/static/openapi.json`;
+const openApiPath = `${appConfig.frontendUrl}/static/openapi.json`;
+
+/** OpenAPI spec URL in public/static (version param busts long-lived caches) */
+export const openApiUrl = versionedUrl(openApiPath);
 
 /**
  * Query keys for docs-related queries.
@@ -44,7 +53,7 @@ const docsKeys = {
  */
 export const openApiSpecQueryOptions = queryOptions({
   queryKey: docsKeys.spec,
-  queryFn: () => fetchJson(openApiUrl),
+  queryFn: () => fetchJson(openApiPath),
   staleTime: Number.POSITIVE_INFINITY, // Static file, cache indefinitely
 });
 

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -55,10 +55,21 @@
 	}
 
 	# Long-cache versioned assets. The frontend build hashes filenames under
-	# /assets/ and /static/, so a year cache is safe.
-	@assets path /assets/* /static/*
+	# /assets/, so a year cache is safe there.
+	@assets path /assets/*
 	handle @assets {
 		header Cache-Control "public, max-age=31536000, immutable"
+		reverse_proxy https://{$ORIGIN_HOST} {
+			header_up Host {$ORIGIN_HOST}
+		}
+	}
+
+	# /static/ keys keep stable names with changing content (docs.gen JSON,
+	# openapi.json, flags), so never mark them immutable: a short cache plus the
+	# ?v=<sha> param the app appends to mutable fetches keeps them fresh.
+	@static path /static/*
+	handle @static {
+		header Cache-Control "public, max-age=3600"
 		reverse_proxy https://{$ORIGIN_HOST} {
 			header_up Host {$ORIGIN_HOST}
 		}

--- a/infra/tasks/frontend-assets.test.ts
+++ b/infra/tasks/frontend-assets.test.ts
@@ -1,0 +1,86 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isHashedPath, uploadFrontendAssets } from './frontend-assets';
+
+/** HEAD responses per key: an object (optionally with ETag) means the key exists, absence means 404. */
+let headResponses: Record<string, { ETag?: string }>;
+/** PutObject inputs captured per key. */
+let puts: Record<string, { CacheControl?: string; ContentType?: string }>;
+
+vi.mock('@aws-sdk/client-s3', () => {
+  class HeadObjectCommand {
+    constructor(public input: { Key: string }) {}
+  }
+  class PutObjectCommand {
+    constructor(public input: { Key: string; CacheControl?: string; ContentType?: string }) {}
+  }
+  class S3Client {
+    async send(cmd: HeadObjectCommand | PutObjectCommand) {
+      if (cmd instanceof HeadObjectCommand) {
+        const response = headResponses[cmd.input.Key];
+        if (!response) throw Object.assign(new Error('NotFound'), { name: 'NotFound' });
+        return response;
+      }
+      puts[cmd.input.Key] = { CacheControl: cmd.input.CacheControl, ContentType: cmd.input.ContentType };
+      return {};
+    }
+  }
+  return { S3Client, HeadObjectCommand, PutObjectCommand };
+});
+
+const md5 = (content: string) => createHash('md5').update(Buffer.from(content)).digest('hex');
+
+describe('isHashedPath', () => {
+  it('treats only /assets/ as content-hashed', () => {
+    expect(isHashedPath('assets/app-abc123.js')).toBe(true);
+    // static/ keys keep stable names with changing content (docs.gen, openapi.json, flags)
+    expect(isHashedPath('static/docs.gen/operations.gen.json')).toBe(false);
+    expect(isHashedPath('static/openapi.json')).toBe(false);
+    expect(isHashedPath('favicon.ico')).toBe(false);
+  });
+});
+
+describe('uploadFrontendAssets', () => {
+  let distDir: string;
+
+  const files: Record<string, string> = {
+    'assets/app-abc123.js': 'hashed existing',
+    'assets/app-def456.js': 'hashed new',
+    'static/docs.gen/operations.gen.json': '[{"id":"getMe"}]',
+    'static/openapi.json': '{"info":{"version":"v2"}}',
+    'favicon.ico': 'icon',
+    'index.html': '<html>entry, must not upload</html>',
+    'sw.js': '// entry, must not upload',
+  };
+
+  beforeEach(() => {
+    distDir = mkdtempSync(join(tmpdir(), 'frontend-assets-'));
+    for (const [key, content] of Object.entries(files)) {
+      mkdirSync(dirname(join(distDir, key)), { recursive: true });
+      writeFileSync(join(distDir, key), content);
+    }
+    puts = {};
+    headResponses = {
+      'assets/app-abc123.js': {},
+      // Same key, same content on the remote: ETag matches the local MD5
+      'static/docs.gen/operations.gen.json': { ETag: `"${md5('[{"id":"getMe"}]')}"` },
+      // Same key, but the remote holds a previous release's content
+      'static/openapi.json': { ETag: `"${md5('{"info":{"version":"v1"}}')}"` },
+    };
+  });
+
+  afterEach(() => rmSync(distDir, { recursive: true, force: true }));
+
+  it('skips existing hashed keys, skips unchanged stable keys, re-uploads changed ones', async () => {
+    const result = await uploadFrontendAssets({ distDir, bucket: 'b', region: 'r', log: () => {} });
+
+    expect(result).toEqual({ uploaded: 3, skipped: 2 });
+    expect(Object.keys(puts).sort()).toEqual(['assets/app-def456.js', 'favicon.ico', 'static/openapi.json']);
+    expect(puts['assets/app-def456.js']?.CacheControl).toBe('public, max-age=31536000, immutable');
+    expect(puts['static/openapi.json']?.CacheControl).toBe('public, max-age=3600');
+    expect(puts['favicon.ico']?.CacheControl).toBe('public, max-age=3600');
+  });
+});

--- a/infra/tasks/frontend-assets.ts
+++ b/infra/tasks/frontend-assets.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
@@ -36,9 +37,14 @@ export function contentTypeFor(key: string): string {
   return (dot >= 0 ? contentTypes[key.slice(dot)] : undefined) ?? 'application/octet-stream';
 }
 
-/** Hashed, immutable paths: existence of the key proves the content matches. */
+/**
+ * Content-hashed, immutable paths: existence of the key proves the content
+ * matches. Only /assets/ qualifies — /static/ keys keep stable names with
+ * changing content (docs.gen JSON, openapi.json, flags), so existence proves
+ * nothing there.
+ */
 export function isHashedPath(key: string): boolean {
-  return key.startsWith('assets/') || key.startsWith('static/');
+  return key.startsWith('assets/');
 }
 
 export function isEntryFile(key: string): boolean {
@@ -67,11 +73,12 @@ export interface UploadAssetsOptions {
 }
 
 /**
- * Upload the built frontend bundle (everything except entry files) with a
- * 1-year immutable cache. Hashed paths skip upload when the key already exists
- * (content-addressed names make that check exact and unchanged deploys nearly
- * free); root files (favicon, robots.txt) always re-upload since their content
- * can change under a stable name.
+ * Upload the built frontend bundle (everything except entry files). Hashed
+ * paths get a 1-year immutable cache and skip upload when the key already
+ * exists (content-addressed names make that check exact). Stable-named keys
+ * (static/, favicon, robots.txt) change content under the same name, so they
+ * get a short cache and skip only when the remote ETag matches the local MD5 —
+ * unchanged deploys stay nearly free either way.
  */
 export async function uploadFrontendAssets(opts: UploadAssetsOptions): Promise<{ uploaded: number; skipped: number }> {
   const log = opts.log ?? ((message: string) => console.info(message));
@@ -93,24 +100,40 @@ export async function uploadFrontendAssets(opts: UploadAssetsOptions): Promise<{
   const queue = [...keys];
   const workers = Array.from({ length: 8 }, async () => {
     for (let key = queue.shift(); key !== undefined; key = queue.shift()) {
+      const head = await s3.send(new HeadObjectCommand({ Bucket: opts.bucket, Key: key })).catch(() => null);
       if (isHashedPath(key)) {
-        const exists = await s3
-          .send(new HeadObjectCommand({ Bucket: opts.bucket, Key: key }))
-          .then(() => true)
-          .catch(() => false);
-        if (exists) {
+        if (head) {
           skipped++;
           continue;
         }
+        const body = readFileSync(join(opts.distDir, key));
+        await s3.send(
+          new PutObjectCommand({
+            Bucket: opts.bucket,
+            Key: key,
+            Body: body,
+            ContentType: contentTypeFor(key),
+            CacheControl: 'public, max-age=31536000, immutable',
+          }),
+        );
+        uploaded++;
+        continue;
       }
+      // Stable-named key: ETag is the content MD5 for single-part uploads, so
+      // a match means the object is already current.
       const body = readFileSync(join(opts.distDir, key));
+      const md5 = createHash('md5').update(body).digest('hex');
+      if (head?.ETag?.replaceAll('"', '') === md5) {
+        skipped++;
+        continue;
+      }
       await s3.send(
         new PutObjectCommand({
           Bucket: opts.bucket,
           Key: key,
           Body: body,
           ContentType: contentTypeFor(key),
-          CacheControl: 'public, max-age=31536000, immutable',
+          CacheControl: 'public, max-age=3600',
         }),
       );
       uploaded++;

--- a/infra/tests/unit/caddyfile.test.ts
+++ b/infra/tests/unit/caddyfile.test.ts
@@ -57,9 +57,15 @@ describe('frontend Caddyfile', () => {
     expect(caddyfile).toMatch(/@notfound\s+status\s+404/);
   });
 
-  it('long-caches versioned /assets/* and /static/* paths', () => {
-    expect(caddyfile).toMatch(/@assets\s+path\s+\/assets\/\*\s+\/static\/\*/);
+  it('long-caches content-hashed /assets/* only', () => {
+    expect(caddyfile).toMatch(/@assets\s+path\s+\/assets\/\*\s*\n/);
     expect(caddyfile).toMatch(/Cache-Control\s+"public,\s*max-age=31536000,\s*immutable"/);
+  });
+
+  it('short-caches stable-named /static/* (docs.gen etc. change per release)', () => {
+    // Marking /static/* immutable froze docs data in browser caches for a year.
+    expect(caddyfile).toMatch(/@static\s+path\s+\/static\/\*/);
+    expect(caddyfile).toMatch(/@static\s+path[^{]*\{\s*\n\s*header Cache-Control "public, max-age=3600"/);
   });
 
   it('reverse-proxies to the {$ORIGIN_HOST} env, not a hardcoded bucket', () => {


### PR DESCRIPTION
## Problem

Production `/docs` broke while the home page kept working. The docs section is the only part of the app that fetches **stable-named** runtime files (`/static/docs.gen/*.json`, `/static/openapi.json`, `/static/zod.gen.ts`, `/static/types.gen.ts`), and three independent layers froze those at a pre-#964 generation while the app shell kept updating:

1. **S3 upload never refreshed them** — `isHashedPath()` in `infra/tasks/frontend-assets.ts` treated all of `static/` as content-addressed, so the skip-if-exists upload skipped changed content under existing keys. `docs.gen`/`openapi.json` changed in #979/#982/#997/#1003/#1008 but prod S3 still served the first post-#964 (2026-07-29) copy. New keys (e.g. renamed `details.gen/<tag>.gen.json`) *did* upload, so the dataset was mixed-generation.
2. **Browsers pinned them for a year** — Caddy served `/static/*` with `Cache-Control: max-age=31536000, immutable`.
3. **The service worker couldn't recover** — its stale-while-revalidate route for docs data revalidates through the HTTP cache, so it just re-cached the same stale bytes.

Net effect: the 0.8.8 app parsed ~July-29 docs JSON (or 404'd on renamed detail files) and `fetchJson`'s validation threw — `/docs` down, home page (fully content-hashed + precached) fine.

## Fix

- **`infra/tasks/frontend-assets.ts`**: `isHashedPath()` now covers only `assets/`. Stable-named keys (`static/`, root files) skip upload only when the remote ETag matches the local content MD5, and upload with `max-age=3600` instead of immutable. Unchanged deploys stay nearly free either way.
- **`infra/caddy/Caddyfile`**: split the cache rule — `/assets/*` stays immutable, `/static/*` drops to `public, max-age=3600`. (Goes live with the next release, since the Caddy image is baked per release.)
- **`frontend/src/modules/docs/query.ts` + `helpers/extract-types.ts`**: all mutable `/static` fetches append `?v=<build sha>`. This is the recovery path for clients that already hold the year-long immutable cache entries — the new URL bypasses both the poisoned browser HTTP cache and old SW runtime-cache keys, no waiting out `max-age`.
- **`frontend/src/lib/sw.ts`**: comment updated to describe the actual freshness mechanism (version param rolls cache keys per release; SWR serves stale-first within a release).

## Tests

- New `infra/tasks/frontend-assets.test.ts` pins the upload semantics: hashed keys skip on existence, stable keys skip only on ETag match, changed stable keys re-upload with the short cache header, entry files stay excluded.
- `infra/tests/unit/caddyfile.test.ts` updated: asserts `/assets/*` immutable and `/static/*` short-cache separately (previously asserted the buggy combined matcher).
- Full infra suite green (77 files, 659 tests); frontend + infra typecheck clean.

## Note for rollout

After this merges and deploys, the bulk upload will rewrite every drifted `static/` key (ETag mismatch), so S3 converges on current content in one deploy. Existing visitors recover on their next app update because the docs fetch URLs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
