### PR TITLE
fix(infra): boot-diag empty-bucket guidance and boot.log selection

### DIFF
--- a/infra/tasks/diag.ts
+++ b/infra/tasks/diag.ts
@@ -1,11 +1,19 @@
 import { isMain } from '../lib/utils/is-main';
 import { getFlag } from './args';
-import { createAwsReader, parseKeys, renderDiagnostics, selectDiagnostics, summarizeBundles } from './fetch-boot-diag';
+import {
+  createAwsReader,
+  emptyBootDiagGuidance,
+  parseKeys,
+  renderDiagnostics,
+  selectDiagnostics,
+  summarizeBundles,
+} from './fetch-boot-diag';
 
 interface ResolvedTarget {
   bucket: string;
   region: string;
   serviceNames: readonly string[];
+  slug: string;
 }
 
 /** Derive bucket/region/service-list from appConfig for the given app mode. */
@@ -16,7 +24,7 @@ async function resolveTarget(mode: string): Promise<ResolvedTarget> {
   const { deriveInfra } = await import('../lib/naming');
   const { serviceNames } = await import('../compose/compose');
   const { naming, region } = deriveInfra(appConfig);
-  return { bucket: naming.bootDiagBucket, region, serviceNames };
+  return { bucket: naming.bootDiagBucket, region, serviceNames, slug: appConfig.slug };
 }
 
 /** Render the `--list` overview as an aligned plain-text table. */
@@ -98,6 +106,11 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   // A list failure (missing aws CLI, bad creds, wrong bucket) throws here with a
   // clear message when the service slug is invalid.
   const keys = parseKeys(reader.list());
