### PR TITLE
chore(lint): clear comment-style backlog and make the style pass blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Run Biome
         run: pnpm biome check .
 
-      - name: Run prose style checks
+      - name: Run style checks (terminology / docs / comments)
         run: pnpm prose:check
 
       - name: Run lens checks (append-only / collision / purity / wire completeness)

--- a/backend/src/modules/memberships/memberships-mocks.ts
+++ b/backend/src/modules/memberships/memberships-mocks.ts
@@ -37,7 +37,7 @@ const rootChannelType = hierarchy.channelTypes.find(
 /**
  * Membership location columns for wire/response mocks: all contexts start null, ancestors get
  * invented UUIDs, and the target column is always identical to the denormalized `channelId`.
- * Never use for rows that are inserted into the database — invented ancestor IDs violate FKs.
+ * Never use for rows that are inserted into the database: invented ancestor IDs violate FKs.
  */
 const generateMockMembershipChannelIdColumns = (
   channelType: ChannelEntityType,

--- a/cella/skills/two-tab-sync-test/two-tab-driver.mjs
+++ b/cella/skills/two-tab-sync-test/two-tab-driver.mjs
@@ -1,7 +1,5 @@
-// Two-tab realtime sync diagnosis for cella attachments. See SKILL.md for auth setup.
-// Drives two signed-in tabs (shared session, real tab-coordinator semantics) and runs:
-//   1. rename control  2. create  3. delete-fresh  4. delete-preseeded  5. reload verify
-// Captures per-tab console, seqCursor network bodies, SSE connections, screenshots.
+// Two-tab realtime sync diagnosis for cella attachments. See SKILL.md for auth setup and the experiment matrix.
+// Drives two signed-in tabs (shared session, real tab-coordinator semantics); captures per-tab console, seqCursor network bodies, SSE connections, screenshots.
 // Usage: ORG_PATH=<tenantId>/<orgSlug> SESSION_COOKIE=<value> [OUT_DIR=...] node two-tab-driver.mjs
 import { globSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
@@ -151,7 +149,7 @@ try {
   writeFileSync(pdfPath, `%PDF-1.1\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]>>endobj\ntrailer<</Size 4/Root 1 0 R>>\n%%EOF\n`);
   let createOk = false;
   try {
-    // NOT /upload/i — that also matches the org page-header "Upload cover" button
+    // NOT /upload/i: that also matches the org page-header "Upload cover" button
     await tabA.getByRole('button', { name: 'Upload', exact: true }).click();
     const dlg = tabA.getByRole('dialog').filter({ has: tabA.locator('.uppy-Dashboard') });
     await dlg.waitFor({ timeout: 10_000 });
@@ -195,7 +193,7 @@ try {
     log('tabA', 'exp4-error', { message: String(err).slice(0, 300) });
   }
 
-  // ── Experiment 5: reload observer tab — server-state truth ────────────────
+  // ── Experiment 5: reload observer tab, server-state truth ─────────────────
   {
     await tabB.reload({ waitUntil: 'domcontentloaded' });
     await tabB.locator('.rdg-row').first().waitFor({ timeout: 30_000 });

--- a/frontend/src/query/realtime/views.test.ts
+++ b/frontend/src/query/realtime/views.test.ts
@@ -101,11 +101,11 @@ describe('deriveGrantBoundaryViews', () => {
 
   it('a role listed in elevatedRoles keeps its unconditional grant subtree (engine parity)', () => {
     // Config-independent form: passing `undefined` here would NOT exercise the
-    // "no elevatedRoles configured" branch — JS default parameters substitute
+    // "no elevatedRoles configured" branch, because JS default parameters substitute
     // the app-config default on any undefined, so that branch is reachable
     // only when the running app's config has no elevatedRoles. Asserting via
     // an explicit list containing the granted role tests the same subtree
-    // semantics against the function's contract instead of ambient config.
+    // semantics against the function's contract, independent of ambient config.
     const studentRead = (ct: ChannelType, role: string): PolicyCellInput =>
       ct === 'course' && role === 'student' ? 1 : 0;
     expect(derive([membership('course', 'c1', 'student')], studentRead, ['student'])).toEqual([

--- a/infra/lib/runtime-secrets.ts
+++ b/infra/lib/runtime-secrets.ts
@@ -63,9 +63,9 @@ export function defineRuntimeSecrets<const T extends Record<string, RuntimeSecre
  * `runtime-secrets.config.ts` entries. Store-owned declarations come first,
  * in store-registry order: database secrets historically led the app config,
  * and the per-consumer union order is genId-fingerprinted, so the merge
- * position is deliberate. Extracted (rather than inlined on the module-level
- * registry) so a non-postgres registry — external `databaseUrl`, `none` — is
- * testable without swapping the app config.
+ * position is deliberate. Kept as a standalone function so a non-postgres
+ * registry (external `databaseUrl`, `none`) is testable without swapping
+ * the app config.
  */
 export function buildRuntimeSecrets(
   stores: Record<string, Pick<StoreProvisioner, 'secrets'>>,

--- a/infra/lib/scaleway/iam-client.ts
+++ b/infra/lib/scaleway/iam-client.ts
@@ -3,20 +3,18 @@ import { resolveFetch } from '../utils/fetch-like';
 import { scwFetch, scwSend } from './scw-fetch';
 
 /**
- * The shared IAM read/key client: app resolution, policy/rule collection, and
- * api-key CRUD, deduplicated from assert-vm-grants, mint-generation-keys, and
- * the CLI's drift check (IAM backlog item 5/8). Bootstrap provisioning flows
- * (scaleway-iam.ts) keep their own interwoven helpers on purpose — their
- * error handling and pagination needs differ per ritual step.
- *
- * Every function takes the same auth shape scwFetch does ({secretKey,
- * fetchImpl?}), so callers that inject a fetch for tests and callers that
- * mock the scw-fetch module both keep working.
+ * Shared IAM read/key client (app resolution, policy/rule collection, api-key CRUD)
+ * used by assert-vm-grants, mint-generation-keys, and the CLI's drift check. Bootstrap
+ * provisioning (scaleway-iam.ts) keeps its own helpers: its error handling and pagination needs differ per ritual step.
  */
 
 export const IAM_BASE = 'https://api.scaleway.com/iam/v1alpha1';
 const ACCOUNT_BASE = 'https://api.scaleway.com/account/v3';
 
+/**
+ * Auth shape every function here shares with scwFetch, so callers that inject a
+ * fetch for tests and callers that mock the scw-fetch module both keep working.
+ */
 export interface IamAuth {
   secretKey: string;
   fetchImpl?: FetchLike;
@@ -155,7 +153,7 @@ export async function fetchAppRulesByName(opts: {
   return fetchGrantedRules(auth, organizationId, applicationId);
 }
 
-/** All api keys on an application (one page of 100 — the fleet keeps ≤2 per app). */
+/** All api keys on an application (one page of 100; the fleet keeps ≤2 per app). */
 export async function listApiKeys(auth: IamAuth, organizationId: string, applicationId: string): Promise<ScwApiKey[]> {
   const { api_keys = [] } = await scwFetch<{ api_keys?: ScwApiKey[] }>(
     auth,

--- a/infra/lib/scaleway/permissions.ts
+++ b/infra/lib/scaleway/permissions.ts
@@ -105,7 +105,7 @@ export const BOOT_PROJECT_PERMISSION_SETS = ['ContainerRegistryReadOnly', 'Objec
  * The CI key-mint grant (D3): IAMApplicationManager, unconditioned. The
  * former `resource.id in [<app ids>]` condition is disproven on live
  * Scaleway (probe 2026-08-10: api-key POST on a LISTED app id → 403; the
- * api-key request carries no `resource.id` for the condition to match) —
+ * api-key request carries no `resource.id` for the condition to match).
  * raak's live rule has run unconditioned since its migration and its repo
  * condition was live/repo drift, not validation. Documented widening: CI can
  * manage applications/api-keys org-wide; the remaining firewall is the
@@ -120,7 +120,7 @@ export const CI_KEY_MINT_PERMISSION_SETS = ['IAMApplicationManager'] as const;
  * by the rule builder (setup-ci-key.ts) and the advisory drift check
  * (setup.ts warnOnCiPolicyDrift) so the two cannot diverge. Every CI rule is
  * UNCONDITIONED by design (the key-mint resource.id condition is disproven on
- * live Scaleway — see CI_KEY_MINT_PERMISSION_SETS); a condition appearing on
+ * live Scaleway, see CI_KEY_MINT_PERMISSION_SETS); a condition appearing on
  * any CI rule is drift worth surfacing.
  */
 export interface CiRuleShape {

--- a/infra/lib/scaleway/scaleway-iam.ts
+++ b/infra/lib/scaleway/scaleway-iam.ts
@@ -216,7 +216,7 @@ export async function provisionScopedKey(
 
   // 3. Mint the fresh API key FIRST (Scaleway reveals each secret only at
   //    creation), THEN purge the older keys. The old purge-then-mint order
-  //    left the principal keyless when the mint failed — for the CI app that
+  //    left the principal keyless when the mint failed; for the CI app that
   //    wedges every deploy until a manual rotate.
   const apiKey = await scwFetch<ScwApiKey>({ secretKey: callerSecretKey }, 'POST', `${IAM_BASE}/api-keys`, {
     application_id: app.id,

--- a/infra/lib/scaleway/secret-paths.ts
+++ b/infra/lib/scaleway/secret-paths.ts
@@ -51,7 +51,7 @@ export function handoffFolderPath(slug: string, mode: string): string {
  * compares the live rule condition against this exact builder output, so
  * producer and checker must share it. No `!has(resource.id)` escape:
  * hydration GETs by id only, so list actions may (and should) stay denied.
- * Pass the full secret scope (lib/services.ts secretScopeSlugs) — for the
+ * Pass the full secret scope (lib/services.ts secretScopeSlugs); for the
  * singleVM host that includes the folded co-hosted/collocated services, whose
  * secrets hydrate on the host VM.
  */

--- a/infra/lib/services.ts
+++ b/infra/lib/services.ts
@@ -91,7 +91,7 @@ export function collocatedServices(
 
 /**
  * Service slugs whose secret folders a service's VMs must be able to read: the
- * service itself, plus — for the singleVM host — every co-hosted worker and
+ * service itself, plus (for the singleVM host) every co-hosted worker and
  * collocated container folded onto it. Their runtime secrets union onto the
  * host VM (resources/generations.ts secretConsumersFor), so the host's
  * secret-path grant must union identically or hydration 403s on the folded
@@ -117,7 +117,7 @@ export function secretScopeSlugs(
  * service that signs S3 requests (`s3Access`); browser CORS on the upload
  * buckets exists only when both do. Engine-owned buckets (Pulumi state,
  * boot-diag) are unconditional and not represented here. A registry with no
- * default route and no s3Access service provisions NO app buckets — the
+ * default route and no s3Access service provisions NO app buckets: the
  * frontend-less consumer scenario.
  */
 export function appStorageNeeds(definitions: readonly ServiceDefinition[]): {

--- a/infra/lib/status/check.ts
+++ b/infra/lib/status/check.ts
@@ -44,7 +44,7 @@ export interface CheckBuilder {
 }
 
 /** One verdict closure per status, so each check branch is a single call
- *  instead of a repeated object literal. */
+ *  without repeating the object literal. */
 export function check(id: string, title: string, credential: CredentialTier = 'none'): CheckBuilder {
   const verdict =
     (status: CheckStatus): Verdict =>

--- a/infra/lib/status/registry.test.ts
+++ b/infra/lib/status/registry.test.ts
@@ -8,9 +8,8 @@ import type { Check, ProbeSession, ScalewayFacts } from './types';
 
 /**
  * Port of the pre-registry evaluate.test.ts: the same assertions, driven by
- * per-provider facts instead of the retired StatusInputs bag. `reportFor`
- * evaluates every registered provider against the given facts, exactly what
- * buildStatusReport does after its gather phase.
+ * per-provider facts. `reportFor` evaluates every registered provider against
+ * the given facts, exactly what buildStatusReport does after its gather phase.
  */
 
 interface Facts {

--- a/infra/lib/status/registry.ts
+++ b/infra/lib/status/registry.ts
@@ -12,7 +12,7 @@ import { STATUS_SCHEMA_VERSION } from './types';
 /**
  * The registered status providers, in report order. Each owns its domain's
  * gather + evaluate; the engine here owns the envelope, the summary, and the
- * cross-domain next-action priority — knowledge no single provider can hold.
+ * cross-domain next-action priority, knowledge no single provider can hold.
  */
 // biome-ignore lint/suspicious/noExplicitAny: heterogeneous provider fact types collapse at the registry boundary
 export const statusProviders: readonly StatusProvider<any>[] = [

--- a/infra/lib/status/types.ts
+++ b/infra/lib/status/types.ts
@@ -106,7 +106,7 @@ export interface ProbeSession {
 
 /**
  * One status domain: `gather` does best-effort I/O (undefined = could not
- * probe), `evaluate` turns facts into checks and never throws — a
+ * probe), `evaluate` turns facts into checks and never throws, so a
  * partially-credentialed run still produces a complete report. Providers are
  * registered in `registry.ts`; registry order is report order.
  */

--- a/infra/resources/stores/catalog.ts
+++ b/infra/resources/stores/catalog.ts
@@ -1,9 +1,7 @@
 /**
- * The store-plugin catalog: every provisioner factory an app's
- * `config/stores.config.ts` can register, re-exported from one
- * side-effect-free module. Import factories from HERE, never from
- * `./index` — importing the index provisions the registered stores, which
- * must only happen inside the Pulumi program.
+ * The store-plugin catalog: every provisioner factory an app's `config/stores.config.ts`
+ * can register, re-exported from one side-effect-free module. Import factories from HERE,
+ * never from `./index`: importing the index provisions the registered stores, which must only happen inside the Pulumi program.
  */
 export { databaseUrl } from './database-url';
 export { externalUrl, mongoUrl, redisUrl } from './external-url';

--- a/infra/resources/stores/postgres-managed.ts
+++ b/infra/resources/stores/postgres-managed.ts
@@ -230,7 +230,7 @@ export function postgresManaged(config: PostgresManagedConfig = {}): StoreProvis
       // effective grants are owned by the role/RLS migrations from then on
       // (their REVOKEs make Scaleway read the privilege back as 'custom').
       // ignoreChanges keeps a refreshed state from arming an enforcement of
-      // 'all' that would clobber migration-owned grants — and that CI cannot
+      // 'all' that would clobber migration-owned grants, and that CI cannot
       // execute anyway (RelationalDatabasesReadOnly), which would fail the
       // deploy (seen live 2026-08-10 after the IAM v2 reconcile refresh).
 

--- a/infra/resources/vm-iam.ts
+++ b/infra/resources/vm-iam.ts
@@ -30,7 +30,7 @@ function findApplicationId(name: string): pulumi.Output<string | undefined> {
         // Only a genuine not-found means "absent" (optional statements drop,
         // required principals fail with guidance). A transient IAM outage must
         // not silently demote a required principal to "not found" or drop
-        // admin statements — rethrow anything else.
+        // admin statements: rethrow anything else.
         const message = error instanceof Error ? error.message : String(error);
         if (/not.?found|404|does not exist/i.test(message)) return undefined;
         throw error;

--- a/infra/tasks/deploy-run.test.ts
+++ b/infra/tasks/deploy-run.test.ts
@@ -126,7 +126,7 @@ describe('runDeploy sequencing', () => {
       expect(index, `${op} missing or out of order in: ${ops.join(', ')}`).toBeGreaterThan(cursor);
       cursor = index;
     }
-    // Public version verification covers every LB-exposed service — including
+    // Public version verification covers every LB-exposed service, including
     // the co-hosted follower (yjs), which is absent from the rollout matrices.
     expect(ops.some((op) => op.startsWith('verify:') && op.endsWith('/health'))).toBe(true);
     expect(ops).toContain('verify:https://www.cellajs.com/yjs/health');

--- a/infra/tasks/deploy-run.ts
+++ b/infra/tasks/deploy-run.ts
@@ -325,7 +325,7 @@ export async function runDeploy(
           ? ['--primary', (JSON.parse(env.primary_rollout_matrix) as RolloutRow[])[0]!.service]
           : []),
         // A provided-but-unreadable --dist is a hard failure in smoke, so a
-        // frontend-less registry omits it instead of pointing at nothing.
+        // frontend-less registry omits the flag entirely.
         ...(env.frontend_bucket ? ['--dist', resolve(distDir, 'index.html')] : []),
       ]),
     );

--- a/infra/tasks/frontend-assets.ts
+++ b/infra/tasks/frontend-assets.ts
@@ -39,7 +39,7 @@ export function contentTypeFor(key: string): string {
 
 /**
  * Content-hashed, immutable paths: existence of the key proves the content
- * matches. Only /assets/ qualifies — /static/ keys keep stable names with
+ * matches. Only /assets/ qualifies; /static/ keys keep stable names with
  * changing content (docs.gen JSON, openapi.json, flags), so existence proves
  * nothing there.
  */
@@ -77,7 +77,7 @@ export interface UploadAssetsOptions {
  * paths get a 1-year immutable cache and skip upload when the key already
  * exists (content-addressed names make that check exact). Stable-named keys
  * (static/, favicon, robots.txt) change content under the same name, so they
- * get a short cache and skip only when the remote ETag matches the local MD5 —
+ * get a short cache and skip only when the remote ETag matches the local MD5;
  * unchanged deploys stay nearly free either way.
  */
 export async function uploadFrontendAssets(opts: UploadAssetsOptions): Promise<{ uploaded: number; skipped: number }> {

--- a/infra/tasks/mint-generation-keys.test.ts
+++ b/infra/tasks/mint-generation-keys.test.ts
@@ -110,8 +110,8 @@ describe('mintGenerationKeys', () => {
     failStagingFor = 'handoff-frontend';
     await expect(mintGenerationKeys(options(join(outDir, 'fail.json')))).rejects.toThrow(/staging failed/);
     expect(ops.some((op) => op.startsWith('delete:ak-'))).toBe(false);
-    // The first service's bundle was staged before the failure — that is fine;
-    // what must not happen is key pruning.
+    // The first service's bundle was staged before the failure, and that is
+    // fine; what must not happen is key pruning.
     expect(ops.filter((op) => op.startsWith('stage:'))).toHaveLength(1);
   });
 });

--- a/infra/tasks/mint-generation-keys.ts
+++ b/infra/tasks/mint-generation-keys.ts
@@ -53,7 +53,7 @@ async function resolveAppId(auth: IamAuth, organizationId: string, name: string)
 }
 
 /** Mint a fresh key on the app. Pruning happens separately, AFTER every
- *  handoff bundle is staged — see pruneStaleKeys. */
+ *  handoff bundle is staged; see pruneStaleKeys. */
 async function mintKey(
   auth: IamAuth,
   projectId: string,
@@ -120,7 +120,7 @@ export async function mintGenerationKeys(opts: MintGenerationKeysOptions): Promi
   }
 
   // Transactional-ish ordering: mint and stage EVERYTHING first, prune keys
-  // LAST. A failure mid-staging then aborts with all existing keys intact —
+  // LAST. A failure mid-staging then aborts with all existing keys intact:
   // the old generation keeps hydrating/signing, and a retry re-mints cleanly.
   // (The keep-newest-2 window can still age out the live key after repeated
   // failed attempts within one deploy; bounded, documented, accepted.)

--- a/infra/tasks/print-deploy-env.ts
+++ b/infra/tasks/print-deploy-env.ts
@@ -124,7 +124,7 @@ export function buildDeployEnv(appConfig: Cfg, opts: { imageTag?: string } = {})
       },
       // The CI app asserts its own grant too: exact set union (missing sets
       // fail deploys later and non-read-only extras are an escalation).
-      // condition '' skips the secret-condition check — CI rules are
+      // condition '' skips the secret-condition check; CI rules are
       // unconditioned by design (see CI_RULE_SHAPES).
       {
         app: principalNames(appConfig.slug, appConfig.mode).ciDeploy,

--- a/infra/tasks/setup-ci-key.ts
+++ b/infra/tasks/setup-ci-key.ts
@@ -39,7 +39,7 @@ export async function setupCiKey(opts: SetupCiKeyOptions): Promise<CiKeyResult> 
     policyDescription: 'Least-privilege policy for CI deployments (auto-generated)',
     // One rule per CI_RULE_SHAPES entry (separate rules per scope type:
     // Scaleway rejects mixing scopes in one rule). The key-mint rule is
-    // unconditioned — the resource.id condition 403s real api-key mints on
+    // unconditioned: the resource.id condition 403s real api-key mints on
     // live Scaleway (disproven 2026-08-10; see CI_KEY_MINT_PERMISSION_SETS).
     buildRules: ({ projectId, organizationId }) =>
       CI_RULE_SHAPES.filter(

--- a/infra/tasks/smoke.ts
+++ b/infra/tasks/smoke.ts
@@ -118,7 +118,7 @@ export function createFetchGet(timeoutMs: number): HttpGet {
 
 export interface SmokeOptions {
   /** Public URL of the default-route (browser) service; absent for a
-   *  frontend-less registry — the SPA/security-header checks then skip. */
+   *  frontend-less registry, where the SPA/security-header checks then skip. */
   defaultRouteUrl?: string;
   /** Public URL of the primary-rollout service (the API that serves the
    *  aggregate /health?depth=full and /openapi.json). */

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "docs:style:audit": "node shared/scripts/check-doc-style.ts --audit",
     "frontend:style": "node shared/scripts/check-frontend-style.ts",
     "style": "node shared/scripts/check-style.ts",
-    "prose:check": "pnpm docs:style && pnpm comments:language",
+    "prose:check": "pnpm style",
     "prose:audit": "pnpm docs:style:audit && pnpm comments:audit",
     "lint": "pnpm biome check . && pnpm style",
     "lint:fix": "pnpm biome check --write --unsafe && pnpm style",

--- a/shared/config/config.default.ts
+++ b/shared/config/config.default.ts
@@ -1,4 +1,4 @@
-import type { ConfigMode, RequiredConfig, S3ConfigInput } from '../src/config-builder/types.ts';
+import type { ConfigMode, ProductEmbedding, RequiredConfig, S3ConfigInput } from '../src/config-builder/types.ts';
 import { nonEmpty } from '../src/config-builder/utils.ts';
 import { hierarchy } from './hierarchy-config.ts';
 
@@ -39,12 +39,7 @@ export const config = {
    * `lifecycle: 'owned'` additionally lets CDC garbage-collect embedded rows that no live
    * host references; the default 'shared' only strips references to dead rows.
    */
-  productEmbeddings: [] as readonly {
-    readonly embeddedProduct: (typeof hierarchy.productTypes)[number];
-    readonly hostProduct: (typeof hierarchy.productTypes)[number];
-    readonly hostColumn: string;
-    readonly lifecycle?: 'shared' | 'owned';
-  }[],
+  productEmbeddings: [] as readonly ProductEmbedding<(typeof hierarchy.productTypes)[number]>[],
 
   /**
    * User menu structure of channel entities with optional nested subentities.

--- a/shared/config/config.template.ts
+++ b/shared/config/config.template.ts
@@ -1,4 +1,4 @@
-import type { ConfigMode, RequiredConfig, S3ConfigInput } from '../src/config-builder/types.ts';
+import type { ConfigMode, ProductEmbedding, RequiredConfig, S3ConfigInput } from '../src/config-builder/types.ts';
 import { nonEmpty } from '../src/config-builder/utils.ts';
 import { hierarchy } from './hierarchy-config.ts';
 
@@ -39,12 +39,7 @@ export const config = {
    * `lifecycle: 'owned'` additionally lets CDC garbage-collect embedded rows that no live
    * host references; the default 'shared' only strips references to dead rows.
    */
-  productEmbeddings: [] as readonly {
-    readonly embeddedProduct: (typeof hierarchy.productTypes)[number];
-    readonly hostProduct: (typeof hierarchy.productTypes)[number];
-    readonly hostColumn: string;
-    readonly lifecycle?: 'shared' | 'owned';
-  }[],
+  productEmbeddings: [] as readonly ProductEmbedding<(typeof hierarchy.productTypes)[number]>[],
 
   /**
    * User menu structure of channel entities with optional nested subentities.

--- a/shared/scripts/README.md
+++ b/shared/scripts/README.md
@@ -2,7 +2,7 @@
 
 ## check-doc-style.ts
 
-CI guard for concrete terminology in authored Markdown and MDX. Run via `pnpm docs:style`; exits 1 with file and line diagnostics when prose should name a more precise rule, constraint, guarantee, requirement, contract, precondition, or assumption. `pnpm prose:check` combines this with the equivalent source-comment rule and is the CI entry point.
+CI guard for concrete terminology in authored Markdown and MDX. Run via `pnpm docs:style`; exits 1 with file and line diagnostics when prose should name a more precise rule, constraint, guarantee, requirement, contract, precondition, or assumption. `pnpm prose:check` runs `pnpm style` (terminology + documentation + all comment rules including placement), which is the blocking entry point for both CI and `pnpm check`.
 
 `pnpm vocabulary:check` rejects source-control-oriented template terminology in paths and tracked
 text. The Cella CLI configuration and migration compatibility instructions are explicit exceptions.

--- a/shared/scripts/check-app-vocabulary.ts
+++ b/shared/scripts/check-app-vocabulary.ts
@@ -16,7 +16,9 @@ const allowedFiles = new Set([
   'shared/scripts/check-app-vocabulary.test.ts',
   'shared/scripts/check-app-vocabulary.ts',
 ]);
-const allowedPrefixes = ['cella/migrations/20260729T0922-app-product-mocks/'];
+// Migration READMEs and the manifest address app maintainers pulling template
+// changes, an audience the CLI's source-control term describes precisely.
+const allowedPrefixes = ['cella/migrations/'];
 
 export interface AppVocabularyFinding {
   file: string;

--- a/shared/scripts/check-style.ts
+++ b/shared/scripts/check-style.ts
@@ -1,7 +1,7 @@
 /**
- * Runs the terminology, documentation, and comment checks as a single non-blocking pass.
+ * Runs the terminology, documentation, and comment checks as a single blocking pass.
  * Clean sub-checks collapse into one `[style]` line; findings print their detail.
- * Always exits 0 so findings surface as warnings during `pnpm check` without breaking the build.
+ * Exits non-zero on any finding: `pnpm check`, `pnpm lint`, and CI's style step all run this same pass, so they cannot diverge.
  */
 import { spawnSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
@@ -34,9 +34,6 @@ const flagged = subChecks.filter((check) => {
 if (flagged.length === 0) {
   console.log('[style] OK, terminology, documentation, and comments follow the required style.');
 } else {
-  console.warn(
-    `[style] ${flagged.length} area(s) reported warnings (${flagged
-      .map((check) => check.label)
-      .join(', ')}); not blocking the build.`,
-  );
+  console.error(`[style] ${flagged.length} area(s) failed (${flagged.map((check) => check.label).join(', ')}).`);
+  process.exit(1);
 }

--- a/shared/src/config-builder/types.ts
+++ b/shared/src/config-builder/types.ts
@@ -103,6 +103,18 @@ export interface CompanyConfig {
   coordinates: { lat: number; lng: number };
 }
 
+/**
+ * A product entity embedded as an ID array inside a host product entity.
+ * `lifecycle: 'owned'` lets CDC garbage-collect embedded rows no live host
+ * references; the default 'shared' only strips references to dead rows.
+ */
+export interface ProductEmbedding<P extends string = string> {
+  readonly embeddedProduct: P;
+  readonly hostProduct: P;
+  readonly hostColumn: string;
+  readonly lifecycle?: 'shared' | 'owned';
+}
+
 export interface MenuStructureItem<C extends string = string> {
   entityType: C;
   subentityType: C | null;
@@ -142,18 +154,7 @@ export interface RequiredConfig<T extends ConfigStringArrays = ConfigStringArray
   entityIdColumnKeys: { readonly [K in T['entityTypes'][number] & string]: `${K}Id` };
   entityActions: T['entityActions'];
   resourceTypes: T['resourceTypes'];
-  productEmbeddings: readonly {
-    readonly embeddedProduct: T['productEntityTypes'][number] & string;
-    readonly hostProduct: T['productEntityTypes'][number] & string;
-    readonly hostColumn: string;
-    /**
-     * 'shared' (default): embedded rows live independently; host arrays hold
-     * best-effort references that CDC strips when the embedded row dies.
-     * 'owned': the union of host arrays is the row's reason to exist; CDC
-     * additionally garbage-collects embedded rows no live host references.
-     */
-    readonly lifecycle?: 'shared' | 'owned';
-  }[];
+  productEmbeddings: readonly ProductEmbedding<T['productEntityTypes'][number] & string>[];
   menuStructure: readonly MenuStructureItem<T['channelEntityTypes'][number] & string>[];
   defaultRestrictions: {
     quotas: Record<string, number>;


### PR DESCRIPTION
## Why

The comment rules (em-dash, contrast-history, placement) only ran in the local `pnpm style` pass, which always exited 0, while CI's `prose:check` ran just the `concrete-language` rule. CI stayed green on PRs that added violations, and 36 accumulated across six PRs in four days (#1022, #1032, #1036, #1039, #1045, #1046).

## What

- **Fix the backlog to zero**: 28 em-dash and 4 contrast-history comment rewrites, plus the 4 detached long comments (condensed to ≤3 prose lines or attached to their declaration). No behavior changes; comments only.
- **Exempt `cella/migrations/` from the app-vocabulary check**: migration READMEs and the manifest address app maintainers pulling template changes, so the CLI's source-control term is the precise one there. Replaces the single-directory allowlist entry.
- **Make the style pass blocking**: `check-style.ts` now exits non-zero on any finding, and `prose:check` (the CI entry point) runs `pnpm style`, so `pnpm check`, `pnpm lint`, and CI enforce the identical rule set (terminology + docs + all comment rules + placement) and cannot diverge again.
- **Bundled**: extract a shared `ProductEmbedding` type for `productEmbeddings` (deduplicates the inline type across `config.default.ts`, `config.template.ts`, and `RequiredConfig`), committed separately.

## Verification

- `pnpm check` passes end-to-end with the blocking gate (sdk, ts all packages, lens:check, biome, style).
- `pnpm --filter shared test`: 249 tests pass.
- The new gate immediately caught a 4-line detached header introduced while editing `check-style.ts` itself, confirming it blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)