### PR TITLE
fix(auth): create OAuth client auth lazily so empty secrets don't crash module load

### DIFF
--- a/backend/src/modules/auth/oauth/helpers/providers.ts
+++ b/backend/src/modules/auth/oauth/helpers/providers.ts
@@ -58,7 +58,6 @@ const createProviderClient = ({
   resolveIssuerFromIdToken,
 }: ProviderSetup) => {
   const client: oauth.Client = { client_id: clientId };
-  const clientAuth = oauth.ClientSecretPost(clientSecret);
 
   return {
     /** Builds the provider authorization URL with state, scopes, and an optional PKCE challenge + OIDC nonce. */
@@ -92,6 +91,9 @@ const createProviderClient = ({
       { codeVerifier, nonce }: OAuthFlowContext = {},
     ): Promise<{ accessToken: string }> {
       try {
+        // Created lazily: ClientSecretPost rejects empty secrets, and they may legitimately be
+        // absent at module load (CI openapi generation, deployments without this provider)
+        const clientAuth = oauth.ClientSecretPost(clientSecret);
         const callbackParams = oauth.validateAuthResponse(as, client, new URLSearchParams({ code, state }), state);
         const response = await oauth.authorizationCodeGrantRequest(
           as,


### PR DESCRIPTION
## Why

The release-please PR (#1044) fails CI at the "Generate OpenAPI spec" step: `TypeError: "clientSecret" must not be empty`. Regression from #1052 — `oauth4webapi`'s `ClientSecretPost` validates eagerly (arctic's constructors accepted empty strings), and `providers.ts` called it at module load. Any context without OAuth secrets crashes on import: CI openapi generation, and any fork/deployment booting without all three providers configured.

## What

Move the `ClientSecretPost` call inside `validateAuthorizationCode`. A missing secret now fails only that provider's code exchange (mapped to `oauth_failed`), which matches pre-migration behavior. No other behavior change.

## Test plan

- [x] Reproduced CI's failure locally: `generate:openapi` with empty `*_CLIENT_SECRET` env fails on main's code, passes with this fix
- [x] backend type-check + oauth sign-in tests (18) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
