### PR TITLE
fix: fall back to port 3000 when deriving storybook port

### DIFF
--- a/backend/src/main.api.ts
+++ b/backend/src/main.api.ts
@@ -99,8 +99,7 @@ const main = async () => {
       console.info(`${pc.bold(pc.greenBright(appConfig.name))} 
 Frontend: ${pc.bold(pc.cyanBright(appConfig.frontendUrl))} 
 Backend: ${pc.bold(pc.cyanBright(appConfig.backendUrl))} 
-Tunnel: ${pc.bold(pc.magentaBright(tunnelUrl || '-'))}
-Storybook: ${pc.cyanBright(`http://localhost:${(Number(new URL(appConfig.frontendUrl).port) || 3000) + 3006}/`)}`);
+Tunnel: ${pc.bold(pc.magentaBright(tunnelUrl || '-'))}`);
 
       console.info(' ');
     },

--- a/frontend/.storybook/start-storybook.ts
+++ b/frontend/.storybook/start-storybook.ts
@@ -3,7 +3,7 @@ import net from 'node:net';
 import { appConfig } from '../../shared';
 
 // Derive Storybook's port from appConfig so each app gets a stable local port.
-const port = Number(new URL(appConfig.frontendUrl).port) + 3006;
+const port = (Number(new URL(appConfig.frontendUrl).port) || 3000) + 3006;
 
 /**
  * Install Playwright's pinned Storybook browser idempotently at test startup.


### PR DESCRIPTION
## Problem

`new URL(appConfig.frontendUrl).port` returns an empty string for URLs without an explicit port, so `Number(...) + 3006` evaluated to `NaN` when deriving Storybook's local port.

## Changes

- `frontend/.storybook/start-storybook.ts`: default the frontend port to `3000` before applying the `+3006` offset.
- `backend/src/main.api.ts`: drop the Storybook line from the API startup banner — the API does not start Storybook, so advertising a URL there is misleading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
