### PR TITLE
feat(frontend): show root package version on docs landing page

### DIFF
--- a/frontend/src/globals.d.ts
+++ b/frontend/src/globals.d.ts
@@ -1,6 +1,9 @@
 /** Release identifier (git SHA, or 'unknown') used as Maple serviceVersion. */
 declare const __APP_VERSION__: string;
 
+/** Root package.json version (release-please), shown on the docs landing page. */
+declare const __PKG_VERSION__: string;
+
 /** Build-time frontmatter + headings index of docs pages (vite/docs-frontmatter.ts). */
 declare module 'virtual:docs-frontmatter' {
   export const docsIndex: Record<

--- a/frontend/src/modules/docs/docs-landing-page.tsx
+++ b/frontend/src/modules/docs/docs-landing-page.tsx
@@ -7,7 +7,7 @@ import { type DocsTile, docsConfig, getDocPageLoader, getResolvedDocPageComponen
 import { mdxComponents } from '~/modules/page/mdx-components';
 
 /**
- * The /docs landing page (title + intro MDX + link tiles), driven by the global docs config
+ * The /docs landing page (title + intro MDX + release version + link tiles), driven by the global docs config
  * (content root index.mdx frontmatter) so apps can customize it without touching code.
  */
 export function DocsLandingPage() {
@@ -32,6 +32,7 @@ export function DocsLandingPage() {
               </MDXProvider>
             </Suspense>
           )}
+          <p className="not-prose text-muted-foreground text-sm">v{__PKG_VERSION__}</p>
           {docsConfig.tiles.length > 0 && (
             <div className="not-prose mt-8 grid gap-3 sm:grid-cols-2">
               {docsConfig.tiles.map((tile) => (

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,6 +18,7 @@ import { defineConfig, type Plugin, type UserConfig } from 'vite';
 import { createHtmlPlugin } from 'vite-plugin-html';
 import { VitePWA } from 'vite-plugin-pwa';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
+import rootPkg from '../package.json' with { type: 'json' };
 import { appConfig } from '../shared/index.ts';
 import { docsEditor } from './vite/docs-editor.ts';
 import { docsFrontmatter } from './vite/docs-frontmatter.ts';
@@ -336,6 +337,8 @@ const viteConfig = {
     __BACKEND_URL__: JSON.stringify(appConfig.backendUrl),
     // Release identifier for observability (lib/maple.ts serviceVersion)
     __APP_VERSION__: JSON.stringify(gitSha),
+    // Root release version, shown on the docs landing page
+    __PKG_VERSION__: JSON.stringify(rootPkg.version),
   },
 } satisfies UserConfig;
 


### PR DESCRIPTION
Shows the root `package.json` version (bumped by release-please) below the intro content on the `/docs` landing page.

## How

- `frontend/vite.config.ts`: new build-time define `__PKG_VERSION__` from the root `package.json` version, next to the existing `__APP_VERSION__` (git SHA) define. `__APP_VERSION__` is untouched — it remains the release identifier for Maple observability.
- `frontend/src/globals.d.ts`: declaration for the new constant.
- `frontend/src/modules/docs/docs-landing-page.tsx`: renders `v0.9.2` (muted, small) below the intro MDX, above the tiles.

A build-time define was chosen over `appConfig` (runtime config, templated per-mode by create-cella — no shape change needed) and over importing the root package.json in client code (keeps it out of the frontend module graph). Since forks sync these files, each fork's docs page shows its own root version automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)