### PR TITLE
fix(frontend): collapse docs sidebar branches only from the route they point at

### DIFF
--- a/frontend/src/modules/docs/sidebar/collapsible-tag-item.tsx
+++ b/frontend/src/modules/docs/sidebar/collapsible-tag-item.tsx
@@ -15,13 +15,13 @@ const tagTypeConfig = {
   operations: {
     linkTo: '/docs/operations' as const,
     getHash: (name: string) => `tag/${name}`,
-    getSearch: (isExpanded: boolean, name: string) => ({ operationTag: isExpanded ? undefined : name }),
+    getSearch: (collapse: boolean, name: string) => ({ operationTag: collapse ? undefined : name }),
     triggerClassName: 'text-left',
   },
   schemas: {
     linkTo: '/docs/schemas' as const,
     getHash: (name: string) => name,
-    getSearch: (isExpanded: boolean, name: string) => ({ schemaTag: isExpanded ? undefined : name }),
+    getSearch: (collapse: boolean, name: string) => ({ schemaTag: collapse ? undefined : name }),
     triggerClassName: 'justify-start lowercase',
   },
 };
@@ -58,6 +58,9 @@ function CollapsibleTagItemBase<T>({
   const isMobile = useBreakpointBelow('md', false);
   const { linkTo, getSearch, getHash, triggerClassName } = tagTypeConfig[type];
   const hash = getHash(tag.name);
+  // Collapsing is a re-click on the section you are already reading. While expanded but scrolled
+  // elsewhere, the click stays a jump to this section instead of folding it away underneath you.
+  const collapseOnClick = isExpanded && isActive;
 
   return (
     <Collapsible open={isExpanded}>
@@ -69,7 +72,7 @@ function CollapsibleTagItemBase<T>({
           render={
             <Link
               to={linkTo}
-              search={(prev) => ({ ...prev, ...getSearch(isExpanded, tag.name) })}
+              search={(prev) => ({ ...prev, ...getSearch(collapseOnClick, tag.name) })}
               hash={hash}
               replace
               resetScroll={false}

--- a/frontend/src/modules/docs/sidebar/collapsible-tag-item.tsx
+++ b/frontend/src/modules/docs/sidebar/collapsible-tag-item.tsx
@@ -59,7 +59,7 @@ function CollapsibleTagItemBase<T>({
   const { linkTo, getSearch, getHash, triggerClassName } = tagTypeConfig[type];
   const hash = getHash(tag.name);
   // Collapsing is a re-click on the section you are already reading. While expanded but scrolled
-  // elsewhere, the click stays a jump to this section instead of folding it away underneath you.
+  // elsewhere, the click jumps to this section and leaves it open.
   const collapseOnClick = isExpanded && isActive;
 
   return (

--- a/frontend/src/modules/docs/sidebar/page-tree-item.tsx
+++ b/frontend/src/modules/docs/sidebar/page-tree-item.tsx
@@ -19,23 +19,13 @@ type PageBranchProps = {
   node: PageNode;
   variant: 'root' | 'parent';
   activePageId: string | undefined;
-  /** Ancestor chain of the active page. This row contains the active page iff its id is included. */
-  activeAncestorIds: ReadonlySet<string>;
   expandedIds: ReadonlySet<string>;
   onToggle: (id: string) => void;
   onClose: () => void;
 };
 
 /** Tier 0 (root) and tier 1 (parent) page rows. Both are collapsible; only visuals differ. */
-export function PageBranch({
-  node,
-  variant,
-  activePageId,
-  activeAncestorIds,
-  expandedIds,
-  onToggle,
-  onClose,
-}: PageBranchProps) {
+export function PageBranch({ node, variant, activePageId, expandedIds, onToggle, onClose }: PageBranchProps) {
   const { page, children } = node;
   const hasChildren = children.length > 0;
   const isExpanded = expandedIds.has(page.id);
@@ -79,8 +69,9 @@ export function PageBranch({
               onToggle(page.id);
               return;
             }
-            // Re-click on an expanded branch collapses it, unless the user is viewing one of its subpages
-            if (hasChildren && isExpanded && !activeAncestorIds.has(page.id)) {
+            // Collapsing is a re-click on the page you are already on. From anywhere else the
+            // click navigates here (the branch has its own page) and leaves the subtree open.
+            if (hasChildren && isExpanded && isActive) {
               e.preventDefault();
               onToggle(page.id);
               return;
@@ -118,7 +109,6 @@ export function PageBranch({
                     node={child}
                     variant="parent"
                     activePageId={activePageId}
-                    activeAncestorIds={activeAncestorIds}
                     expandedIds={expandedIds}
                     onToggle={onToggle}
                     onClose={onClose}

--- a/frontend/src/modules/docs/sidebar/pages-sidebar.tsx
+++ b/frontend/src/modules/docs/sidebar/pages-sidebar.tsx
@@ -22,7 +22,7 @@ export function PagesSidebar({ onClose }: PagesSidebarProps) {
 
   const pageTree = buildPageNodeTree(pages);
 
-  // Ancestor chain seeds expansion on route change and tells rows whether a subpage is active
+  // Ancestor chain of the active page: seeds expansion on route change.
   const activeAncestorIds = useMemo(() => computeAncestorIds(pages, activePageId), [pages, activePageId]);
 
   // Effective parent per page id for sibling lookup (orphans count as roots, like buildPageNodeTree)
@@ -68,7 +68,6 @@ export function PagesSidebar({ onClose }: PagesSidebarProps) {
             node={node}
             variant="root"
             activePageId={activePageId}
-            activeAncestorIds={activeAncestorIds}
             expandedIds={expandedIds}
             onToggle={togglePageExpanded}
             onClose={onClose}


### PR DESCRIPTION
Clicking an expanded node with children in the docs sidebar folded it shut from anywhere in the docs. A click meant as "take me there" hid the subtree instead of navigating. Collapsing should be a re-click on what you are already viewing — which is what the operations/schemas tier-1 rows already did, so the rule was applied inconsistently across the three menus.

| menu | before | after |
|---|---|---|
| operations / schemas (tier-1) | collapses only when on `/docs/operations` / `/docs/schemas` | unchanged |
| operation & schema tags | always collapsed while expanded | collapses only when that tag is the current section |
| pages tree | collapsed unless you were on one of its *subpages* | collapses only when on the branch page itself |

### Tags

Sidebar tag expansion is the same state as the page's "show details" section (`operationTag` / `schemaTag`), and all tags render stacked on one scrolling page — so the "exact route" analogue is the scroll-spy section: `collapseOnClick = isExpanded && isActive`. Expanded but scrolled away, the click now jumps to that section instead of folding it shut behind you; the search param only clears when you are already there.

### Pages

The old condition was `isExpanded && !activeAncestorIds.has(page.id)`, which covered "I'm on your subpage" but treated every *other* route as a collapse. Now `isExpanded && isActive`: from an unrelated page, clicking an expanded branch navigates to the branch's own page and leaves the subtree open. The subpage case is unchanged (navigates), which makes `activeAncestorIds` dead in `PageBranch` — dropped from the props; `PagesSidebar` still uses it to seed expansion on route change.

`nodeOnly` branches (no page of their own) still toggle on every click — they have nothing to navigate to.

## Test plan

- [ ] Docs pages tree: with a branch expanded, navigate to an unrelated page → clicking the branch goes to the branch page and keeps it open; clicking it again (now on it) collapses.
- [ ] Operations/schemas: expand a tag, scroll to another tag → clicking the expanded tag scrolls back to it; clicking it while reading it collapses.
- [ ] Tier-1 operations/schemas rows behave as before.
- [ ] Sheet mode (below `md`) unchanged.

Typecheck clean across the monorepo (pre-commit hook). Not runtime-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
