### PR TITLE
feat(frontend): inactive badge on last-seen, profile content owns its container

### DIFF
--- a/frontend/src/modules/memberships/members-table/members-columns.tsx
+++ b/frontend/src/modules/memberships/members-table/members-columns.tsx
@@ -5,6 +5,7 @@ import { enumSelectEditorOptions, RenderEnumSelect } from '~/modules/common/data
 import { CheckboxColumn } from '~/modules/common/data-table/checkbox-column';
 import type { ColumnOrColumnGroup } from '~/modules/common/data-table/types';
 import type { Member } from '~/modules/memberships/types';
+import { Badge } from '~/modules/ui/badge';
 import { UserCell } from '~/modules/user/user-cell';
 import { dateShort } from '~/utils/date-short';
 
@@ -85,7 +86,15 @@ export const useColumns = (isAdmin: boolean, isSheet: boolean) => {
         minBreakpoint: 'md',
         minWidth: 120,
         placeholderValue: '-',
-        renderCell: ({ row }) => dateShort(row.lastSeenAt),
+        // An empty lastSeenAt means the member never signed in, which the badge states explicitly
+        renderCell: ({ row }) =>
+          row.lastSeenAt ? (
+            dateShort(row.lastSeenAt)
+          ) : (
+            <Badge variant="secondary" size="xs">
+              {t('c:inactive')}
+            </Badge>
+          ),
       },
     ];
 

--- a/frontend/src/modules/user/user-profile-content.tsx
+++ b/frontend/src/modules/user/user-profile-content.tsx
@@ -8,7 +8,10 @@ interface Props {
 }
 
 export function UserProfileContent({ isSheet, user }: Props) {
+  // The page does not wrap this: content owns its container, so a replacement can span full width
   return (
-    <OrganizationsGrid fixedQuery={{ relatableUserId: user.id }} saveDataInSearch={!isSheet} focusView={!isSheet} />
+    <div className="container">
+      <OrganizationsGrid fixedQuery={{ relatableUserId: user.id }} saveDataInSearch={!isSheet} focusView={!isSheet} />
+    </div>
   );
 }

--- a/frontend/src/modules/user/user-profile.tsx
+++ b/frontend/src/modules/user/user-profile.tsx
@@ -66,9 +66,8 @@ export function UserProfilePage({ user, organizationId, isSheet }: Props) {
         }
       />
       <Suspense>
-        <div className="container">
-          <ProfilePageContent user={user} organizationId={organizationId} isSheet={isSheet} />
-        </div>
+        {/* No wrapper: the content owns its own container, so it can run a full-width tab nav */}
+        <ProfilePageContent user={user} organizationId={organizationId} isSheet={isSheet} />
       </Suspense>
     </>
   );

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -210,6 +210,7 @@
   "impersonate": "Impersonate",
   "import": "Import",
   "in_waitlist": "{{appName}} will soon contact you for early access!",
+  "inactive": "Inactive",
   "info": "Info",
   "introduction": "Introduction",
   "invitation_settled": "Invitation has been {{action}}!",


### PR DESCRIPTION
Two template gains picked out of a fork's drifted files (projectcampus). Both were single-axis local deltas there; assessed as generic and adopted upstream.

## Inactive badge on last-seen

The members table rendered `-` for a member who never signed in. That reads as missing data, but it is a state the invite lifecycle knows about — natural companion to the pending-invite resend column added in #1069. Now shows a secondary `Inactive` badge. Adds one locale key (`c:inactive`).

## Profile content owns its container

`user-profile.tsx` wrapped `ProfilePageContent` in `<div className="container">`. That decides the content's width from the page, so any replacement content is capped at container width and cannot run a full-width tab nav across the profile.

Moved the container into `user-profile-content.tsx`: the page owns the header, the content owns its width. `UserProfileContent` is the placeholder forks replace, so the ownership lands in the file that should decide. Renders identically in cella.

## Not adopted from the same drift set

- `organizations-grid.tsx` losing `pt-4` — the fork's reason is that *their* app shell already supplies page top padding. That is a claim about their shell, not ours, and removing it would change cella's own spacing for no upstream benefit. Left alone; the real question (does the shell or the grid own page top padding?) is worth answering deliberately.
- `auth-layout.tsx` wrapper + placeholder around `BgAnimation`, and the fixed `<Logo height={40} />` — the fork's animation positions and fades itself, so the template's wrapper is dead weight there. Possible seam (let the animation own its positioning) but it is a behavioural change to a template surface, not a copy.
- `globals.d.ts` svgr types — app-specific, skipped unless cella wants svgr by default.
- blocknote `styles.css` compact-composer title sizing — coupled to the fork's `{ level: 2 }` choice; only upstreamable as an optional density rule alongside `titleLevel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
