### PR TITLE
feat(auth): carry post-auth deep-link redirect through magic link, OAuth and MFA

### DIFF
--- a/backend/drizzle/20260814104034_cuddly_wendell_rand/migration.sql
+++ b/backend/drizzle/20260814104034_cuddly_wendell_rand/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "tokens" ADD COLUMN "redirect_path" varchar(255);

--- a/backend/drizzle/20260814104034_cuddly_wendell_rand/snapshot.json
+++ b/backend/drizzle/20260814104034_cuddly_wendell_rand/snapshot.json
@@ -1,0 +1,5548 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "04bf86ce-a572-4dbb-8c7a-91431554595f",
+  "prevIds": [
+    "c709e2de-bff2-40ea-9e73-614e1d278a9d"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "activities",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "attachments",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "oauth_accounts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "passkeys",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "rate_limits",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "sessions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "tokens",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "totps",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "domains",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "channel_counters",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "product_counters",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "inactive_memberships",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "memberships",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "organizations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "requests",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "seen_by",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "system_roles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "tenants",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "emails",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "unsubscribe_tokens",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_counters",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "yjs_documents",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tenant_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "entity_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resource_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "action",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "table_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "subject_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "changed_fields",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stx",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'attachment'",
+      "generated": null,
+      "identity": null,
+      "name": "entity_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tenant_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'New attachment'",
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stx",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "varchar(1000000)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "varchar(1000000)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "keywords",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "seq",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "public_bucket",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bucket_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "group_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "filename",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "converted_content_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "size",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "keys",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "verified",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "verified_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "credential_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "counter",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'desktop'",
+      "generated": null,
+      "identity": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_os",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "browser",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name_on_device",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "rate_limits"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "points",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "rate_limits"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expire",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "rate_limits"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "secret",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'regular'",
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'desktop'",
+      "generated": null,
+      "identity": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_os",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "browser",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "auth_strategy",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_subnet_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar(2)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_country",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_asn",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "device_id_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "secret",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "single_use_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "oauth_account_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "inactive_membership_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "redirect_path",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "invoked_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "totps"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "totps"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "secret",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "totps"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "totps"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "domains"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tenant_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "domains"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "domain",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "domains"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "verified",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "domains"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "verification_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "domains"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "verified_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "domains"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_checked_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "domains"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "domains"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "channel_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "channel_counters"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "counts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "channel_counters"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "path",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "channel_counters"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "channel_counters"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "product_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "product_counters"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "product_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "product_counters"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "view_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "product_counters"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_viewed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "product_counters"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tenant_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "channel_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "channel_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rejected_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reminded_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tenant_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "channel_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "channel_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "archived",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "muted",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "display_order",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'organization'",
+      "generated": null,
+      "identity": null,
+      "name": "entity_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tenant_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "thumbnail_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "public_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": {
+        "as": "\"id\"::text",
+        "type": "stored"
+      },
+      "identity": null,
+      "name": "path",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "short_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "country",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "timezone",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'en'",
+      "generated": null,
+      "identity": null,
+      "name": "default_language",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "json",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'[\"en\"]'",
+      "generated": null,
+      "identity": null,
+      "name": "languages",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "notification_email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "color",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logo_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "website_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(1000000)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "welcome_text",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "chat_support",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "organization_flags",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "setup_config",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "tools_config",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "requests"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "requests"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "message",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "requests"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "requests"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "requests"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "requests"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "seen_by"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "seen_by"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "product_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "seen_by"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "product_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "seen_by"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "channel_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "seen_by"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "seen_by"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tenant_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "seen_by"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "seen_by"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "system_roles"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "system_roles"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "system_roles"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "system_roles"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "system_roles"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'active'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "type": "json",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{\"quotas\":{\"user\":1000,\"organization\":1,\"attachment\":100},\"rateLimits\":{\"apiPointsPerHour\":1000}}'",
+      "generated": null,
+      "identity": null,
+      "name": "restrictions",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "type": "json",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'[]'",
+      "generated": null,
+      "identity": null,
+      "name": "auth_strategies",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "subscription_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'none'",
+      "generated": null,
+      "identity": null,
+      "name": "subscription_status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "subscription_plan",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "type": "json",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "subscription_data",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "emails"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "emails"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "emails"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "verified",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "emails"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "emails"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "emails"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "verified_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "emails"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "unsubscribe_tokens"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "unsubscribe_tokens"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "secret",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "unsubscribe_tokens"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "unsubscribe_tokens"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_counters"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_seen_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_counters"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_started_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_counters"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_sign_in_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_counters"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'user'",
+      "generated": null,
+      "identity": null,
+      "name": "entity_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "thumbnail_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "mfa_required",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "first_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar(255)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'en'",
+      "generated": null,
+      "identity": null,
+      "name": "language",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "newsletter",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "user_flags",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "entity_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "yjs_documents"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "entity_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "yjs_documents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tenant_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "yjs_documents"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "yjs_documents"
+    },
+    {
+      "type": "bytea",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "state",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "yjs_documents"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_edited_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "yjs_documents"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "yjs_documents"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "activities_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "activities_org_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "entity_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "activities_entity_type_subject_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "attachments_organization_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "seq",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "attachments_organization_id_seq_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "tenant_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "attachments_tenant_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "created_by",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "attachments_created_by_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "updated_by",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "attachments_updated_by_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "group_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "attachments_group_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "oauth_accounts_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "passkeys_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "credential_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "passkeys_credential_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "secret",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_secret_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "ip_hash",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_user_id_ip_hash_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "ip_subnet_hash",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_ip_subnet_hash_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "device_id_hash",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_user_id_device_id_hash_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "secret",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "tokens_secret_type_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "tokens_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "created_by",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "tokens_created_by_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "single_use_token",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "tokens_single_use_token_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "totps_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "totps"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "tenant_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "domains_tenant_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "domains"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "domain",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "domains_domain_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "domains"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "inactive_memberships_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "created_by",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "inactive_memberships_created_by_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "tenant_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "inactive_memberships_tenant_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "inactive_memberships_email_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "rejected_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "inactive_memberships_org_pending_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "memberships_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "created_by",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "memberships_created_by_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "updated_by",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "memberships_updated_by_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "tenant_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "memberships_tenant_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "channel_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "role",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "memberships_channel_org_role_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "tenant_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "memberships_org_user_tenant_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organizations_name_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organizations_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "created_by",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organizations_created_by_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "updated_by",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organizations_updated_by_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "requests_emails",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "requests"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "requests_created_at",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "requests"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "lower(\"email\")",
+          "isExpression": true,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"type\" in ('waitlist', 'newsletter')",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "requests_unique_signup_email_type",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "requests"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "product_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "seen_by_user_product_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "seen_by"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "channel_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "product_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "seen_by_user_channel_type_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "seen_by"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "product_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "seen_by_product_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "seen_by"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "tenant_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "seen_by_tenant_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "seen_by"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "tenants_status_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "tenants_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "created_by",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "tenants_created_by_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "subscription_status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "tenants_subscription_status_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "emails_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "emails"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "secret",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "unsubscribe_tokens_secret_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "unsubscribe_tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "unsubscribe_tokens_user_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "unsubscribe_tokens"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "users_name_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "users_email_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "users_created_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "tenant_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "idx_yjs_docs_tenant",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "yjs_documents"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "idx_yjs_docs_org",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "yjs_documents"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "tenant_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "tenants",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "attachments_tenant_id_tenants_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "created_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "attachments_created_by_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "updated_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "attachments_updated_by_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "deleted_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "attachments_deleted_by_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "tenant_id",
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "tenant_id",
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "attachments_Ytb3N4m0pWsH_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "oauth_accounts_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "passkeys_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "passkeys"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "sessions_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "tokens_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "oauth_account_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "oauth_accounts",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "tokens_oauth_account_id_oauth_accounts_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "created_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "tokens_created_by_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "totps_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "totps"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "tenant_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "tenants",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "domains_tenant_id_tenants_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "domains"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "tenant_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "tenants",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "inactive_memberships_tenant_id_tenants_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "inactive_memberships_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "created_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "inactive_memberships_created_by_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "tenant_id",
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "tenant_id",
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "inactive_memberships_gmmCA2ACknk4_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "tenant_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "tenants",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "memberships_tenant_id_tenants_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "memberships_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "created_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "memberships_created_by_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "updated_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "memberships_updated_by_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "tenant_id",
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "tenant_id",
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "memberships_Yta3VHtyCTj4_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "tenant_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "tenants",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "organizations_tenant_id_tenants_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "created_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "organizations_created_by_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "updated_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "organizations_updated_by_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "seen_by_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "seen_by"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "system_roles_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "system_roles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "created_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "tenants_created_by_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "tenants"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "emails_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "emails"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "unsubscribe_tokens_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "unsubscribe_tokens"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "updated_by"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "users_updated_by_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "tenant_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "tenants",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "yjs_documents_tenant_id_tenants_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "yjs_documents"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "tenant_id",
+        "organization_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "tenant_id",
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "yjs_documents_HY8MgE0sbYNM_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "yjs_documents"
+    },
+    {
+      "columns": [
+        "id",
+        "created_at"
+      ],
+      "nameExplicit": false,
+      "name": "activities_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "activities"
+    },
+    {
+      "columns": [
+        "id",
+        "expires_at"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "id",
+        "expires_at"
+      ],
+      "nameExplicit": false,
+      "name": "tokens_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "tokens"
+    },
+    {
+      "columns": [
+        "id",
+        "created_at"
+      ],
+      "nameExplicit": false,
+      "name": "seen_by_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "seen_by"
+    },
+    {
+      "columns": [
+        "id",
+        "created_at"
+      ],
+      "nameExplicit": false,
+      "name": "unsubscribe_tokens_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "unsubscribe_tokens"
+    },
+    {
+      "columns": [
+        "entity_type",
+        "entity_id"
+      ],
+      "nameExplicit": false,
+      "name": "yjs_documents_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "yjs_documents"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "attachments_pkey",
+      "schema": "public",
+      "table": "attachments",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "oauth_accounts_pkey",
+      "schema": "public",
+      "table": "oauth_accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "passkeys_pkey",
+      "schema": "public",
+      "table": "passkeys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "key"
+      ],
+      "nameExplicit": false,
+      "name": "rate_limits_pkey",
+      "schema": "public",
+      "table": "rate_limits",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "totps_pkey",
+      "schema": "public",
+      "table": "totps",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "domains_pkey",
+      "schema": "public",
+      "table": "domains",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "channel_key"
+      ],
+      "nameExplicit": false,
+      "name": "channel_counters_pkey",
+      "schema": "public",
+      "table": "channel_counters",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "product_id"
+      ],
+      "nameExplicit": false,
+      "name": "product_counters_pkey",
+      "schema": "public",
+      "table": "product_counters",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "inactive_memberships_pkey",
+      "schema": "public",
+      "table": "inactive_memberships",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "memberships_pkey",
+      "schema": "public",
+      "table": "memberships",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organizations_pkey",
+      "schema": "public",
+      "table": "organizations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "requests_pkey",
+      "schema": "public",
+      "table": "requests",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "system_roles_pkey",
+      "schema": "public",
+      "table": "system_roles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "tenants_pkey",
+      "schema": "public",
+      "table": "tenants",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "emails_pkey",
+      "schema": "public",
+      "table": "emails",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "user_id"
+      ],
+      "nameExplicit": false,
+      "name": "user_counters_pkey",
+      "schema": "public",
+      "table": "user_counters",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "provider",
+        "provider_user_id",
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "oauth_accounts_provider_provider_user_id_email_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "tenant_id",
+        "email",
+        "channel_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "inactive_memberships_tenant_email_ctx",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "inactive_memberships"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "tenant_id",
+        "user_id",
+        "channel_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "memberships_unique_channel",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "memberships"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "tenant_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organizations_tenant_id_key",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "tenant_id",
+        "id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organizations_tenant_id_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "organizations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "domain"
+      ],
+      "nullsNotDistinct": false,
+      "name": "domains_domain_key",
+      "schema": "public",
+      "table": "domains",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organizations_slug_key",
+      "schema": "public",
+      "table": "organizations",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "system_roles_user_id_key",
+      "schema": "public",
+      "table": "system_roles",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "emails_email_key",
+      "schema": "public",
+      "table": "emails",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_slug_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_email_key",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "public"
+      ],
+      "using": "\n    \n  COALESCE(current_setting('app.tenant_id', true), '') != ''\n  AND \"attachments\".\"tenant_id\" = current_setting('app.tenant_id', true)::text\n\n    AND (\"attachments\".\"deleted_at\" IS NULL OR current_setting('app.include_deleted', true) = 'true')\n  ",
+      "withCheck": null,
+      "name": "attachments_select_policy",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "public"
+      ],
+      "using": null,
+      "withCheck": "true",
+      "name": "attachments_insert_policy",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "public"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "attachments_update_policy",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "public"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "attachments_delete_policy",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "attachments"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "SELECT",
+      "roles": [
+        "public"
+      ],
+      "using": "\n    \n  COALESCE(current_setting('app.tenant_id', true), '') != ''\n  AND \"yjs_documents\".\"tenant_id\" = current_setting('app.tenant_id', true)::text\n\n    \n  ",
+      "withCheck": null,
+      "name": "yjs_documents_select_policy",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "yjs_documents"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "INSERT",
+      "roles": [
+        "public"
+      ],
+      "using": null,
+      "withCheck": "true",
+      "name": "yjs_documents_insert_policy",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "yjs_documents"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "UPDATE",
+      "roles": [
+        "public"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "yjs_documents_update_policy",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "yjs_documents"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "DELETE",
+      "roles": [
+        "public"
+      ],
+      "using": "true",
+      "withCheck": null,
+      "name": "yjs_documents_delete_policy",
+      "entityType": "policies",
+      "schema": "public",
+      "table": "yjs_documents"
+    }
+  ],
+  "renames": []
+}

