### PR TITLE
fix(frontend): tab drag preview label + lone entity grid tile width

### DIFF
--- a/frontend/src/modules/entities/entity-grid/grid.tsx
+++ b/frontend/src/modules/entities/entity-grid/grid.tsx
@@ -83,7 +83,7 @@ export function BaseEntityGrid<TEntity extends { id: string }>({
 
   return (
     <div className="mb-12">
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-1 md:grid-cols-2 md:gap-6 lg:grid-cols-[repeat(auto-fit,minmax(330px,1fr))]">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-1 md:grid-cols-2 md:gap-6 lg:grid-cols-[repeat(auto-fill,minmax(330px,1fr))]">
         {visibleEntities.map((entity) => (
           <TileComponent key={entity.id} entity={entity} />
         ))}

--- a/frontend/src/modules/entities/entity-grid/skeleton.tsx
+++ b/frontend/src/modules/entities/entity-grid/skeleton.tsx
@@ -15,7 +15,7 @@ export function EntityGridSkeleton({ tileHeight = 180 }: EntityGridSkeletonProps
 
   return (
     <div
-      className={`transition-opacity duration-300 ${hasStarted ? 'opacity-100' : 'opacity-0'} mb-12 grid grid-cols-1 gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-[repeat(auto-fit,minmax(330px,1fr))]`}
+      className={`transition-opacity duration-300 ${hasStarted ? 'opacity-100' : 'opacity-0'} mb-12 grid grid-cols-1 gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-[repeat(auto-fill,minmax(330px,1fr))]`}
     >
       {Array.from({ length: 6 }).map((_, index) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: static keys are fine here as this is a skeleton

--- a/frontend/src/modules/entities/tabs-arrangement-card.tsx
+++ b/frontend/src/modules/entities/tabs-arrangement-card.tsx
@@ -15,6 +15,8 @@ interface TabRow {
   id: string;
   label: TKey;
   resource?: TKey;
+  /** Pre-translated label, resolved once per render so module-scope renderers can use it. */
+  name: string;
   order: number;
   locked?: boolean;
   visible: boolean;
@@ -23,6 +25,11 @@ interface TabRow {
 /** Stable row key getter, defined outside the component to keep its identity stable. */
 function rowKeyGetter(row: TabRow) {
   return row.id;
+}
+
+/** Stable drag preview renderer, defined at module scope so DataGrid's prop identity stays stable. */
+function renderRowDragPreview(row: TabRow) {
+  return <div className="rounded border bg-background px-2 py-1 text-sm shadow-md">{row.name}</div>;
 }
 
 interface TabsArrangementCardProps {
@@ -54,7 +61,11 @@ export function TabsArrangementCard({ entity, parentRouteId, persist }: TabsArra
     order,
     locked,
   }));
-  const rows = orderBySlotConfig(candidates, slotConfig).map((tab) => ({ ...tab, visible: !hidden.has(tab.id) }));
+  const rows = orderBySlotConfig(candidates, slotConfig).map((tab) => ({
+    ...tab,
+    name: t(tab.label, { resource: tab.resource ? t(tab.resource).toLowerCase() : '' }),
+    visible: !hidden.has(tab.id),
+  }));
 
   const persistSlot = (nextConfig: SlotToolsConfig) => persist({ [slot]: nextConfig });
 
@@ -86,11 +97,7 @@ export function TabsArrangementCard({ entity, parentRouteId, persist }: TabsArra
       key: 'label',
       name: '',
       minWidth: 160,
-      renderCell: ({ row }) => (
-        <span className="truncate text-sm">
-          {t(row.label, { resource: row.resource ? t(row.resource).toLowerCase() : '' })}
-        </span>
-      ),
+      renderCell: ({ row }) => <span className="truncate text-sm">{row.name}</span>,
     },
     {
       key: 'visible',
@@ -117,6 +124,7 @@ export function TabsArrangementCard({ entity, parentRouteId, persist }: TabsArra
         readOnly
         enableVirtualization={false}
         onRowReorder={onRowReorder}
+        renderRowDragPreview={renderRowDragPreview}
       />
     </ToolCard>
   );


### PR DESCRIPTION
Two small UI fixes.

## Tabs arrangement drag preview shows the tab label

The tabs arrangement card (org settings, `toolsConfig['<channelType>.tabs']`) wired `onRowReorder` without `renderRowDragPreview`, so dragging a row showed the data-grid engine's generic fallback chip ("Row 1") instead of the tab's name. Now follows the pages-table pattern: the label is translated once when rows are built (also reused by the label cell) and rendered by a module-scope preview renderer, keeping the prop identity stable for the grid's row memoization.

Forks using `TabsArrangementCard` get this on sync. Forks that built their own reorderable tables still see the engine fallback until they pass `renderRowDragPreview` themselves — nothing breaks, purely additive.

## Lone entity grid tile keeps its normal width

`lg:grid-cols-[repeat(auto-fit,minmax(330px,1fr))]` collapses empty tracks, so a single tile stretched across the full row on large screens. Switched to `auto-fill`, which keeps the empty tracks: a lone tile gets the same width it would have in a populated grid, fully populated rows render identically, and row height stays content-driven. Skeleton grid updated in sync to avoid load-time layout shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
