### PR TITLE
fix(backend): accept any membership in the org in orgGuard

### DIFF
--- a/backend/src/middlewares/guard/org-guard.test.ts
+++ b/backend/src/middlewares/guard/org-guard.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppError } from '#/core/error';
+import { clearOrgCache, setOrgCache } from './org-cache';
+import { orgGuard } from './org-guard';
+
+// The org row is served from the cache, so the database is reached only on a miss, where this stub
+// returns no row. Membership shape is what the guard actually reads.
+const TENANT_ID = 'tenant-1';
+const ORG_ID = 'org-1';
+const OTHER_ORG_ID = 'org-2';
+
+const orgRow = {
+  id: ORG_ID,
+  tenantId: TENANT_ID,
+  entityType: 'organization',
+  name: 'Org',
+  slug: 'org',
+  organizationFlags: {},
+  setupConfig: {},
+};
+
+/**
+ * Membership row as the guard sees it. `channelType` is widened past cella's own vocabulary on
+ * purpose: the case this guard has to get right only exists in apps whose hierarchy has channels
+ * below the organization, and those rows carry organizationId as an ancestor column.
+ */
+const membership = (channelType: string, organizationId: string) =>
+  ({ channelType, organizationId, channelId: 'channel-1', role: 'member' }) as never;
+
+const emptyDb = { select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }) };
+
+const mockCtx = (opts: { memberships: unknown[]; isSystemAdmin?: boolean; organizationId?: string }) => ({
+  req: { param: () => opts.organizationId ?? ORG_ID },
+  var: {
+    db: emptyDb as never,
+    memberships: opts.memberships,
+    isSystemAdmin: opts.isSystemAdmin ?? false,
+    tenantId: TENANT_ID,
+  },
+  set: vi.fn(),
+});
+
+const run = async (ctx: ReturnType<typeof mockCtx>) => {
+  const next = vi.fn();
+  await orgGuard(ctx as never, next);
+  return next;
+};
+
+const runExpectingError = async (ctx: ReturnType<typeof mockCtx>) => {
+  try {
+    await run(ctx);
+  } catch (error) {
+    return error as AppError;
+  }
+  throw new Error('expected orgGuard to throw');
+};
+
+describe('orgGuard — organization access', () => {
+  beforeEach(() => {
+    clearOrgCache();
+    setOrgCache(TENANT_ID, ORG_ID, orgRow as never);
+  });
+
+  it('admits an organization-level member and exposes the row on the context', async () => {
+    const ctx = mockCtx({ memberships: [membership('organization', ORG_ID)] });
+
+    const next = await run(ctx);
+
+    expect(next).toHaveBeenCalled();
+    expect(ctx.set).toHaveBeenCalledWith('organizationId', ORG_ID);
+    const [, organization] = ctx.set.mock.calls.find(([key]) => key === 'organization') ?? [];
+    expect((organization as { membership: unknown }).membership).toMatchObject({ channelType: 'organization' });
+  });
+
+  it('admits a member of a channel below the organization', async () => {
+    const ctx = mockCtx({ memberships: [membership('course', ORG_ID)] });
+
+    const next = await run(ctx);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('leaves membership null for a sub-channel member, since there is no organization-level row', async () => {
+    const ctx = mockCtx({ memberships: [membership('course', ORG_ID)] });
+
+    await run(ctx);
+
+    const [, organization] = ctx.set.mock.calls.find(([key]) => key === 'organization') ?? [];
+    expect((organization as { membership: unknown }).membership).toBeNull();
+  });
+
+  it('rejects a caller whose only membership is in another organization', async () => {
+    const ctx = mockCtx({ memberships: [membership('course', OTHER_ORG_ID)] });
+
+    const error = await runExpectingError(ctx);
+
+    expect(error.status).toBe(403);
+  });
+
+  it('rejects a caller with no memberships at all', async () => {
+    const ctx = mockCtx({ memberships: [] });
+
+    const error = await runExpectingError(ctx);
+
+    expect(error.status).toBe(403);
+  });
+
+  it('admits a system admin holding no membership in the organization', async () => {
+    const ctx = mockCtx({ memberships: [], isSystemAdmin: true });
+
+    const next = await run(ctx);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('404s when the organization does not resolve within the tenant', async () => {
+    const ctx = mockCtx({ memberships: [membership('organization', ORG_ID)], organizationId: 'missing-org' });
+
+    const error = await runExpectingError(ctx);
+
+    expect(error.status).toBe(404);
+  });
+});

--- a/backend/src/middlewares/guard/org-guard.ts
+++ b/backend/src/middlewares/guard/org-guard.ts
@@ -5,7 +5,11 @@ import { withOrganizationDefaults } from '#/modules/organization/helpers/select'
 import { organizationsTable } from '#/modules/organization/organization-db';
 import { getOrgCache, setOrgCache } from './org-cache';
 
-/** Grants org-scoped routes to org members and system admins. Must run after tenantGuard for the RLS transaction. */
+/**
+ * Grants org-scoped routes to system admins and to anyone holding a membership inside the
+ * organization, at organization level or in any channel below it. Must run after tenantGuard for
+ * the RLS transaction.
+ */
 export const orgGuard = xMiddleware(
   {
     functionName: 'orgGuard',
@@ -52,14 +56,19 @@ export const orgGuard = xMiddleware(
       throw new AppError(403, 'forbidden', 'warn', { entityType: 'organization' });
     }
 
+    // Deeper channel rows carry organizationId as an ancestor column, so a sub-channel member is
+    // in the org. This guard only rejects callers with no foothold at all; the permission engine
+    // does the fine-grained work.
     const orgMembership =
       memberships.find((m) => m.organizationId === organization.id && m.channelType === 'organization') || null;
-    if (!isSystemAdmin && !orgMembership) {
+    const isInOrganization = orgMembership !== null || memberships.some((m) => m.organizationId === organization.id);
+    if (!isSystemAdmin && !isInOrganization) {
       throw new AppError(403, 'forbidden', 'warn', { entityType: 'organization' });
     }
     const orgWithMembership = { ...organization, membership: orgMembership };
 
-    // membership is null for system admins
+    // membership is the organization-level row: null for system admins, and for members who hold
+    // rows only in channels below the organization
     ctx.set('organization', orgWithMembership);
     ctx.set('organizationId', orgWithMembership.id);
 


### PR DESCRIPTION
Closes #1058 — implements the change proposed there, with the risk audit done.

## Change

`orgGuard` job 3 goes from "caller holds a membership row with `channelType === 'organization'`" to "caller holds **any** membership row carrying this `organizationId`". Membership rows for deeper channels already store `organizationId` as an ancestor column, so this is a one-predicate change.

Jobs 1/2/4 (resolve the org within the tenant, tenant alignment sanity check, populate `ctx.organization` / `organizationId`) are untouched.

## Why

Today the auto-created root membership row is **load-bearing for access**, not just UX. `insertMemberships` upserts an organization-level row for every non-root target membership, with the role from `resolveParentMembershipRole` — carry the invited role if the org vocabulary has it, else `member`. Consequences for any fork with channels below the organization:

- a member invited to a sub-channel is 403'd out of every org-scoped route, even though the permission engine would have allowed the request (it unions grants per level and skips levels without membership)
- so the root row must be materialized to compensate, which silently promotes low-trust child roles: inviting someone as a course *guest* creates an org *member* row, because `member` is the fallback and the org vocabulary has no `guest`. The guest then gets whatever `organization.member` grants

After this change, root rows become a pure product/UX decision and forks can choose not to create them for low-trust roles.

## Risk audit

The issue flagged that `ctx.organization.membership` is now null for more callers and that handlers assuming "non-admin ⇒ org membership present" need a pass. Audited every consumer of `ctx.var.organization` — `can-create`, `get-attachments`, `mark-seen`, `get-members`, `get-pending-memberships`, `create-memberships`, `resend-pending-invitation`, `get-valid-product`:

**No backend handler reads `.membership` off it.** They all use `.id` / `.tenantId`. The only `organization.membership` read in the repo is [organization-page.tsx:64](frontend/src/modules/organization/organization-page.tsx#L64), which is already null-guarded and is fed by `getOrganizationOp` — an engine-only path (`getValidChannel`) that never went through `orgGuard` anyway.

403/404 shapes unchanged, so no new org-existence oracle. Nothing becomes reachable for a caller with no row in the org at all.

## Tests

`org-guard.test.ts` drives the middleware directly with a stubbed context, the same pattern
`product-cache/presets.test.ts` already uses. The guard reads only `ctx.var.memberships` and takes
the organization row from the org cache, so seeding the cache keeps the database out of the admitted
paths; a `select` stub returning no row covers the 404.

Seven cases: organization-level member admitted with the row on the context, sub-channel member
admitted, `membership` left null for that sub-channel member, member of a *different* organization
rejected, no memberships rejected, system admin admitted, unresolvable organization 404s.

Membership `channelType` is widened past cella's own vocabulary on purpose — the case this change
exists for only arises in apps with channels below the organization. Verified the test bites:
against the previous organization-level-only predicate, exactly the two sub-channel assertions fail.

## Blast radius here

Cella core declares exactly one channel type (`organization`), so `memberships.some(m => m.organizationId === org.id)` is equivalent to the old predicate by construction — the new branch is unreachable through cella's own config at runtime. Full core suite passes (2314 tests).

Forks that (accidentally) relied on job 3 to hide org-scoped *collection* endpoints from sub-org members should re-check their collection scoping — those endpoints are now reachable and must scope by engine grants, which they already should.

## Follow-up left open

Making the root-role mapping explicit in config, or dropping job 3 entirely in favour of engine-only authorization (matching the org/entities route precedent). Neither is required for this change. This also unblocks the self-join proposal (scan #6b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
