### PR TITLE
perf(infra): take reap and per-key HEAD probes off the deploy critical path

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -270,5 +270,5 @@ jobs:
 # GitHub creates one deployment record per environment-declaring job
 # (secrets are environment-scoped, so that is every secret-using job,
 # matrix legs included) and offers no way to opt out. The records are
-# write-only audit noise; we accept the clutter rather than carry
-# GitHub-specific pruning administration in the deploy path.
+# write-only audit noise; the accepted clutter keeps GitHub-specific
+# pruning administration out of the deploy path.

--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -267,47 +267,8 @@ jobs:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
         run: pnpm --filter infra run reap --mode "${{ needs.setup.outputs.environment }}" --sha "${{ needs.setup.outputs.image_tag }}"
 
-  # -------------------------------------------------------------------------
-  # Prune stale deployment records. Every secret-using job above declares
-  # `environment:` (secrets are environment-scoped), and GitHub creates one
-  # deployment record per such job, including matrix legs. Each run leaves
-  # several records behind. They are audit-only; keep just the newest per
-  # environment so the /deployments list stays readable.
-  # A record must be marked `inactive` before it can be DELETEd.
-  # -------------------------------------------------------------------------
-  prune-deployments:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    # After reap so the newest record kept per environment is the reap's.
-    needs: [setup, deploy, reap]
-    if: success()
-    permissions:
-      deployments: write
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ENVIRONMENT: ${{ needs.setup.outputs.environment }}
-    steps:
-      - name: Delete all but the newest deployment record
-        run: |
-          set -euo pipefail
-          # Newest first; keep index 0, prune the rest.
-          ids=$(gh api --paginate \
-            "repos/${GITHUB_REPOSITORY}/deployments?environment=${ENVIRONMENT}&per_page=100" \
-            --jq '.[].id' || true)
-          first=true
-          kept=""
-          deleted=0
-          while IFS= read -r id; do
-            [ -z "$id" ] && continue
-            if [ "$first" = true ]; then
-              first=false
-              kept="$id"
-              continue
-            fi
-            # Must be inactive before it can be deleted.
-            gh api -X POST "repos/${GITHUB_REPOSITORY}/deployments/${id}/statuses" \
-              -f state=inactive >/dev/null
-            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/deployments/${id}" >/dev/null
-            deleted=$((deleted + 1))
-          done <<< "$ids"
-          echo "Kept newest deployment ${kept:-<none>} for '${ENVIRONMENT}'; deleted ${deleted} stale record(s)."
+# GitHub creates one deployment record per environment-declaring job
+# (secrets are environment-scoped, so that is every secret-using job,
+# matrix legs included) and offers no way to opt out. The records are
+# write-only audit noise; we accept the clutter rather than carry
+# GitHub-specific pruning administration in the deploy path.

--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -219,11 +219,54 @@ jobs:
           SCW_DEFAULT_ORGANIZATION_ID: ${{ secrets.SCW_ORGANIZATION_ID }}
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm --filter infra run deploy --mode "${{ needs.setup.outputs.environment }}" --sha "${{ needs.setup.outputs.image_tag }}" --git-ref "${{ github.ref }}"
+        run: pnpm --filter infra run deploy --mode "${{ needs.setup.outputs.environment }}" --sha "${{ needs.setup.outputs.image_tag }}" --git-ref "${{ github.ref }}" --defer-reap
 
   # -------------------------------------------------------------------------
-  # Upload versioned (content-hashed, immutable) frontend assets to the bucket.
+  # Reap the generations the deploy displaced. --defer-reap above leaves the
+  # old VMs running (detached from every LB pool) so verification, entry
+  # publish, and smoke run minutes earlier; this follow-up update destroys
+  # them off the critical path. A failure here is visible but not urgent: the
+  # displaced VMs only cost money, and any later stack update (including the
+  # next deploy) converges them.
   # -------------------------------------------------------------------------
