### PR TITLE
fix(frontend): grids no longer set their own page padding

### DIFF
--- a/frontend/src/modules/memberships/pending-table/pending-memberships-table.tsx
+++ b/frontend/src/modules/memberships/pending-table/pending-memberships-table.tsx
@@ -68,7 +68,7 @@ export function PendingMembershipsTable({ channel }: PendingMembershipsTableProp
   };
 
   return (
-    <div className="flex h-full flex-col gap-2 pt-4">
+    <div className="flex h-full flex-col gap-2">
       <PendingMembershipsTableBar queryKey={queryOptions.queryKey} />
       <DataTable<PendingMembership>
         {...{

--- a/frontend/src/modules/organization/organizations-grid.tsx
+++ b/frontend/src/modules/organization/organizations-grid.tsx
@@ -37,7 +37,7 @@ export function OrganizationsGrid({ fixedQuery, saveDataInSearch, focusView, lim
   const entities = data;
 
   return (
-    <div className="flex h-full flex-col gap-2 pt-4">
+    <div className="flex h-full flex-col gap-2">
       {!limitedView && (
         <EntityGridBar
           queryKey={queryOptions.queryKey}

--- a/frontend/src/modules/user/user-profile-content.tsx
+++ b/frontend/src/modules/user/user-profile-content.tsx
@@ -8,9 +8,9 @@ interface Props {
 }
 
 export function UserProfileContent({ isSheet, user }: Props) {
-  // The page does not wrap this: content owns its container, so a replacement can span full width
+  // The page does not wrap this: content owns its container (so it can span full width) and its top padding
   return (
-    <div className="container">
+    <div className="container pt-4">
       <OrganizationsGrid fixedQuery={{ relatableUserId: user.id }} saveDataInSearch={!isSheet} focusView={!isSheet} />
     </div>
   );


### PR DESCRIPTION
Takes the minor note at the bottom of #1079: grid components setting their own page padding, which every app whose shell already pads the top has to strip in each copied grid.

## What was there

Exactly two places in `frontend/` opened with `flex h-full flex-col gap-2 pt-4`:

- `frontend/src/modules/organization/organizations-grid.tsx`
- `frontend/src/modules/memberships/pending-table/pending-memberships-table.tsx`

They are the outliers. Every other table — users, organizations, members — returns a bare fragment and lets the page own layout: `FocusViewContainer` already supplies `container flex min-h-svh flex-col gap-2 pt-3` for the routed ones. So the convention already exists; these two just predate it.

## What changed

- `pt-4` dropped from both containers.
- The one consumer that structurally needs it gets it: `user-profile-content.tsx`'s container, which sits directly under `PageHeader` with nothing in between (in the routed page and in the sheet alike). `container` → `container pt-4`, so the profile page is pixel-identical.
- The pending-invites sheet gets no replacement on purpose: `SheetHeader` is `p-4`, so it already separates its content. It loses the doubled 32px top gap and now matches sheet spacing elsewhere in the app.

## Visual impact

| Surface | Before | After |
| --- | --- | --- |
| User profile page + profile sheet | 16px above the grid bar | unchanged (moved to the container) |
| Pending invites sheet | 32px (header `p-4` + `pt-4`) | 16px, same as other sheets |

The second row is the only intended visual change.

## Not included

The two real extension-point asks in #1079 — moving the `BgAnimation` wrapper/fallback out of `auth-layout.tsx`, and adopting `vite-plugin-svgr` — are untouched; that issue stays open for them.

Closes nothing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
