### PR TITLE
feat(frontend): animate row reorder in data grid via row-box mode

### DIFF
--- a/frontend/src/modules/common/data-grid/data-grid.tsx
+++ b/frontend/src/modules/common/data-grid/data-grid.tsx
@@ -464,8 +464,8 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
   });
 
   // Row-box mode: draggable, non-virtualized, keyed tables without frozen columns render
-  // rows as real subgrid boxes and animate reorders via motion layout. Each condition is
-  // load-bearing: virtualized rows unmount mid-scroll (breaking FLIP), index keys defeat
+  // rows as real subgrid boxes and animate reorders via motion layout. Every condition is
+  // required: virtualized rows unmount mid-scroll (breaking FLIP), index keys defeat
   // DOM persistence, and a transformed row would unstick frozen cells.
   const animateReorder =
     rowDragEnabled && !enableRowVirtualization && typeof rowKeyGetter === 'function' && lastFrozenColumnIndex === -1;

--- a/frontend/src/modules/common/data-grid/data-grid.tsx
+++ b/frontend/src/modules/common/data-grid/data-grid.tsx
@@ -463,6 +463,13 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
     activeModes,
   });
 
+  // Row-box mode: draggable, non-virtualized, keyed tables without frozen columns render
+  // rows as real subgrid boxes and animate reorders via motion layout. Each condition is
+  // load-bearing: virtualized rows unmount mid-scroll (breaking FLIP), index keys defeat
+  // DOM persistence, and a transformed row would unstick frozen cells.
+  const animateReorder =
+    rowDragEnabled && !enableRowVirtualization && typeof rowKeyGetter === 'function' && lastFrozenColumnIndex === -1;
+
   // Pin header row(s) to viewport top when grid scrolls out of view
   useStickyHeader(gridRef, headerRowsCount, headerRowHeight, enableStickyHeader);
 
