### PR TITLE
fix(frontend): scope role selectors to the channel's role vocabulary

### DIFF
--- a/frontend/src/modules/common/form-fields/select-role.tsx
+++ b/frontend/src/modules/common/form-fields/select-role.tsx
@@ -1,21 +1,22 @@
 import { useTranslation } from 'react-i18next';
-import { appConfig, roles } from 'shared';
+import { appConfig, type ChannelEntityType, hierarchy } from 'shared';
 import { useOnlineManager } from '~/hooks/use-online-manager';
 import { ResponsiveSelect } from '~/modules/ui/responsive-select';
 
 interface SelectRoleProps {
-  entity?: boolean;
+  /** Restrict options to this channel entity's role vocabulary; omit for system roles. */
+  entityType?: ChannelEntityType;
   onChange: (value?: string) => void;
   value?: string;
   className?: string;
 }
 
-/** Single-role select over entity and system roles. Renders a drawer on mobile. */
-export function SelectRole({ entity = false, onChange, value, className }: SelectRoleProps) {
+/** Single-role select. Renders a drawer on mobile. */
+export function SelectRole({ entityType, onChange, value, className }: SelectRoleProps) {
   const { t } = useTranslation();
   const isOnline = useOnlineManager();
 
-  const roleOptions = entity ? roles.all : appConfig.systemRoles;
+  const roleOptions = entityType ? hierarchy.getRoles(entityType) : appConfig.systemRoles;
 
   const options = [
     { value: 'all', label: t('c:all') },

--- a/frontend/src/modules/common/stories/select-role.stories.tsx
+++ b/frontend/src/modules/common/stories/select-role.stories.tsx
@@ -31,7 +31,7 @@ export const Default: Story = {
 
 export const EntityRoles: Story = {
   args: {
-    entity: true,
+    entityType: 'organization',
     value: 'all',
     onChange: () => {},
   },
@@ -40,7 +40,7 @@ export const EntityRoles: Story = {
 
     return (
       <div className="w-80">
-        <SelectRole entity value={value} onChange={setValue} />
+        <SelectRole entityType="organization" value={value} onChange={setValue} />
       </div>
     );
   },
@@ -48,16 +48,16 @@ export const EntityRoles: Story = {
 
 export const Preselected: Story = {
   args: {
-    entity: true,
-    value: 'owner',
+    entityType: 'organization',
+    value: 'member',
     onChange: () => {},
   },
   render: function Render() {
-    const [value, setValue] = useState<string | undefined>('owner');
+    const [value, setValue] = useState<string | undefined>('member');
 
     return (
       <div className="w-80">
-        <SelectRole entity value={value} onChange={setValue} />
+        <SelectRole entityType="organization" value={value} onChange={setValue} />
       </div>
     );
   },

--- a/frontend/src/modules/entities/entity-grid/entity-grid-bar.tsx
+++ b/frontend/src/modules/entities/entity-grid/entity-grid-bar.tsx
@@ -1,6 +1,7 @@
 import type { QueryKey } from '@tanstack/react-query';
 import { ArrowDownAZIcon, CalendarIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
+import type { ChannelEntityType } from 'shared';
 import type { TKey } from '~/lib/i18n-locales';
 import { TableBarContainer } from '~/modules/common/data-table/table-bar-container';
 import { TableCount } from '~/modules/common/data-table/table-count';
@@ -38,6 +39,8 @@ const entityGridSortOptions: readonly EntityGridSortOption[] = [
 type Props = {
   queryKey: QueryKey;
   label: TKey;
+  /** Channel entity the grid lists; scopes the role filter to that entity's role vocabulary. */
+  entityType: ChannelEntityType;
   searchVars: EntityGridBarSearch;
   setSearch: (search: EntityGridBarSearch) => void;
   isSheet?: boolean;
@@ -51,6 +54,7 @@ type Props = {
 export function EntityGridBar({
   queryKey,
   label,
+  entityType,
   searchVars,
   setSearch,
   isSheet,
@@ -95,7 +99,7 @@ export function EntityGridBar({
             sortOptions={sortOptions}
           />
           <SelectRole
-            entity
+            entityType={entityType}
             value={role === undefined ? 'all' : role}
             onChange={onRoleChange}
             className="h-10 sm:min-w-32"

--- a/frontend/src/modules/memberships/members-table/members-bar.tsx
+++ b/frontend/src/modules/memberships/members-table/members-bar.tsx
@@ -158,7 +158,7 @@ export function MembersTableBar({
           </FilterBarSearch>
           <FilterBarFilters>
             <SelectRole
-              entity
+              entityType={channel.entityType}
               value={role === undefined ? 'all' : role}
               onChange={onRoleChange}
               className="h-10 w-auto sm:min-w-32"

--- a/frontend/src/modules/memberships/members-table/members-columns.tsx
+++ b/frontend/src/modules/memberships/members-table/members-columns.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { roles } from 'shared';
+import { type ChannelEntityType, hierarchy } from 'shared';
 import { enumSelectEditorOptions, RenderEnumSelect } from '~/modules/common/data-grid/cell-renderers';
 import { CheckboxColumn } from '~/modules/common/data-table/checkbox-column';
 import type { ColumnOrColumnGroup } from '~/modules/common/data-table/types';
@@ -9,7 +9,7 @@ import { Badge } from '~/modules/ui/badge';
 import { UserCell } from '~/modules/user/user-cell';
 import { dateShort } from '~/utils/date-short';
 
-export const useColumns = (isAdmin: boolean, isSheet: boolean) => {
+export const useColumns = (isAdmin: boolean, isSheet: boolean, entityType: ChannelEntityType) => {
   const { t } = useTranslation();
 
   const columns = () => {
@@ -60,7 +60,7 @@ export const useColumns = (isAdmin: boolean, isSheet: boolean) => {
           renderEditCell: (props) => (
             <RenderEnumSelect
               {...props}
-              options={roles.all}
+              options={hierarchy.getRoles(entityType)}
               currentValue={props.row.membership?.role}
               setValue={(row, role) => ({ ...row, membership: { ...row.membership, role } })}
               renderOption={(role) => t(role)}

--- a/frontend/src/modules/memberships/members-table/members-table.tsx
+++ b/frontend/src/modules/memberships/members-table/members-table.tsx
@@ -49,7 +49,7 @@ function MembersTable({ channel, isSheet = false, children }: MembersTableWrappe
   const limit = LIMIT;
 
   const [selected, setSelected] = useState<Member[]>([]);
-  const [columns, setColumns] = useColumns(canUpdate, isSheet);
+  const [columns, setColumns] = useColumns(canUpdate, isSheet, entityType);
   const { sortColumns, setSortColumns: onSortColumnsChange } = useSortColumns(sort, order, setSearch);
 
   const queryOptions = membersListQueryOptions({ entityId, entityType, tenantId, organizationId, ...search, limit });

--- a/frontend/src/modules/organization/organizations-grid.tsx
+++ b/frontend/src/modules/organization/organizations-grid.tsx
@@ -43,6 +43,7 @@ export function OrganizationsGrid({ fixedQuery, saveDataInSearch, focusView, lim
           queryKey={queryOptions.queryKey}
           searchVars={baseSearch}
           label={'c:organization'}
+          entityType="organization"
           setSearch={setSearch}
           isSheet={!focusView}
           focusView={focusView}

--- a/frontend/src/modules/organization/table/organizations-columns.tsx
+++ b/frontend/src/modules/organization/table/organizations-columns.tsx
@@ -3,7 +3,7 @@ import i18n from 'i18next';
 import { BoxIcon, PencilIcon, ShieldIcon, TrashIcon, UserRoundIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { hierarchy, isChannel, roles } from 'shared';
+import { hierarchy, isChannel } from 'shared';
 import { enumSelectEditorOptions, RenderEnumSelect } from '~/modules/common/data-grid/cell-renderers';
 import { CheckboxColumn } from '~/modules/common/data-table/checkbox-column';
 import { type EllipsisOption, TableEllipsis } from '~/modules/common/data-table/table-ellipsis';
@@ -104,7 +104,7 @@ export const useColumns = () => {
       renderEditCell: (props) => (
         <RenderEnumSelect
           {...props}
-          options={roles.all}
+          options={hierarchy.getRoles('organization')}
           currentValue={props.row.membership?.role}
           setValue={(row, role) => ({
             ...row,
@@ -135,7 +135,7 @@ export const useColumns = () => {
         row.createdBy && <UserCell compactable user={row.createdBy} tabIndex={tabIndex} />,
     },
     // Dynamic membership count columns from role config
-    ...roles.all.map((role) => ({
+    ...hierarchy.getRoles('organization').map((role) => ({
       key: `${role}Count`,
       name: t(`c:${role}`, { count: 2 }),
       minBreakpoint: 'md' as const,

--- a/frontend/src/modules/user/invite-search-form.tsx
+++ b/frontend/src/modules/user/invite-search-form.tsx
@@ -19,7 +19,7 @@ interface Props {
 export function InviteSearchForm({ channel, dialog: isDialog }: Props) {
   const { t } = useTranslation();
 
-  const form = useInviteFormDraft(channel?.id);
+  const form = useInviteFormDraft(channel?.id, channel?.entityType);
   const { mutate: invite, isPending } = useInviteMemberMutation();
 
   if (!channel) return null;
@@ -68,7 +68,7 @@ export function InviteSearchForm({ channel, dialog: isDialog }: Props) {
           render={({ field: { value, onChange } }) => (
             <FormItem className="flex-row items-center gap-4">
               <FormLabel>{t('c:role')}:</FormLabel>
-              <SelectRoleRadio value={value} onValueChange={onChange} />
+              <SelectRoleRadio value={value} onValueChange={onChange} entityType={channel.entityType} />
               <FormMessage />
             </FormItem>
           )}


### PR DESCRIPTION
Closes the last open small item from the projectcampus proposal round (scan #16).

## Problem

Three cella-owned role surfaces offered the full role registry (`roles.all`) regardless of which channel the user was looking at. Invisible in cella core — organization is the only channel, so `roles.all` *is* the org vocabulary — but any fork with a multi-channel hierarchy sees every role from every channel. Observed on a projectcampus project members page: the role filter listed Admin/Staff/Student/Coach/Follower.

Worse than cosmetic in one spot: the inline role editor let an admin **assign an out-of-vocabulary role**.

## Change

`SelectRole` now mirrors the seam `SelectRoleRadio` already had — `entity?: boolean` becomes `entityType?: ChannelEntityType`, and options resolve via `hierarchy.getRoles(entityType)`, still falling back to system roles when omitted. Call sites thread the channel through:

- members bar filter and inline role editor → `channel.entityType`
- `EntityGridBar` → new required `entityType` prop (organizations grid passes `organization`)
- organizations table role editor + role count columns → scoped to the organization vocabulary
- user-search invite form → the last unscoped invite surface: unlike the email and bulk-email forms it passed `entityType` neither to `SelectRoleRadio` nor to `useInviteFormDraft`, so it offered every role *and* defaulted to `member` even for channels whose vocabulary has no `member` role

`SelectRoles` (plural, newsletter targeting) deliberately keeps `roles.all` — it is a system-admin surface that targets across channels.

Zero behavioural change for cella itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
