### PR TITLE
feat(frontend): show single healthy summary in info panel status section

### DIFF
--- a/frontend/src/modules/navigation/menu-sheet/info-section.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/info-section.tsx
@@ -46,6 +46,7 @@ export function InfoContent() {
   const contactRef = useRef<HTMLButtonElement | null>(null);
   const { data: health, isError } = useQuery(healthQueryOptions());
   const statusServices = Object.entries(health?.components ?? {}).filter(([, component]) => component.label);
+  const allHealthy = !isError && health?.status === 'healthy';
 
   const hasStatusPage = !!appConfig.statusUrl?.trim();
 
@@ -106,9 +107,11 @@ export function InfoContent() {
             </Button>
           )}
         </div>
-        <div className="grid grid-cols-2 gap-2 pt-1">
+        <div className={cn('gap-2 pt-1', allHealthy ? 'flex flex-col' : 'grid grid-cols-2')}>
           {isError ? (
             <StatusCard label="API" status="unhealthy" />
+          ) : allHealthy ? (
+            <StatusCard label={t('c:all_systems_healthy')} status="healthy" />
           ) : (
             statusServices.map(([key, component]) => (
               <StatusCard key={key} label={component.label ?? key} status={component.status} />

--- a/frontend/src/modules/navigation/menu-sheet/query.ts
+++ b/frontend/src/modules/navigation/menu-sheet/query.ts
@@ -22,7 +22,7 @@ async function fetchHealth(signal?: AbortSignal): Promise<HealthResponse> {
 
 /**
  * Query options for the backend health status shown in the info panel.
- * Polls on an interval and is safe to prefetch on intent (e.g. button hover).
+ * Polls on an interval while the info panel is open.
  */
 export const healthQueryOptions = () =>
   queryOptions({

--- a/frontend/src/modules/navigation/menu-sheet/sheet-panel.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/sheet-panel.tsx
@@ -6,24 +6,20 @@ import type { TKey } from '~/lib/i18n-locales';
 import { FocusTrap } from '~/modules/common/focus-trap';
 import { InfoContent } from '~/modules/navigation/menu-sheet/info-section';
 import { PreferencesContent } from '~/modules/navigation/menu-sheet/preferences-section';
-import { healthQueryOptions } from '~/modules/navigation/menu-sheet/query';
 import { useNavigationStore } from '~/modules/navigation/navigation-store';
 import { Button } from '~/modules/ui/button';
-import { queryClient } from '~/query/query-client';
 import { cn } from '~/utils/cn';
 
 interface MenuSheetPanelProps {
   id: string;
   label: TKey;
   children: ReactNode;
-  /** Fired on hover/focus of the panel button to warm data before the panel opens. */
-  onPrefetch?: () => void;
 }
 
 /**
  * Single accordion panel button + expandable content.
  */
-function MenuSheetPanel({ id, label, children, onPrefetch }: MenuSheetPanelProps) {
+function MenuSheetPanel({ id, label, children }: MenuSheetPanelProps) {
   const { t } = useTranslation();
   const menuSheetPanel = useNavigationStore((state) => state.menuSheetPanel);
   const toggleMenuSheetPanel = useNavigationStore((state) => state.toggleMenuSheetPanel);
@@ -34,8 +30,6 @@ function MenuSheetPanel({ id, label, children, onPrefetch }: MenuSheetPanelProps
     <div>
       <Button
         onClick={() => toggleMenuSheetPanel(id)}
-        onMouseEnter={onPrefetch}
-        onFocus={onPrefetch}
         className="w-full justify-between shadow-none"
         variant={isOpen ? 'secondary' : 'ghost'}
       >
@@ -114,7 +108,7 @@ export function MenuSheetPanels() {
           <MenuSheetPanel id="preferences" label="c:preferences">
             <PreferencesContent />
           </MenuSheetPanel>
-          <MenuSheetPanel id="info" label="c:info" onPrefetch={() => queryClient.prefetchQuery(healthQueryOptions())}>
+          <MenuSheetPanel id="info" label="c:info">
             <InfoContent />
           </MenuSheetPanel>
         </div>

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -15,6 +15,7 @@
   "admin_other": "Admins",
   "admins": "Admins",
   "all": "All",
+  "all_systems_healthy": "All systems healthy",
   "almost_there": "Almost there!",
   "alphabetical": "Alphabetical",
   "already_connected_to": "Account connected to",


### PR DESCRIPTION
## What

- When the backend health envelope reports an overall `healthy` status, the menu sheet info panel now shows a single full-width "All systems healthy" row (same pulsing dot styling) instead of the per-service grid.
- The two-column grid still appears when one or more components are degraded/unhealthy, and the fetch-error case keeps its single unhealthy "API" card.
- Removes the hover/focus prefetch of the health query on the panel button. It existed to warm the grid so the expand animation measured the right height, but never worked reliably; the animation targets `height: auto` and re-flows fine once data lands.
- Adds the `all_systems_healthy` key to `locales/en/common.json` (Dutch overlay intentionally untouched).

## Notes

- First open of the info panel now briefly shows an empty status section until the health fetch resolves (~one round trip). A skeleton row could cover this later if it bothers anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)