### PR TITLE
perf(frontend): keep the editor out of startup, defer the upload service

### DIFF
--- a/frontend/src/query/provider.tsx
+++ b/frontend/src/query/provider.tsx
@@ -11,6 +11,14 @@ import { cleanupOrphanedSessions, persister, sessionPersister } from '~/query/pe
 import { markCacheRestored, queryClient, silentRevalidateOnReconnect, updateStaleTime } from '~/query/query-client';
 import { waitForActiveCatchup } from '~/query/realtime/stream-store';
 
+/** Idle scheduling with a ceiling, so a browser that never goes idle still starts the service. */
+const IDLE_TIMEOUT_MS = 5000;
+const scheduleIdle =
+  typeof requestIdleCallback === 'function'
+    ? (cb: () => void) => requestIdleCallback(cb, { timeout: IDLE_TIMEOUT_MS })
+    : (cb: () => void) => setTimeout(cb, IDLE_TIMEOUT_MS) as unknown as number;
+const cancelIdle = typeof cancelIdleCallback === 'function' ? cancelIdleCallback : clearTimeout;
+
 // Runs before cache restoration: stores the queryClient so entity modules self-register their mutationFn via addMutationRegistrar() on load.
 initMutationDefaults(queryClient);
 
@@ -39,15 +47,24 @@ export function QueryClientProvider({ children }: { children: React.ReactNode })
   // Started at mount, not module eval, to avoid a circular-import TDZ during HMR: provider -> download-service -> attachment/query -> realtime -> query/index -> provider.
   useEffect(() => {
     downloadService.start();
-    // Loaded on mount: this provider evaluates before any route, so a module-scope import places
-    // @uppy/core and its dashboard on the boot path.
-    const started = import('~/modules/attachment/offline/upload-service').then((m) => {
-      m.uploadService.start();
-      return m.uploadService;
+
+    // Waits for idle: nothing can be queued for upload during the first paint, and the import pulls
+    // @uppy/core with it, which on a slow link competes with the chunks the first render needs.
+    let service: { stop: () => void } | undefined;
+    let cancelled = false;
+    const idle = scheduleIdle(() => {
+      import('~/modules/attachment/offline/upload-service').then((m) => {
+        if (cancelled) return;
+        service = m.uploadService;
+        m.uploadService.start();
+      });
     });
+
     return () => {
+      cancelled = true;
+      cancelIdle(idle);
       downloadService.stop();
-      started.then((service) => service.stop());
+      service?.stop();
     };
   }, []);
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -48,7 +48,7 @@ const isDev = appConfig.mode === 'development';
  * is what puts it on the boot path. `pnpm deps:bundle:check` asserts the result.
  */
 const FEATURE_LIBS: [name: string, packages: RegExp][] = [
-  ['editor', /^(@blocknote|@tiptap|prosemirror-[\w-]+|yjs|y-protocols|y-prosemirror|lib0)/],
+  ['editor', /^(@blocknote|@tiptap|@handlewithcare|prosemirror-[\w-]+|yjs|y-protocols|y-prosemirror|lib0)/],
   ['pdf', /^(pdfjs-dist|react-pdf|jspdf[\w.-]*)$/],
   ['media', /^(media-chrome|player\.style)$/],
   ['gleap', /^gleap$/],
@@ -293,7 +293,9 @@ const viteConfig = {
               name: (id: string) => {
                 if (!ON_DEMAND_APP.test(id)) return null;
                 if (/[\\/]attachment[\\/]render[\\/]/.test(id)) return 'attachment-render';
-                if (/[\\/]attachment[\\/]offline[\\/]upload-service/.test(id)) return 'uploader';
+                // Kept apart from the uploader UI: the UI reaches the editor statically, so sharing
+                // a chunk made starting this background service load the editor too.
+                if (/[\\/]attachment[\\/]offline[\\/]upload-service/.test(id)) return 'upload-service';
                 if (/[\\/]common[\\/]uploader[\\/]/.test(id)) return 'uploader';
                 if (/[\\/]common[\\/]gleap-support/.test(id)) return 'gleap-support';
                 return 'editor-app';


### PR DESCRIPTION
Lighthouse mobile scores production **48** (FCP 7.4 s, LCP 10.2 s, of which **92% is render delay**). TBT is 410 ms and CLS is 0, so this is not a CPU or layout problem — the page cannot paint until its JS arrives.

Profiling the load found a burst of **27 requests and 517 KiB starting at ~1.2 s** that the first paint has no use for: the uploader UI, the editor, and their vendor packages. Both causes were introduced by earlier passes in this series.

## 1. Starting the upload service loaded the editor

The on-demand group named `attachment/offline/upload-service` into the same chunk as `common/uploader/**`. That chunk statically imports `editor-app`, which imports `editor` — so starting a background service pulled the entire rich-text editor.

The service now gets its own chunk. Its static imports are `app-core`, `shared-config`, `tanstack`, `sdk-gen`, `attachment-core` and `uppy` — no editor code.

## 2. It started during bootstrap

[query/provider.tsx](frontend/src/query/provider.tsx) began that service from a mount effect, so the import fired while the first render was still waiting for its own chunks. Nothing can be queued for upload before the first paint, so it now waits for `requestIdleCallback` with a 5 s ceiling — the same pattern already used in [modules/seen/unseen-delta.ts](frontend/src/modules/seen/unseen-delta.ts).

## 3. `@handlewithcare` split prosemirror out of the editor chunk

`@handlewithcare/prosemirror-inputrules` ships prosemirror plugins but did not match the editor group's package pattern, so the per-package backstop claimed it first and took `prosemirror-model`, `-transform`, `-state` and `-history` into a 34 KiB chunk of its own. This is the same failure mode as the `react-dom` case fixed earlier: a package the feature group should own, claimed by an earlier group, dragging its dependencies along. Adding it to the pattern returns them to the editor chunk.

## Measured

Driven through CDP against a preview of the built output:

| Chunk | Before | After |
|---|---|---|
| `editor` (286 KiB) | loaded at startup | **not loaded** |
| `editor-app` | loaded at startup | **not loaded** |
| `uploader` | loaded at startup | **not loaded** |
| `v--handlewithcare-…` (34 KiB) | loaded at startup | **not loaded** (merged into `editor`) |
| `upload-service` + `uppy` | loaded at startup | deferred to idle |

Roughly **339 KiB leaves startup entirely**; the remaining uppy load moves behind first paint. Critical path is unchanged at 846 kB brotli across 39 chunks and stays within the 900 kB budget.

`pnpm ts` clean across 9 workspaces, 870 frontend tests passing, `pnpm style` clean.

## What this does not fix

FCP is still gated on JavaScript. `index.html` ships an empty `<div id="root">` with no paintable content, so first paint waits for the app to mount no matter how much the payload shrinks — the critical path is still ~1096 KiB, about 6 s of link time on Lighthouse's mobile profile.

Closing that properly means serving real content in the initial HTML, which is an architectural decision rather than a tuning change, and it should be genuine prerendered content — injecting a skeleton purely to trigger an earlier FCP would move the metric without helping anyone.

Two smaller corrections to earlier claims in this series, for the record: the extra startup bytes are **not** the service worker precache (it registers after `load`), and production compression is **fine** — it negotiates zstd, and my earlier probe simply failed to advertise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
