### PR TITLE
refactor(blocknote): align UI adapter with @blocknote/shadcn 0.53 Base UI contract

### DIFF
--- a/frontend/src/modules/common/blocknote/custom-side-menu/side-menu.tsx
+++ b/frontend/src/modules/common/blocknote/custom-side-menu/side-menu.tsx
@@ -5,7 +5,7 @@ import { useRef, useState } from 'react';
 import { customBlockTypeSwitchItems } from '~/modules/common/blocknote/blocknote-config';
 import { ResetBlockTypeItem } from '~/modules/common/blocknote/custom-side-menu/reset-block-type';
 import type { CustomBlockNoteMenuProps } from '~/modules/common/blocknote/types';
-import { DropdownMenu, DropdownMenuContentNoPortal, DropdownMenuTrigger } from '~/modules/ui/dropdown-menu';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '~/modules/ui/dropdown-menu';
 
 // in this menu we have only drag button
 /** Renders the custom side menu component. */
@@ -111,9 +111,13 @@ function DragHandle({
       }}
     >
       <DropdownMenuTrigger render={gripButton} />
-      <DropdownMenuContentNoPortal side="left" className="bn-menu-dropdown bn-drag-handle-menu">
+      <DropdownMenuContent
+        container={editor.portalElement}
+        side="left"
+        className="bn-menu-dropdown bn-drag-handle-menu"
+      >
         <ResetBlockTypeItem editor={editor} allowedTypes={allowedTypes} headingLevels={headingLevels} />
-      </DropdownMenuContentNoPortal>
+      </DropdownMenuContent>
     </DropdownMenu>
   );
 }

--- a/frontend/src/modules/common/blocknote/helpers/shad-cn.tsx
+++ b/frontend/src/modules/common/blocknote/helpers/shad-cn.tsx
@@ -1,95 +1,33 @@
-import { Menu as MenuPrimitive } from '@base-ui/react/menu';
-import { Popover as PopoverPrimitive } from '@base-ui/react/popover';
-import { Tooltip as TooltipPrimitive } from '@base-ui/react/tooltip';
-import { isValidElement, type ReactElement } from 'react';
+import type { ShadCNComponents } from '@blocknote/shadcn';
 import * as Badge from '~/modules/ui/badge';
 import * as Button from '~/modules/ui/button';
 import * as Card from '~/modules/ui/card';
 import * as DropdownMenu from '~/modules/ui/dropdown-menu';
-import { DropdownMenuContentNoPortal } from '~/modules/ui/dropdown-menu';
 import * as Input from '~/modules/ui/input';
 import * as Label from '~/modules/ui/label';
 import * as Popover from '~/modules/ui/popover';
-import { PopoverContentNoPortal } from '~/modules/ui/popover';
 import * as Select from '~/modules/ui/select';
-import { SelectContentNoPortal } from '~/modules/ui/select';
 import * as Tabs from '~/modules/ui/tabs';
 import * as Toggle from '~/modules/ui/toggle';
 import * as Tooltip from '~/modules/ui/tooltip';
 
