### PR TITLE
fix(tests): adopt projectcampus fixes — hierarchy seeding, fixture parity, flaky cleanup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,7 +19,7 @@ The canonical agent guidelines live in [cella/AGENTS.md](../cella/AGENTS.md). Re
 - **Frontend SDK**: Generated in `sdk/gen/`, consumed via the `sdk` package; never edit manually. Run `pnpm sdk` after backend route/schema changes.
 - **Routing**: File-based routes in `frontend/src/routes/` auto-registered into `routeTree.gen.ts` (committed, never hand-edited). Route files are thin shims; logic/components live in modules, wired via `getRouteApi('<route id>')`.
 - **State**: Server state → TanStack Query, in `frontend/src/modules/<module>/query.ts`; client state → Zustand `*-store.ts` files inside their module.
-- **Entities**: `ContextEntityType` (has memberships, e.g. `organization`) and `ProductEntityType` (content, e.g. `attachment`). See `frontend/src/modules/attachment/` for reference.
+- **Entities**: `ChannelEntityType` (has memberships, e.g. `organization`) and `ProductEntityType` (content, e.g. `attachment`). See `frontend/src/modules/attachment/` for reference.
 
 ## Code style
 

--- a/backend/src/modules/requests/requests-queries.test.ts
+++ b/backend/src/modules/requests/requests-queries.test.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { DbContext } from '#/core/context';
 import { baseDb } from '#/db/db';
