### PR TITLE
fix(frontend): keep role visible in menu sheet item, append submenu count only in compact menu

### DIFF
--- a/frontend/src/modules/navigation/menu-sheet/item.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/item.tsx
@@ -92,11 +92,11 @@ export function MenuSheetItem({ item, icon: Icon, className }: MenuSheetItemProp
         </div>
         <div className="pointer-events-none text-muted-foreground text-xs">
           <span className="absolute opacity-0 transition-opacity duration-100 ease-in-out group-hover/menuItem:delay-300 sm:group-hover/menuItem:opacity-100">
-            {item.submenu?.length
-              ? `${item.submenu?.length} ${t(item.submenu?.length > 1 ? item.submenu[0].entityType : item.submenu[0].entityType).toLowerCase()}`
-              : item.membership.role
-                ? t(item.membership.role)
-                : ''}
+            {item.membership.role ? t(item.membership.role) : ''}
+            {/* Submenu count is redundant when detailedMenu already renders the sub-items */}
+            {!detailedMenu && item.submenu?.length
+              ? `${item.membership.role ? ' · ' : ''}${item.submenu.length} ${t(item.submenu[0].entityType, { count: item.submenu.length }).toLowerCase()}`
+              : ''}
           </span>
         </div>
       </div>


### PR DESCRIPTION
In forks with sub-items (raak, projectcampus), the menu sheet item label replaced the membership role with a submenu count ("1 project"). This keeps the role always visible and appends a centerdot separator plus the pluralized count after it — but only when `detailedMenu` is off, since with the detailed menu on the sub-items are already rendered below and the count is redundant.

Also cleans up the old ternary (both branches were identical) and switches to `t(entityType, { count })` so the count label pluralizes via the `_one`/`_other` locale keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)