### PR TITLE
refactor(infra): shared iam-client + doc sweeps (teardown, vocabulary, credentials)

### DIFF
--- a/cella/DEPLOYMENT.md
+++ b/cella/DEPLOYMENT.md
@@ -54,7 +54,7 @@ The key resources and how traffic flows between them:
      └─────────────────────────────┘  presigned URLs)
 ```
 
-- **Load balancer:** the single public entrypoint, and **dual-homed**: a public IP terminates TLS on one side, a private-network attachment forwards plain HTTP to VM private IPs on the other. The frontend (SPA proxy) is the default backend; backend, yjs and mcp are reached on the same app origin via registry-declared `lbPathBegin` prefixes (`/api`, `/yjs`, `/mcp`). The LB never rewrites paths, so each service serves itself under its prefix.
+- **Load balancer:** the single public entrypoint, and **dual-homed**: a public IP terminates TLS on one side, a private-network attachment forwards plain HTTP to VM private IPs on the other. The frontend (SPA proxy) is the default backend; backend, yjs and mcp are reached on the same app origin via registry-declared `pathPrefix` prefixes (`/api`, `/yjs`, `/mcp`). The LB never rewrites paths, so each service serves itself under its prefix.
 - **Private network (VPC):** VMs and db connect over private IPs. Only the LB accepts inbound public traffic. Each VM keeps a public IP for egress (image pulls) but drops all inbound, including SSH.
 - **Frontend:** a Caddy VM behind the LB that reverse-proxies the SPA bucket over its public S3 endpoint, adding security headers/CSP and the SPA deep-link fallback.
 - **Backend VM:** the critical API path; replaced one generation at a time with LB overlap.
@@ -153,8 +153,8 @@ Every deploy is a **create-then-replace**: the image SHA is baked into a new VM 
 
 | `replacementStrategy` | Services | How |
 | --- | --- | --- |
-| **lb-overlap** | backend, frontend, yjs, mcp | Record the SHA as `pendingSha`; the Pulumi program provisions the content-addressed pending generation alongside the active one. [tasks/cutover.ts](../infra/tasks/cutover.ts) then reconciles the live LB server list toward the desired state with idempotent Scaleway `SetBackendServers` calls: expand to `[old,new]`, health/version-gate through the public LB, contract to `[new]`, drain. It re-reads live state and always issues the corrective call, so an empty or stale pool (or a same-generation redeploy) is repaired rather than assumed correct. The new generation is promoted to `active`; every displaced generation is reaped by ONE final stack update after all cutovers succeeded. No generation is retained, so a deploy never runs two VMs per service beyond the overlap window. |
-| **exclusive** | cdc | No LB overlap: cdc holds one Postgres replication slot. The Pulumi program provisions only the new generation (the old one is replaced in the same `up`); the new worker contends for the slot the old one releases on drain (handoff is lossless: the slot retains the WAL position). |
+| **start-first** | backend, frontend, yjs, mcp | Record the SHA as `pendingSha`; the Pulumi program provisions the content-addressed pending generation alongside the active one. [tasks/cutover.ts](../infra/tasks/cutover.ts) then reconciles the live LB server list toward the desired state with idempotent Scaleway `SetBackendServers` calls: expand to `[old,new]`, health/version-gate through the public LB, contract to `[new]`, drain. It re-reads live state and always issues the corrective call, so an empty or stale pool (or a same-generation redeploy) is repaired rather than assumed correct. The new generation is promoted to `active`; every displaced generation is reaped by ONE final stack update after all cutovers succeeded. No generation is retained, so a deploy never runs two VMs per service beyond the overlap window. |
+| **stop-first** | cdc | No LB overlap: cdc holds one Postgres replication slot. The Pulumi program provisions only the new generation (the old one is replaced in the same `up`); the new worker contends for the slot the old one releases on drain (handoff is lossless: the slot retains the WAL position). |
 
 **`drainPolicy`** tunes how the old generation leaves the LB: `requests` (HTTP; `onMarkedDownAction: none`, in-flight requests finish) for backend/frontend/mcp, or `reconnect` (WebSocket; sessions shed, clients re-dial and resync from durable state) for yjs.
 
@@ -462,11 +462,11 @@ Unlike **Rotate keys**, no bootstrap key is needed: nothing changes on the Scale
 
 > Losing the current passphrase means you cannot decrypt existing secret outputs; there is no recovery. The GitHub Environment holds a copy, but Actions secrets are write-only: CI keeps working with it, yet it can never be viewed again, so keep your password-manager copy current.
 
-### Teardown (manual)
+### Teardown
 
-Decommissioning a stack — deleting every resource to stop billing — is a deliberate manual operation you perform yourself in the Scaleway console. The CLI has **no** teardown action on purpose: a full destroy needs owner-tier credentials the [descending-privilege model](#credentials) keeps off laptops and out of CI (the CI deploy key can create but not delete the database or VPC, and the state-bucket policy denies it `DeleteBucket`), and `pulumi destroy` is unavailable once the passphrase is gone.
+Decommissioning a stack — deleting every resource to stop billing — is the CLI's **Teardown** action. It never *holds* owner-tier credentials (the [descending-privilege model](#credentials) keeps those off laptops and out of CI): it prompts for a transient bootstrap-grade key (`SCW_TEARDOWN_*` env for unattended runs), requires typing `<slug>-<mode>`, runs `pulumi destroy --refresh` under the stack lock, and then optionally deletes the stack's IAM principals. Production resources marked `protect: true` (frontend/private buckets, database) are refused unless protection is deliberately lifted in code first — that refusal is the point. The versioned state bucket, operator secret values, and GitHub Environment secrets are deliberately left in place.
 
-Delete in dependency order: load balancer (+IP) → instance (+volumes, +IP) → database → registry namespace → secrets → buckets (empty incl. versions, then delete; state bucket last) → private network → VPC → IAM apps/policies → DNS records → the now-empty project. The database and VPC need an owner or full-access key, not the CI key.
+**Manual fallback (lost passphrase):** `pulumi destroy` is unavailable once the passphrase is gone — then you delete by hand in the Scaleway console, in dependency order: load balancer (+IP) → instance (+volumes, +IP) → database → registry namespace → secrets → buckets (empty incl. versions, then delete; state bucket last) → private network → VPC → IAM apps/policies → DNS records → the now-empty project. The database and VPC need an owner or full-access key, not the CI key.
 
 > **Clean slate** below is *not* a teardown — it resets stack tracking to re-bootstrap a still-running stack, and leaves live resources in place.
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -101,11 +101,15 @@ Each check reports one of `ok | warn | missing | error | unknown`, where `unknow
 }
 ```
 
-Check `id`s are stable identifiers (`tooling.pulumi`, `config.stackState`, `identity.project`, `github.environment`, `state.bucket`, `state.lock`, `rollout`, `secrets.required`, `live.<service>`, `dns.zone`). The evaluator is a pure function of gathered facts, so the mapping from facts to verdicts is unit-tested in isolation.
+Check `id`s are stable identifiers (`tooling.pulumi`, `config.stackState`, `identity.project`, `github.environment`, `state.bucket`, `state.lock`, `rollout`, `secrets.required`, `live.<service>`, `dns.zone`, `stores.<storeId>`). Each domain is a self-contained provider (`lib/status/providers/`) whose evaluation is a pure function of its gathered facts, so the mapping from facts to verdicts is unit-tested in isolation; registered stores contribute their own `validate()` posture checks.
+
+## Credentials files
+
+Operator credentials load in a fixed order (implemented once in `lib/utils/env-files.ts`, shared by the CLI and the standalone status task): `backend/.env`, then the repo-root `.env` (existing environment variables keep precedence over both), then the mode-scoped override **`infra/.env.<mode>`** — which OVERRIDES the ambient env, so a staging run cannot silently inherit production values. The mode file carries a live secret key and the Pulumi passphrase; the CLI tightens its permissions to `0600` on sight. It is a standing convenience for day-2 operator work only: one-off privileged rituals (bootstrap, migrations) use session-ephemeral shell exports and delete any temporary env file afterwards.
 
 ## Teardown
 
-There is no teardown command, on purpose. Destroying a stack is a rare, irreversible operation that needs owner-tier credentials the descending-privilege model deliberately keeps off laptops and out of CI — the CI deploy key can create but not delete the database or VPC, and the state-bucket policy denies it `DeleteBucket`. So you do it yourself, by hand, in the Scaleway console. See **Teardown** in [../cella/DEPLOYMENT.md](../cella/DEPLOYMENT.md) for the order.
+Teardown is a first-class CLI action (menu: **Teardown**), designed so the CLI never *holds* owner-tier credentials: it prompts for a transient bootstrap-grade key (`SCW_TEARDOWN_*` env for unattended runs), requires typing `<slug>-<mode>` to proceed, and runs `pulumi destroy --refresh` under the stack lock, then optionally deletes the stack's IAM principals. Production is additionally protected: the frontend/private buckets and database carry `protect: true`, so Pulumi refuses them unless protection is deliberately lifted in code first. Deliberately untouched: the versioned Pulumi state bucket, Secret Manager containers with operator values, and GitHub Environment secrets. See **Teardown** in [../cella/DEPLOYMENT.md](../cella/DEPLOYMENT.md) for the walkthrough.
 
 ## Extending
 

--- a/infra/cli/actions/setup.ts
+++ b/infra/cli/actions/setup.ts
@@ -7,6 +7,7 @@ import { deriveInfra } from '../../lib/naming';
 import { operatorManagedRuntimeSecrets } from '../../lib/runtime-secrets';
 import { buildProviderEnv } from '../../lib/scaleway/bootstrap-scw-env';
 import { ensureDnsZone } from '../../lib/scaleway/ensure-dns-zone';
+import { fetchAppRulesByName } from '../../lib/scaleway/iam-client';
 import { CI_RULE_SHAPES } from '../../lib/scaleway/permissions';
 import { principalNames } from '../../lib/scaleway/principals';
 import { createProject, listProjects, resolveOrganizationIdFromKey } from '../../lib/scaleway/scaleway-account';
@@ -23,7 +24,6 @@ import { changeMark, checkMark, DIVIDER, failWithHint, pc, warningMark, withSpin
 import { writeEnvVar } from '../../lib/utils/env-file';
 import { errorMessage } from '../../lib/utils/errors';
 import { infraDir } from '../../lib/utils/paths';
-import { fetchAppRulesByName } from '../../tasks/assert-vm-grants';
 import { provisionManagedKey } from '../../tasks/provision-managed-key';
 import { seedOperatorSecrets } from '../../tasks/seed-operator-secrets';
 import { setupAdminApp } from '../../tasks/setup-admin-app';

--- a/infra/lib/scaleway/iam-client.ts
+++ b/infra/lib/scaleway/iam-client.ts
@@ -1,0 +1,183 @@
+import type { FetchLike } from '../utils/fetch-like';
+import { resolveFetch } from '../utils/fetch-like';
+import { scwFetch, scwSend } from './scw-fetch';
+
+/**
+ * The shared IAM read/key client: app resolution, policy/rule collection, and
+ * api-key CRUD, deduplicated from assert-vm-grants, mint-generation-keys, and
+ * the CLI's drift check (IAM backlog item 5/8). Bootstrap provisioning flows
+ * (scaleway-iam.ts) keep their own interwoven helpers on purpose — their
+ * error handling and pagination needs differ per ritual step.
+ *
+ * Every function takes the same auth shape scwFetch does ({secretKey,
+ * fetchImpl?}), so callers that inject a fetch for tests and callers that
+ * mock the scw-fetch module both keep working.
+ */
+
+export const IAM_BASE = 'https://api.scaleway.com/iam/v1alpha1';
+const ACCOUNT_BASE = 'https://api.scaleway.com/account/v3';
+
+export interface IamAuth {
+  secretKey: string;
+  fetchImpl?: FetchLike;
+}
+
+export interface GrantedRule {
+  policyName: string;
+  permissionSets: string[];
+  condition: string;
+}
+
+export interface ScwApiKey {
+  access_key: string;
+  secret_key: string;
+  created_at?: string;
+}
+
+/** Resolve the organization id owning a project (the api-key-free path). */
+export async function resolveOrganizationIdViaProject(auth: IamAuth, projectId: string): Promise<string> {
+  const project = await scwFetch<{ organization_id?: string }>(auth, 'GET', `${ACCOUNT_BASE}/projects/${projectId}`);
+  if (!project?.organization_id) {
+    throw new Error(`Could not resolve organization_id from project ${projectId}. Pass --organization-id explicitly.`);
+  }
+  return project.organization_id;
+}
+
+/** Resolve an IAM application's id from its (unique) name. Returns null when not found. */
+export async function resolveApplicationIdByName(
+  auth: IamAuth,
+  organizationId: string,
+  name: string,
+): Promise<string | null> {
+  const { applications = [] } = await scwFetch<{ applications?: Array<{ id: string; name: string }> }>(
+    auth,
+    'GET',
+    `${IAM_BASE}/applications?name=${encodeURIComponent(name)}&organization_id=${organizationId}&page_size=20`,
+  );
+  return applications.find((app) => app.name === name)?.id ?? null;
+}
+
+interface IamPolicy {
+  id: string;
+  name: string;
+  /** Principal bindings: a policy targets exactly one of application / user / group. */
+  application_id?: string;
+  user_id?: string;
+  group_id?: string;
+}
+
+/**
+ * Every policy in the organization, paging past `page_size`. The list endpoint's
+ * `application_id` filter is unreliable (Scaleway returns all policies regardless),
+ * so callers filter by principal client-side against the `application_id` /
+ * `group_id` each list item carries.
+ */
+async function listOrganizationPolicies(auth: IamAuth, organizationId: string): Promise<IamPolicy[]> {
+  const pageSize = 100;
+  const all: IamPolicy[] = [];
+  for (let page = 1; page <= 100; page++) {
+    const { policies = [], total_count = 0 } = await scwFetch<{ policies?: IamPolicy[]; total_count?: number }>(
+      auth,
+      'GET',
+      `${IAM_BASE}/policies?organization_id=${organizationId}&page=${page}&page_size=${pageSize}`,
+    );
+    all.push(...policies);
+    if (policies.length === 0 || all.length >= total_count) break;
+  }
+  return all;
+}
+
+/** Group ids the application belongs to; a group's policies grant the app too. */
+async function fetchApplicationGroupIds(
+  auth: IamAuth,
+  organizationId: string,
+  applicationId: string,
+): Promise<Set<string>> {
+  const ids = new Set<string>();
+  for (let page = 1; page <= 100; page++) {
+    const { groups = [], total_count = 0 } = await scwFetch<{
+      groups?: Array<{ id: string; application_ids?: string[] }>;
+      total_count?: number;
+    }>(auth, 'GET', `${IAM_BASE}/groups?organization_id=${organizationId}&page=${page}&page_size=100`);
+    for (const group of groups) if ((group.application_ids ?? []).includes(applicationId)) ids.add(group.id);
+    if (groups.length === 0 || (page - 1) * 100 + groups.length >= total_count) break;
+  }
+  return ids;
+}
+
+/** Every rule (permission sets + condition) granted to an application across its policies. */
+export async function fetchGrantedRules(
+  auth: IamAuth,
+  organizationId: string,
+  applicationId: string,
+): Promise<GrantedRule[]> {
+  const groupIds = await fetchApplicationGroupIds(auth, organizationId, applicationId);
+  const policies = await listOrganizationPolicies(auth, organizationId);
+  const bound = policies.filter(
+    (policy) =>
+      policy.application_id === applicationId || (policy.group_id !== undefined && groupIds.has(policy.group_id)),
+  );
+  const collected: GrantedRule[] = [];
+  for (const policy of bound) {
+    const { rules = [] } = await scwFetch<{ rules?: Array<{ permission_set_names?: string[]; condition?: string }> }>(
+      auth,
+      'GET',
+      `${IAM_BASE}/rules?policy_id=${policy.id}&page_size=100`,
+    );
+    for (const rule of rules) {
+      collected.push({
+        policyName: policy.name,
+        permissionSets: rule.permission_set_names ?? [],
+        condition: rule.condition ?? '',
+      });
+    }
+  }
+  return collected;
+}
+
+/**
+ * Every rule granted to an application resolved by name. Returns null when the
+ * application does not exist. Convenience wrapper (resolve org → resolve app
+ * id → collect rules) for callers that only have the deterministic
+ * `<slug>-<suffix>` name (the CLI's per-rule CI-policy drift check).
+ */
+export async function fetchAppRulesByName(opts: {
+  secretKey: string;
+  projectId: string;
+  applicationName: string;
+  organizationId?: string;
+  fetchImpl?: FetchLike;
+}): Promise<GrantedRule[] | null> {
+  const auth: IamAuth = { secretKey: opts.secretKey, fetchImpl: resolveFetch(opts.fetchImpl) };
+  const organizationId = opts.organizationId ?? (await resolveOrganizationIdViaProject(auth, opts.projectId));
+  const applicationId = await resolveApplicationIdByName(auth, organizationId, opts.applicationName);
+  if (!applicationId) return null;
+  return fetchGrantedRules(auth, organizationId, applicationId);
+}
+
+/** All api keys on an application (one page of 100 — the fleet keeps ≤2 per app). */
+export async function listApiKeys(auth: IamAuth, organizationId: string, applicationId: string): Promise<ScwApiKey[]> {
+  const { api_keys = [] } = await scwFetch<{ api_keys?: ScwApiKey[] }>(
+    auth,
+    'GET',
+    `${IAM_BASE}/api-keys?application_id=${applicationId}&organization_id=${organizationId}&page_size=100`,
+  );
+  return api_keys;
+}
+
+/** Mint a fresh api key on an application. */
+export async function createApiKey(
+  auth: IamAuth,
+  opts: { applicationId: string; description: string; defaultProjectId: string },
+): Promise<ScwApiKey> {
+  return scwFetch<ScwApiKey>(auth, 'POST', `${IAM_BASE}/api-keys`, {
+    application_id: opts.applicationId,
+    description: opts.description,
+    default_project_id: opts.defaultProjectId,
+  });
+}
+
+/** Delete one api key by access key. */
+export async function deleteApiKey(auth: IamAuth, accessKey: string): Promise<void> {
+  await scwSend(auth, 'DELETE', `${IAM_BASE}/api-keys/${accessKey}`);
+}

--- a/infra/tasks/assert-vm-grants.ts
+++ b/infra/tasks/assert-vm-grants.ts
@@ -1,10 +1,12 @@
-import { scwFetch } from '../lib/scaleway/scw-fetch';
+import {
+  fetchGrantedRules,
+  type IamAuth,
+  resolveApplicationIdByName,
+  resolveOrganizationIdViaProject,
+} from '../lib/scaleway/iam-client';
 import { type FetchLike, resolveFetch } from '../lib/utils/fetch-like';
 import { isMain } from '../lib/utils/is-main';
 import { getFlag } from './args';
-
-const IAM_BASE = 'https://api.scaleway.com/iam/v1alpha1';
-const ACCOUNT_BASE = 'https://api.scaleway.com/account/v3';
 
 /** Permission sets that decrypt or enumerate secret values/metadata. */
 const SECRET_PERMISSION_SETS = new Set([
@@ -58,147 +60,6 @@ export interface AssertVmGrantsResult {
   unconditionedSecretRules: string[];
 }
 
-function scwGet<T>(fetchImpl: FetchLike, secretKey: string, url: string): Promise<T> {
-  return scwFetch<T>({ secretKey, fetchImpl }, 'GET', url);
-}
-
-async function resolveOrgId(fetchImpl: FetchLike, secretKey: string, projectId: string): Promise<string> {
-  const project = await scwGet<{ organization_id?: string }>(
-    fetchImpl,
-    secretKey,
-    `${ACCOUNT_BASE}/projects/${projectId}`,
-  );
-  if (!project?.organization_id) {
-    throw new Error(`Could not resolve organization_id from project ${projectId}. Pass --organization-id explicitly.`);
-  }
-  return project.organization_id;
-}
-
-/** Resolve an IAM application's id from its (unique) name. Returns null when not found. */
-export async function resolveApplicationIdByName(
-  fetchImpl: FetchLike,
-  secretKey: string,
-  organizationId: string,
-  name: string,
-): Promise<string | null> {
-  const { applications = [] } = await scwGet<{ applications?: Array<{ id: string; name: string }> }>(
-    fetchImpl,
-    secretKey,
-    `${IAM_BASE}/applications?name=${encodeURIComponent(name)}&organization_id=${organizationId}&page_size=20`,
-  );
-  return applications.find((app) => app.name === name)?.id ?? null;
-}
-
-interface IamPolicy {
-  id: string;
-  name: string;
-  /** Principal bindings: a policy targets exactly one of application / user / group. */
-  application_id?: string;
-  user_id?: string;
-  group_id?: string;
-}
-
-/**
- * Every policy in the organization, paging past `page_size`. The list endpoint's
- * `application_id` filter is unreliable (Scaleway returns all policies regardless),
- * so callers filter by principal client-side against the `application_id` /
- * `group_id` each list item carries.
- */
-async function listOrganizationPolicies(
-  fetchImpl: FetchLike,
-  secretKey: string,
-  organizationId: string,
-): Promise<IamPolicy[]> {
-  const pageSize = 100;
-  const all: IamPolicy[] = [];
-  for (let page = 1; page <= 100; page++) {
-    const { policies = [], total_count = 0 } = await scwGet<{ policies?: IamPolicy[]; total_count?: number }>(
-      fetchImpl,
-      secretKey,
-      `${IAM_BASE}/policies?organization_id=${organizationId}&page=${page}&page_size=${pageSize}`,
-    );
-    all.push(...policies);
-    if (policies.length === 0 || all.length >= total_count) break;
-  }
-  return all;
-}
-
-/** Group ids the application belongs to; a group's policies grant the app too. */
-async function fetchApplicationGroupIds(
-  fetchImpl: FetchLike,
-  secretKey: string,
-  organizationId: string,
-  applicationId: string,
-): Promise<Set<string>> {
-  const ids = new Set<string>();
-  for (let page = 1; page <= 100; page++) {
-    const { groups = [], total_count = 0 } = await scwGet<{
-      groups?: Array<{ id: string; application_ids?: string[] }>;
-      total_count?: number;
-    }>(fetchImpl, secretKey, `${IAM_BASE}/groups?organization_id=${organizationId}&page=${page}&page_size=100`);
-    for (const group of groups) if ((group.application_ids ?? []).includes(applicationId)) ids.add(group.id);
-    if (groups.length === 0 || (page - 1) * 100 + groups.length >= total_count) break;
-  }
-  return ids;
-}
-
-/**
- * Every rule (permission sets + condition) granted to an application resolved
- * by name. Returns null when the application does not exist. Convenience
- * wrapper (resolve org → resolve app id → collect rules) for callers that only
- * have the deterministic `<slug>-<suffix>` name (the CLI's per-rule CI-policy
- * drift check).
- */
-export async function fetchAppRulesByName(opts: {
-  secretKey: string;
-  projectId: string;
-  applicationName: string;
-  organizationId?: string;
-  fetchImpl?: FetchLike;
-}): Promise<Array<{ policyName: string; permissionSets: string[]; condition: string }> | null> {
-  const fetchImpl = resolveFetch(opts.fetchImpl);
-  const organizationId = opts.organizationId ?? (await resolveOrgId(fetchImpl, opts.secretKey, opts.projectId));
-  const applicationId = await resolveApplicationIdByName(
-    fetchImpl,
-    opts.secretKey,
-    organizationId,
-    opts.applicationName,
-  );
-  if (!applicationId) return null;
-  return fetchGrantedRules(fetchImpl, opts.secretKey, organizationId, applicationId);
-}
-
-/** Every rule (permission sets + condition) granted to an application across its policies. */
-export async function fetchGrantedRules(
-  fetchImpl: FetchLike,
-  secretKey: string,
-  organizationId: string,
-  applicationId: string,
-): Promise<Array<{ policyName: string; permissionSets: string[]; condition: string }>> {
-  const groupIds = await fetchApplicationGroupIds(fetchImpl, secretKey, organizationId, applicationId);
-  const policies = await listOrganizationPolicies(fetchImpl, secretKey, organizationId);
-  const bound = policies.filter(
-    (policy) =>
-      policy.application_id === applicationId || (policy.group_id !== undefined && groupIds.has(policy.group_id)),
-  );
-  const collected: Array<{ policyName: string; permissionSets: string[]; condition: string }> = [];
-  for (const policy of bound) {
-    const { rules = [] } = await scwGet<{ rules?: Array<{ permission_set_names?: string[]; condition?: string }> }>(
-      fetchImpl,
-      secretKey,
-      `${IAM_BASE}/rules?policy_id=${policy.id}&page_size=100`,
-    );
-    for (const rule of rules) {
-      collected.push({
-        policyName: policy.name,
-        permissionSets: rule.permission_set_names ?? [],
-        condition: rule.condition ?? '',
-      });
-    }
-  }
-  return collected;
-}
-
 /**
  * Collect the union of permission set names granted to an application across all
  * its IAM policies and their rules, then verify it EQUALS the required set:
@@ -208,21 +69,20 @@ export async function fetchGrantedRules(
  * carries EXACTLY that condition (string equality against the shared builder).
  */
 export async function assertVmGrants(opts: AssertVmGrantsOptions): Promise<AssertVmGrantsResult> {
-  const fetchImpl = resolveFetch(opts.fetchImpl);
+  const auth: IamAuth = { secretKey: opts.secretKey, fetchImpl: resolveFetch(opts.fetchImpl) };
   const log = opts.log ?? ((msg) => console.info(msg));
   const required = opts.required;
-  const organizationId = opts.organizationId ?? (await resolveOrgId(fetchImpl, opts.secretKey, opts.projectId));
+  const organizationId = opts.organizationId ?? (await resolveOrganizationIdViaProject(auth, opts.projectId));
 
   let applicationId = opts.applicationId;
   if (!applicationId && opts.applicationName) {
-    applicationId =
-      (await resolveApplicationIdByName(fetchImpl, opts.secretKey, organizationId, opts.applicationName)) ?? undefined;
+    applicationId = (await resolveApplicationIdByName(auth, organizationId, opts.applicationName)) ?? undefined;
     if (!applicationId)
       throw new Error(`IAM application '${opts.applicationName}' not found in organization ${organizationId}`);
   }
   if (!applicationId) throw new Error('assertVmGrants: provide applicationId or applicationName');
 
-  const rules = await fetchGrantedRules(fetchImpl, opts.secretKey, organizationId, applicationId);
+  const rules = await fetchGrantedRules(auth, organizationId, applicationId);
   const granted = new Set(rules.flatMap((rule) => rule.permissionSets));
 
   const requiredSet = new Set(required);

--- a/infra/tasks/mint-generation-keys.ts
+++ b/infra/tasks/mint-generation-keys.ts
@@ -1,12 +1,17 @@
 import { writeFile } from 'node:fs/promises';
+import {
+  createApiKey,
+  deleteApiKey,
+  type IamAuth,
+  listApiKeys,
+  resolveApplicationIdByName,
+  type ScwApiKey,
+} from '../lib/scaleway/iam-client';
 import { principalNames } from '../lib/scaleway/principals';
 import { createSecretManagerClient } from '../lib/scaleway/scaleway-secret-manager';
-import { scwFetch, scwSend } from '../lib/scaleway/scw-fetch';
 import { handoffServicePath } from '../lib/scaleway/secret-paths';
 import { isMain } from '../lib/utils/is-main';
 import { getFlag } from './args';
-
-const IAM_BASE = 'https://api.scaleway.com/iam/v1alpha1';
 
 /**
  * How many API keys each service/boot app retains after a mint: the fresh key
@@ -40,56 +45,41 @@ export interface GenerationKeys {
   handoffSecretIds: Record<string, string>;
 }
 
-interface ScwApiKey {
-  access_key: string;
-  secret_key: string;
-  created_at?: string;
-}
-
-async function resolveAppId(secretKey: string, organizationId: string, name: string): Promise<string> {
-  const { applications = [] } = await scwFetch<{ applications?: Array<{ id: string; name: string }> }>(
-    { secretKey },
-    'GET',
-    `${IAM_BASE}/applications?name=${encodeURIComponent(name)}&organization_id=${organizationId}&page_size=20`,
-  );
-  const app = applications.find((a) => a.name === name);
-  if (!app)
+async function resolveAppId(auth: IamAuth, organizationId: string, name: string): Promise<string> {
+  const id = await resolveApplicationIdByName(auth, organizationId, name);
+  if (!id)
     throw new Error(`mint-generation-keys: IAM application '${name}' not found — run the infra CLI bootstrap first.`);
-  return app.id;
+  return id;
 }
 
 /** Mint a fresh key on the app. Pruning happens separately, AFTER every
  *  handoff bundle is staged — see pruneStaleKeys. */
 async function mintKey(
-  secretKey: string,
+  auth: IamAuth,
   projectId: string,
   appId: string,
   label: string,
   sha: string,
 ): Promise<ScwApiKey> {
-  return scwFetch<ScwApiKey>({ secretKey }, 'POST', `${IAM_BASE}/api-keys`, {
-    application_id: appId,
+  return createApiKey(auth, {
+    applicationId: appId,
     description: `${label} gen ${sha.slice(0, 10)}`,
-    default_project_id: projectId,
+    defaultProjectId: projectId,
   });
 }
 
 /** Delete all but the newest KEYS_TO_KEEP keys on the app. */
 async function pruneStaleKeys(
-  secretKey: string,
+  auth: IamAuth,
   organizationId: string,
   appId: string,
   label: string,
   log: (msg: string) => void,
 ): Promise<void> {
-  const { api_keys = [] } = await scwFetch<{ api_keys?: ScwApiKey[] }>(
-    { secretKey },
-    'GET',
-    `${IAM_BASE}/api-keys?application_id=${appId}&organization_id=${organizationId}&page_size=100`,
-  );
-  const byNewest = [...api_keys].sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''));
+  const apiKeys = await listApiKeys(auth, organizationId, appId);
+  const byNewest = [...apiKeys].sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''));
   for (const stale of byNewest.slice(KEYS_TO_KEEP)) {
-    await scwSend({ secretKey }, 'DELETE', `${IAM_BASE}/api-keys/${stale.access_key}`);
+    await deleteApiKey(auth, stale.access_key);
     log(`  ~ pruned ${label} key ${stale.access_key}`);
   }
 }
@@ -113,6 +103,7 @@ async function pruneStaleKeys(
  */
 export async function mintGenerationKeys(opts: MintGenerationKeysOptions): Promise<GenerationKeys> {
   const log = opts.log ?? ((msg: string) => console.info(msg));
+  const auth: IamAuth = { secretKey: opts.callerSecretKey };
   const names = principalNames(opts.slug, opts.mode);
   const client = createSecretManagerClient({
     secretKey: opts.callerSecretKey,
@@ -122,10 +113,10 @@ export async function mintGenerationKeys(opts: MintGenerationKeysOptions): Promi
 
   // Resolve every app id first: a missing principal fails before anything is
   // minted or pruned.
-  const bootAppId = await resolveAppId(opts.callerSecretKey, opts.organizationId, names.boot);
+  const bootAppId = await resolveAppId(auth, opts.organizationId, names.boot);
   const serviceAppIds = new Map<string, string>();
   for (const service of opts.services) {
-    serviceAppIds.set(service, await resolveAppId(opts.callerSecretKey, opts.organizationId, names.vmService(service)));
+    serviceAppIds.set(service, await resolveAppId(auth, opts.organizationId, names.vmService(service)));
   }
 
   // Transactional-ish ordering: mint and stage EVERYTHING first, prune keys
@@ -133,7 +124,7 @@ export async function mintGenerationKeys(opts: MintGenerationKeysOptions): Promi
   // the old generation keeps hydrating/signing, and a retry re-mints cleanly.
   // (The keep-newest-2 window can still age out the live key after repeated
   // failed attempts within one deploy; bounded, documented, accepted.)
-  const bootKey = await mintKey(opts.callerSecretKey, opts.projectId, bootAppId, names.boot, opts.sha);
+  const bootKey = await mintKey(auth, opts.projectId, bootAppId, names.boot, opts.sha);
   log(`✓ minted boot key ${bootKey.access_key}`);
 
   const handoffSecretIds: Record<string, string> = {};
@@ -141,7 +132,7 @@ export async function mintGenerationKeys(opts: MintGenerationKeysOptions): Promi
     const appName = names.vmService(service);
     const appId = serviceAppIds.get(service);
     if (!appId) throw new Error(`mint-generation-keys: no app id resolved for ${appName}`);
-    const serviceKey = await mintKey(opts.callerSecretKey, opts.projectId, appId, appName, opts.sha);
+    const serviceKey = await mintKey(auth, opts.projectId, appId, appName, opts.sha);
 
     // Prune older handoff bundles first: an unconsumed bundle from a failed
     // deploy is stale (VMs cache the key after their single read), and leaving
@@ -168,10 +159,10 @@ export async function mintGenerationKeys(opts: MintGenerationKeysOptions): Promi
   }
 
   // Every bundle is staged; only now retire stale keys.
-  await pruneStaleKeys(opts.callerSecretKey, opts.organizationId, bootAppId, names.boot, log);
+  await pruneStaleKeys(auth, opts.organizationId, bootAppId, names.boot, log);
   for (const service of opts.services) {
     const appId = serviceAppIds.get(service);
-    if (appId) await pruneStaleKeys(opts.callerSecretKey, opts.organizationId, appId, names.vmService(service), log);
+    if (appId) await pruneStaleKeys(auth, opts.organizationId, appId, names.vmService(service), log);
   }
 
   const result: GenerationKeys = {


### PR DESCRIPTION
The last two queued cleanups from `.todos/INFRA.md` todo 10, in one PR.

## iam-client consolidation (IAM backlog items 5 + 8)
New `lib/scaleway/iam-client.ts` owns the IAM read/key helpers that three call sites each re-declared: application resolution by name, org-resolution via project, policy/rule collection with group-membership expansion, and api-key list/create/delete. One auth shape (`{secretKey, fetchImpl?}`, the same contract `scwFetch` takes) serves both test styles — assert-vm-grants' injected-fetch tests and mint-generation-keys' module-mock tests both pass unchanged. `assert-vm-grants.ts` shrinks to the assertion logic itself; `mint-generation-keys` and the CLI drift check consume the client. Deliberately out of scope, noted in the module doc: `scaleway-iam.ts`'s bootstrap provisioning flows keep their own ritual-specific helpers.

## Doc sweeps (unblocked by #1038)
- **Stale teardown claim, both docs**: `infra/README.md` and `DEPLOYMENT.md` still said "there is no teardown command, on purpose" — false since #989 shipped the Teardown action. Both now describe the real flow (transient bootstrap-grade key, typed `<slug>-<mode>` token, `protect: true` refusal on production, state bucket/secrets/GitHub deliberately untouched), with the lost-passphrase **manual console fallback** preserved as the original doc's real lesson.
- **Deploy vocabulary**: `lbPathBegin` → `pathPrefix`, the strategy table rows **lb-overlap**/**exclusive** → **start-first**/**stop-first**, matching #1038.
- **README "Credentials files" section** (backlog item 19): the `infra/.env.<mode>` convention — load order (backend/.env → root .env → mode override), override semantics (staging can't inherit production), the 0600 hardening, and the day-2-only scope (privileged rituals stay session-ephemeral).
- **README status section**: documents the provider registry and the `stores.<storeId>` validate checks.

## Verification
659 infra tests green (78 files) — the two rewired consumers' existing test suites pass without modification, which is the proof the client extraction is behavior-free. Typecheck + hook green.

With this, INFRA.md todo 10 is fully closed. Next phase on the board: **P-pkg**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