@@ -1222,6 +1229,7 @@ export function DataGrid<R, SR = unknown, K extends Key = Key>(props: DataGridPr
           onCellContextMenu: onCellContextMenuLatest,
           isCellSelectionEnabled,
           rowClass,
+          animateReorder,
           gridRowStart,
           selectedCellIdx: selectedRowIdx === rowIdx ? selectedIdx : undefined,
           lastFrozenColumnIndex,

--- a/frontend/src/modules/common/data-grid/row.tsx
+++ b/frontend/src/modules/common/data-grid/row.tsx
@@ -1,3 +1,4 @@
+import { type HTMLMotionProps, motion, useReducedMotion } from 'motion/react';
 import { memo, useMemo } from 'react';
 import { useLatestCallback } from '~/hooks/use-latest-ref';
 import { RowSelectionContext, type RowSelectionContextValue } from './hooks';
@@ -25,15 +26,20 @@ function Row<R, SR>({
   renderCell,
   selectedCellRange,
   isCellSelectionEnabled,
+  animateReorder,
   style,
   ...props
 }: RenderRowProps<R, SR>) {
+  const reducedMotion = useReducedMotion();
   const handleRowChange = useLatestCallback((column: CalculatedColumn<R, SR>, newRow: R) => {
     onRowChange(column, rowIdx, newRow);
   });
 
   className = cn(
-    'rdg-row group/row contents aria-selected:bg-accent aria-selected:hover:bg-accent',
+    'rdg-row group/row aria-selected:bg-accent aria-selected:hover:bg-accent',
+    // Row-box mode needs a real box for motion layout measurement; cells flow into the
+    // row's own subgrid so column tracks still resolve at the root grid.
+    animateReorder ? 'rdg-row-box col-span-full grid grid-cols-subgrid' : 'contents',
     `rdg-row-${rowIdx % 2 === 0 ? 'even' : 'odd'}`,
     {
       'rdg-row-selected': selectedCellIdx === -1,
@@ -90,17 +96,34 @@ function Row<R, SR>({
     [isRowSelectionDisabled, isRowSelected],
   );
 
+  const rowStyle = {
+    ...getRowStyle(gridRowStart),
+    ...style,
+  };
+
+  if (animateReorder) {
+    return (
+      <RowSelectionContext value={selectionValue}>
+        <motion.div
+          role="row"
+          // Position-only layout animation: rows keep their size on reorder, and
+          // animating scale would distort cell borders.
+          layout={reducedMotion ? false : 'position'}
+          className={className}
+          style={rowStyle}
+          // React's DOM drag/animation handler types collide with motion's same-named
+          // props; the runtime props (aria attributes) are compatible.
+          {...(props as unknown as HTMLMotionProps<'div'>)}
+        >
+          {cells}
+        </motion.div>
+      </RowSelectionContext>
+    );
+  }
+
   return (
     <RowSelectionContext value={selectionValue}>
-      <div
-        role="row"
-        className={className}
-        style={{
-          ...getRowStyle(gridRowStart),
-          ...style,
-        }}
-        {...props}
-      >
+      <div role="row" className={className} style={rowStyle} {...props}>
         {cells}
       </div>
     </RowSelectionContext>

--- a/frontend/src/modules/common/data-grid/style/data-grid.css
+++ b/frontend/src/modules/common/data-grid/style/data-grid.css
@@ -7,6 +7,16 @@
   grid-row-start: var(--rdg-grid-row-start);
 }
 
+/* Row-box rows (animated reorder) carry the row placement themselves; their cells reset
+ * to auto so they flow into the row's subgrid instead of the root grid's row tracks. */
+.rdg-row-box {
+  grid-row-start: var(--rdg-grid-row-start);
+}
+
+.rdg-row-box > .rdg-cell {
+  grid-row-start: auto;
+}
+
 /* Show the last frozen cell shadow only when the grid is scrolled horizontally. */
 [data-scrolled-left] > .rdg-cell-frozen:nth-last-child(1 of .rdg-cell-frozen),
 [data-scrolled-left] > * > .rdg-cell-frozen:nth-last-child(1 of .rdg-cell-frozen) {

--- a/frontend/src/modules/common/data-grid/style/data-grid.css
+++ b/frontend/src/modules/common/data-grid/style/data-grid.css
@@ -8,7 +8,7 @@
 }
 
 /* Row-box rows (animated reorder) carry the row placement themselves; their cells reset
- * to auto so they flow into the row's subgrid instead of the root grid's row tracks. */
+ * to auto so they flow into the row's subgrid, not the root grid's row tracks. */
 .rdg-row-box {
   grid-row-start: var(--rdg-grid-row-start);
 }

--- a/frontend/src/modules/common/data-grid/types.ts
+++ b/frontend/src/modules/common/data-grid/types.ts
@@ -339,6 +339,12 @@ export interface BaseRenderRowProps<TRow, TSummaryRow = unknown> extends BaseCel
 
 export interface RenderRowProps<TRow, TSummaryRow = unknown> extends BaseRenderRowProps<TRow, TSummaryRow> {
   row: TRow;
+  /**
+   * Row-box mode: render the row as a real subgrid box (instead of display:contents) and
+   * animate order changes via motion layout. Derived by DataGrid for draggable,
+   * non-virtualized, keyed tables without frozen columns.
+   */
+  animateReorder?: boolean;
   lastFrozenColumnIndex: number;
   selectedCellEditor: ReactElement<RenderEditCellProps<TRow>> | undefined;
   onRowChange: (column: CalculatedColumn<TRow, TSummaryRow>, rowIdx: number, newRow: TRow) => void;

--- a/frontend/src/modules/common/data-grid/types.ts
+++ b/frontend/src/modules/common/data-grid/types.ts
@@ -340,7 +340,7 @@ export interface BaseRenderRowProps<TRow, TSummaryRow = unknown> extends BaseCel
 export interface RenderRowProps<TRow, TSummaryRow = unknown> extends BaseRenderRowProps<TRow, TSummaryRow> {
   row: TRow;
   /**
-   * Row-box mode: render the row as a real subgrid box (instead of display:contents) and
+   * Row-box mode: render the row as a real subgrid box (not display:contents) and
    * animate order changes via motion layout. Derived by DataGrid for draggable,
    * non-virtualized, keyed tables without frozen columns.
    */

--- a/frontend/src/modules/entities/tabs-arrangement-card.tsx
+++ b/frontend/src/modules/entities/tabs-arrangement-card.tsx
@@ -55,8 +55,8 @@ export function TabsArrangementCard({ entity, parentRouteId, persist }: TabsArra
   const slotConfig = entity.toolsConfig?.[slot];
   const hidden = new Set(slotConfig?.hidden ?? []);
 
-  // Draft order applied at drop time so the reorder animates as a response to the drop
-  // instead of after the mutation round-trip; cleared once a persisted order arrives.
+  // Draft order applied at drop time so the reorder animates as a response to the drop,
+  // without waiting on the mutation round-trip; cleared once a persisted order arrives.
   const [draftOrder, setDraftOrder] = useState<string[] | null>(null);
   const persistedOrderKey = (slotConfig?.order ?? []).join();
   useEffect(() => setDraftOrder(null), [persistedOrderKey]);

--- a/frontend/src/modules/entities/tabs-arrangement-card.tsx
+++ b/frontend/src/modules/entities/tabs-arrangement-card.tsx
@@ -1,4 +1,5 @@
 import { GripVerticalIcon, LockIcon } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { SlotToolsConfig, ToolsConfig } from 'shared/tools-config';
 import type { TKey } from '~/lib/i18n-locales';
@@ -54,6 +55,12 @@ export function TabsArrangementCard({ entity, parentRouteId, persist }: TabsArra
   const slotConfig = entity.toolsConfig?.[slot];
   const hidden = new Set(slotConfig?.hidden ?? []);
 
+  // Draft order applied at drop time so the reorder animates as a response to the drop
+  // instead of after the mutation round-trip; cleared once a persisted order arrives.
+  const [draftOrder, setDraftOrder] = useState<string[] | null>(null);
+  const persistedOrderKey = (slotConfig?.order ?? []).join();
+  useEffect(() => setDraftOrder(null), [persistedOrderKey]);
+
   const candidates = getNavTabCandidates(parentRouteId).map(({ id, label, resource, order, locked }) => ({
     id,
     label,
@@ -61,7 +68,7 @@ export function TabsArrangementCard({ entity, parentRouteId, persist }: TabsArra
     order,
     locked,
   }));
-  const rows = orderBySlotConfig(candidates, slotConfig).map((tab) => ({
+  const rows = orderBySlotConfig(candidates, draftOrder ? { order: draftOrder } : slotConfig).map((tab) => ({
     ...tab,
     name: t(tab.label, { resource: tab.resource ? t(tab.resource).toLowerCase() : '' }),
     visible: !hidden.has(tab.id),
@@ -80,6 +87,7 @@ export function TabsArrangementCard({ entity, parentRouteId, persist }: TabsArra
     let insertAt = edge === 'bottom' ? toIdx + 1 : toIdx;
     if (fromIdx < insertAt) insertAt -= 1;
     ids.splice(insertAt, 0, moved);
+    setDraftOrder(ids);
     persistSlot({ order: ids, hidden: [...hidden] });
   };
 


### PR DESCRIPTION
Reordering a tab in the org settings tools card now animates rows into place with a motion layout animation, the same feel as the menu sheet. The capability lives in the vendored data grid so every qualifying table gets it.

## How

**Row-box mode in the DataGrid engine.** Rows in the grid are `display: contents`, so they have no box to animate — the cells are the real grid items. When a table is draggable (`onRowReorder`), non-virtualized, keyed (`rowKeyGetter`), and has no frozen columns, rows now render as real subgrid boxes (`grid grid-cols-subgrid col-span-full`) and become `motion.div` elements with a position-only `layout` animation. Cells inside a row box reset `grid-row-start` to auto and flow into the row's subgrid, so column tracks still resolve at the root grid and column auto-measurement keeps working.

Each gate condition is load-bearing:
- virtualized rows unmount mid-scroll, which breaks FLIP measurement;
- index-based keys defeat the DOM persistence FLIP needs;
- a transform on the row would unstick frozen (sticky) cells.

`prefers-reduced-motion` disables the animation via `useReducedMotion`.

**Draft order in the tabs arrangement card.** The org update mutation is not optimistic, so without local state the reorder would only animate after the server round-trip. The card now applies the new order locally at drop time and clears the draft when a persisted order arrives — the animation reads as a response to the drop, and a server rejection that returns a different order animates the rows back.

## Verified

- `pnpm --filter frontend ts`, biome, and all 858 frontend unit tests pass (plus workspace-wide tsgo via the commit hook).
- Playwright against the live dev stack (org settings page, minted admin session): row-box mode active, row/cell geometry intact (rows 745×52 with cells matching column tracks), drag-reorder of the tabs card applies the correct closest-edge order immediately, and a mid-drop frame confirms the transform animation runs.

## Notes for reviewers / fork sync

- The engine now has two row layout paths (`contents` vs row-box). The drop-edge indicator CSS still targets cells and works in both modes; collapsing it to a single row-level shadow in row-box mode is a possible follow-up.
- This adds the first `motion/react` import to the vendored grid (already an app-wide dependency, so no bundle impact).
- raak syncs these engine files — flagging since the row DOM structure changes in row-box mode (a real box instead of `display: contents`; only for tables matching the gate). `pages-table` is virtualized and unaffected.
- If a persist fails without changing the entity, the card keeps showing the drafted order until the next successful sync — same failure envelope as before (the old code showed the stale order instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