-// BlockNote passes Radix-style `asChild`; translate to Base UI's `render` prop.
-function BlockNoteDropdownMenuTrigger({
-  asChild,
-  children,
-  ...props
-}: MenuPrimitive.Trigger.Props & { asChild?: boolean }) {
-  if (asChild && isValidElement(children)) {
-    return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" render={children as ReactElement} {...props} />;
-  }
-  return (
-    <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props}>
-      {children}
-    </MenuPrimitive.Trigger>
-  );
-}
-
-function BlockNotePopoverTrigger({
-  asChild,
-  children,
-  ...props
-}: PopoverPrimitive.Trigger.Props & { asChild?: boolean }) {
-  if (asChild && isValidElement(children)) {
-    return <PopoverPrimitive.Trigger data-slot="popover-trigger" render={children as ReactElement} {...props} />;
-  }
-  return (
-    <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props}>
-      {children}
-    </PopoverPrimitive.Trigger>
-  );
-}
-
-function BlockNoteTooltipTrigger({
-  asChild,
-  children,
-  ...props
-}: TooltipPrimitive.Trigger.Props & { asChild?: boolean }) {
-  if (asChild && isValidElement(children)) {
-    return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" render={children as ReactElement} {...props} />;
-  }
-  return (
-    <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props}>
-      {children}
-    </TooltipPrimitive.Trigger>
-  );
-}
-
-// Ensure compatibility, your ShadCN components should not use Portals (comment these out from your DropdownMenu, Popover and Select components).
-/** Maps BlockNote elements to the application UI components. */
-// biome-ignore lint/suspicious/noExplicitAny: BlockNote expects Radix-compatible types; our Base UI wrapper types are narrower
-export const shadCNComponents: Record<string, any> = {
+/**
+ * Maps BlockNote elements to the application UI components. Since @blocknote/shadcn 0.53
+ * both sides speak Base UI: triggers receive `render` props and popup content receives a
+ * `container` (editor.portalElement) that our components forward to their portals.
+ */
+// Cast: our kit deliberately narrows some Base UI prop types (string-only className,
+// single-value Select) and uses different cva variant unions than BlockNote's defaults.
+export const shadCNComponents = {
   Button,
-  DropdownMenu: {
-    ...DropdownMenu,
-    DropdownMenuTrigger: BlockNoteDropdownMenuTrigger,
-    DropdownMenuContent: DropdownMenuContentNoPortal,
-  },
-  Select: {
-    ...Select,
-    SelectContent: SelectContentNoPortal,
-  },
-  Popover: {
-    ...Popover,
-    PopoverTrigger: BlockNotePopoverTrigger,
-    PopoverContent: PopoverContentNoPortal,
-  },
-  Tooltip: {
-    ...Tooltip,
-    TooltipTrigger: BlockNoteTooltipTrigger,
-  },
+  DropdownMenu,
+  Select,
+  Popover,
+  Tooltip,
   Label,
   Input,
   Card,
   Badge,
   Toggle,
   Tabs,
-};
+} as unknown as Partial<ShadCNComponents>;

--- a/frontend/src/modules/common/root.tsx
+++ b/frontend/src/modules/common/root.tsx
@@ -31,7 +31,7 @@ export function Root() {
   }, []);
 
   return (
-    <TooltipProvider disableHoverableContent delayDuration={300} skipDelayDuration={0}>
+    <TooltipProvider delay={300} timeout={0}>
       <HeadContent />
       <Outlet />
       <ReloadPrompt />

--- a/frontend/src/modules/ui/dropdown-menu.tsx
+++ b/frontend/src/modules/ui/dropdown-menu.tsx
@@ -1,6 +1,6 @@
 import { Menu as MenuPrimitive } from '@base-ui/react/menu';
 import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
-import { type ComponentProps, type HTMLAttributes, type RefAttributes, type RefObject, useRef } from 'react';
+import type { ComponentProps, HTMLAttributes, RefAttributes, RefObject } from 'react';
 import { cn } from '~/utils/cn';
 
 function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
@@ -15,10 +15,7 @@ function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props & RefAttr
   return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
 }
 