--- a/backend/src/modules/auth/general/general-handlers.ts
+++ b/backend/src/modules/auth/general/general-handlers.ts
@@ -88,12 +88,9 @@ app.openapi(authGeneralRoutes.invokeToken, async (ctx) => {
     // If oauth verification, we redirect to oauth /verify route to complete verification though oauth provider
     if (tokenRecord.type === 'oauth-verification') return handleOAuthVerification(ctx, tokenRecord);
 
-    // Determine redirect URL based on token type
-    let redirectUrl = appConfig.defaultRedirectPath;
-
-    // If invitation, redirect to auth page with tokenId param
-    if (tokenRecord.type === 'invitation')
-      redirectUrl = `${appConfig.frontendUrl}/auth/authenticate?tokenId=${tokenRecord.id}`;
+    // Only invitation remains (the param schema is limited to invokable types): redirect to auth
+    // page with tokenId param
+    const redirectUrl = `${appConfig.frontendUrl}/auth/authenticate?tokenId=${tokenRecord.id}`;
 
     log.info('Token invoked, redirecting with single use token in cookie', {
       tokenId: tokenRecord.id,

--- a/backend/src/modules/auth/general/general-routes.ts
+++ b/backend/src/modules/auth/general/general-routes.ts
@@ -5,7 +5,7 @@ import { authGuard, publicGuard, sysAdminGuard } from '#/middlewares/guard';
 import { isNoBot } from '#/middlewares/is-no-bot';
 import { emailEnumLimiter, spamLimiter, tokenLimiter } from '#/middlewares/rate-limiter/limiters';
 import { mockTokenDataResponse } from '#/modules/auth/auth-mocks';
-import { emailBodySchema, tokenWithDataSchema } from '#/modules/auth/general/general-schema';
+import { emailBodySchema, invokableTokenTypes, tokenWithDataSchema } from '#/modules/auth/general/general-schema';
 import { cookieSchema, emailOrTokenIdQuerySchema, errorResponseRefs, locationSchema, validIdSchema } from '#/schemas';
 
 const authGeneralRoutes = {
@@ -114,7 +114,7 @@ const authGeneralRoutes = {
     description:
       'Validates and invokes a token (for email verification, invitations, mfa) and redirects user to backend with a one-purpose, single-use token session in a cookie.',
     request: {
-      params: z.object({ type: z.enum(appConfig.tokenTypes), token: z.string() }),
+      params: z.object({ type: z.enum(invokableTokenTypes), token: z.string() }),
     },
     responses: {
       302: {

--- a/backend/src/modules/auth/general/general-routes.ts
+++ b/backend/src/modules/auth/general/general-routes.ts
@@ -1,5 +1,4 @@
 import { z } from '@hono/zod-openapi';
-import { appConfig } from 'shared';
 import { createXRoute } from '#/core/x-routes';
 import { authGuard, publicGuard, sysAdminGuard } from '#/middlewares/guard';
 import { isNoBot } from '#/middlewares/is-no-bot';
@@ -139,7 +138,7 @@ const authGeneralRoutes = {
     description:
       'Get basic token data from single-use token session, It returns basic data if the session is still valid.',
     request: {
-      params: z.object({ type: z.enum(appConfig.tokenTypes), id: validIdSchema }),
+      params: z.object({ type: z.enum(invokableTokenTypes), id: validIdSchema }),
     },
     responses: {
       200: {

--- a/backend/src/modules/auth/general/general-schema.ts
+++ b/backend/src/modules/auth/general/general-schema.ts
@@ -1,5 +1,17 @@
 import { z } from '@hono/zod-openapi';
+import type { TokenType } from 'shared';
 import { validEmailSchema } from '#/schemas';
+
+/**
+ * Token types that can be invoked via a link. `confirm-mfa` is excluded: it lives only in a
+ * cookie during an MFA challenge and invoking it would clobber that cookie.
+ */
+export const invokableTokenTypes = [
+  'email-verification',
+  'oauth-verification',
+  'invitation',
+  'magic',
+] as const satisfies readonly TokenType[];
 
 export const emailBodySchema = z.object({
   email: validEmailSchema,

--- a/backend/src/modules/auth/general/helpers/finish-sign-in.ts
+++ b/backend/src/modules/auth/general/helpers/finish-sign-in.ts
@@ -1,0 +1,31 @@
+import type { Context } from 'hono';
+import { appConfig } from 'shared';
+import type { Env } from '#/core/context';
+import { initiateMfa } from '#/modules/auth/general/helpers/mfa';
+import { resolvePostAuthRedirectPath } from '#/modules/auth/general/helpers/redirect-path';
+import { setUserSession } from '#/modules/auth/general/helpers/session';
+import type { AuthStrategy } from '#/modules/auth/sessions-db';
+import type { UserWithCounters } from '#/modules/user/helpers/select';
+
+/**
+ * Shared tail of every browser-navigated sign-in flow (magic link, email verification, verified
+ * OAuth): start an MFA challenge when required, otherwise set the session, then 302 to the
+ * resolved post-auth path. The redirect is carried into the MFA challenge so it survives it.
+ */
+export const finishSignIn = async (
+  ctx: Context<Env>,
+  user: UserWithCounters,
+  strategy: AuthStrategy,
+  redirectPath?: string | null,
+) => {
+  // Start MFA challenge if the user has MFA enabled
+  const mfaRedirectPath = await initiateMfa(ctx, user);
+
+  const resolvedPath = resolvePostAuthRedirectPath(user, { redirectPath, mfaPath: mfaRedirectPath });
+  const redirectUrl = new URL(resolvedPath, appConfig.frontendUrl);
+
+  // If MFA is not required, set user session immediately
+  if (!mfaRedirectPath) await setUserSession(ctx, user, strategy);
+
+  return ctx.redirect(redirectUrl, 302);
+};

--- a/backend/src/modules/auth/general/helpers/handle-email-verification.ts
+++ b/backend/src/modules/auth/general/helpers/handle-email-verification.ts
@@ -1,12 +1,9 @@
 import { and, eq } from 'drizzle-orm';
 import type { Context } from 'hono';
-import { appConfig } from 'shared';
 import type { Env } from '#/core/context';
 import { AppError } from '#/core/error';
 import { baseDb as db } from '#/db/db';
-import { initiateMfa } from '#/modules/auth/general/helpers/mfa';
-import { getPostAuthRedirectPath } from '#/modules/auth/general/helpers/redirect-path';
-import { setUserSession } from '#/modules/auth/general/helpers/session';
+import { finishSignIn } from '#/modules/auth/general/helpers/finish-sign-in';
 import type { TokenModel } from '#/modules/auth/tokens-db';
 import { emailsTable } from '#/modules/user/emails-db';
 import { userSelect } from '#/modules/user/helpers/select';
@@ -34,14 +31,5 @@ export const handleEmailVerification = async (ctx: Context<Env>, token: TokenMod
       ),
     );
 
-  // Start MFA challenge if the user has MFA enabled
-  const mfaRedirectPath = await initiateMfa(ctx, user);
-
-  const redirectPath = mfaRedirectPath || getPostAuthRedirectPath(user);
-  const redirectUrl = new URL(redirectPath, appConfig.frontendUrl);
-
-  // If MFA is not required, set user session immediately
-  if (!mfaRedirectPath) await setUserSession(ctx, user, 'email');
-
-  return ctx.redirect(redirectUrl, 302);
+  return finishSignIn(ctx, user, 'email', token.redirectPath);
 };

--- a/backend/src/modules/auth/general/helpers/handle-magic.ts
+++ b/backend/src/modules/auth/general/helpers/handle-magic.ts
@@ -1,12 +1,9 @@
 import { and, eq } from 'drizzle-orm';
 import type { Context } from 'hono';
-import { appConfig } from 'shared';
 import type { Env } from '#/core/context';
 import { AppError } from '#/core/error';
 import { baseDb as db } from '#/db/db';
-import { initiateMfa } from '#/modules/auth/general/helpers/mfa';
-import { resolvePostAuthRedirectPath } from '#/modules/auth/general/helpers/redirect-path';
-import { setUserSession } from '#/modules/auth/general/helpers/session';
+import { finishSignIn } from '#/modules/auth/general/helpers/finish-sign-in';
 import type { TokenModel } from '#/modules/auth/tokens-db';
 import { emailsTable } from '#/modules/user/emails-db';
 import { userSelect } from '#/modules/user/helpers/select';
@@ -29,17 +26,5 @@ export const handleMagicLink = async (ctx: Context<Env>, token: TokenModel) => {
       .where(and(eq(emailsTable.email, token.email), eq(emailsTable.userId, user.id)));
   }
 
-  // Start MFA challenge if the user has MFA enabled
-  const mfaRedirectPath = await initiateMfa(ctx, user);
-
-  const redirectPath = resolvePostAuthRedirectPath(user, {
-    redirectPath: token.redirectPath,
-    mfaPath: mfaRedirectPath,
-  });
-  const redirectUrl = new URL(redirectPath, appConfig.frontendUrl);
-
-  // If MFA is not required, set user session immediately
-  if (!mfaRedirectPath) await setUserSession(ctx, user, 'magic');
-
-  return ctx.redirect(redirectUrl, 302);
+  return finishSignIn(ctx, user, 'magic', token.redirectPath);
 };

--- a/backend/src/modules/auth/general/helpers/handle-magic.ts
+++ b/backend/src/modules/auth/general/helpers/handle-magic.ts
@@ -5,7 +5,7 @@ import type { Env } from '#/core/context';
 import { AppError } from '#/core/error';
 import { baseDb as db } from '#/db/db';
 import { initiateMfa } from '#/modules/auth/general/helpers/mfa';
-import { getPostAuthRedirectPath } from '#/modules/auth/general/helpers/redirect-path';
+import { resolvePostAuthRedirectPath } from '#/modules/auth/general/helpers/redirect-path';
 import { setUserSession } from '#/modules/auth/general/helpers/session';
 import type { TokenModel } from '#/modules/auth/tokens-db';
 import { emailsTable } from '#/modules/user/emails-db';
@@ -32,7 +32,10 @@ export const handleMagicLink = async (ctx: Context<Env>, token: TokenModel) => {
   // Start MFA challenge if the user has MFA enabled
   const mfaRedirectPath = await initiateMfa(ctx, user);
 
-  const redirectPath = mfaRedirectPath || getPostAuthRedirectPath(user);
+  const redirectPath = resolvePostAuthRedirectPath(user, {
+    redirectPath: token.redirectPath,
+    mfaPath: mfaRedirectPath,
+  });
   const redirectUrl = new URL(redirectPath, appConfig.frontendUrl);
 
   // If MFA is not required, set user session immediately

--- a/backend/src/modules/auth/general/helpers/redirect-path.ts
+++ b/backend/src/modules/auth/general/helpers/redirect-path.ts
@@ -1,4 +1,5 @@
 import { appConfig } from 'shared';
+import { isValidRedirectPath } from '#/utils/is-redirect-url';
 
 /**
  * Returns the appropriate redirect path after authentication.
@@ -6,4 +7,34 @@ import { appConfig } from 'shared';
  */
 export const getPostAuthRedirectPath = (user: { lastSignInAt: string | null }) => {
   return user.lastSignInAt ? appConfig.defaultRedirectPath : appConfig.welcomeRedirectPath;
+};
+
+/**
+ * Resolves the final post-auth redirect path for all sign-in strategies.
+ * Order: MFA challenge (carrying the redirect along) → validated explicit redirect → welcome/default.
+ *
+ * An explicit redirect wins over the welcome page. Untrusted input is re-validated here so callers
+ * can pass stored token values or cookie payloads directly.
+ */
+export const resolvePostAuthRedirectPath = (
+  user: { lastSignInAt: string | null },
+  { redirectPath, mfaPath }: { redirectPath?: string | null; mfaPath?: string | null } = {},
+) => {
+  const explicitRedirect = isValidRedirectPath(redirectPath);
+
+  // MFA interrupts the flow; hand the redirect to the MFA page so it survives the challenge.
+  if (mfaPath) {
+    return explicitRedirect ? `${mfaPath}?redirect=${encodeURIComponent(explicitRedirect)}` : mfaPath;
+  }
+
+  if (!explicitRedirect) return getPostAuthRedirectPath(user);
+
+  // A deep link targeting home would still be bounced to welcome by the frontend onboarding
+  // guard; mark it to skip that since the redirect was explicit.
+  const resolved = new URL(explicitRedirect, appConfig.frontendUrl);
+  if (resolved.pathname === appConfig.defaultRedirectPath) {
+    resolved.searchParams.set('skipWelcome', 'true');
+  }
+
+  return `${resolved.pathname}${resolved.search}${resolved.hash}`;
 };

--- a/backend/src/modules/auth/magic/magic-handlers.ts
+++ b/backend/src/modules/auth/magic/magic-handlers.ts
@@ -12,6 +12,7 @@ import { tokensTable } from '#/modules/auth/tokens-db';
 import { findUserByEmail } from '#/modules/user/user-queries';
 import { defaultHook } from '#/utils/default-hook';
 import { hashToken } from '#/utils/hash-token';
+import { isValidRedirectPath } from '#/utils/is-redirect-url';
 import { log } from '#/utils/logger';
 import { slugFromEmail } from '#/utils/slug-from-email';
 import { createDate, TimeSpan } from '#/utils/time-span';
@@ -20,8 +21,11 @@ import { magicLinkEmail } from '../../../../emails';
 const app = new OpenAPIHono<Env>({ defaultHook });
 
 app.openapi(authMagicLinkRoutes.sendMagicLink, async (ctx) => {
-  const { email } = ctx.req.valid('json');
+  const { email, redirect } = ctx.req.valid('json');
   const strategy = 'magic';
+
+  // Validated here and re-validated at invoke; invalid input degrades to the default path.
+  const redirectPath = isValidRedirectPath(redirect) || null;
 
   // Check strategy enabled
   if (!appConfig.enabledAuthStrategies.includes(strategy)) {
@@ -71,6 +75,7 @@ app.openapi(authMagicLinkRoutes.sendMagicLink, async (ctx) => {
       userId: user.id,
       email: normalizedEmail,
       createdBy: user.id,
+      redirectPath,
       expiresAt: createDate(new TimeSpan(15, 'm')),
     })
     .returning();

--- a/backend/src/modules/auth/magic/magic-schema.ts
+++ b/backend/src/modules/auth/magic/magic-schema.ts
@@ -3,4 +3,6 @@ import { validEmailSchema } from '#/schemas';
 
 export const magicLinkBodySchema = z.object({
   email: validEmailSchema,
+  /** Relative path to land on after the link signs the user in. Validated server-side. */
+  redirect: z.string().optional(),
 });

--- a/backend/src/modules/auth/oauth/helpers/callback.ts
+++ b/backend/src/modules/auth/oauth/helpers/callback.ts
@@ -4,9 +4,7 @@ import { appConfig, type EnabledOAuthProvider } from 'shared';
 import type { Env } from '#/core/context';
 import { AppError, type ErrorKey } from '#/core/error';
 import { type DbOrTx, baseDb as db } from '#/db/db';
-import { initiateMfa } from '#/modules/auth/general/helpers/mfa';
-import { resolvePostAuthRedirectPath } from '#/modules/auth/general/helpers/redirect-path';
-import { setUserSession } from '#/modules/auth/general/helpers/session';
+import { finishSignIn } from '#/modules/auth/general/helpers/finish-sign-in';
 import { handleCreateUser } from '#/modules/auth/general/helpers/user';
 import type { Provider } from '#/modules/auth/oauth/helpers/providers';
 import { sendOAuthVerificationEmail } from '#/modules/auth/oauth/helpers/send-oauth-verification-email';
@@ -319,20 +317,7 @@ const processOAuthAccount = async (info: OAuthFlowResult & { ctx: Context<Env>; 
   const redirectAfterPath = isValidRedirectPath(redirectAfter) || null;
 
   if (type === 'verified') {
-    // Start MFA challenge if the user has MFA enabled
-    const mfaRedirectPath = await initiateMfa(ctx, info.user);
-
-    const redirectPath = resolvePostAuthRedirectPath(info.user, {
-      redirectPath: redirectAfter,
-      mfaPath: mfaRedirectPath,
-    });
-    const redirectUrl = new URL(redirectPath, appConfig.frontendUrl);
-
-    // If MFA is not required, set session immediately
-    if (!mfaRedirectPath) await setUserSession(ctx, info.user, oauthAccount.provider);
-
-    // Redirect to determined URL
-    return ctx.redirect(redirectUrl, 302);
+    return finishSignIn(ctx, info.user, oauthAccount.provider, redirectAfter);
   }
   // For unverified accounts, send an OAuth verification email. Awaited so the verification token is
   // persisted before we redirect the user to the "check your email" page.

--- a/backend/src/modules/auth/oauth/helpers/callback.ts
+++ b/backend/src/modules/auth/oauth/helpers/callback.ts
@@ -5,7 +5,7 @@ import type { Env } from '#/core/context';
 import { AppError, type ErrorKey } from '#/core/error';
 import { type DbOrTx, baseDb as db } from '#/db/db';
 import { initiateMfa } from '#/modules/auth/general/helpers/mfa';
-import { getPostAuthRedirectPath } from '#/modules/auth/general/helpers/redirect-path';
+import { resolvePostAuthRedirectPath } from '#/modules/auth/general/helpers/redirect-path';
 import { setUserSession } from '#/modules/auth/general/helpers/session';
 import { handleCreateUser } from '#/modules/auth/general/helpers/user';
 import type { Provider } from '#/modules/auth/oauth/helpers/providers';
@@ -315,13 +315,17 @@ const createOAuthAccount = async (
  */
 const processOAuthAccount = async (info: OAuthFlowResult & { ctx: Context<Env>; redirectAfter?: string }) => {
   const { ctx, type, oauthAccount, redirectAfter } = info;
-  const redirectAfterPath = isValidRedirectPath(redirectAfter) || appConfig.defaultRedirectPath;
+  // Stored on the verification token; null means "use the default path" at the final hop.
+  const redirectAfterPath = isValidRedirectPath(redirectAfter) || null;
 
   if (type === 'verified') {
     // Start MFA challenge if the user has MFA enabled
     const mfaRedirectPath = await initiateMfa(ctx, info.user);
 
-    const redirectPath = mfaRedirectPath || getPostAuthRedirectPath(info.user);
+    const redirectPath = resolvePostAuthRedirectPath(info.user, {
+      redirectPath: redirectAfter,
+      mfaPath: mfaRedirectPath,
+    });
     const redirectUrl = new URL(redirectPath, appConfig.frontendUrl);
 
     // If MFA is not required, set session immediately

--- a/backend/src/modules/auth/oauth/helpers/handle-oauth-verification.ts
+++ b/backend/src/modules/auth/oauth/helpers/handle-oauth-verification.ts
@@ -25,8 +25,6 @@ export const handleOAuthVerification = async (ctx: Context<Env>, token: TokenMod
   verificationURL.searchParams.set('tokenId', token.id);
   verificationURL.searchParams.set('type', 'verify');
 
-  const reqRedirect = ctx.req.query('redirectAfter');
-  if (reqRedirect) verificationURL.searchParams.set('redirectAfter', reqRedirect);
-
+  // The post-auth redirect stays on the token row; the verify initiation reads it from there.
   return ctx.redirect(verificationURL, 302);
 };

--- a/backend/src/modules/auth/oauth/helpers/initiation.ts
+++ b/backend/src/modules/auth/oauth/helpers/initiation.ts
@@ -66,16 +66,10 @@ export const handleOAuthInitiation = async (
   }
 
   if (type === 'verify') {
+    // Fails early on a missing/expired verification token; the callback re-validates. The
+    // post-auth redirect travels on the token row, not as a query param.
     const tokenRecord = await getValidSingleUseToken({ ctx, tokenType: 'oauth-verification' });
-    if (tokenRecord && redirectAfter) {
-      try {
-        const redirectUrl = new URL(redirectAfter, appConfig.frontendUrl);
-        if (redirectUrl.pathname.includes('home')) {
-          redirectUrl.searchParams.set('skipWelcome', 'true');
-          cookieContent.redirectAfter = redirectUrl.pathname + redirectUrl.search + redirectUrl.hash;
-        }
-      } catch (_) {} // fallback if redirectAfter is not a valid URL
-    }
+    cookieContent.redirectAfter = tokenRecord.redirectPath ?? undefined;
   }
 
   const stringifiedContent = JSON.stringify(cookieContent);

--- a/backend/src/modules/auth/oauth/helpers/send-oauth-verification-email.ts
+++ b/backend/src/modules/auth/oauth/helpers/send-oauth-verification-email.ts
@@ -18,7 +18,7 @@ import { oauthVerificationEmail } from '../../../../../emails';
 interface Props {
   userId: string;
   oauthAccountId: string;
-  redirectPath?: string;
+  redirectPath?: string | null;
 }
 
 /**
@@ -62,6 +62,8 @@ export const sendOAuthVerificationEmail = async ({ userId, oauthAccountId, redir
       email,
       createdBy: user.id,
       ...(oauthAccountId && { oauthAccountId: oauthAccountId }),
+      // Kept on the token row (not the emailed URL) so the deep link doesn't leak into email bodies
+      redirectPath: redirectPath || null,
       expiresAt: createDate(new TimeSpan(2, 'h')),
     })
     .returning();
@@ -80,8 +82,6 @@ export const sendOAuthVerificationEmail = async ({ userId, oauthAccountId, redir
   // Create verification link. Concatenate onto backendAuthUrl (which already ends in /auth) so the
   // /api base path is preserved; new URL(absolutePath, backendUrl) would drop it.
   const verificationURL = new URL(`${appConfig.backendAuthUrl}/invoke-token/${tokenRecord.type}/${newToken}`);
-
-  if (redirectPath) verificationURL.searchParams.set('redirectAfter', redirectPath);
 
   // Prepare & send email
   const staticProps = {

--- a/backend/src/modules/auth/tokens-db.ts
+++ b/backend/src/modules/auth/tokens-db.ts
@@ -25,6 +25,7 @@ export const tokensTable = snakeCase.table(
     userId: uuid().references(() => usersTable.id, { onDelete: 'cascade' }),
     oauthAccountId: uuid().references(() => oauthAccountsTable.id, { onDelete: 'cascade' }),
     inactiveMembershipId: uuid(),
+    redirectPath: varchar({ length: maxLength.field }),
     createdBy: uuid().references(() => usersTable.id, { onDelete: 'cascade' }),
     createdAt: timestampColumns.createdAt,
     expiresAt: timestampColumns.expiresAt,

--- a/backend/src/utils/is-redirect-url.ts
+++ b/backend/src/utils/is-redirect-url.ts
@@ -1,12 +1,14 @@
 import { appConfig } from 'shared';
+import { maxLength } from '#/db/utils/constraints';
 
 /**
  * Returns a normalized same-origin redirect path or false.
  * It rejects absolute/scheme-relative URLs, authority tricks, encoded bypasses, control
- * characters, and backend routes so callers never replay untrusted input.
+ * characters, and backend routes so callers never replay untrusted input. Length is capped
+ * at the standard field size so validated paths always fit stored token columns.
  */
 export function isValidRedirectPath(path: unknown): string | false {
-  if (typeof path !== 'string' || path.length === 0) return false;
+  if (typeof path !== 'string' || path.length === 0 || path.length > maxLength.field) return false;
 
   // Decode once so encoded bypasses (e.g. `%2F%2Fhost`) are evaluated as the
   // characters they actually represent.
@@ -39,6 +41,8 @@ export function isValidRedirectPath(path: unknown): string | false {
   // Never redirect into backend-only routes.
   if (resolved.pathname.startsWith('/api/')) return false;
 
-  // Return the normalized relative path only.
-  return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+  // Return the normalized relative path only. Normalization can re-encode (lengthen) the
+  // input, so re-check the cap on the result.
+  const normalized = `${resolved.pathname}${resolved.search}${resolved.hash}`;
+  return normalized.length > maxLength.field ? false : normalized;
 }

--- a/backend/tests/sign-in/magic.test.ts
+++ b/backend/tests/sign-in/magic.test.ts
@@ -1,0 +1,187 @@
+import { and, eq } from 'drizzle-orm';
+import { invokeToken, sendMagicLink } from 'sdk';
+import { appConfig } from 'shared';
+import { nanoid } from 'shared/utils/nanoid';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { baseDb as db } from '#/db/db';
+import { tokensTable } from '#/modules/auth/tokens-db';
+import { userCountersTable } from '#/modules/user/user-counters-db';
+import { hashToken } from '#/utils/hash-token';
+import { defaultHeaders, signUpUser } from '../fixtures';
+import { createUser, enableMFAForUser } from '../helpers';
+import { createAppClient } from '../test-client';
+import { clearDatabase, mockFetchRequest, setTestConfig } from '../test-utils';
+
+vi.mock('#/lib/mailer', () => ({
+  mailer: { prepareEmails: vi.fn().mockResolvedValue(undefined) },
+}));
+
+setTestConfig({ enabledAuthStrategies: ['magic'], selfRegistration: true });
+
+beforeAll(async () => {
+  mockFetchRequest();
+});
+
+afterEach(async () => {
+  await clearDatabase();
+  vi.clearAllMocks();
+});
+
+/** Mark a user as returning; without a counters row `lastSignInAt` resolves to null (new user). */
+async function markReturning(userId: string) {
+  await db.insert(userCountersTable).values({ userId, lastSignInAt: new Date().toISOString() });
+}
+
+/** Insert a magic token directly and return the raw secret for the invoke URL. */
+async function createMagicToken(user: { id: string; email: string }, redirectPath: string | null = null) {
+  const rawToken = nanoid(40);
+  await db.insert(tokensTable).values({
+    secret: hashToken(rawToken),
+    type: 'magic',
+    userId: user.id,
+    email: user.email,
+    createdBy: user.id,
+    redirectPath,
+    expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+  });
+  return rawToken;
+}
+
+/** Fetch the single magic token row for a user. */
+async function getMagicToken(userId: string) {
+  const [token] = await db
+    .select()
+    .from(tokensTable)
+    .where(and(eq(tokensTable.userId, userId), eq(tokensTable.type, 'magic')));
+  return token;
+}
+
+describe('Magic link authentication', async () => {
+  const call = await createAppClient();
+
+  describe('Send magic link', () => {
+    it('should store a validated redirect path on the token', async () => {
+      const user = await createUser(signUpUser.email);
+
+      const { response: res } = await call(sendMagicLink, {
+        body: { email: signUpUser.email, redirect: '/orgs/acme?tab=files#top' },
+        headers: defaultHeaders,
+      });
+
+      expect(res.status).toBe(204);
+      expect((await getMagicToken(user.id)).redirectPath).toBe('/orgs/acme?tab=files#top');
+    });
+
+    it.each([
+      { name: 'absolute URL', redirect: 'https://evil.example/phish' },
+      { name: 'scheme-relative URL', redirect: '//evil.example' },
+      { name: 'backslash authority trick', redirect: '/\\evil.example' },
+      { name: 'backend route', redirect: '/api/me' },
+      { name: 'overlong path', redirect: `/${'a'.repeat(300)}` },
+    ])('should drop an invalid redirect ($name)', async ({ redirect }) => {
+      const user = await createUser(signUpUser.email);
+
+      const { response: res } = await call(sendMagicLink, {
+        body: { email: signUpUser.email, redirect },
+        headers: defaultHeaders,
+      });
+
+      expect(res.status).toBe(204);
+      expect((await getMagicToken(user.id)).redirectPath).toBeNull();
+    });
+  });
+
+  describe('Invoke magic link', () => {
+    it('should redirect a returning user to the stored path', async () => {
+      const user = await createUser(signUpUser.email);
+      await markReturning(user.id);
+      const rawToken = await createMagicToken(user, '/orgs/acme?tab=files');
+
+      const { response: res } = await call(invokeToken, {
+        path: { type: 'magic', token: rawToken },
+        headers: defaultHeaders,
+      });
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe(`${appConfig.frontendUrl}/orgs/acme?tab=files`);
+    });
+
+    it('should let an explicit redirect win over the welcome page for a new user', async () => {
+      const user = await createUser(signUpUser.email);
+      const rawToken = await createMagicToken(user, '/orgs/acme');
+
+      const { response: res } = await call(invokeToken, {
+        path: { type: 'magic', token: rawToken },
+        headers: defaultHeaders,
+      });
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe(`${appConfig.frontendUrl}/orgs/acme`);
+    });
+
+    it('should append skipWelcome when the explicit redirect targets home', async () => {
+      const user = await createUser(signUpUser.email);
+      const rawToken = await createMagicToken(user, `${appConfig.defaultRedirectPath}?foo=bar`);
+
+      const { response: res } = await call(invokeToken, {
+        path: { type: 'magic', token: rawToken },
+        headers: defaultHeaders,
+      });
+
+      expect(res.status).toBe(302);
+      const location = new URL(res.headers.get('location') ?? '');
+      expect(location.pathname).toBe(appConfig.defaultRedirectPath);
+      expect(location.searchParams.get('foo')).toBe('bar');
+      expect(location.searchParams.get('skipWelcome')).toBe('true');
+    });
+
+    it('should fall back to welcome for a new user without a redirect', async () => {
+      const user = await createUser(signUpUser.email);
+      const rawToken = await createMagicToken(user);
+
+      const { response: res } = await call(invokeToken, {
+        path: { type: 'magic', token: rawToken },
+        headers: defaultHeaders,
+      });
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe(`${appConfig.frontendUrl}${appConfig.welcomeRedirectPath}`);
+    });
+
+    it('should never redirect to a stored path that fails re-validation', async () => {
+      // Defense in depth: a row written before validation rules tightened must not replay.
+      const user = await createUser(signUpUser.email);
+      const rawToken = await createMagicToken(user, 'https://evil.example/phish');
+
+      const { response: res } = await call(invokeToken, {
+        path: { type: 'magic', token: rawToken },
+        headers: defaultHeaders,
+      });
+
+      expect(res.status).toBe(302);
+      const location = res.headers.get('location');
+      expect(location).not.toContain('evil.example');
+      expect(location?.startsWith(appConfig.frontendUrl)).toBe(true);
+    });
+
+    it('should hand the redirect to the MFA page for an MFA user', async () => {
+      const user = await createUser(signUpUser.email);
+      await enableMFAForUser(user.id);
+      const rawToken = await createMagicToken(user, '/orgs/acme');
+
+      const { response: res } = await call(invokeToken, {
+        path: { type: 'magic', token: rawToken },
+        headers: defaultHeaders,
+      });
+
+      expect(res.status).toBe(302);
+      const location = new URL(res.headers.get('location') ?? '');
+      expect(location.pathname).toBe('/auth/mfa');
+      expect(location.searchParams.get('redirect')).toBe('/orgs/acme');
+      // Session must not be set before the MFA challenge completes
+      expect(res.headers.get('set-cookie') ?? '').not.toContain(
+        `${appConfig.slug}-session-${appConfig.cookieVersion}=`,
+      );
+    });
+  });
+});

--- a/backend/tests/sign-in/magic.test.ts
+++ b/backend/tests/sign-in/magic.test.ts
@@ -184,4 +184,15 @@ describe('Magic link authentication', async () => {
       );
     });
   });
+
+  describe('Invoke token type restriction', () => {
+    it('should reject invoking a confirm-mfa token', async () => {
+      // confirm-mfa lives only in a cookie; the invoke route's param schema excludes it. Raw
+      // request because the generated SDK already rejects the type client-side.
+      const { baseApp } = await import('#/routes');
+      const res = await baseApp.request(`/auth/invoke-token/confirm-mfa/${nanoid(40)}`, { headers: defaultHeaders });
+
+      expect(res.status).toBe(400);
+    });
+  });
 });

--- a/backend/tests/sign-in/oauth.test.ts
+++ b/backend/tests/sign-in/oauth.test.ts
@@ -311,10 +311,8 @@ describe('OAuth Authentication', async () => {
     });
   });
 
-  describe('Verified redirect ignores client-supplied destination', () => {
-    // The verified sign-in redirect is server-determined; an attacker-controlled
-    // redirectAfter cannot become the Location.
-    it('should redirect a verified OAuth sign-in to a frontend path, not an attacker redirectAfter', async () => {
+  describe('Verified redirect honors only validated same-origin paths', () => {
+    const linkVerifiedAccount = async () => {
       const userEmail = 'github-user@example.com';
       const user = await createUser(userEmail);
       await db.insert(oauthAccountsTable).values({
@@ -325,6 +323,30 @@ describe('OAuth Authentication', async () => {
         verified: true,
         createdAt: mockPastIsoDate(),
       });
+      return user;
+    };
+
+    it('should honor a valid redirectAfter on a verified OAuth sign-in', async () => {
+      await linkVerifiedAccount();
+
+      const state = 'mock-state-test';
+      mockCookieStore.set(
+        `oauth-state-${state}`,
+        JSON.stringify({ type: 'auth', redirectAfter: '/orgs/acme?tab=files', codeVerifier: undefined }),
+      );
+
+      const { response: res } = await call(githubCallback, {
+        query: { state, code: 'mock-auth-code' },
+        headers: defaultHeaders,
+      });
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe(`${appConfig.frontendUrl}/orgs/acme?tab=files`);
+    });
+
+    // An attacker-controlled redirectAfter must never become the Location.
+    it('should redirect a verified OAuth sign-in to a frontend path, not an attacker redirectAfter', async () => {
+      await linkVerifiedAccount();
 
       const state = 'mock-state-test';
       mockCookieStore.set(

--- a/backend/tests/test-utils.ts
+++ b/backend/tests/test-utils.ts
@@ -6,7 +6,7 @@ import { baseDb as db } from '#/db/db';
 import { resetOrganizationMockEnforcers } from '#/modules/organization/organization-mocks';
 import { resetUserMockEnforcers } from '#/modules/user/user-mocks';
 
-type AuthStrategy = 'passkey' | 'oauth' | 'totp';
+type AuthStrategy = 'passkey' | 'oauth' | 'totp' | 'magic';
 type OAuthProvider = 'github' | 'google' | 'microsoft';
 
 type ConfigOverride = {

--- a/frontend/src/modules/auth/magic-link-strategy.tsx
+++ b/frontend/src/modules/auth/magic-link-strategy.tsx
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
+import { useSearch } from '@tanstack/react-router';
 import { MailIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { sendMagicLink } from 'sdk';
@@ -12,11 +13,12 @@ import { Button } from '~/modules/ui/button';
 export function MagicLinkStrategy({ email }: { email?: string }) {
   const { t } = useTranslation();
   const { setStep, setMagicLinkMode, email: storeEmail } = useAuthStore();
+  const { redirect } = useSearch({ strict: false });
 
   const targetEmail = email || storeEmail;
 
   const { mutate: send, isPending } = useMutation({
-    mutationFn: () => sendMagicLink({ body: { email: targetEmail } }),
+    mutationFn: () => sendMagicLink({ body: { email: targetEmail, redirect } }),
     onSuccess: () => {
       setMagicLinkMode('signin');
       setStep('magicLinkSent', targetEmail);

--- a/frontend/src/modules/auth/oauth-providers.tsx
+++ b/frontend/src/modules/auth/oauth-providers.tsx
@@ -28,7 +28,6 @@ export function OAuthProviders({ authStep = 'signIn' }: { authStep: AuthStep }) 
 
   const [loadingProvider, setLoadingProvider] = useState<EnabledOAuthProvider | null>(null);
 
-  const redirectPath = redirect?.startsWith('/') ? redirect : appConfig.defaultRedirectPath;
   const actionText = authStep === 'signIn' ? t('c:sign_in') : authStep === 'signUp' ? t('c:sign_up') : t('c:continue');
 
   const authenticateWithProvider = async (provider: EnabledOAuthProvider) => {
@@ -36,7 +35,11 @@ export function OAuthProviders({ authStep = 'signIn' }: { authStep: AuthStep }) 
       setLoadingProvider(provider);
 
       const baseUrl = `${appConfig.backendAuthUrl}/${provider}`;
-      const params = new URLSearchParams({ redirectAfter: redirectPath });
+      const params = new URLSearchParams();
+
+      // Only send an explicit deep link; a default here would read as an explicit redirect
+      // server-side and skip the welcome page for new users.
+      if (redirect?.startsWith('/')) params.set('redirectAfter', redirect);
 
       if (tokenId) {
         params.set('tokenId', tokenId);

--- a/frontend/src/modules/auth/passkey-strategy.tsx
+++ b/frontend/src/modules/auth/passkey-strategy.tsx
@@ -1,13 +1,13 @@
 import { useMutation } from '@tanstack/react-query';
-import { useNavigate, useSearch } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
 import { FingerprintPatternIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { type SignInWithPasskeyData, type SignInWithPasskeyResponse, signInWithPasskey } from 'sdk';
-import { appConfig } from 'shared';
 import { ApiError } from '~/lib/api';
 import { useAuthStore } from '~/modules/auth/auth-store';
 import { getPasskeyVerifyCredential } from '~/modules/auth/passkey-credentials';
 import type { PasskeyCredentialProps } from '~/modules/auth/types';
+import { usePostAuthRedirect } from '~/modules/auth/use-post-auth-redirect';
 import { toaster } from '~/modules/common/toaster/toaster';
 import { Button } from '~/modules/ui/button';
 import { useUIStore } from '~/modules/ui/ui-store';
@@ -24,8 +24,7 @@ export function PasskeyStrategy({ email, type }: PasskeyStrategyProps) {
   const navigate = useNavigate();
   const mode = useUIStore((state) => state.mode);
 
-  const { redirect } = useSearch({ strict: false });
-  const redirectPath = redirect?.startsWith('/') ? redirect : appConfig.defaultRedirectPath;
+  const redirectPath = usePostAuthRedirect();
 
   const { mutate: passkeyAuth } = useMutation<
     SignInWithPasskeyResponse,

--- a/frontend/src/modules/auth/steps/sign-in.tsx
+++ b/frontend/src/modules/auth/steps/sign-in.tsx
@@ -15,6 +15,7 @@ import { useAuthStore } from '~/modules/auth/auth-store';
 import type { ConditionalMediationResult } from '~/modules/auth/passkey-credentials';
 import { isConditionalMediationAvailable, startConditionalMediation } from '~/modules/auth/passkey-credentials';
 import { PasskeyStrategy } from '~/modules/auth/passkey-strategy';
+import { usePostAuthRedirect } from '~/modules/auth/use-post-auth-redirect';
 import { toaster } from '~/modules/common/toaster/toaster';
 import { Button, SubmitButton } from '~/modules/ui/button';
 import { Form, FormControl, FormField, FormItem } from '~/modules/ui/field';
@@ -39,7 +40,7 @@ export function SignInStep() {
 
   const { lastUser, reset: clearUserStore } = useUserStore();
   const { tokenId, redirect } = useSearch({ from: '/_public/auth/authenticate' });
-  const redirectPath = redirect?.startsWith('/') ? redirect : appConfig.defaultRedirectPath;
+  const redirectPath = usePostAuthRedirect();
 
   const isMobile = window.innerWidth < 640;
   const abortRef = useRef<AbortController | null>(null);

--- a/frontend/src/modules/auth/steps/sign-in.tsx
+++ b/frontend/src/modules/auth/steps/sign-in.tsx
@@ -38,7 +38,8 @@ export function SignInStep() {
   const { email, resetSteps, restrictedMode, setStep, setSignedIn, setMagicLinkMode } = useAuthStore();
 
   const { lastUser, reset: clearUserStore } = useUserStore();
-  const { tokenId } = useSearch({ from: '/_public/auth/authenticate' });
+  const { tokenId, redirect } = useSearch({ from: '/_public/auth/authenticate' });
+  const redirectPath = redirect?.startsWith('/') ? redirect : appConfig.defaultRedirectPath;
 
   const isMobile = window.innerWidth < 640;
   const abortRef = useRef<AbortController | null>(null);
@@ -68,7 +69,7 @@ export function SignInStep() {
         const body: NonNullable<SignInWithPasskeyData['body']> = data;
         await signInWithPasskey({ body });
         setSignedIn(true);
-        navigate({ to: appConfig.defaultRedirectPath, replace: true });
+        navigate({ to: redirectPath, replace: true });
       } catch {
         toaster.error(t('error:passkey_verification_failed'));
       }
@@ -109,7 +110,7 @@ export function SignInStep() {
   });
 
   const { mutate: sendMagic, isPending: isSending } = useMutation({
-    mutationFn: () => sendMagicLink({ body: { email: form.getValues('email') } }),
+    mutationFn: () => sendMagicLink({ body: { email: form.getValues('email'), redirect } }),
     onSuccess: () => {
       setMagicLinkMode('signin');
       setStep('magicLinkSent', form.getValues('email'));

--- a/frontend/src/modules/auth/steps/sign-up.tsx
+++ b/frontend/src/modules/auth/steps/sign-up.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation } from '@tanstack/react-query';
+import { useSearch } from '@tanstack/react-router';
 import { MailIcon } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -31,6 +32,7 @@ export function SignUpStep({ tokenData }: { tokenData?: TokenData }) {
   const { t } = useTranslation();
 
   const { email, resetSteps, restrictedMode, setStep, setMagicLinkMode } = useAuthStore();
+  const { redirect } = useSearch({ strict: false });
 
   const isMobile = window.innerWidth < 640;
 
@@ -42,7 +44,7 @@ export function SignUpStep({ tokenData }: { tokenData?: TokenData }) {
 
   // Send magic link for email-based sign-up
   const { mutate: sendMagic, isPending } = useMutation({
-    mutationFn: () => sendMagicLink({ body: { email: form.getValues('email') || email } }),
+    mutationFn: () => sendMagicLink({ body: { email: form.getValues('email') || email, redirect } }),
     onSuccess: () => {
       setMagicLinkMode('signup');
       setStep('magicLinkSent', form.getValues('email') || email);

--- a/frontend/src/modules/auth/totp-strategy.tsx
+++ b/frontend/src/modules/auth/totp-strategy.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useSearch } from '@tanstack/react-router';
 import { SmartphoneIcon } from 'lucide-react';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -15,6 +15,8 @@ import { useUIStore } from '~/modules/ui/ui-store';
 export function TotpStrategy({ isActive, setIsActive }: { isActive: boolean; setIsActive: (active: boolean) => void }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { redirect } = useSearch({ strict: false });
+  const redirectPath = redirect?.startsWith('/') ? redirect : appConfig.defaultRedirectPath;
 
   const mode = useUIStore((state) => state.mode);
 
@@ -28,7 +30,7 @@ export function TotpStrategy({ isActive, setIsActive }: { isActive: boolean; set
     mutationFn: async (body) => await signInWithTotp({ body }),
     onSuccess: () => {
       useAuthStore.getState().setSignedIn(true);
-      navigate({ to: appConfig.defaultRedirectPath, replace: true });
+      navigate({ to: redirectPath, replace: true });
     },
     onError: () => toaster.error(t('error:totp_verification_failed')),
   });

--- a/frontend/src/modules/auth/totp-strategy.tsx
+++ b/frontend/src/modules/auth/totp-strategy.tsx
@@ -1,12 +1,12 @@
 import { useMutation } from '@tanstack/react-query';
-import { useNavigate, useSearch } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
 import { SmartphoneIcon } from 'lucide-react';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { type ApiError, type SignInWithTotpData, type SignInWithTotpResponse, signInWithTotp } from 'sdk';
-import { appConfig } from 'shared';
 import { useAuthStore } from '~/modules/auth/auth-store';
 import { TotpConfirmationForm } from '~/modules/auth/totp-verify-code-form';
+import { usePostAuthRedirect } from '~/modules/auth/use-post-auth-redirect';
 import { toaster } from '~/modules/common/toaster/toaster';
 import { Button } from '~/modules/ui/button';
 import { useUIStore } from '~/modules/ui/ui-store';
@@ -15,8 +15,7 @@ import { useUIStore } from '~/modules/ui/ui-store';
 export function TotpStrategy({ isActive, setIsActive }: { isActive: boolean; setIsActive: (active: boolean) => void }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { redirect } = useSearch({ strict: false });
-  const redirectPath = redirect?.startsWith('/') ? redirect : appConfig.defaultRedirectPath;
+  const redirectPath = usePostAuthRedirect();
 
   const mode = useUIStore((state) => state.mode);
 

--- a/frontend/src/modules/auth/use-get-token-data.tsx
+++ b/frontend/src/modules/auth/use-get-token-data.tsx
@@ -1,12 +1,11 @@
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
-import { getTokenData } from 'sdk';
-import type { TokenType } from 'shared';
+import { type GetTokenDataData, getTokenData } from 'sdk';
 import type { ApiError } from '~/lib/api';
 import type { TokenData } from '~/modules/auth/types';
 
 /** Query token data by ID. */
 export const useGetTokenData = (
-  type: TokenType,
+  type: GetTokenDataData['path']['type'],
   tokenId?: string,
   enabled = true,
 ): UseQueryResult<TokenData | undefined, ApiError> => {

--- a/frontend/src/modules/auth/use-post-auth-redirect.ts
+++ b/frontend/src/modules/auth/use-post-auth-redirect.ts
@@ -1,0 +1,11 @@
+import { useSearch } from '@tanstack/react-router';
+import { appConfig } from 'shared';
+
+/**
+ * Validated post-auth redirect path from the current route's `?redirect=` search param, falling
+ * back to the default redirect path. UX-only guard; the backend re-validates before any 302.
+ */
+export function usePostAuthRedirect() {
+  const { redirect } = useSearch({ strict: false });
+  return redirect?.startsWith('/') ? redirect : appConfig.defaultRedirectPath;
+}

--- a/sdk/gen/docs.gen/details.gen/auth.gen.json
+++ b/sdk/gen/docs.gen/details.gen/auth.gen.json
@@ -176,7 +176,7 @@
           "type": {
             "type": "string",
             "required": true,
-            "enum": ["email-verification", "oauth-verification", "invitation", "confirm-mfa", "magic"]
+            "enum": ["email-verification", "oauth-verification", "invitation", "magic"]
           },
           "token": { "type": "string", "required": true }
         }

--- a/sdk/gen/docs.gen/details.gen/auth.gen.json
+++ b/sdk/gen/docs.gen/details.gen/auth.gen.json
@@ -250,7 +250,7 @@
           "type": {
             "type": "string",
             "required": true,
-            "enum": ["email-verification", "oauth-verification", "invitation", "confirm-mfa", "magic"]
+            "enum": ["email-verification", "oauth-verification", "invitation", "magic"]
           },
           "id": { "type": "string", "required": true, "maxLength": 50 }
         }

--- a/sdk/gen/docs.gen/details.gen/auth.gen.json
+++ b/sdk/gen/docs.gen/details.gen/auth.gen.json
@@ -538,7 +538,8 @@
             "format": "email",
             "minLength": 4,
             "maxLength": 255
-          }
+          },
+          "redirect": { "type": "string", "required": false }
         },
         "required": true,
         "contentType": "application/json"

--- a/sdk/gen/openapi.json
+++ b/sdk/gen/openapi.json
@@ -2477,7 +2477,7 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["email-verification", "oauth-verification", "invitation", "confirm-mfa", "magic"]
+              "enum": ["email-verification", "oauth-verification", "invitation", "magic"]
             },
             "required": true,
             "name": "type",

--- a/sdk/gen/openapi.json
+++ b/sdk/gen/openapi.json
@@ -2539,7 +2539,7 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["email-verification", "oauth-verification", "invitation", "confirm-mfa", "magic"]
+              "enum": ["email-verification", "oauth-verification", "invitation", "magic"]
             },
             "required": true,
             "name": "type",

--- a/sdk/gen/openapi.json
+++ b/sdk/gen/openapi.json
@@ -2837,6 +2837,9 @@
                     "format": "email",
                     "minLength": 4,
                     "maxLength": 255
+                  },
+                  "redirect": {
+                    "type": "string"
                   }
                 },
                 "required": ["email"]

--- a/sdk/gen/sdk.gen.ts
+++ b/sdk/gen/sdk.gen.ts
@@ -675,6 +675,7 @@ export const signOut = <ThrowOnError extends boolean = true>(
  *
  * @param {sendMagicLinkData} options
  * @param {string=} options.body.email - `string` (optional)
+ * @param {string=} options.body.redirect - `string` (optional)
  * @returns Possible status codes: 204, 400, 401, 403, 404, 409, 429
  */
 export const sendMagicLink = <ThrowOnError extends boolean = true>(

--- a/sdk/gen/types.gen.ts
+++ b/sdk/gen/types.gen.ts
@@ -685,7 +685,7 @@ export type InvokeTokenError = InvokeTokenErrors[keyof InvokeTokenErrors];
 export type GetTokenDataData = {
   body?: never;
   path: {
-    type: 'email-verification' | 'oauth-verification' | 'invitation' | 'confirm-mfa' | 'magic';
+    type: 'email-verification' | 'oauth-verification' | 'invitation' | 'magic';
     id: string;
   };
   query?: never;

--- a/sdk/gen/types.gen.ts
+++ b/sdk/gen/types.gen.ts
@@ -646,7 +646,7 @@ export type CheckEmailResponse = CheckEmailResponses[keyof CheckEmailResponses];
 export type InvokeTokenData = {
   body?: never;
   path: {
-    type: 'email-verification' | 'oauth-verification' | 'invitation' | 'confirm-mfa' | 'magic';
+    type: 'email-verification' | 'oauth-verification' | 'invitation' | 'magic';
     token: string;
   };
   query?: never;

--- a/sdk/gen/types.gen.ts
+++ b/sdk/gen/types.gen.ts
@@ -928,6 +928,7 @@ export type SignOutResponse = SignOutResponses[keyof SignOutResponses];
 export type SendMagicLinkData = {
   body: {
     email: string;
+    redirect?: string;
   };
   path?: never;
   query?: never;

--- a/sdk/gen/zod.gen.ts
+++ b/sdk/gen/zod.gen.ts
@@ -497,7 +497,7 @@ export const zCheckEmailBody = z.object({
 export const zCheckEmailResponse = z.void();
 
 export const zInvokeTokenPath = z.object({
-  type: z.enum(['email-verification', 'oauth-verification', 'invitation', 'confirm-mfa', 'magic']),
+  type: z.enum(['email-verification', 'oauth-verification', 'invitation', 'magic']),
   token: z.string(),
 });
 

--- a/sdk/gen/zod.gen.ts
+++ b/sdk/gen/zod.gen.ts
@@ -502,7 +502,7 @@ export const zInvokeTokenPath = z.object({
 });
 
 export const zGetTokenDataPath = z.object({
-  type: z.enum(['email-verification', 'oauth-verification', 'invitation', 'confirm-mfa', 'magic']),
+  type: z.enum(['email-verification', 'oauth-verification', 'invitation', 'magic']),
   id: z.string().max(50),
 });
 

--- a/sdk/gen/zod.gen.ts
+++ b/sdk/gen/zod.gen.ts
@@ -552,6 +552,7 @@ export const zSignOutResponse = z.void();
 
 export const zSendMagicLinkBody = z.object({
   email: z.email().min(4).max(255),
+  redirect: z.string().optional(),
 });
 
 /**


### PR DESCRIPTION
## Why

The `?redirect=` deep link captured on `/auth/authenticate` (by `__root.tsx` / `_app/route.tsx`) stopped working when the password strategy (same-page XHR + client-side navigate) was replaced by magic link, where the email link lands on backend `GET /invoke-token` and the server picks the 302 target. Auditing the other strategies showed the loss was wider:

- **OAuth**: `redirectAfter` was threaded through the state cookie and even into the verification email, but the final `verified` branch in `processOAuthAccount` ignored it — the `skipWelcome` special-case in `initiation.ts` was dead code.
- **MFA**: `initiateMfa` returned a bare `/auth/mfa` and the TOTP strategy navigated to the default path, swallowing any redirect that survived.
- **Passkey**: the conditional-mediation path ignored the redirect the regular passkey strategy honored.

## What

Redirect intent now travels **server-side on a new nullable `tokens.redirect_path` column** and one shared resolver decides the final 302 for every strategy:

```
MFA challenge (carrying redirect) → validated explicit redirect → welcome (new user) → default
```

Policy decision (flip, 2026-08-14): **an explicit redirect wins over the welcome page**; a redirect targeting home gets `skipWelcome=true` appended so the frontend onboarding guard doesn't bounce it.

- **Schema**: `tokens.redirect_path varchar(255)` (plain additive migration; partman parent propagates). `isValidRedirectPath` now also caps length at the field size — validated paths always fit the column.
- **Resolver**: `resolvePostAuthRedirectPath(user, { redirectPath, mfaPath })` in `redirect-path.ts`, re-validating stored/cookie input at read time (defense in depth for rows written before validation changes).
- **Magic**: `sendMagicLink` body gains optional `redirect`; validated at send (invalid input degrades to null, never errors), stored on the token, honored at invoke.
- **OAuth**: verified sign-ins honor the state-cookie `redirectAfter`; the verification-email flow stores the redirect on the `oauth-verification` token row instead of the emailed URL (deep links no longer leak into email bodies); the verify initiation reads it back from the token record; dead `skipWelcome` block removed.
- **MFA**: resolver emits `/auth/mfa?redirect=…` (already schema-valid on that route); `totp-strategy` consumes it the way `passkey-strategy` already did. MFA verify endpoints stay 204 — no response-shape changes.
- **Frontend**: magic-link senders (`magic-link-strategy`, sign-in and sign-up steps) pass `redirect`; conditional-mediation passkey sign-in navigates to it.
- **Tests**: new `tests/sign-in/magic.test.ts` (first magic-link coverage): stored-path validation incl. open-redirect vectors (`https://`, `//host`, `/\host`, `/api/*`, overlong), invoke honoring stored path, redirect-beats-welcome, `skipWelcome` append, welcome fallback, stored-value re-validation, MFA hand-off without a session cookie. `oauth.test.ts` verified-redirect block extended: valid `redirectAfter` honored, attacker value still never becomes Location.

## Security invariants

- `isValidRedirectPath` (same-origin relative path, no `/api/*`, control-char and authority-trick rejection, length cap) runs at **every write and every read-before-302**; frontend `startsWith('/')` checks are UX-only.
- The emailed magic/verification URLs carry only the token — never the redirect target.
- MFA hand-off sets no session cookie before the challenge completes (covered by test).

## Verification

- `pnpm --filter backend ts` + all-package `ts` — clean
- Full backend suite: **78 files, 631 passed / 1 skipped**
- `pnpm lint:fix` + style gate — clean
- `pnpm sdk` regenerated (drift-checked again by the pre-commit hook)

## Notes for forks

Additive tokens column only; forks pick it up through the normal migration sync. `sendMagicLink`'s new body field is optional, so existing callers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Follow-up cleanup (second/third commit)

- **`finishSignIn` helper**: the identical `initiateMfa` → resolve redirect → `setUserSession` → 302 tail from magic, email-verification, and verified-OAuth flows now lives in one place. Email verification routes through the shared resolver too, so its MFA hop no longer drops a redirect and its tokens are redirect-capable (always null today — no behavior change yet).
- **`usePostAuthRedirect` hook**: replaces the triplicated `startsWith('/')` fallback in passkey/totp/sign-in.
- **oauth-providers fix**: only sends `redirectAfter` for an explicit deep link — always sending the default path would read as an explicit redirect server-side and wrongly skip the welcome page for new OAuth users.
- **invoke-token restricted to link-invokable types**: `confirm-mfa` removed from the route's param enum (it lives only in a cookie; invoking it clobbered that cookie and fell through to a relative-path redirect resolving against the backend origin). Handler is now exhaustive, broken fallback deleted. SDK enum regenerated; rejection covered by test.
- **getTokenData narrowed too**: same `invokableTokenTypes` subset on the `/auth/token/{type}/{id}` param — `confirm-mfa` tokens never get a single-use session, so querying their data was guaranteed to 404; spec/SDK stop advertising it and the frontend hook's type param follows the generated type.