+
+  if (keys.length === 0 && !wantReplay) {
+    for (const line of emptyBootDiagGuidance(target.slug)) console.info(`[diag] ${line}`);
+    return;
+  }
 
   if (wantList) {
     printSummary(keys, services);

--- a/infra/tasks/fetch-boot-diag.test.ts
+++ b/infra/tasks/fetch-boot-diag.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   type DiagReader,
+  emptyBootDiagGuidance,
+  isEmptyPrefixLs,
   parseArgs,
   parseKeys,
   renderDiagnostics,
@@ -66,6 +68,14 @@ describe('selectDiagnostics', () => {
     expect(sel.latestFull).toBeUndefined();
   });
 
+  it('prefers the boot transcript over the sibling events bundle', () => {
+    const sel = selectDiagnostics(
+      ['backend-20260807T081154Z-boot.log', 'backend-20260807T081154Z-events.jsonl'],
+      'backend',
+    );
+    expect(sel.latestFull).toBe('backend-20260807T081154Z-boot.log');
+  });
+
   it('caps stage details at the 10 most recent', () => {
     const many = Array.from({ length: 15 }, (_, i) => `backend-stage-${String(i).padStart(2, '0')}-x`);
     const sel = selectDiagnostics(many, 'backend');
@@ -117,7 +127,20 @@ describe('renderDiagnostics', () => {
     expect(logs).toContain('BODY(backend-20260531T090509-boot.log)');
   });
 
-  it('warns when there is no full boot-diag log', () => {
+  it('warns when there is no full boot-diag log but markers exist', () => {
+    const logs: string[] = [];
+    const cat = vi.fn((key: string) => `BODY(${key})`);
+    renderDiagnostics(
+      'cdc',
+      { markers: ['cdc-stage-1-pull'], stageDetailKeys: ['cdc-stage-1-pull'], latestFull: undefined, failureKeys: [] },
+      { list: () => '', cat },
+      (m) => logs.push(m),
+    );
+
+    expect(logs).toContain('::warning::No cdc full boot-diag log uploaded');
+  });
+
+  it('prints a single no-diagnostics line for a service that owns nothing', () => {
     const logs: string[] = [];
     const cat = vi.fn(() => '');
     renderDiagnostics(
@@ -127,7 +150,7 @@ describe('renderDiagnostics', () => {
       (m) => logs.push(m),
     );
 
-    expect(logs).toContain('::warning::No cdc full boot-diag log uploaded');
+    expect(logs).toEqual(['::warning::No boot diagnostics for cdc: nothing was ever uploaded for this service']);
     expect(cat).not.toHaveBeenCalled();
   });
 
@@ -172,7 +195,7 @@ describe('renderDiagnostics', () => {
     const logs: string[] = [];
     renderDiagnostics(
       'cdc',
-      { markers: [], stageDetailKeys: [], latestFull: undefined, failureKeys: [] },
+      { markers: ['cdc-stage-1-pull'], stageDetailKeys: [], latestFull: undefined, failureKeys: [] },
       { list: () => '', cat: () => '' },
       (m) => logs.push(m),
       'plain',
@@ -218,6 +241,29 @@ describe('summarizeBundles', () => {
       { service: 'cdc', total: 1, failures: 0, latestFull: undefined },
       { service: 'yjs', total: 0, failures: 0, latestFull: undefined },
     ]);
+  });
+});
+
+describe('isEmptyPrefixLs', () => {
+  it('classifies exit 1 with no output as an empty prefix', () => {
+    expect(isEmptyPrefixLs(1, '', '')).toBe(true);
+    expect(isEmptyPrefixLs(1, '\n', ' ')).toBe(true);
+  });
+
+  it('keeps real failures fatal', () => {
+    // Denied / bad endpoint: stderr is populated.
+    expect(isEmptyPrefixLs(1, '', 'An error occurred (AccessDenied)')).toBe(false);
+    expect(isEmptyPrefixLs(255, '', '')).toBe(false);
+    // A successful non-empty listing is not "empty prefix".
+    expect(isEmptyPrefixLs(0, '2026-05-31 09:00:01 12 backend-stage-1-pull', '')).toBe(false);
+  });
+});
+
+describe('emptyBootDiagGuidance', () => {
+  it('names both known causes and embeds the serial-console marker for the slug', () => {
+    const lines = emptyBootDiagGuidance('cella');
+    expect(lines.join('\n')).toContain('::cella::');
+    expect(lines.join('\n')).toContain('ObjectStorageObjectsWrite');
   });
 });
 

--- a/infra/tasks/fetch-boot-diag.ts
+++ b/infra/tasks/fetch-boot-diag.ts
@@ -48,7 +48,9 @@ export function selectDiagnostics(keys: string[], service: string): DiagSelectio
   const sorted = [...keys].sort();
   const markers = sorted.filter((k) => new RegExp(`^${svc}-(stage|[0-9])`).test(k)).slice(-30);
   const stageDetailKeys = sorted.filter((k) => k.startsWith(`${service}-stage-`)).slice(-10);
-  const latestFull = sorted.filter((k) => new RegExp(`^${svc}-[0-9]{8}T`).test(k)).at(-1);
+  // Pin to -boot.log: the sibling -events.jsonl sorts after it and would win
+  // .at(-1), replacing the readable transcript with raw OTLP records.
+  const latestFull = sorted.filter((k) => new RegExp(`^${svc}-[0-9]{8}T.*-boot\\.log$`).test(k)).at(-1);
   // Reconciler failure captures: <svc>-failed-* (slot logs), <svc>-pull-failed-*
   // (docker pull/auth stderr) and <svc>-migrate-failed-* (one-shot migrator
   // output). Keep the few most recent.
@@ -65,14 +67,38 @@ export interface DiagReader {
 }
 
 /**
+ * True when an `aws s3 ls <prefix>` result means the prefix holds zero objects:
+ * the AWS CLI exits 1 with no output at all in that case. That is a finding
+ * (nothing was ever uploaded), not a listing failure; real failures (denied,
+ * bad endpoint, bad bucket) carry stderr and must still abort.
+ */
+export function isEmptyPrefixLs(status: number | null, stdout: string, stderr: string): boolean {
+  return status === 1 && stdout.trim() === '' && stderr.trim() === '';
+}
+
+/**
+ * Actionable guidance for an EMPTY boot-diag prefix. Every boot uploads a
+ * transcript, success or failure, so an empty prefix means no VM ever got a
+ * diagnostic object into the bucket.
+ */
+export function emptyBootDiagGuidance(slug = '<slug>'): string[] {
+  return [
+    'boot-diag is empty: no VM has ever uploaded diagnostics (every boot uploads, even a healthy one).',
+    'Two known causes:',
+    `  1. The boot runner never ran (cloud-init or launcher failure). Open the VM's serial console in the Scaleway web console and look for ::${slug}:: markers and "BOOT FAILED (exit N)".`,
+    '  2. Uploads are denied: a boot principal provisioned before the IAM v2 model carries no Object Storage permission set, and Scaleway does not honor bucket-policy-only grants, so every boot-diag PUT fails. Re-run the infra CLI "Stack setup" apply with a bootstrap key; the current boot principal carries ObjectStorageObjectsWrite.',
+  ];
+}
+
+/**
  * Reads boot diagnostics through the AWS CLI while preserving actionable failures.
- * Listing errors abort; individual object errors are returned for inline rendering so one bad
- * object does not hide the rest.
+ * An empty prefix lists as '' (see isEmptyPrefixLs); other listing errors abort. Individual
+ * object errors are returned for inline rendering so one bad object does not hide the rest.
  */
 export function createAwsReader(endpoint: string, bucket: string): DiagReader {
   const prefix = `s3://${bucket}/boot-diag/`;
-  const run = (args: string[], what: string): string => {
-    const res = spawnSync('aws', args, { encoding: 'utf-8' });
+  const spawnAws = (args: string[]) => spawnSync('aws', args, { encoding: 'utf-8' });
+  const check = (res: ReturnType<typeof spawnAws>, what: string): string => {
     if (res.error) {
       if ((res.error as NodeJS.ErrnoException).code === 'ENOENT') {
         throw new Error('aws CLI not found on PATH — install the AWS CLI to read boot diagnostics');
@@ -85,8 +111,12 @@ export function createAwsReader(endpoint: string, bucket: string): DiagReader {
     return res.stdout ?? '';
   };
   return {
-    list: () => run(['--endpoint-url', endpoint, 's3', 'ls', prefix], `s3 ls ${prefix}`),
-    cat: (key) => run(['--endpoint-url', endpoint, 's3', 'cp', `${prefix}${key}`, '-'], `s3 cp ${key}`),
+    list: () => {
+      const res = spawnAws(['--endpoint-url', endpoint, 's3', 'ls', prefix]);
+      if (!res.error && isEmptyPrefixLs(res.status, res.stdout ?? '', res.stderr ?? '')) return '';
+      return check(res, `s3 ls ${prefix}`);
+    },
+    cat: (key) => check(spawnAws(['--endpoint-url', endpoint, 's3', 'cp', `${prefix}${key}`, '-']), `s3 cp ${key}`),
   };
 }
 
@@ -139,6 +169,13 @@ export function renderDiagnostics(
     }
   };
 
+  const owned =
+    (sel.failureKeys?.length ?? 0) + sel.markers.length + sel.stageDetailKeys.length + (sel.latestFull ? 1 : 0);
+  if (owned === 0) {
+    warn(`No boot diagnostics for ${service}: nothing was ever uploaded for this service`);
+    return;
+  }
+
   // Failure captures first. This is usually the actual answer (pull/auth error
   // or the failed slot's logs), so surface it before the boot transcript.
   for (const key of sel.failureKeys ?? []) {
@@ -186,7 +223,12 @@ export function parseArgs(argv: string[]): CliArgs {
 export async function main(argv = process.argv.slice(2)): Promise<void> {
   const { bucket, service, region } = parseArgs(argv);
   const reader = createAwsReader(`https://s3.${region}.scw.cloud`, bucket);
-  const selection = selectDiagnostics(parseKeys(reader.list()), service);
+  const keys = parseKeys(reader.list());
+  if (keys.length === 0) {
+    for (const line of emptyBootDiagGuidance()) console.info(line);
+    return;
+  }
+  const selection = selectDiagnostics(keys, service);
   // CI gets collapsible groups; a manual local run gets plain headers.
   renderDiagnostics(service, selection, reader, console.info, process.env.GITHUB_ACTIONS === 'true' ? 'ci' : 'plain');
 }


### PR DESCRIPTION
Adopts raak's boot-diag improvements upstream (cellajs/raak#125, merged there), from a production incident where every deploy failed at cutover and `pnpm --filter infra diag` gave no useful signal.

## What

- **Empty boot-diag prefix explains instead of aborting.** `aws s3 ls` on a zero-object prefix exits 1 with no stdout and no stderr; `createAwsReader.list()` treated that as a fatal listing failure. New `isEmptyPrefixLs()` classifies it (exit 1 + empty stdout + empty stderr only, so AccessDenied / bad endpoint / bad bucket still abort), `list()` returns `''` for it, and `emptyBootDiagGuidance()` prints the two known causes: the boot runner never ran (check serial console for `::<slug>::` markers and "BOOT FAILED"), or uploads are denied because the boot principal predates the IAM v2 model (Scaleway does not honor bucket-policy-only grants). Every boot uploads a transcript, success or failure ([boot.ts](infra/boot/src/boot.ts) `finally`), so an empty prefix is a finding, not an error.
- **`selectDiagnostics` picks the actual transcript.** The sibling `<svc>-<stamp>-events.jsonl` sorts after `<svc>-<stamp>-boot.log`, so `.at(-1)` returned raw OTLP records instead of the readable transcript. `latestFull` is now pinned to `-boot.log` keys.
- **`renderDiagnostics` prints a single "nothing was ever uploaded" line** when a service owns zero objects, instead of misleading per-section noise.
- `diag.ts` threads `appConfig.slug` into the guidance and prints it when `parseKeys` yields nothing (except under `--replay`).

## Delta from the raak original

raak's guidance pointed at the infra CLI "Migrate IAM model" flow, which no longer exists: the IAM migration machinery was deleted in #1024 (IAM v2 only). The guidance (and its test) now points at the "Stack setup" apply, which is what provisions the current boot principal (`ObjectStorageObjectsWrite` via `BOOT_PROJECT_PERMISSION_SETS`).

Not adopted: raak's `cella/migrations/manifest.json` roots tweak for `20260730T0858-frontend-module-placements`. That migration precedes `20260730T1258-cella-config-into-cella-folder` in replay order, so `cella.config.ts` is still at the repo root at that point in the sequence; the existing value is correct.

## Verification

- `pnpm --filter infra exec vitest run`: 78 files, 665 passed (includes new coverage for `isEmptyPrefixLs`, empty-prefix listing, boot.log-over-events selection, and the single no-diagnostics line)
- `pnpm check`: clean
- Not sync-breaking, no migration needed; behavior-only improvement to a diagnostic tool. raak converges on its next `pnpm cella sync`. projectcampus's copies are byte-identical to current main, so it inherits conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)