### PR TITLE
fix(frontend): probe session cookie before bouncing signed-in users to authenticate

### DIFF
--- a/frontend/src/modules/auth/use-post-auth-redirect.ts
+++ b/frontend/src/modules/auth/use-post-auth-redirect.ts
@@ -2,10 +2,19 @@ import { useSearch } from '@tanstack/react-router';
 import { appConfig } from 'shared';
 
 /**
+ * Validates a post-auth redirect target, falling back to the default redirect path. Only
+ * same-origin absolute paths pass (`//host` is scheme-relative and rejected). UX-only guard;
+ * the backend re-validates before any 302.
+ */
+export function resolvePostAuthRedirect(redirect: string | undefined): string {
+  return redirect?.startsWith('/') && !redirect.startsWith('//') ? redirect : appConfig.defaultRedirectPath;
+}
+
+/**
  * Validated post-auth redirect path from the current route's `?redirect=` search param, falling
- * back to the default redirect path. UX-only guard; the backend re-validates before any 302.
+ * back to the default redirect path.
  */
 export function usePostAuthRedirect() {
   const { redirect } = useSearch({ strict: false });
-  return redirect?.startsWith('/') ? redirect : appConfig.defaultRedirectPath;
+  return resolvePostAuthRedirect(redirect);
 }

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -46,8 +46,7 @@ export const Route = createRootRouteWithContext()({
     try {
       await queryClient.ensureQueryData({ ...meQueryOptions() });
     } catch (error) {
-      // Only a definitive 401 means signed out. Anything else (network blip, 5xx) rethrows to
-      // the root error boundary instead of masquerading a transient failure as a sign-out.
+      // Only a definitive 401 means signed out; network blips and 5xx rethrow to the root error boundary.
       if (!(error instanceof ApiError) || Number(error.status) !== 401) throw error;
 
       console.info('[RootRoute] Not authenticated -> redirect to sign in');

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -1,5 +1,6 @@
 import { createRootRouteWithContext, redirect } from '@tanstack/react-router';
 import i18n from 'i18next';
+import { ApiError } from '~/lib/api';
 import { ErrorNotice, type ErrorNoticeError } from '~/modules/common/error-notice';
 import { Root } from '~/modules/common/root';
 import { meQueryOptions } from '~/modules/me/query';
@@ -44,7 +45,11 @@ export const Route = createRootRouteWithContext()({
 
     try {
       await queryClient.ensureQueryData({ ...meQueryOptions() });
-    } catch {
+    } catch (error) {
+      // Only a definitive 401 means signed out. Anything else (network blip, 5xx) rethrows to
+      // the root error boundary instead of masquerading a transient failure as a sign-out.
+      if (!(error instanceof ApiError) || Number(error.status) !== 401) throw error;
+
       console.info('[RootRoute] Not authenticated -> redirect to sign in');
       const redirectPath = location.pathname + location.searchStr;
       throw redirect({ to: '/auth/authenticate', search: { fromRoot: true, redirect: redirectPath } });

--- a/frontend/src/routes/_app/route.tsx
+++ b/frontend/src/routes/_app/route.tsx
@@ -22,25 +22,32 @@ export const Route = createFileRoute('/_app')({
   beforeLoad: async ({ location, cause }) => {
     if (cause !== 'enter') return;
 
-    const storedUser = useUserStore.getState().user;
+    let storedUser = useUserStore.getState().user;
 
-    // Redirect immediately without awaiting `/me`, preserving first paint when backend is slow.
-    // Background hydration restores valid sessions; global query handling owns failures.
     if (!storedUser) {
-      void queryClient.ensureQueryData({ ...meQueryOptions() }).catch(() => {});
-
-      // If root domain, check for last user to decide where to redirect
+      // On root domain, check for last user to decide where to redirect
       if (location.pathname === '/') {
         const { lastUser } = useUserStore.getState();
-        if (lastUser) throw redirect({ to: '/auth/authenticate', replace: true });
-        throw redirect({ to: '/about', replace: true });
+        if (!lastUser) throw redirect({ to: '/about', replace: true });
+
+        // Returning user: the session cookie may still be valid while the store is empty (e.g.
+        // right after a backend-driven sign-in). Probe /me before bouncing to sign-in.
+        try {
+          storedUser = await queryClient.ensureQueryData({ ...meQueryOptions() });
+        } catch {
+          throw redirect({ to: '/auth/authenticate', search: { fromRoot: true }, replace: true });
+        }
+      } else {
+        // Redirect immediately without awaiting `/me`, preserving first paint when backend is slow.
+        // Background hydration restores valid sessions; global query handling owns failures.
+        void queryClient.ensureQueryData({ ...meQueryOptions() }).catch(() => {});
+
+        console.info('Not authenticated -> redirect to sign in');
+
+        const url = new URL(location.pathname, window.location.origin);
+        const redirectPath = url.pathname + url.search;
+        throw redirect({ to: '/auth/authenticate', search: { fromRoot: true, redirect: redirectPath } });
       }
-
-      console.info('Not authenticated -> redirect to sign in');
-
-      const url = new URL(location.pathname, window.location.origin);
-      const redirectPath = url.pathname + url.search;
-      throw redirect({ to: '/auth/authenticate', search: { fromRoot: true, redirect: redirectPath } });
     }
 
     // Stored user -> continue into the app and revalidate the session in the background

--- a/frontend/src/routes/_public/auth/authenticate.tsx
+++ b/frontend/src/routes/_public/auth/authenticate.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, redirect } from '@tanstack/react-router';
-import { appConfig } from 'shared';
 import { useAuthStore } from '~/modules/auth/auth-store';
 import { AuthenticatePage } from '~/modules/auth/authenticate-page';
 import { authenticateRouteSearchParamsSchema } from '~/modules/auth/search-params-schemas';
+import { resolvePostAuthRedirect } from '~/modules/auth/use-post-auth-redirect';
+import { meQueryOptions } from '~/modules/me/query';
 import { useUserStore } from '~/modules/user/user-store';
+import { queryClient } from '~/query/query-client';
 import { appTitle } from '~/utils/app-title';
 
 /**
@@ -16,13 +18,22 @@ export const Route = createFileRoute('/_public/auth/authenticate')({
   beforeLoad: async ({ cause, search }) => {
     useAuthStore.getState().resetSteps();
 
-    // Only check auth if entering to prevent loop
+    // Only check auth if entering. `fromRoot` means a route guard already probed the session
+    // and found none, so don't probe again (prevents a redirect loop).
     if (cause !== 'enter' || search.fromRoot) return;
 
-    // If stored user, redirect to home
-    const { user: storedUser } = useUserStore.getState();
-    if (!storedUser) return;
-    throw redirect({ to: appConfig.defaultRedirectPath, replace: true });
+    // The session cookie is the authority, not the persisted store: after a backend-driven
+    // sign-in (magic link, OAuth) the cookie is valid while the store is still empty.
+    if (!useUserStore.getState().user) {
+      try {
+        await queryClient.ensureQueryData({ ...meQueryOptions() });
+      } catch {
+        return; // No valid session -> show the authenticate page
+      }
+    }
+
+    // Signed in: honor a validated redirect target, else go home
+    throw redirect({ to: resolvePostAuthRedirect(search.redirect), replace: true });
   },
   component: AuthenticatePage,
 });


### PR DESCRIPTION
## Problem

Magic link sign-in sometimes lands on `/auth/authenticate` even though the session is valid. The magic-link flow signs in entirely on the backend (`invoke-token` sets the cookie and 302s to the app), so on landing the browser is signed in while the persisted user store is still empty — and the route guards treated the **store**, not the cookie, as the source of truth.

Three paths could strand a signed-in user on the sign-in form:

1. `/auth/authenticate` `beforeLoad` only checked the stored user, never the cookie.
2. The root guard turned **any** `/me` failure (network blip, 5xx, cold start) into a `fromRoot=true` redirect to authenticate — and `fromRoot` disables the authenticate route's own bounce-home check, so the valid session never rescued you.
3. The `_app` guard on `/` bounced returning users (`lastUser` set) to authenticate immediately, without awaiting the `/me` probe it had just fired in the background.

## Changes

- **`/auth/authenticate`**: when the store is empty, probe `/me` before showing the form; on success redirect to the validated `?redirect=` target or home. `fromRoot` keeps its meaning — "a guard already probed and failed" — so there is no probe loop and no double probe.
- **Root guard**: only a definitive `ApiError` 401 redirects to sign-in; other failures rethrow to the root error boundary instead of masquerading as a sign-out.
- **`_app` guard on `/`**: awaits the `/me` probe for returning users and only redirects to authenticate when it fails (with `fromRoot: true` so authenticate doesn't re-probe. Unknown visitors still go straight to ; the non-root fast path is unchanged.
- ****: extracted  so the route guard can reuse it, and tightened it to reject scheme-relative () targets (frontend UX guard; the backend already re-validated these).

## Verification

- Full workspace typecheck (Scope: 10 of 11 workspace projects
shared ts$ cd .. && tsgo -p shared/tsconfig.json --pretty
shared ts: Done
infra ts$ cd .. && tsgo -p infra/tsconfig.json --pretty
bench ts$ tsgo --pretty
mcp ts$ cd .. && tsgo -p mcp/tsconfig.json --pretty
sdk ts$ cd .. && tsgo -p sdk/tsconfig.json --pretty
sdk ts: Done
yjs ts$ tsgo --pretty
bench ts: Done
yjs ts: Done
infra ts: Done
mcp ts: Done
frontend ts$ cd .. && tsgo -p frontend/tsconfig.json --pretty
cdc ts$ tsgo --pretty
cdc ts: Done
frontend ts: Done
backend ts$ cd .. && tsgo -p backend/tsconfig.json --pretty
backend ts: Done), biome, and SDK generation pass (pre-commit gates).
- No existing tests cover these route guards; behavior verified by tracing the guard flow for the magic-link landing,  visit with , and transient  failure scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)