### PR TITLE
docs(cella): sync skill routes commit/ship through the CLI, never plain git

### DIFF
--- a/cella/skills/cella-sync/SKILL.md
+++ b/cella/skills/cella-sync/SKILL.md
@@ -10,8 +10,9 @@ Run this flow whenever the app pulls the cella template: `pnpm cella sync` (merg
 each pass should leave the fork delta smaller or better-protected than before.
 
 **Hard rule**: on the sync branch, the merge is committed and shipped by the CLI, never by
-plain git — `pnpm cella sync --no-ship` to commit, `pnpm cella sync` to push and open the PR.
-Why in step 6.
+plain git. Each `pnpm cella sync` run advances one stage and the run that commits never ships:
+a clean merge is committed by the first run, a conflicted one by the rerun after resolution,
+and a further rerun on the committed branch ships (push + PR). Why in step 6.
 
 ## Vocabulary
 
@@ -80,13 +81,14 @@ unmarked; the pending list must be empty at the end of a sync.
 
 ## 6. Commit, then drift triage
 
-Commit the merge with `pnpm cella sync --no-ship`. Never commit the merge with plain
-`git commit`: while the merge is staged, that records a two-parent merge commit, and because
-sync PRs are squash-merged (upstream ancestry never reaches origin) the PR then lists the
-entire upstream history — hundreds of commits, growing every release. The rerun instead
-squash-commits the staged delta as a single-parent commit; `--no-ship` makes it stop there
-instead of pushing, so the branch can be triaged first. (CLI without `--no-ship`, pre-0.2.0:
-let the plain rerun commit *and* ship, then do this triage as follow-up pushes to the open PR.)
+If the merge was clean, `pnpm cella sync` already committed it in step 1's run; after conflict
+resolution, rerun `pnpm cella sync` to commit. Never commit the merge with plain `git commit`:
+while the merge is staged, that records a two-parent merge commit, and because sync PRs are
+squash-merged (upstream ancestry never reaches origin) the PR then lists the entire upstream
+history — hundreds of commits, growing every release. The CLI instead squash-commits the staged
+delta as a single-parent commit and stops on the branch without pushing, so it can be triaged
+first. (Pre-0.2.0 CLI: the commit rerun also ships; let it, then do this triage as follow-up
+pushes to the open PR.)
 
 Then `pnpm cella analyze` (it diffs committed HEAD in a worktree, so content reverts only show
 after commit). Follow-up commits from the triage are fine as plain `git commit` — only the

--- a/cella/skills/cella-sync/SKILL.md
+++ b/cella/skills/cella-sync/SKILL.md
@@ -9,6 +9,10 @@ Run this flow whenever the app pulls the cella template: `pnpm cella sync` (merg
 `pnpm cella analyze` (dry-run drift report). The goal of every sync is not just a green merge:
 each pass should leave the fork delta smaller or better-protected than before.
 
+**Hard rule**: on the sync branch, the merge is committed and shipped by the CLI, never by
+plain git — `pnpm cella sync --no-ship` to commit, `pnpm cella sync` to push and open the PR.
+Why in step 6.
+
 ## Vocabulary
 
 - **fork-owned**: file exists only in the app; sync never touches it. Preferred home for app code.
@@ -74,10 +78,20 @@ registration disappears while CI stays green until typecheck.
 Mark with `pnpm exec tsx cella/migrations/run.ts mark <id...>`. Never leave satisfied migrations
 unmarked; the pending list must be empty at the end of a sync.
 
-## 6. Post-commit drift triage
+## 6. Commit, then drift triage
 
-Commit the merge, then `pnpm cella analyze` (it diffs committed HEAD in a worktree, so content
-reverts only show after commit). For every `drifted` file, apply the decision matrix:
+Commit the merge with `pnpm cella sync --no-ship`. Never commit the merge with plain
+`git commit`: while the merge is staged, that records a two-parent merge commit, and because
+sync PRs are squash-merged (upstream ancestry never reaches origin) the PR then lists the
+entire upstream history — hundreds of commits, growing every release. The rerun instead
+squash-commits the staged delta as a single-parent commit; `--no-ship` makes it stop there
+instead of pushing, so the branch can be triaged first. (CLI without `--no-ship`, pre-0.2.0:
+let the plain rerun commit *and* ship, then do this triage as follow-up pushes to the open PR.)
+
+Then `pnpm cella analyze` (it diffs committed HEAD in a worktree, so content reverts only show
+after commit). Follow-up commits from the triage are fine as plain `git commit` — only the
+staged merge itself must go through the rerun. For every `drifted` file, apply the decision
+matrix:
 
 | Finding | Action |
 |---|---|
@@ -93,6 +107,11 @@ the pinned list did not grow except for documented scaffolding with an unwind co
 
 ## 7. Finish
 
-Push the sync branch and open the PR (`pnpm cella sync` reruns to commit/push if it drove the
-merge). PR description lists: upstream range, conflicts and their resolution shape, migrations
-marked, and the drift delta (before/after counts from analyze).
+Ship with `pnpm cella sync` (on a committed sync branch it flattens any merge commits, pushes,
+and opens the PR). Never ship with plain `git push` + `gh pr create` — that skips the flatten
+safety net, which is the last chance to catch a merge commit from step 6. If a bloated sync PR
+already exists, the same rerun repairs it: it rewrites the branch to a single commit with
+identical content and force-pushes with lease.
+
+PR description lists: upstream range, conflicts and their resolution shape, migrations marked,
+and the drift delta (before/after counts from analyze).


### PR DESCRIPTION
Rewrites the cella-sync skill's finish flow to make the ship mechanism unambiguous: on the sync branch, the merge is committed and shipped by `pnpm cella sync`, never by plain `git commit` / `git push` / `gh pr create`.

Paired with cellajs/cella-cli#19, the flow is flagless and staged — each sync run advances one stage, and the run that commits never ships:

- Hard rule up front: a clean merge is committed by the first run, a conflicted one by the rerun after resolution, and a further rerun on the committed branch ships (push + PR).
- Step 6 becomes "Commit, then drift triage": the CLI squash-commits the staged delta and stops without pushing — that pause is the triage window (`cella analyze` needs committed HEAD). The why is spelled out: a plain `git commit` on the staged merge records a two-parent commit, and since sync PRs are squash-merged the PR would list the entire upstream history (raak#97: 247 commits). Follow-up triage commits may use plain git.
- Step 7 becomes "Ship with `pnpm cella sync`" — the rerun flattens any merge commits before pushing, which manual `git push` + `gh pr create` would skip; a bloated sync PR is repairable by the same rerun (force-push with lease).

Merge order: cella-cli#19 → cli 0.2.0 release → dep bump here → this PR. The doc carries a pre-0.2.0 fallback line (the old CLI ships on the commit rerun; triage then happens as follow-up pushes to the open PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