-/**
- * Renders dropdown content without a portal for custom layering.
- */
-export function DropdownMenuContentNoPortal({
+function DropdownMenuContent({
   className,
   sideOffset = 4,
   side,
@@ -26,6 +23,7 @@ export function DropdownMenuContentNoPortal({
   anchor,
   collisionPadding,
   finalFocus,
+  container,
   ...props
 }: MenuPrimitive.Popup.Props &
   RefAttributes<HTMLDivElement> & {
@@ -35,38 +33,29 @@ export function DropdownMenuContentNoPortal({
     anchor?: Element | null | RefObject<Element | null>;
     collisionPadding?: number;
     finalFocus?: MenuPrimitive.Popup.Props['finalFocus'];
+    // `container` is part of @blocknote/shadcn's component contract: BlockNote portals menus into editor.portalElement
+    container?: MenuPrimitive.Portal.Props['container'];
   }) {
-  const containerRef = useRef<HTMLDivElement>(null);
   return (
-    <div ref={containerRef} style={{ display: 'contents' }}>
-      <MenuPrimitive.Portal container={containerRef}>
-        <MenuPrimitive.Positioner
-          sideOffset={sideOffset}
-          side={side}
-          align={align}
-          anchor={anchor}
-          collisionPadding={collisionPadding}
-          className="z-270"
-        >
-          <MenuPrimitive.Popup
-            data-slot="dropdown-menu-content"
-            className={cn(
-              'data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-h-(--available-height) min-w-32 origin-(--transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-closed:animate-out data-open:animate-in',
-              className,
-            )}
-            finalFocus={finalFocus}
-            {...props}
-          />
-        </MenuPrimitive.Positioner>
-      </MenuPrimitive.Portal>
-    </div>
-  );
-}
-
-function DropdownMenuContent({ ...props }: ComponentProps<typeof DropdownMenuContentNoPortal>) {
-  return (
-    <MenuPrimitive.Portal>
-      <DropdownMenuContentNoPortal {...props} />
+    <MenuPrimitive.Portal container={container}>
+      <MenuPrimitive.Positioner
+        sideOffset={sideOffset}
+        side={side}
+        align={align}
+        anchor={anchor}
+        collisionPadding={collisionPadding}
+        className="z-270"
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn(
+            'data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-h-(--available-height) min-w-32 origin-(--transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-closed:animate-out data-open:animate-in',
+            className,
+          )}
+          finalFocus={finalFocus}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
     </MenuPrimitive.Portal>
   );
 }
@@ -217,12 +206,14 @@ function DropdownMenuSubTrigger({
 
 function DropdownMenuSubContent({
   className,
+  container,
   ...props
 }: HTMLAttributes<HTMLDivElement> & {
   className?: string;
+  container?: MenuPrimitive.Portal.Props['container'];
 }) {
   return (
-    <MenuPrimitive.Portal>
+    <MenuPrimitive.Portal container={container}>
       <MenuPrimitive.Positioner className="z-270">
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-sub-content"

--- a/frontend/src/modules/ui/popover.tsx
+++ b/frontend/src/modules/ui/popover.tsx
@@ -1,5 +1,5 @@
 import { Popover as PopoverPrimitive } from '@base-ui/react/popover';
-import { type ComponentProps, type ComponentPropsWithoutRef, type ReactNode, type RefAttributes, useRef } from 'react';
+import type { ComponentProps, RefAttributes } from 'react';
 import { cn } from '~/utils/cn';
 
 /** Renders the styled popover primitive. */
@@ -22,6 +22,7 @@ export function PopoverContent({
   anchor,
   collisionPadding,
   finalFocus,
+  container,
   children,
   ...props
 }: {
@@ -33,10 +34,12 @@ export function PopoverContent({
   anchor?: Element | null | React.RefObject<Element | null>;
   collisionPadding?: number;
   finalFocus?: PopoverPrimitive.Popup.Props['finalFocus'];
+  // `container` is part of @blocknote/shadcn's component contract: BlockNote portals popovers into editor.portalElement
+  container?: PopoverPrimitive.Portal.Props['container'];
   children?: React.ReactNode;
 } & Omit<React.ComponentPropsWithoutRef<'div'>, 'className'>) {
   return (
-    <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Portal container={container}>
       <PopoverPrimitive.Positioner
         side={side}
         sideOffset={sideOffset}
@@ -59,50 +62,6 @@ export function PopoverContent({
         </PopoverPrimitive.Popup>
       </PopoverPrimitive.Positioner>
     </PopoverPrimitive.Portal>
-  );
-}
-
-/** Renders the styled popover content no portal primitive. */
-export function PopoverContentNoPortal({
-  className,
-  align = 'center',
-  sideOffset = 4,
-  side,
-  alignOffset,
-  children,
-  ...props
-}: {
-  className?: string;
-  align?: 'start' | 'center' | 'end';
-  sideOffset?: number;
-  side?: 'top' | 'bottom' | 'left' | 'right';
-  alignOffset?: number;
-  children?: ReactNode;
-} & Omit<ComponentPropsWithoutRef<'div'>, 'className'>) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  return (
-    <div ref={containerRef} style={{ display: 'contents' }}>
-      <PopoverPrimitive.Portal container={containerRef}>
-        <PopoverPrimitive.Positioner
-          side={side}
-          sideOffset={sideOffset}
-          align={align}
-          alignOffset={alignOffset}
-          className="z-200"
-        >
-          <PopoverPrimitive.Popup
-            data-slot="popover-content"
-            className={cn(
-              'data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 w-72 origin-(--transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-closed:animate-out data-open:animate-in',
-              className,
-            )}
-            {...props}
-          >
-            {children}
-          </PopoverPrimitive.Popup>
-        </PopoverPrimitive.Positioner>
-      </PopoverPrimitive.Portal>
-    </div>
   );
 }
 

--- a/frontend/src/modules/ui/select.tsx
+++ b/frontend/src/modules/ui/select.tsx
@@ -128,10 +128,7 @@ function SelectTrigger({
   );
 }
 
-/**
- * Renders select content without a portal for custom layering.
- */
-export function SelectContentNoPortal({
+function SelectContent({
   className,
   children,
   position = 'popper',
@@ -139,6 +136,8 @@ export function SelectContentNoPortal({
   side = 'bottom',
   sideOffset,
   alignOffset,
+  alignItemWithTrigger,
+  container,
   ...props
 }: React.HTMLAttributes<HTMLDivElement> & {
   className?: string;
@@ -148,40 +147,37 @@ export function SelectContentNoPortal({
   side?: 'top' | 'bottom' | 'left' | 'right';
   sideOffset?: number;
   alignOffset?: number;
+  alignItemWithTrigger?: boolean;
+  // `container` is part of @blocknote/shadcn's component contract: BlockNote portals selects into editor.portalElement
+  container?: SelectPrimitive.Portal.Props['container'];
 }) {
   return (
-    <SelectPrimitive.Positioner
-      align={align}
-      side={side}
-      sideOffset={position === 'popper' ? (sideOffset ?? 1) : sideOffset}
-      alignOffset={alignOffset}
-      alignItemWithTrigger={position !== 'popper'}
-      className="z-270"
-    >
-      <SelectPrimitive.Popup
-        data-slot="select-content"
-        className={cn(
-          'data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative max-h-(--available-height) min-w-32 origin-(--transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-closed:animate-out data-open:animate-in',
-          className,
-        )}
-        {...props}
+    <SelectPrimitive.Portal container={container}>
+      <SelectPrimitive.Positioner
+        align={align}
+        side={side}
+        sideOffset={position === 'popper' ? (sideOffset ?? 1) : sideOffset}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger ?? position !== 'popper'}
+        className="z-270"
       >
-        <SelectScrollUpButton />
-        <SelectPrimitive.List
-          className={cn('p-1', position === 'popper' && 'w-full min-w-(--anchor-width) scroll-my-1')}
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          className={cn(
+            'data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative max-h-(--available-height) min-w-32 origin-(--transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-closed:animate-out data-open:animate-in',
+            className,
+          )}
+          {...props}
         >
-          {children}
-        </SelectPrimitive.List>
-        <SelectScrollDownButton />
-      </SelectPrimitive.Popup>
-    </SelectPrimitive.Positioner>
-  );
-}
-
-function SelectContent(props: React.ComponentProps<typeof SelectContentNoPortal>) {
-  return (
-    <SelectPrimitive.Portal>
-      <SelectContentNoPortal {...props} />
+          <SelectScrollUpButton />
+          <SelectPrimitive.List
+            className={cn('p-1', position === 'popper' && 'w-full min-w-(--anchor-width) scroll-my-1')}
+          >
+            {children}
+          </SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
     </SelectPrimitive.Portal>
   );
 }

--- a/frontend/src/modules/ui/sidebar.tsx
+++ b/frontend/src/modules/ui/sidebar.tsx
@@ -83,7 +83,7 @@ function Sidebar({
 
   if (collapsible === 'none') {
     return (
-      <TooltipProvider delayDuration={0}>
+      <TooltipProvider delay={0}>
         <div
           data-slot="sidebar"
           className={cn('flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground', className)}
@@ -96,7 +96,7 @@ function Sidebar({
   }
 
   return (
-    <TooltipProvider delayDuration={0}>
+    <TooltipProvider delay={0}>
       <div
         className="group peer hidden text-sidebar-foreground md:block"
         data-state={state}

--- a/frontend/src/modules/ui/tooltip.tsx
+++ b/frontend/src/modules/ui/tooltip.tsx
@@ -4,24 +4,15 @@ import { cn } from '~/utils/cn';
 
 /** Renders the styled tooltip provider primitive. */
 export function TooltipProvider({
-  delayDuration,
-  skipDelayDuration,
-  disableHoverableContent: _disableHoverableContent,
+  delay = 200,
+  timeout = 400,
   ...props
 }: {
   children: ReactNode;
-  delayDuration?: number;
-  skipDelayDuration?: number;
-  disableHoverableContent?: boolean;
+  delay?: number;
+  timeout?: number;
 }) {
-  return (
-    <TooltipPrimitive.Provider
-      data-slot="tooltip-provider"
-      delay={delayDuration ?? 200}
-      timeout={skipDelayDuration ?? 400}
-      {...props}
-    />
-  );
+  return <TooltipPrimitive.Provider data-slot="tooltip-provider" delay={delay} timeout={timeout} {...props} />;
 }
 
 /** Renders the styled tooltip primitive. */
@@ -47,6 +38,7 @@ export function TooltipContent({
   side,
   align,
   hideWhenDetached,
+  container,
   children,
   ...props
 }: {
@@ -55,11 +47,13 @@ export function TooltipContent({
   side?: 'top' | 'bottom' | 'left' | 'right';
   align?: 'start' | 'center' | 'end';
   hideWhenDetached?: boolean;
+  // `container` is part of @blocknote/shadcn's component contract: BlockNote portals tooltips into editor.portalElement
+  container?: TooltipPrimitive.Portal.Props['container'];
   children?: ReactNode;
   hidden?: boolean;
 } & Omit<ComponentPropsWithoutRef<'div'>, 'className'>) {
   return (
-    <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Portal container={container}>
       <TooltipPrimitive.Positioner side={side} sideOffset={sideOffset} align={align} className="z-200">
         <TooltipPrimitive.Popup
           data-slot="tooltip-content"


### PR DESCRIPTION
## Why

The 0.52.1 → 0.53.0 bump in #1051 brought BlockNote's one breaking change: `@blocknote/shadcn` migrated from Radix to Base UI (TypeCellOS/BlockNote#2913). It now builds on the same `@base-ui/react@1.7.0` instance we ship, so the Radix↔Base UI adapter layer in `shad-cn.tsx` is obsolete — and its `Record<string, any>` cast meant none of the 0.53 contract drift was caught by CI.

## What

Aligns our side with upstream's new contract, accepting some regression risk in exchange for staying on BlockNote's happy path:

- **Delete the `asChild`→`render` trigger bridges.** 0.53 passes Base UI `render` props natively (zero `asChild` left upstream); our kit triggers accept `render` as-is. `shad-cn.tsx` is now plain kit spreads.
- **Portal popups like upstream.** 0.53 passes `container={editor.portalElement}` to every injected Content component. `DropdownMenuContent`/`SubContent`, `PopoverContent`, `SelectContent` and `TooltipContent` now forward `container` to their Base UI Portal, and the `*NoPortal` variants are deleted (their only consumers were the blocknote adapter and the custom side menu). `SelectContent` also accepts `alignItemWithTrigger`, which BlockNote passes explicitly.
- **Portal the drag-handle side menu into `editor.portalElement`** instead of rendering inline, matching upstream's side menu.
- **`TooltipProvider` speaks Base UI prop names** (`delay`/`timeout`; callers updated). The `disableHoverableContent` prop was silently discarded before, so dropping it changes nothing.

## Typing note

Typing the map as `Partial<ShadCNComponents>` surfaces 7 mismatches that are all deliberate kit narrowings (string-only `className` vs Base UI's callable form, single-value `Select`, different cva variant unions), so it carries one documented `as unknown as Partial<ShadCNComponents>` cast — the target shape is now stated, unlike the old `Record<string, any>`.

## Testing

- tsgo typecheck, biome, vite build, and all 858 frontend tests pass.
- **Not yet runtime-verified** — needs a manual editor pass (slash menu, formatting-toolbar dropdowns/tooltips, drag-handle menu, select, file panel, dark-mode popups) in cella and in raak, especially the task card/board where popups have historically been fragile inside the virtualized board panel list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)