### PR TITLE
fix(infra): defer Caddy's Cache-Control so it replaces the origin's

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -17,7 +17,6 @@
 # Configurable env (set in infra/config/services.config.ts `frontend` entry):
 #   RELEASE_SHA : bound to X-App-Version (defaulted to "dev" in Dockerfile)
 #   ORIGIN_HOST : S3 REST hostname for the frontend bucket
-
 {
 	admin off
 	auto_https off
@@ -56,9 +55,14 @@
 
 	# Long-cache versioned assets. The frontend build hashes filenames under
 	# /assets/, so a year cache is safe there.
+	#
+	# Every Cache-Control below carries the `>` prefix, which sets the field with `defer`. An
+	# unprefixed header runs before the reverse_proxy response arrives, so S3's own Cache-Control
+	# (written as object metadata by tasks/frontend-assets.ts and tasks/deploy-run.ts) lands after
+	# it and the response carries the field twice. Deferring makes these values replace it.
 	@assets path /assets/*
 	handle @assets {
-		header Cache-Control "public, max-age=31536000, immutable"
+		header >Cache-Control "public, max-age=31536000, immutable"
 		reverse_proxy https://{$ORIGIN_HOST} {
 			header_up Host {$ORIGIN_HOST}
 		}
@@ -69,7 +73,7 @@
 	# ?v=<sha> param the app appends to mutable fetches keeps them fresh.
 	@static path /static/*
 	handle @static {
-		header Cache-Control "public, max-age=3600"
+		header >Cache-Control "public, max-age=3600"
 		reverse_proxy https://{$ORIGIN_HOST} {
 			header_up Host {$ORIGIN_HOST}
 		}
@@ -80,7 +84,7 @@
 	# index.html directly for "/".
 	@root path /
 	handle @root {
-		header Cache-Control "no-cache"
+		header >Cache-Control "no-cache"
 		rewrite * /index.html
 		reverse_proxy https://{$ORIGIN_HOST} {
 			header_up Host {$ORIGIN_HOST}
@@ -90,7 +94,7 @@
 	# Default: proxy to S3; on a 404 from origin (deep link to a client-side
 	# route), rewrite to /index.html and re-proxy so the SPA can take over.
 	handle {
-		header Cache-Control "no-cache"
+		header >Cache-Control "no-cache"
 		reverse_proxy https://{$ORIGIN_HOST} {
 			header_up Host {$ORIGIN_HOST}
 			@notfound status 404

--- a/infra/tests/unit/caddyfile.test.ts
+++ b/infra/tests/unit/caddyfile.test.ts
@@ -57,13 +57,15 @@ describe('frontend Caddyfile', () => {
 
   it('long-caches content-hashed /assets/* only', () => {
     expect(caddyfile).toMatch(/@assets\s+path\s+\/assets\/\*\s*\n/);
-    expect(caddyfile).toMatch(/Cache-Control\s+"public,\s*max-age=31536000,\s*immutable"/);
+    // `>` sets the header with defer, which is what makes it replace the Cache-Control S3 returns;
+    // without it the response carries the field twice.
+    expect(caddyfile).toMatch(/header >Cache-Control\s+"public,\s*max-age=31536000,\s*immutable"/);
   });
 
   it('short-caches stable-named /static/* (docs.gen etc. change per release)', () => {
     // Marking /static/* immutable froze docs data in browser caches for a year.
     expect(caddyfile).toMatch(/@static\s+path\s+\/static\/\*/);
-    expect(caddyfile).toMatch(/@static\s+path[^{]*\{\s*\n\s*header Cache-Control "public, max-age=3600"/);
+    expect(caddyfile).toMatch(/@static\s+path[^{]*\{\s*\n\s*header >Cache-Control "public, max-age=3600"/);
   });
 
   it('reverse-proxies to the {$ORIGIN_HOST} env, not a hardcoded bucket', () => {


### PR DESCRIPTION
Production returns `Cache-Control` twice on every response:

```
cache-control: no-cache
cache-control: no-cache, no-store, must-revalidate     # index.html

cache-control: public, max-age=31536000, immutable
cache-control: public, max-age=31536000, immutable     # /assets/*
```

## Cause

An unprefixed `header` directive runs **before** the `reverse_proxy` response arrives. S3 then returns its own `Cache-Control` from object metadata — written at upload by [frontend-assets.ts:130](infra/tasks/frontend-assets.ts#L130) and [deploy-run.ts:432](infra/tasks/deploy-run.ts#L432) — which lands after Caddy's, so both survive.

Caddy's `>` prefix sets the field with `defer`, which is exactly the documented remedy for overriding an upstream header.

## Why fix it in Caddy rather than at upload

Caddy stays the single owner of cache policy: the rules are path-based, documented in place, and changeable with a config deploy. Letting S3 metadata win instead would mean any policy change requires re-uploading every object.

## One real behaviour change

For **`/assets/*`** both values are identical, so nothing changes.

For **index.html** they differ. A repeated `Cache-Control` is read as a comma-joined list, so today the strictest wins and **`no-store` is in effect**. After this, Caddy's `no-cache` applies alone — the shell still revalidates on every load, but may be stored, so the existing ETag can answer **304 instead of resending 5.6 kB**.

That is the better behaviour for an SPA shell, and it's the reason to prefer Caddy's value over the origin's here. If you'd rather keep `no-store`, change the two `no-cache` values in the Caddyfile to match the strict form instead — the deferred replace works either way.

## Verification

- `caddy validate` on the real `caddy:2-alpine` binary: **Valid configuration** — it accepts the `>` syntax.
- `caddy fmt` clean; it also drops one blank line above the global options block that it already considered misformatted.
- infra suite: 679 tests passing.
- The two Caddyfile assertions now require the `>` prefix rather than merely tolerating it, so the defer behaviour is pinned rather than incidental.

## Not included: compression

I looked at this while measuring and it is **not** a problem, contrary to what I first reported. Production negotiates **zstd** with real browsers; my earlier probe advertised `br, gzip`, which excluded zstd and made it look like gzip was the best on offer. Caddy has no native brotli, only gzip and zstd, so `encode zstd gzip` is already the right directive.

There is a smaller, separate opportunity: Caddy compresses on the fly at fast settings, so the editor chunk ships at 284 kB where brotli at quality 11 reaches 221 kB. Capturing that means precompressing at build time and uploading with `Content-Encoding` metadata — worth roughly 180 kB across the critical path, but it is an upload-pipeline change and does not belong in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