+  reap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [setup, deploy]
+    if: success()
+    permissions:
+      contents: read
+    environment: ${{ needs.setup.outputs.environment }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7.0.0
+        with:
+          pulumi-version: 3.236.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --filter infra... --filter shared...
+
+      - name: Reap displaced generations in ${{ needs.setup.outputs.environment }}
+        env:
+          SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
+          SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
+          SCW_DEFAULT_PROJECT_ID: ${{ secrets.SCW_PROJECT_ID }}
+          SCW_DEFAULT_ORGANIZATION_ID: ${{ secrets.SCW_ORGANIZATION_ID }}
+          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+        run: pnpm --filter infra run reap --mode "${{ needs.setup.outputs.environment }}" --sha "${{ needs.setup.outputs.image_tag }}"
+
   # -------------------------------------------------------------------------
   # Prune stale deployment records. Every secret-using job above declares
   # `environment:` (secrets are environment-scoped), and GitHub creates one
@@ -235,7 +278,8 @@ jobs:
   prune-deployments:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [setup, deploy]
+    # After reap so the newest record kept per environment is the reap's.
+    needs: [setup, deploy, reap]
     if: success()
     permissions:
       deployments: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,4 +88,3 @@ jobs:
     secrets: inherit
     permissions:
       contents: read
-      deployments: write

--- a/infra/README.md
+++ b/infra/README.md
@@ -51,6 +51,9 @@ Wave 2: one stack update provisions every remaining generation;
 verify SHAs, publish frontend entry files, smoke checks
         ↓
 one final stack update reaps every displaced generation
+(CI defers it: the deploy runs with --defer-reap and a follow-up
+ `pnpm --filter infra run reap` job destroys the displaced VMs
+ off the critical path — they are already detached from every LB pool)
 ```
 
 **Manage** is the same `pnpm infra` entrypoint on an existing stack: instead of the wizard it opens an operator menu for day-2 work. From there you re-sync config and GitHub Environment secrets (Resume), rotate the CI deploy key or the Pulumi passphrase, run a privileged `pulumi up` for protected infra (database, VPC, private network), preview drift, manage runtime secrets in Secret Manager (list, set, rotate, delete), run database actions (reset, seed, temporary public exposure), and clear a stale stack lock. See [cella/DEPLOYMENT.md](../cella/DEPLOYMENT.md#advanced-operations) for the step-by-steps.

--- a/infra/package.json
+++ b/infra/package.json
@@ -16,6 +16,7 @@
     "install-pulumi-providers": "tsx tasks/install-pulumi-providers.ts",
     "sync-rollout-config": "tsx tasks/sync-rollout-config.ts",
     "deploy": "tsx tasks/deploy.ts",
+    "reap": "tsx tasks/reap.ts",
     "status": "tsx tasks/status.ts",
     "deploy-rollout": "tsx tasks/deploy-rollout.ts",
     "repair-control-store": "tsx tasks/repair-control-store.ts",

--- a/infra/tasks/deploy-rollout.test.ts
+++ b/infra/tasks/deploy-rollout.test.ts
@@ -23,7 +23,12 @@ describe('deploy-rollout parseArgs', () => {
         { service: 'cdc', health_url: '' },
         { service: 'frontend', health_url: 'https://app' },
       ],
+      skipReap: false,
     });
+  });
+
+  it('parses --skip-reap', () => {
+    expect(parseArgs(['--stack', 'production', '--sha', 'abc123', '--skip-reap']).skipReap).toBe(true);
   });
 
   it('throws when required flags are missing', () => {

--- a/infra/tasks/deploy-rollout.ts
+++ b/infra/tasks/deploy-rollout.ts
@@ -15,25 +15,37 @@ function parseRolloutJson(raw: string, flag: string): RolloutItem[] {
   return parseServiceRows(raw, flag, { required: ['service', 'health_url'] });
 }
 
-export function parseArgs(argv: string[]): { primary: RolloutItem[]; rest: RolloutItem[]; stack: string; sha: string } {
+export function parseArgs(argv: string[]): {
+  primary: RolloutItem[];
+  rest: RolloutItem[];
+  stack: string;
+  sha: string;
+  skipReap: boolean;
+} {
   const primaryRaw = getFlag(argv, '--primary-json') ?? '[]';
   const restRaw = getFlag(argv, '--rest-json') ?? '[]';
   const stack = getFlag(argv, '--stack');
   const sha = getFlag(argv, '--sha');
   if (!stack || !sha)
     throw new Error(
-      'Usage: deploy-rollout.ts --stack <stack> --sha <git-sha> --primary-json <json> --rest-json <json>',
+      'Usage: deploy-rollout.ts --stack <stack> --sha <git-sha> --primary-json <json> --rest-json <json> [--skip-reap]',
     );
   return {
     primary: parseRolloutJson(primaryRaw, '--primary-json'),
     rest: parseRolloutJson(restRaw, '--rest-json'),
     stack,
     sha,
+    skipReap: argv.includes('--skip-reap'),
   };
 }
 
 /** Build the two-wave plan from the CI rollout matrices. */
-export function buildWavedPlan(args: { primary: RolloutItem[]; rest: RolloutItem[]; sha: string }): WavedRolloutPlan {
+export function buildWavedPlan(args: {
+  primary: RolloutItem[];
+  rest: RolloutItem[];
+  sha: string;
+  skipReap?: boolean;
+}): WavedRolloutPlan {
   if (args.primary.length > 1)
     throw new Error(`Expected at most one primary rollout service, got ${args.primary.length}`);
   if (args.primary.length === 0) console.info('No primary rollout service configured — skipping wave 1.');
@@ -42,6 +54,7 @@ export function buildWavedPlan(args: { primary: RolloutItem[]; rest: RolloutItem
     sha: args.sha,
     primary: primaryItem ? planForService(primaryItem.service, primaryItem.health_url || undefined) : undefined,
     rest: args.rest.map((item) => planForService(item.service, item.health_url || undefined)),
+    skipFinalReap: args.skipReap,
   };
 }
 

--- a/infra/tasks/deploy-run.test.ts
+++ b/infra/tasks/deploy-run.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { type DeployEffects, type DeployOptions, parseDeployArgs, runDeploy } from './deploy-run';
+import {
+  type DeployEffects,
+  type DeployOptions,
+  parseDeployArgs,
+  parseReapArgs,
+  runDeploy,
+  runReap,
+} from './deploy-run';
 import type { AllowedKey } from './print-deploy-env';
 
 /** Cella-shaped deploy env table, injected in place of the shared config load. */
@@ -42,8 +49,9 @@ async function fakeDeployEnv(opts: DeployOptions): Promise<Record<AllowedKey, st
   };
 }
 
-function makeFake(opts: { rolloutFails?: boolean; verifyFails?: boolean } = {}) {
+function makeFake(opts: { rolloutFails?: boolean; verifyFails?: boolean; updateFails?: boolean } = {}) {
   const ops: string[] = [];
+  const rolloutArgs: string[][] = [];
   const fx: DeployEffects = {
     initTelemetry: async () => {
       ops.push('telemetry:init');
@@ -59,9 +67,11 @@ function makeFake(opts: { rolloutFails?: boolean; verifyFails?: boolean } = {}) 
     },
     update: async (stack) => {
       ops.push(`update:${stack}`);
+      if (opts.updateFails) throw new Error('stack update failed');
     },
-    rollout: async () => {
+    rollout: async (argv) => {
       ops.push('rollout');
+      rolloutArgs.push([...argv]);
       if (opts.rolloutFails) throw new Error('cutover failed');
     },
     verifyVersion: async (url) => {
@@ -78,7 +88,7 @@ function makeFake(opts: { rolloutFails?: boolean; verifyFails?: boolean } = {}) 
     groupEnd: () => {},
     info: () => {},
   };
-  return { fx, ops };
+  return { fx, ops, rolloutArgs };
 }
 
 const baseOpts = { mode: 'production', sha: 'abc123', distDir: '/tmp/dist' };
@@ -91,8 +101,10 @@ describe('parseDeployArgs', () => {
       distDir: 'dist',
       build: false,
       gitRef: undefined,
+      deferReap: false,
     });
     expect(parseDeployArgs(['--mode', 'staging', '--sha', 'abc', '--build']).build).toBe(true);
+    expect(parseDeployArgs(['--mode', 'staging', '--sha', 'abc', '--defer-reap']).deferReap).toBe(true);
     expect(() => parseDeployArgs(['--mode', 'staging', '--sha', 'latest'])).toThrow(/non-pinned/);
     expect(() => parseDeployArgs(['--mode', 'staging'])).toThrow(/Usage/);
   });
@@ -185,6 +197,16 @@ describe('runDeploy sequencing', () => {
     expect(waitIndex).toBeGreaterThan(bakeIndex);
   });
 
+  it('passes --skip-reap to the rollout only with deferReap', async () => {
+    const withDefer = makeFake();
+    await runDeploy({ ...baseOpts, deferReap: true }, withDefer.fx, fakeDeployEnv);
+    expect(withDefer.rolloutArgs[0]).toContain('--skip-reap');
+
+    const without = makeFake();
+    await runDeploy(baseOpts, without.fx, fakeDeployEnv);
+    expect(without.rolloutArgs[0]).not.toContain('--skip-reap');
+  });
+
   it('rejects production deploys from untrusted refs before touching anything', async () => {
     const { fx, ops } = makeFake();
     await expect(runDeploy({ ...baseOpts, gitRef: 'refs/heads/feature' }, fx, fakeDeployEnv)).rejects.toThrow(
@@ -196,5 +218,36 @@ describe('runDeploy sequencing', () => {
   it('accepts production deploys from release tags', async () => {
     const { fx } = makeFake();
     await expect(runDeploy({ ...baseOpts, gitRef: 'refs/tags/1.2.3' }, fx, fakeDeployEnv)).resolves.toBeUndefined();
+  });
+});
+
+describe('parseReapArgs', () => {
+  it('requires mode and sha', () => {
+    expect(parseReapArgs(['--mode', 'production', '--sha', 'abc123'])).toEqual({ mode: 'production', sha: 'abc123' });
+    expect(() => parseReapArgs(['--mode', 'production'])).toThrow(/Usage/);
+    expect(() => parseReapArgs(['--sha', 'abc123'])).toThrow(/Usage/);
+  });
+});
+
+describe('runReap sequencing', () => {
+  it('logs in, locks, updates the stack, then releases the lock', async () => {
+    const { fx, ops } = makeFake();
+    await runReap({ mode: 'production', sha: 'abc123' }, fx, fakeDeployEnv);
+    expect(ops).toEqual([
+      'exec:pulumi:login',
+      'exec:pulumi:stack',
+      'task:stack-lock:acquire',
+      'task:install-pulumi-providers',
+      'update:production',
+      'task:stack-lock:release',
+    ]);
+  });
+
+  it('releases the lock when the update fails', async () => {
+    const { fx, ops } = makeFake({ updateFails: true });
+    await expect(runReap({ mode: 'production', sha: 'abc123' }, fx, fakeDeployEnv)).rejects.toThrow(
+      /stack update failed/,
+    );
+    expect(ops.at(-1)).toBe('task:stack-lock:release');
   });
 });

--- a/infra/tasks/deploy-run.ts
+++ b/infra/tasks/deploy-run.ts
@@ -374,9 +374,9 @@ export function parseReapArgs(argv: string[]): ReapOptions {
  * Converge the stack on the control object's promoted pointers, destroying the
  * generations a `--defer-reap` deploy displaced. Runs off the deploy's critical
  * path (CI's follow-up reap job, or an operator shell). Safe without the
- * generation keys file: only planning a NEW generation requires it and a reap
- * plans none — active generations are pre-existing and carry `ignoreChanges`
- * on cloud-init and image. Idempotent: with nothing displaced the update is a
+ * generation keys file: only planning a NEW generation requires it, and a reap
+ * plans none (active generations are pre-existing and carry `ignoreChanges`
+ * on cloud-init and image). Idempotent: with nothing displaced the update is a
  * no-op, and a skipped reap is recovered by any later stack update.
  */
 export async function runReap(

--- a/infra/tasks/deploy-run.ts
+++ b/infra/tasks/deploy-run.ts
@@ -31,6 +31,12 @@ export interface DeployOptions {
   build?: boolean;
   /** CI ref for the production trust gate; local operator runs may omit it. */
   gitRef?: string;
+  /**
+   * Skip the rollout's final displaced-generation reap so verification, entry
+   * publish, and smoke run right after cutover. The displaced VMs stay off
+   * every LB pool; a follow-up `reap` run (runReap below) destroys them.
+   */
+  deferReap?: boolean;
 }
 
 /** Deploy step tasks runnable in-process (tasks/<name>.ts, main(argv) throws on failure). */
@@ -81,7 +87,9 @@ export function parseDeployArgs(argv: string[]): DeployOptions {
   const mode = getFlag(argv, '--mode');
   const sha = getFlag(argv, '--sha');
   if (!mode || !sha)
-    throw new Error('Usage: deploy.ts --mode <staging|production> --sha <git-sha> [--dist <dir>] [--git-ref <ref>]');
+    throw new Error(
+      'Usage: deploy.ts --mode <staging|production> --sha <git-sha> [--dist <dir>] [--git-ref <ref>] [--defer-reap]',
+    );
   if (sha === 'latest' || sha.endsWith(':latest')) throw new Error(`Refusing to deploy non-pinned image tag '${sha}'`);
   return {
     mode,
@@ -89,6 +97,7 @@ export function parseDeployArgs(argv: string[]): DeployOptions {
     distDir: getFlag(argv, '--dist'),
     build: argv.includes('--build'),
     gitRef: getFlag(argv, '--git-ref'),
+    deferReap: argv.includes('--defer-reap'),
   };
 }
 
@@ -281,6 +290,7 @@ export async function runDeploy(
           env.primary_rollout_matrix,
           '--rest-json',
           env.roll_rest_matrix,
+          ...(opts.deferReap ? ['--skip-reap'] : []),
         ]),
       );
     } catch (err) {
@@ -346,6 +356,64 @@ export async function runDeploy(
     );
     await telemetry?.flush();
   }
+}
+
+export interface ReapOptions {
+  mode: string;
+  sha: string;
+}
+
+export function parseReapArgs(argv: string[]): ReapOptions {
+  const mode = getFlag(argv, '--mode');
+  const sha = getFlag(argv, '--sha');
+  if (!mode || !sha) throw new Error('Usage: reap.ts --mode <staging|production> --sha <git-sha>');
+  return { mode, sha };
+}
+
+/**
+ * Converge the stack on the control object's promoted pointers, destroying the
+ * generations a `--defer-reap` deploy displaced. Runs off the deploy's critical
+ * path (CI's follow-up reap job, or an operator shell). Safe without the
+ * generation keys file: only planning a NEW generation requires it and a reap
+ * plans none — active generations are pre-existing and carry `ignoreChanges`
+ * on cloud-init and image. Idempotent: with nothing displaced the update is a
+ * no-op, and a skipped reap is recovered by any later stack update.
+ */
+export async function runReap(
+  opts: ReapOptions,
+  fx: DeployEffects,
+  loadDeployEnv: (opts: DeployOptions) => Promise<Record<AllowedKey, string>> = loadDeployEnvFromConfig,
+): Promise<void> {
+  const env = await loadDeployEnv(opts);
+  const stack = env.pulumi_stack;
+
+  process.env.AWS_ACCESS_KEY_ID ??= process.env.SCW_ACCESS_KEY ?? '';
+  process.env.AWS_SECRET_ACCESS_KEY ??= process.env.SCW_SECRET_KEY ?? '';
+  process.env.AWS_DEFAULT_REGION ??= env.region;
+  process.env.SCW_DEFAULT_REGION ??= env.region;
+
+  let lockHeld = false;
+  try {
+    fx.exec('pulumi', ['login', `s3://${env.state_bucket}?endpoint=s3.${env.region}.scw.cloud&region=${env.region}`]);
+    fx.exec('pulumi', ['stack', 'select', stack]);
+    await fx.task('stack-lock', ['acquire', '--stack', stack, '--operation', 'reap', '--ttl-min', '30']);
+    lockHeld = true;
+    await fx.task('install-pulumi-providers');
+    fx.info(`[reap] converging '${stack}' on promoted generations (destroys displaced VMs)`);
+    await fx.update(stack);
+    fx.info('[reap] displaced generations reaped');
+  } finally {
+    if (lockHeld) {
+      await fx
+        .task('stack-lock', ['release', '--stack', stack])
+        .catch((err) => fx.info(`[reap] lock release failed: ${errorMessage(err)}`));
+    }
+  }
+}
+
+/** Entry called by tasks/reap.ts once APP_MODE is set (imports here evaluate shared). */
+export async function reapMain(argv = process.argv.slice(2)): Promise<void> {
+  await runReap(parseReapArgs(argv), createRealEffects());
 }
 
 // Real effects: subprocesses in the infra dir, S3 entry publish, GitHub-aware