@@ -10,7 +10,9 @@ const email = 'query-request-uniqueness@example.com';
 
 describe('request query uniqueness', () => {
   afterEach(async () => {
-    await baseDb.delete(requestsTable).where(eq(requestsTable.email, email));
+    // Case-insensitive cleanup: the case-insensitivity test inserts an uppercase variant that an
+    // exact-match delete leaves behind, tripping the unique signup index on the next run.
+    await baseDb.delete(requestsTable).where(sql`lower(${requestsTable.email}) = lower(${email})`);
   });
 
   it('allows distinct signup types and finds each type precisely', async () => {

--- a/backend/src/permissions/get-valid-product.ts
+++ b/backend/src/permissions/get-valid-product.ts
@@ -18,7 +18,7 @@ export interface ValidProductResult<K extends ProductEntityType> {
 
 /**
  * Checks whether the current user may perform `action` on a product entity, resolving it by `id`
- * (system-admin bypass handled inside `checkPermission`). Returns the resolved entity; throws 404 if
+ * (system-admin bypass handled inside `checkAccess`). Returns the resolved entity; throws 404 if
  * not found, 403 if not allowed.
  */
 export const getValidProduct = async <K extends ProductEntityType>(

--- a/backend/tests/hierarchy-helpers.ts
+++ b/backend/tests/hierarchy-helpers.ts
@@ -13,12 +13,23 @@ export async function seedEntityHierarchy(
   opts: { tenantId: string; createdBy: string; slugPrefix: string },
 ): Promise<void> {
   for (const row of plan.seedChannelRows) {
+    // Insert every ancestor id column, not just the immediate parent: deep hierarchies keep all
+    // ancestor columns NOT NULL on channel tables. With cella's default hierarchy the chain has
+    // length 1 (the parent), so the generated SQL is unchanged.
+    const ancestorNames = sql.join(
+      row.ancestorColumns.map((column) => sql.raw(quoteIdent(column.columnName))),
+      sql`, `,
+    );
+    const ancestorValues = sql.join(
+      row.ancestorColumns.map((column) => sql`${column.id}`),
+      sql`, `,
+    );
     await db.execute(sql`
       INSERT INTO ${sql.raw(quoteIdent(row.tableName))}
-        (id, tenant_id, entity_type, name, slug, created_by, ${sql.raw(quoteIdent(row.parentColumnName))})
+        (id, tenant_id, entity_type, name, slug, created_by, ${ancestorNames})
       VALUES (
         ${row.id}, ${opts.tenantId}, ${row.channelType}, ${`${opts.slugPrefix} ${row.channelType}`},
-        ${`${opts.slugPrefix}-${row.channelType}-${row.id.slice(0, 8)}`}, ${opts.createdBy}, ${row.parentId}
+        ${`${opts.slugPrefix}-${row.channelType}-${row.id.slice(0, 8)}`}, ${opts.createdBy}, ${ancestorValues}
       )
       ON CONFLICT (id) DO NOTHING
     `);

--- a/backend/tests/integration/rls-security.test.ts
+++ b/backend/tests/integration/rls-security.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { eq, getTableName, sql } from 'drizzle-orm';
+import { eq, getColumns, getTableName, sql } from 'drizzle-orm';
 import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { appConfig, type ProductEntityType } from 'shared';
 import { testAdminRoleDatabaseUrl, testRuntimeDatabaseUrl } from 'shared/test-db';
@@ -58,11 +58,21 @@ async function seedEntityHierarchy(
   slugPrefix: string,
 ) {
   for (const row of plan.seedChannelRows) {
+    // Insert every ancestor id column, not just the immediate parent: deep hierarchies keep all
+    // ancestor columns NOT NULL on channel tables (length 1 == the parent under cella's default).
+    const ancestorNames = sql.join(
+      row.ancestorColumns.map((column) => sql.raw(quoteIdent(column.columnName))),
+      sql`, `,
+    );
+    const ancestorValues = sql.join(
+      row.ancestorColumns.map((column) => sql`${column.id}`),
+      sql`, `,
+    );
     await adminDb.execute(sql`
       INSERT INTO ${sql.raw(quoteIdent(row.tableName))}
-        (id, tenant_id, entity_type, name, slug, created_by, ${sql.raw(quoteIdent(row.parentColumnName))})
+        (id, tenant_id, entity_type, name, slug, created_by, ${ancestorNames})
       VALUES
-        (${row.id}, ${tenantId}, ${row.channelType}, ${`RLS ${row.channelType}`}, ${`${slugPrefix}-${row.channelType}-${row.id.slice(0, 8)}`}, ${createdBy}, ${row.parentId})
+        (${row.id}, ${tenantId}, ${row.channelType}, ${`RLS ${row.channelType}`}, ${`${slugPrefix}-${row.channelType}-${row.id.slice(0, 8)}`}, ${createdBy}, ${ancestorValues})
       ON CONFLICT (id) DO NOTHING
     `);
   }
@@ -142,6 +152,10 @@ const makeRlsProductFixture = (entityType: ProductEntityType): RlsProductFixture
       // Recent so the unseen-count tests attribute it; the mock's createdAt is a random past date.
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
+      // Feed parity: findUnseenCountsByUser hides unpublished drafts (isNotNull(publishedAt)), so
+      // publish draft-lifecycle rows. Inert when the table has no publishedAt column ('in' rather
+      // than property access: cella's precise column types reject a key no table here has).
+      ...('publishedAt' in getColumns(table) ? { publishedAt: new Date().toISOString() } : {}),
       seq: 0,
       ...extra,
     }) as never;

--- a/cella/skills/cella-sync/SKILL.md
+++ b/cella/skills/cella-sync/SKILL.md
@@ -9,6 +9,11 @@ Run this flow whenever the app pulls the cella template: `pnpm cella sync` (merg
 `pnpm cella analyze` (dry-run drift report). The goal of every sync is not just a green merge:
 each pass should leave the fork delta smaller or better-protected than before.
 
+**Hard rule**: on the sync branch, the merge is committed and shipped by the CLI, never by
+plain git. Each `pnpm cella sync` run advances one stage and the run that commits never ships:
+a clean merge is committed by the first run, a conflicted one by the rerun after resolution,
+and a further rerun on the committed branch ships (push + PR). Why in step 6.
+
 ## Vocabulary
 
 - **fork-owned**: file exists only in the app; sync never touches it. Preferred home for app code.
@@ -74,10 +79,21 @@ registration disappears while CI stays green until typecheck.
 Mark with `pnpm exec tsx cella/migrations/run.ts mark <id...>`. Never leave satisfied migrations
 unmarked; the pending list must be empty at the end of a sync.
 
-## 6. Post-commit drift triage
+## 6. Commit, then drift triage
 
-Commit the merge, then `pnpm cella analyze` (it diffs committed HEAD in a worktree, so content
-reverts only show after commit). For every `drifted` file, apply the decision matrix:
+If the merge was clean, `pnpm cella sync` already committed it in step 1's run; after conflict
+resolution, rerun `pnpm cella sync` to commit. Never commit the merge with plain `git commit`:
+while the merge is staged, that records a two-parent merge commit, and because sync PRs are
+squash-merged (upstream ancestry never reaches origin) the PR then lists the entire upstream
+history — hundreds of commits, growing every release. The CLI instead squash-commits the staged
+delta as a single-parent commit and stops on the branch without pushing, so it can be triaged
+first. (Pre-0.2.0 CLI: the commit rerun also ships; let it, then do this triage as follow-up
+pushes to the open PR.)
+
+Then `pnpm cella analyze` (it diffs committed HEAD in a worktree, so content reverts only show
+after commit). Follow-up commits from the triage are fine as plain `git commit` — only the
+staged merge itself must go through the rerun. For every `drifted` file, apply the decision
+matrix:
 
 | Finding | Action |
 |---|---|
@@ -93,6 +109,11 @@ the pinned list did not grow except for documented scaffolding with an unwind co
 
 ## 7. Finish
 
-Push the sync branch and open the PR (`pnpm cella sync` reruns to commit/push if it drove the
-merge). PR description lists: upstream range, conflicts and their resolution shape, migrations
-marked, and the drift delta (before/after counts from analyze).
+Ship with `pnpm cella sync` (on a committed sync branch it flattens any merge commits, pushes,
+and opens the PR). Never ship with plain `git push` + `gh pr create` — that skips the flatten
+safety net, which is the last chance to catch a merge commit from step 6. If a bloated sync PR
+already exists, the same rerun repairs it: it rewrites the branch to a single commit with
+identical content and force-pushes with lease.
+
+PR description lists: upstream range, conflicts and their resolution shape, migrations marked,
+and the drift delta (before/after counts from analyze).

--- a/frontend/src/query/realtime/views.test.ts
+++ b/frontend/src/query/realtime/views.test.ts
@@ -99,10 +99,16 @@ describe('deriveGrantBoundaryViews', () => {
     ]);
   });
 
-  it('without elevatedRoles every unconditional grant is subtree (engine parity)', () => {
+  it('a role listed in elevatedRoles keeps its unconditional grant subtree (engine parity)', () => {
+    // Config-independent form: passing `undefined` here would NOT exercise the
+    // "no elevatedRoles configured" branch — JS default parameters substitute
+    // the app-config default on any undefined, so that branch is reachable
+    // only when the running app's config has no elevatedRoles. Asserting via
+    // an explicit list containing the granted role tests the same subtree
+    // semantics against the function's contract instead of ambient config.
     const studentRead = (ct: ChannelType, role: string): PolicyCellInput =>
       ct === 'course' && role === 'student' ? 1 : 0;
-    expect(derive([membership('course', 'c1', 'student')], studentRead, undefined)).toEqual([
+    expect(derive([membership('course', 'c1', 'student')], studentRead, ['student'])).toEqual([
       {
         key: `${ORG}:item:subtree`,
         organizationId: ORG,

--- a/shared/src/testing/entity-hierarchy.ts
+++ b/shared/src/testing/entity-hierarchy.ts
@@ -18,6 +18,8 @@ export interface TestChannelRow {
   parentId: string;
   parentIdKey: EntityIdColumnKey<ChannelEntityType>;
   parentColumnName: string;
+  /** Every ancestor id column this row must carry (deep hierarchies keep them all NOT NULL). */
+  ancestorColumns: TestChannelColumn[];
 }
 
 export interface TestEntityHierarchyPlan {
@@ -78,6 +80,19 @@ export const buildTestEntityHierarchyPlan = ({
     setChannelId(channelType, id);
 
     const parentIdKey = appConfig.entityIdColumnKeys[parentChannelType];
+    // Walk the full parent chain: rows are seeded root-first, so every ancestor id is known here.
+    // Deep hierarchies keep ALL ancestor id columns NOT NULL on channel tables, so a seeder that
+    // fills only the immediate parent column fails on any grandchild channel.
+    const ancestorColumns: TestChannelColumn[] = [];
+    for (let cursor: ChannelEntityType | null = parentChannelType; cursor; ) {
+      const ancestorId = channelIdsByType[cursor];
+      if (!ancestorId) {
+        throw new Error(`Cannot seed ${channelType}: missing ancestor channel id for ${cursor}`);
+      }
+      const idKey = appConfig.entityIdColumnKeys[cursor];
+      ancestorColumns.push({ channelType: cursor, id: ancestorId, idKey, columnName: toColumnName(idKey) });
+      cursor = hierarchy.getParent(cursor) as ChannelEntityType | null;
+    }
     seedChannelRows.push({
       channelType,
       id,
@@ -86,6 +101,7 @@ export const buildTestEntityHierarchyPlan = ({
       parentId,
       parentIdKey,
       parentColumnName: toColumnName(parentIdKey),
+      ancestorColumns,
     });
   }
 


### PR DESCRIPTION
Adopts the verified fixes from the projectcampus contribution brief (a fork with a four-level channel hierarchy and draft-lifecycle products — it exercises paths cella's single-channel default config masks). All six claims were verified against main before adoption; every mechanical claim checked out.

## The fixes

1. **Flaky requests-test cleanup** — the case-insensitivity test's uppercase row survived the exact-match `afterEach` delete and tripped the unique `(lower(email), type)` index on the *next* run: flaky only on persistent local databases, invisible in CI. Cleanup now deletes with `lower()` on **both** sides (one hardening beyond the brief: it stays correct if the fixture email ever changes case). **Proven by the run-twice-same-DB gate.**
2. **Hierarchy seeders insert the full ancestor chain** — `TestChannelRow` gains `ancestorColumns` (walked root-first, so every ancestor id is known), and both seeders (`hierarchy-helpers.ts` + the rls-security local copy) insert every ancestor id column instead of only the immediate parent. Deep hierarchies keep all ancestor columns NOT NULL, so grandchild seeding died at setup. Upstream-safe: with cella's default hierarchy the chain has length 1 and the generated SQL is unchanged — RLS suite 50/50 green here, 123/0 in the originating fork. The `parent*` fields stay for compatibility (now derivable as `ancestorColumns[0]` — flagged for a later cleanup).
3. **RLS product fixtures publish draft-lifecycle rows** — matching `findUnseenCountsByUser`'s `isNotNull(publishedAt)` filter; inert for cella's attachment. One deviation from the brief worth noting: the brief's `'publishedAt' in table` idiom turned out to be *deliberately* type-safe — the "more canonical" `getColumns(table).publishedAt` fails typecheck against cella's precise column types. Landed as `'publishedAt' in getColumns(table)`, which keeps both the column-accuracy and the type-check.
4. **copilot-instructions**: `ContextEntityType` → `ChannelEntityType` (dead since the 2026-07 channel rename).
5. **get-valid-product comment**: `checkPermission` → `checkAccess`.
6. **views engine-parity test made config-independent** (the brief's option (c)): passing `undefined` never exercised the no-elevatedRoles branch — JS default parameters substitute the app-config default on ANY undefined — so the test asserted ambient app config and necessarily failed in forks that configure elevatedRoles. It now asserts the same subtree semantics via an explicit elevatedRoles list containing the granted role, with a comment explaining why `undefined` cannot test that branch. The deeper contract question (empty array as canonical "none" + dropping the undefined branch) is filed separately — it needs coordination with the permission engine's `isHomeScopedGrant` semantics.

## Verification

- `pnpm check` green (biome, full-repo typecheck, sdk unchanged).
- Requests test run **twice against the same database**: both green (the literal proof of fix 1).
- `TEST_MODE=full` rls-security: 50/50; attachment-seq-reads (the other hierarchy-plan consumer): green; realtime views: green.

Fork-facing note: raak consumes the shared testing infrastructure (items 2+3) — auto-migrating, no codemod needed; the changes are additive and byte-stable for any depth-≤2 hierarchy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
