### PR TITLE
fix(frontend): floating-nav touch taps via touchend + shorter reset cooldown

### DIFF
--- a/frontend/src/hooks/use-scroll-visibility.ts
+++ b/frontend/src/hooks/use-scroll-visibility.ts
@@ -3,7 +3,7 @@ import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
 const SCROLL_THRESHOLD = 10; // Minimum scroll delta to toggle visibility
 const MAX_GESTURE_DELTA = 150; // Larger single-frame jumps are hash jumps/restorations, not finger scrolls
 const MIN_VISIBLE_MS = 800; // Grace period after showing before a down-scroll may hide again
-const RESET_COOLDOWN_MS = 3000; // Cooldown period after reset where scroll events are ignored
+const RESET_COOLDOWN_MS = 500; // Post-reset window that swallows layout-driven scroll jank (e.g. drawer close, docs page swap)
 const INITIAL_COOLDOWN_MS = 500; // Brief cooldown on mount to prevent hiding from restored scroll position
 
 /** Shows on scroll up, hides on scroll down; returns `{ isVisible, scrollTop, reset }`. */

--- a/frontend/src/modules/navigation/floating-nav/button.tsx
+++ b/frontend/src/modules/navigation/floating-nav/button.tsx
@@ -34,8 +34,8 @@ export function FloatingNavButton({
   direction = 'right',
 }: FloatingNavButtonProps) {
   // A tap that interrupts a momentum scroll cancels the fling, and the browser suppresses its click,
-  // so touch taps run on touchend. preventDefault there stops the synthesized click entirely — it
-  // would otherwise hit-test against whatever onClick just mounted (e.g. a drawer overlay) and
+  // so touch taps run on touchend. preventDefault there stops the synthesized click entirely, since
+  // it would otherwise hit-test against whatever onClick just mounted (e.g. a drawer overlay) and
   // dismiss it. Touchcancel (scroll takeover) and the slop check keep drags from triggering.
   const touchStart = useRef<{ x: number; y: number } | null>(null);
 

--- a/frontend/src/modules/navigation/floating-nav/button.tsx
+++ b/frontend/src/modules/navigation/floating-nav/button.tsx
@@ -1,9 +1,9 @@
-import { type PointerEvent, useRef } from 'react';
+import { type TouchEvent, useRef } from 'react';
 import type { IconComponent } from '~/modules/common/icons/types';
 import { Button } from '~/modules/ui/button';
 import { cn } from '~/utils/cn';
 
-const TAP_SLOP_PX = 12; // Max finger travel for a pointerup to still count as a tap
+const TAP_SLOP_PX = 12; // Max finger travel for a touchend to still count as a tap
 
 export interface FloatingNavItem {
   id: string;
@@ -34,34 +34,28 @@ export function FloatingNavButton({
   direction = 'right',
 }: FloatingNavButtonProps) {
   // A tap that interrupts a momentum scroll cancels the fling, and the browser suppresses its click,
-  // so touch taps run on pointerup. Pointercancel (scroll takeover) and the slop check keep drags
-  // from triggering; suppressClick avoids double-firing when a click does arrive.
+  // so touch taps run on touchend. preventDefault there stops the synthesized click entirely — it
+  // would otherwise hit-test against whatever onClick just mounted (e.g. a drawer overlay) and
+  // dismiss it. Touchcancel (scroll takeover) and the slop check keep drags from triggering.
   const touchStart = useRef<{ x: number; y: number } | null>(null);
-  const suppressClick = useRef(false);
 
-  const handlePointerDown = (event: PointerEvent<HTMLButtonElement>) => {
-    touchStart.current = event.pointerType === 'touch' ? { x: event.clientX, y: event.clientY } : null;
-    suppressClick.current = false;
+  const handleTouchStart = (event: TouchEvent<HTMLButtonElement>) => {
+    const touch = event.touches.length === 1 ? event.touches[0] : null;
+    touchStart.current = touch ? { x: touch.clientX, y: touch.clientY } : null;
   };
 
-  const handlePointerCancel = () => {
+  const handleTouchCancel = () => {
     touchStart.current = null;
   };
 
-  const handlePointerUp = (event: PointerEvent<HTMLButtonElement>) => {
+  const handleTouchEnd = (event: TouchEvent<HTMLButtonElement>) => {
     const start = touchStart.current;
     touchStart.current = null;
-    if (!start) return;
-    if (Math.hypot(event.clientX - start.x, event.clientY - start.y) > TAP_SLOP_PX) return;
-    suppressClick.current = true;
-    onClick();
-  };
-
-  const handleClick = () => {
-    if (suppressClick.current) {
-      suppressClick.current = false;
-      return;
-    }
+    const touch = event.changedTouches[0];
+    if (!start || !touch) return;
+    if (Math.hypot(touch.clientX - start.x, touch.clientY - start.y) > TAP_SLOP_PX) return;
+    // Not cancelable means the browser consumed the gesture as a scroll and suppresses the click itself
+    if (event.cancelable) event.preventDefault();
     onClick();
   };
 
@@ -71,10 +65,10 @@ export function FloatingNavButton({
       size="icon"
       data-direction={direction}
       variant="secondary"
-      onClick={handleClick}
-      onPointerDown={handlePointerDown}
-      onPointerUp={handlePointerUp}
-      onPointerCancel={handlePointerCancel}
+      onClick={onClick}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchCancel}
       className={cn(
         'fixed bottom-[calc(1rem+var(--bottom-inset,0px))] z-105 flex h-14 w-14 transform items-center justify-center rounded-full bg-secondary opacity-100 shadow-xl transition-all duration-300 ease-in-out hover:bg-secondary active:scale-95 data-[direction=right]:right-4 data-[direction=left]:left-4',
         // Animate out while the floating selection action bar is shown


### PR DESCRIPTION
## Problem

Real-device testing on mobile Chrome (about page) surfaced three floating-nav issues:

1. The pointerup tap fix that shipped in #1082 broke the marketing menu trigger: firing the toggle on `pointerup` opens the drawer, but the browser still synthesizes the tap's `click` afterwards — which hit-tests against the drawer overlay that just mounted and dismisses it. The menu flashed open and shut, which also read as "first tap during a fling still doesn't work".
2. After opening/closing the menu drawer, the buttons ignored scroll input for 3 seconds (`RESET_COOLDOWN_MS`), so they wouldn't hide on scroll-down.

## Fix

- **FloatingNavButton**: touch taps now trigger on `touchend` with `preventDefault()`, so no click is synthesized at all — nothing left to land on the overlay or double-toggle. Fling-stop taps still work (`touchend` is delivered there; only the click was suppressed). Drag-away and scroll-takeover are guarded by the 12px slop check and `touchcancel`. Mouse/keyboard keep the plain `click` path.
- **use-scroll-visibility**: `RESET_COOLDOWN_MS` 3000 → 500. The 3s value predates the scrollHeight resync and the 150px `MAX_GESTURE_DELTA` jump filter, which now cover the docs page-swap jank it was added for; 500ms still swallows drawer-close layout jank.

## Testing

- biome + workspace-wide typecheck pass.
- Needs a real-device pass on mobile Chrome: menu opens and stays open, first tap mid-fling works on both buttons, buttons hide promptly on scroll-down right after closing the drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)