--- a/infra/tasks/frontend-assets.test.ts
+++ b/infra/tasks/frontend-assets.test.ts
@@ -5,30 +5,39 @@ import { dirname, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { isHashedPath, uploadFrontendAssets } from './frontend-assets';
 
-/** HEAD responses per key: an object (optionally with ETag) means the key exists, absence means 404. */
-let headResponses: Record<string, { ETag?: string }>;
+/** Objects the bucket already holds (key + ETag), served by the mocked listing. */
+let remoteObjects: Array<{ Key: string; ETag?: string }>;
+/** Page size for the mocked ListObjectsV2 pagination. */
+let listPageSize: number;
+/** Number of ListObjectsV2 calls observed. */
+let listCalls: number;
 /** PutObject inputs captured per key. */
 let puts: Record<string, { CacheControl?: string; ContentType?: string }>;
 
 vi.mock('@aws-sdk/client-s3', () => {
-  class HeadObjectCommand {
-    constructor(public input: { Key: string }) {}
+  class ListObjectsV2Command {
+    constructor(public input: { ContinuationToken?: string }) {}
   }
   class PutObjectCommand {
     constructor(public input: { Key: string; CacheControl?: string; ContentType?: string }) {}
   }
   class S3Client {
-    async send(cmd: HeadObjectCommand | PutObjectCommand) {
-      if (cmd instanceof HeadObjectCommand) {
-        const response = headResponses[cmd.input.Key];
-        if (!response) throw Object.assign(new Error('NotFound'), { name: 'NotFound' });
-        return response;
+    async send(cmd: ListObjectsV2Command | PutObjectCommand) {
+      if (cmd instanceof ListObjectsV2Command) {
+        listCalls++;
+        const offset = cmd.input.ContinuationToken ? Number(cmd.input.ContinuationToken) : 0;
+        const next = offset + listPageSize;
+        return {
+          Contents: remoteObjects.slice(offset, next),
+          IsTruncated: next < remoteObjects.length,
+          NextContinuationToken: next < remoteObjects.length ? String(next) : undefined,
+        };
       }
       puts[cmd.input.Key] = { CacheControl: cmd.input.CacheControl, ContentType: cmd.input.ContentType };
       return {};
     }
   }
-  return { S3Client, HeadObjectCommand, PutObjectCommand };
+  return { S3Client, ListObjectsV2Command, PutObjectCommand };
 });
 
 const md5 = (content: string) => createHash('md5').update(Buffer.from(content)).digest('hex');
@@ -63,13 +72,17 @@ describe('uploadFrontendAssets', () => {
       writeFileSync(join(distDir, key), content);
     }
     puts = {};
-    headResponses = {
-      'assets/app-abc123.js': {},
+    listCalls = 0;
+    listPageSize = 1000;
+    remoteObjects = [
+      { Key: 'assets/app-abc123.js', ETag: `"${md5('anything: existence alone decides hashed keys')}"` },
       // Same key, same content on the remote: ETag matches the local MD5
-      'static/docs.gen/operations.gen.json': { ETag: `"${md5('[{"id":"getMe"}]')}"` },
+      { Key: 'static/docs.gen/operations.gen.json', ETag: `"${md5('[{"id":"getMe"}]')}"` },
       // Same key, but the remote holds a previous release's content
-      'static/openapi.json': { ETag: `"${md5('{"info":{"version":"v1"}}')}"` },
-    };
+      { Key: 'static/openapi.json', ETag: `"${md5('{"info":{"version":"v1"}}')}"` },
+      // Entry file published by a previous deploy: irrelevant to the bundle upload
+      { Key: 'index.html', ETag: `"${md5('<html>previous</html>')}"` },
+    ];
   });
 
   afterEach(() => rmSync(distDir, { recursive: true, force: true }));
@@ -82,5 +95,15 @@ describe('uploadFrontendAssets', () => {
     expect(puts['assets/app-def456.js']?.CacheControl).toBe('public, max-age=31536000, immutable');
     expect(puts['static/openapi.json']?.CacheControl).toBe('public, max-age=3600');
     expect(puts['favicon.ico']?.CacheControl).toBe('public, max-age=3600');
+  });
+
+  it('walks the full listing across pages instead of probing per key', async () => {
+    listPageSize = 2;
+    const result = await uploadFrontendAssets({ distDir, bucket: 'b', region: 'r', log: () => {} });
+
+    // 4 remote objects at 2 per page; a truncated listing must not hide the
+    // later pages' keys (they would re-upload as false-new otherwise).
+    expect(listCalls).toBe(2);
+    expect(result).toEqual({ uploaded: 3, skipped: 2 });
   });
 });

--- a/infra/tasks/frontend-assets.ts
+++ b/infra/tasks/frontend-assets.ts
@@ -82,7 +82,7 @@ export interface UploadAssetsOptions {
  */
 export async function uploadFrontendAssets(opts: UploadAssetsOptions): Promise<{ uploaded: number; skipped: number }> {
   const log = opts.log ?? ((message: string) => console.info(message));
-  const { S3Client, HeadObjectCommand, PutObjectCommand } = await import('@aws-sdk/client-s3');
+  const { S3Client, ListObjectsV2Command, PutObjectCommand } = await import('@aws-sdk/client-s3');
   const s3 = new S3Client({
     region: opts.region,
     endpoint: `https://s3.${opts.region}.scw.cloud`,
@@ -93,16 +93,30 @@ export async function uploadFrontendAssets(opts: UploadAssetsOptions): Promise<{
     forcePathStyle: false,
   });
 
+  // One paginated listing replaces a HeadObject round trip per key: existence
+  // answers the hashed paths, the listed ETag answers the stable-named ones
+  // (ETag is the content MD5 for single-part uploads, which is all this
+  // uploader ever performs).
+  const remoteEtags = new Map<string, string>();
+  let continuationToken: string | undefined;
+  do {
+    const page = await s3.send(new ListObjectsV2Command({ Bucket: opts.bucket, ContinuationToken: continuationToken }));
+    for (const object of page.Contents ?? []) {
+      if (object.Key) remoteEtags.set(object.Key, object.ETag?.replaceAll('"', '') ?? '');
+    }
+    continuationToken = page.IsTruncated ? page.NextContinuationToken : undefined;
+  } while (continuationToken);
+
   const keys = listDistKeys(opts.distDir).filter((key) => !isEntryFile(key));
   let uploaded = 0;
   let skipped = 0;
-  // Modest parallelism: hundreds of small objects, no need for a full pool.
   const queue = [...keys];
-  const workers = Array.from({ length: 8 }, async () => {
+  // Small objects and no per-key existence probe left: wide parallelism keeps
+  // the upload S3-bound instead of round-trip-bound.
+  const workers = Array.from({ length: 32 }, async () => {
     for (let key = queue.shift(); key !== undefined; key = queue.shift()) {
-      const head = await s3.send(new HeadObjectCommand({ Bucket: opts.bucket, Key: key })).catch(() => null);
       if (isHashedPath(key)) {
-        if (head) {
+        if (remoteEtags.has(key)) {
           skipped++;
           continue;
         }
@@ -119,11 +133,10 @@ export async function uploadFrontendAssets(opts: UploadAssetsOptions): Promise<{
         uploaded++;
         continue;
       }
-      // Stable-named key: ETag is the content MD5 for single-part uploads, so
-      // a match means the object is already current.
+      // Stable-named key: an ETag match means the object is already current.
       const body = readFileSync(join(opts.distDir, key));
       const md5 = createHash('md5').update(body).digest('hex');
-      if (head?.ETag?.replaceAll('"', '') === md5) {
+      if (remoteEtags.get(key) === md5) {
         skipped++;
         continue;
       }

--- a/infra/tasks/frontend-assets.ts
+++ b/infra/tasks/frontend-assets.ts
@@ -111,8 +111,8 @@ export async function uploadFrontendAssets(opts: UploadAssetsOptions): Promise<{
   let uploaded = 0;
   let skipped = 0;
   const queue = [...keys];
-  // Small objects and no per-key existence probe left: wide parallelism keeps
-  // the upload S3-bound instead of round-trip-bound.
+  // Uploads are the only per-key round trip; wide parallelism over these
+  // small objects keeps the transfer S3-bound.
   const workers = Array.from({ length: 32 }, async () => {
     for (let key = queue.shift(); key !== undefined; key = queue.shift()) {
       if (isHashedPath(key)) {

--- a/infra/tasks/reap.ts
+++ b/infra/tasks/reap.ts
@@ -1,0 +1,24 @@
+// Thin loader for the deferred-reap command (the counterpart of a deploy run
+// with --defer-reap). ESM hoists imports and the implementation's import graph
+// evaluates the shared appConfig at load time, so APP_MODE must be in the
+// environment BEFORE that graph loads. Parse the mode here with no app
+// imports, then load the implementation dynamically.
+const argv = process.argv.slice(2);
+const modeIndex = argv.indexOf('--mode');
+const mode = modeIndex >= 0 ? argv[modeIndex + 1] : undefined;
+if (!mode) {
+  console.error('Usage: reap.ts --mode <staging|production> --sha <git-sha>');
+  process.exit(1);
+}
+process.env.APP_MODE = mode;
+
+const { reapMain } = await import('./deploy-run');
+await reapMain(argv).catch(async (err: unknown) => {
+  const { failWithHint } = await import('../lib/utils/cli-output');
+  failWithHint(err instanceof Error ? err.message : String(err), {
+    command: 'pnpm --filter infra run reap --mode <mode> --sha <sha>',
+    description: 'Re-running is safe (the update converges on promoted pointers). The next deploy also reaps:',
+  });
+});
+
+export {};

--- a/infra/tasks/rollout.test.ts
+++ b/infra/tasks/rollout.test.ts
@@ -193,6 +193,21 @@ describe('runWavedRollout sequencing', () => {
     expect(frontendServers).toContain('10.0.0.4');
   });
 
+  it('skips the final reap update with skipFinalReap, still promoting every service', async () => {
+    const fake = makeFake(cellaFixture());
+    await runWavedRollout(
+      { sha: SHA, primary: backendPlan, rest: [cdcPlan, frontendPlan], skipFinalReap: true },
+      fake.rt,
+    );
+
+    // Wave-1 and wave-2 provisioning updates only: no trailing reap update.
+    expect(fake.ops.filter((op) => op === 'update')).toHaveLength(2);
+    expect(fake.ops.at(-1)).not.toBe('update');
+    expect(fake.ops).toContain('promote:backend:b-new');
+    expect(fake.ops).toContain('promote:cdc:c-new');
+    expect(fake.ops).toContain('promote:frontend:f-new');
+  });
+
   it('supports a rollout without a primary service', async () => {
     const fake = makeFake(cellaFixture());
     await runWavedRollout({ sha: SHA, rest: [cdcPlan, frontendPlan] }, fake.rt);

--- a/infra/tasks/rollout.ts
+++ b/infra/tasks/rollout.ts
@@ -143,10 +143,10 @@ export interface WavedRolloutPlan {
   /** Rolled together in wave 2: one provisioning update, concurrent cutovers. */
   rest: RolloutServicePlan[];
   /**
-   * Leave displaced generations running after promotion instead of reaping them
-   * in a final stack update. The displaced VMs are already detached from every
-   * LB pool, so a separate `reap` run (CI's follow-up job) destroys them off
-   * the deploy's critical path; any later stack update also converges them.
+   * Skip the final reap update and leave displaced generations running after
+   * promotion. The displaced VMs are already detached from every LB pool, so a
+   * separate `reap` run (CI's follow-up job) destroys them off the deploy's
+   * critical path; any later stack update also converges them.
    */
   skipFinalReap?: boolean;
 }

--- a/infra/tasks/rollout.ts
+++ b/infra/tasks/rollout.ts
@@ -142,6 +142,13 @@ export interface WavedRolloutPlan {
   primary?: RolloutServicePlan;
   /** Rolled together in wave 2: one provisioning update, concurrent cutovers. */
   rest: RolloutServicePlan[];
+  /**
+   * Leave displaced generations running after promotion instead of reaping them
+   * in a final stack update. The displaced VMs are already detached from every
+   * LB pool, so a separate `reap` run (CI's follow-up job) destroys them off
+   * the deploy's critical path; any later stack update also converges them.
+   */
+  skipFinalReap?: boolean;
 }
 
 /**
@@ -150,8 +157,9 @@ export interface WavedRolloutPlan {
  * records pending intent for every remaining service, provisions all their
  * generations in ONE stack update (which also reaps the primary's displaced
  * generation), then health-gates and cuts each service over concurrently.
- * A final update reaps every remaining displaced generation. Any cutover
- * failure skips that reap: a displaced generation may still be serving.
+ * A final update reaps every remaining displaced generation (deferred to a
+ * separate reap run with `skipFinalReap`). Any cutover failure skips that
+ * reap: a displaced generation may still be serving.
  */
 export async function runWavedRollout(plan: WavedRolloutPlan, rt: RolloutRuntime): Promise<void> {
   const { sha } = plan;
@@ -193,6 +201,10 @@ export async function runWavedRollout(plan: WavedRolloutPlan, rt: RolloutRuntime
     }
   }
 
+  if (plan.skipFinalReap) {
+    rt.info('[rollout] leaving displaced generations for a deferred reap run');
+    return;
+  }
   rt.info('[rollout] reaping displaced generations');
   await rt.update([...(plan.primary ? [plan.primary.service] : []), ...plan.rest.map((item) => item.service)]);
 }


### PR DESCRIPTION
## Why

Raak's 0.1.10 production deploy took ~18.5 minutes wall clock ([run 31841714568](https://github.com/cellajs/raak/actions/runs/31841714568)). Image builds were done in under 3 minutes; nearly everything else was the deploy job. Two segments were pure critical-path waste:

- **Final reap update (~2 min):** the rollout's last stack update destroys the displaced generation VMs *before* version verification, entry-file publish, and smoke run — so users get the new `index.html` two minutes later than the moment every service already serves the new release.
- **Frontend asset upload (~2 min):** one `HeadObject` round trip per dist key (~1,300 HEADs for a 750-upload deploy) on an 8-worker pool.

## What

**1. Deferred displaced-generation reap.** CI now deploys with `--defer-reap` (rollout `--skip-reap`): the rollout promotes every service and stops. Verification, entry publish, and smoke run immediately; a new follow-up `reap` job in `deploy-pipeline.yml` runs `pnpm --filter infra run reap --mode <env> --sha <tag>` — login, stack select, lock (`operation: reap`), one converging stack update, unlock — destroying the displaced VMs off the critical path.

Safety reasoning, verified against the engine:
- Displaced generations are already detached from every LB pool when cutover contracts to `[new]` and repoints follower pools; leaving their VMs running serves no traffic.
- A reap-only update is safe **without** the generation keys file: `promote()` clears `pendingSha`, so the program plans only active (pre-existing) generations, which carry `ignoreChanges` on cloud-init/image; the keys-file guard only fires when planning a NEW generation.
- Idempotent & recoverable: a failed reap job is visible in the run, and any later stack update — including the next deploy — converges the displaced VMs (same property the cutover-failure path already relies on).
- Operator behavior unchanged: plain `infra deploy` without the flag still reaps inline.
**2. List-based asset upload.** One paginated `ListObjectsV2` sweep replaces all per-key HEADs: key existence answers content-hashed `assets/` paths, the listed ETag vs local MD5 answers stable-named keys (ETags are content MD5s — this uploader only ever does single-part puts). Worker pool widened 8 → 32 now that uploads are the only per-key round trip left.

**3. Deployment-record pruning removed.** GitHub creates one deployment record per environment-declaring job (secrets are environment-scoped, so every secret-using job, matrix legs included — ~7 records per run) and offers no opt-out: the record is created by the Actions service itself, not the job's token. The `prune-deployments` job existed only to inactivate-and-delete that write-only audit noise. We now accept the clutter instead of carrying GitHub-specific administration in the deploy path; the `deployments: write` grant is gone from both `deploy.yml` and the pipeline.

## Expected effect

~3.5–4 minutes off the deploy job (~18.5 → ~14.5 min for a raak-shaped deploy), and the new release's entry files publish ~2 minutes sooner. Remaining time is dominated by VM provision + boot-to-healthy per wave — that's the option-3 (wave pipelining) discussion, deliberately not in this PR.

## Tests

- `runWavedRollout` skips the trailing update with `skipFinalReap`, still promoting every service.
- `--skip-reap` / `--defer-reap` flag parsing; deploy passes `--skip-reap` to the rollout only when deferring.
- `runReap` sequencing (login → select → lock → providers → update → unlock) and lock release on a failed update.
- Asset upload: same skip/re-upload semantics via the listing, plus a pagination test (truncated listings must not hide later pages' keys).

Full infra suite: 78 files, 672 passed. (`engine-gate` fails on `lib/scaleway/*` on main too — pre-existing, untouched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

