### PR TITLE
perf(infra): Tier 1 deploy critical-path trims + honest singleVM cutover

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -208,8 +208,11 @@ jobs:
         with:
           pulumi-version: 3.236.0
 
+      # Only the workspaces the deploy command touches (it builds the frontend
+      # in-process): fewer packages and lifecycle scripts in the one job that
+      # holds the deploy credentials.
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --filter infra... --filter shared... --filter frontend...
 
       - name: Deploy ${{ needs.setup.outputs.image_tag }} to ${{ needs.setup.outputs.environment }}
         env:

--- a/infra/compose.gen.yml
+++ b/infra/compose.gen.yml
@@ -29,7 +29,7 @@ services:
       MCP_API_URL: ${MCP_API_URL}
     healthcheck:
       test: ['CMD', 'wget', '-qO-', 'http://127.0.0.1:4000/health']
-      interval: '30s'
+      interval: '5s'
       timeout: '5s'
       retries: 3
       start_period: '15s'
@@ -85,7 +85,7 @@ services:
       CDC_HEALTH_PORT: '4001'
     healthcheck:
       test: ['CMD', 'wget', '-qO-', 'http://127.0.0.1:4001/health']
-      interval: '30s'
+      interval: '5s'
       timeout: '5s'
       retries: 3
       start_period: '10s'
@@ -121,7 +121,7 @@ services:
       YJS_PORT: '4002'
     healthcheck:
       test: ['CMD', 'wget', '-qO-', 'http://127.0.0.1:4002/health']
-      interval: '30s'
+      interval: '5s'
       timeout: '5s'
       retries: 3
       start_period: '10s'
@@ -162,7 +162,7 @@ services:
       MCP_API_URL: ${MCP_API_URL}
     healthcheck:
       test: ['CMD', 'wget', '-qO-', 'http://127.0.0.1:4003/health']
-      interval: '30s'
+      interval: '5s'
       timeout: '5s'
       retries: 3
       start_period: '15s'
@@ -194,7 +194,7 @@ services:
       ORIGIN_HOST: ${ORIGIN_HOST}
     healthcheck:
       test: ['CMD', 'wget', '-qO-', 'http://127.0.0.1:80/health']
-      interval: '30s'
+      interval: '5s'
       timeout: '5s'
       retries: 3
       start_period: '10s'

--- a/infra/compose/infrastructure.ts
+++ b/infra/compose/infrastructure.ts
@@ -38,11 +38,11 @@ const STANDARD_ENV = {
   TZ: 'UTC',
 } as const;
 
-/** Uniform identity healthcheck injected into every app service. */
+/** Uniform identity healthcheck injected into every app service. The interval floors how fast `compose up --wait` can observe readiness at boot (the deploy's health gate waits on it), so it stays short; `start_interval` would scope that to startup but needs a compose/engine version floor the marketplace VM image cannot guarantee. */
 function healthcheck(port: number, startPeriod: string): HealthCheck {
   return {
     test: ['CMD', 'wget', '-qO-', `http://127.0.0.1:${port}${healthContract.path}`],
-    interval: '30s',
+    interval: '5s',
     timeout: '5s',
     retries: 3,
     start_period: startPeriod,

--- a/infra/lib/services.ts
+++ b/infra/lib/services.ts
@@ -63,6 +63,25 @@ export function collocatedServices(
   return collocated;
 }
 
+/** Resolve the VM replacement strategy. A singleVM host folding a stop-first worker must cut over stop-first too, so two replication-slot consumers never run at once. */
+export function effectiveStrategy(
+  serviceConfig: Record<string, EngineServiceEndpoint>,
+  singleVM: boolean,
+  svc: ServiceDefinition,
+): ServiceDefinition['replacementStrategy'] {
+  const host = deployedServices(serviceConfig, singleVM).find((s) => s.primaryRollout)?.slug;
+  if (
+    singleVM &&
+    svc.slug === host &&
+    [...coHostedServices(serviceConfig, singleVM), ...collocatedServices(serviceConfig, singleVM)].some(
+      (s) => s.replacementStrategy === 'stop-first',
+    )
+  ) {
+    return 'stop-first';
+  }
+  return svc.replacementStrategy;
+}
+
 /** Secret folders a service's VMs must read: itself plus, for the singleVM host, every folded co-hosted worker and collocated container. The host's secret-path grant must union identically or hydration 403s on the folded secrets. */
 export function secretScopeSlugs(
   serviceConfig: Record<string, EngineServiceEndpoint>,

--- a/infra/resources/generations.ts
+++ b/infra/resources/generations.ts
@@ -7,7 +7,13 @@ import { sizing } from '../config/sizing';
 import { deriveGenId } from '../lib/gen-id';
 import { type RuntimeSecretConsumer, unionRuntimeSecrets } from '../lib/runtime-secrets';
 import { type Generation, selectGenerations } from '../lib/select-generations';
-import { coHostedServices, collocatedServices, deployedServices, type ServiceDefinition } from '../lib/services';
+import {
+  coHostedServices,
+  collocatedServices,
+  deployedServices,
+  effectiveStrategy as resolveEffectiveStrategy,
+  type ServiceDefinition,
+} from '../lib/services';
 import { controlState } from './control';
 
 // Each service gets a VM except workers co-hosted on the backend and containers collocated on the host under singleVM, which route through the host VM.
@@ -28,16 +34,9 @@ export function secretConsumersFor(svc: ServiceDefinition): RuntimeSecretConsume
   return [svc.slug as RuntimeSecretConsumer];
 }
 
-/** Resolve the VM replacement strategy. A singleVM host containing a stop-first worker must cut over stop-first too, so two replication-slot consumers never run at once. */
+/** The VM replacement strategy under this app config; the resolution rule lives in lib/services.ts so the rollout plan shares it. */
 export function effectiveStrategy(svc: ServiceDefinition): ServiceDefinition['replacementStrategy'] {
-  if (
-    appConfig.singleVM &&
-    svc.slug === hostSlug &&
-    [...coHosted, ...collocated].some((s) => s.replacementStrategy === 'stop-first')
-  ) {
-    return 'stop-first';
-  }
-  return svc.replacementStrategy;
+  return resolveEffectiveStrategy(appConfig.services, appConfig.singleVM, svc);
 }
 
 export type { Generation } from '../lib/select-generations';

--- a/infra/tasks/cutover.test.ts
+++ b/infra/tasks/cutover.test.ts
@@ -151,6 +151,25 @@ describe('sequenceCutover: start-first', () => {
     expect(order.indexOf('contract')).toBeLessThan(order.indexOf('drain'));
   });
 
+  it('sets the LB straight to [new] and skips the drain when no old generation exists', async () => {
+    const lb = recordingSetServers();
+    let slept = false;
+    const res = await sequenceCutover(
+      lbPlan({
+        oldIps: [],
+        setServers: lb.fn,
+        sleep: async () => {
+          slept = true;
+        },
+      }),
+    );
+    expect(res.ok).toBe(true);
+    expect(lb.calls).toEqual([['10.0.0.9']]);
+    expect(res.steps).toContain('set LB to [new] (no old generation); was 10.0.0.4');
+    expect(res.steps.some((s) => s.includes('drain'))).toBe(false);
+    expect(slept).toBe(false);
+  });
+
   it('skips the drain sleep when drainSeconds is 0', async () => {
     let slept = false;
     await sequenceCutover(

--- a/infra/tasks/cutover.ts
+++ b/infra/tasks/cutover.ts
@@ -104,7 +104,11 @@ export async function sequenceCutover(plan: CutoverPlan): Promise<CutoverResult>
     if (sameIps(live, overlap)) {
       record('LB already expanded to [old, new]');
     } else {
-      record(`expand LB to [old, new] (${overlap.length} server(s)); was ${live.join(',') || '<empty>'}`);
+      record(
+        plan.oldIps.length === 0
+          ? `set LB to [new] (no old generation); was ${live.join(',') || '<empty>'}`
+          : `expand LB to [old, new] (${overlap.length} server(s)); was ${live.join(',') || '<empty>'}`,
+      );
       await setServers(overlap);
     }
     live = overlap;
@@ -124,8 +128,11 @@ export async function sequenceCutover(plan: CutoverPlan): Promise<CutoverResult>
     record('LB already serving [new]');
   }
 
-  record(`drain old generation for ${plan.drainSeconds}s (drainPolicy=${plan.drainPolicy ?? 'requests'})`);
-  if (plan.drainSeconds > 0) await sleep(plan.drainSeconds * 1000);
+  // Nothing drains when no old generation was behind the LB (first deploy, or an exclusive host whose old VM is already destroyed).
+  if (plan.oldIps.length > 0) {
+    record(`drain old generation for ${plan.drainSeconds}s (drainPolicy=${plan.drainPolicy ?? 'requests'})`);
+    if (plan.drainSeconds > 0) await sleep(plan.drainSeconds * 1000);
+  }
 
   return { ok: true, steps };
 }

--- a/infra/tasks/rollout-plans.test.ts
+++ b/infra/tasks/rollout-plans.test.ts
@@ -24,6 +24,18 @@ describe('planForService', () => {
     const plan = planForService('cdc');
     expect(plan.strategy).toBe('stop-first');
     expect(plan.healthUrl).toBeUndefined();
+    expect(plan.exclusive).toBeUndefined();
+  });
+
+  it('marks the singleVM host exclusive with nothing to drain (its stop-first worker folds in)', () => {
+    setEngineConfig(fakeConfig({ singleVM: true }));
+    try {
+      const plan = planForService('backend', 'https://www.cellajs.com/api');
+      expect(plan).toMatchObject({ strategy: 'start-first', exclusive: true, drainSeconds: 0 });
+      expect(plan.healthUrl).toBe('https://www.cellajs.com/api/health');
+    } finally {
+      setEngineConfig(fakeConfig());
+    }
   });
 
   it('requires a health URL for lb-overlap services', () => {

--- a/infra/tasks/rollout-plans.ts
+++ b/infra/tasks/rollout-plans.ts
@@ -1,7 +1,7 @@
 import type { ServiceName } from '../compose/compose';
 import { engineConfig } from '../config/engine-config';
 import { healthContract } from '../config/health.config';
-import { coHostedServices, collocatedServices, servicesByName } from '../lib/services';
+import { coHostedServices, collocatedServices, effectiveStrategy, servicesByName } from '../lib/services';
 import type { RolloutServicePlan } from './rollout';
 
 function normalizeHealthUrl(explicit?: string): string | undefined {
@@ -20,13 +20,19 @@ export function planForService(serviceFlag: string, healthUrl?: string): Rollout
   if (!definition) throw new Error(`Unknown service '${serviceFlag}'`);
   const service = definition.slug;
 
+  // A singleVM host folding a stop-first worker replaces its VM within the provisioning update: the LB pool moves straight to [new] and there is no displaced generation left to drain.
+  const exclusive =
+    definition.replacementStrategy !== 'stop-first' &&
+    effectiveStrategy(appConfig.services, appConfig.singleVM, definition) === 'stop-first';
+
   const plan: RolloutServicePlan = {
     service,
     strategy: definition.replacementStrategy,
     drainPolicy: definition.drainPolicy,
-    drainSeconds: definition.drainSeconds ?? 10,
+    drainSeconds: exclusive ? 0 : (definition.drainSeconds ?? 10),
     healthUrl: normalizeHealthUrl(healthUrl),
   };
+  if (exclusive) plan.exclusive = true;
 
   if (definition.replacementStrategy !== 'stop-first') {
     if (!definition.lbRoute)

--- a/infra/tasks/rollout.test.ts
+++ b/infra/tasks/rollout.test.ts
@@ -261,6 +261,30 @@ describe('runWavedRollout update batching', () => {
   });
 });
 
+describe('activateService exclusive singleVM host', () => {
+  it('ignores the displaced generation and drives the LB straight to [new]', async () => {
+    // The provisioning update destroyed b-old in the same pass that created b-new; only b-new exists in the outputs.
+    const fake = makeFake({
+      generations: [gen('backend', 'b-new', SHA, '10.0.0.2')],
+      active: { backend: { id: 'b-old', sha: 'sha-old' } },
+      backendIds: { backend: 'b-bid', frontend: 'f-bid' },
+      initialLb: { 'b-bid': ['10.0.0.1'], 'f-bid': ['10.0.0.1'] },
+    });
+    const plan: RolloutServicePlan = {
+      ...backendPlan,
+      exclusive: true,
+      drainSeconds: 0,
+      repointBackendKeys: ['frontend'],
+    };
+    await activateService(plan, SHA, await fake.rt.readGenerations(), await fake.rt.readLbBackendIds(), fake.rt);
+
+    // One LB write per pool: no [dead, new] overlap step, and the follower pool moves too.
+    expect(fake.lbHistory.get('b-bid')).toEqual([['10.0.0.1'], ['10.0.0.2']]);
+    expect(fake.lbHistory.get('f-bid')?.at(-1)).toEqual(['10.0.0.2']);
+    expect(fake.ops).toContain('promote:backend:b-new');
+  });
+});
+
 describe('activateService co-hosted repoint', () => {
   it('repoints co-hosted worker LB backends to the new generation IP after cutover', async () => {
     const fake = makeFake({

--- a/infra/tasks/rollout.ts
+++ b/infra/tasks/rollout.ts
@@ -14,6 +14,8 @@ export interface RolloutServicePlan {
   healthUrl?: string;
   /** Co-hosted worker slugs (singleVM) whose LB backends follow this VM. */
   repointBackendKeys?: string[];
+  /** singleVM host whose effective strategy is stop-first: the provisioning update replaces the VM in place, so no old generation exists to overlap with or drain. */
+  exclusive?: boolean;
 }
 
 /** Every effect the waved rollout performs, injected so wave sequencing is unit-testable. rollout-runtime.ts holds the Pulumi, control-object, LB, and health-polling implementation. */
@@ -77,11 +79,12 @@ export async function activateService(
   const backendId = backendIds[service];
   if (!backendId) throw new Error(`Could not resolve LB backend id for ${service}`);
 
-  // Serving generation before this deploy; empty on a first deploy, where the reconciler drives the LB straight to [new] once it is healthy.
+  // Serving generation before this deploy; empty on a first deploy or an exclusive host (whose old VM the provisioning update already destroyed), where the reconciler drives the LB straight to [new] once it is healthy.
   const activeRef = current?.active;
-  const oldGen = activeRef
-    ? generations.find((item) => item.service === service && item.genId === activeRef.id)
-    : undefined;
+  const oldGen =
+    activeRef && !plan.exclusive
+      ? generations.find((item) => item.service === service && item.genId === activeRef.id)
+      : undefined;
   const oldIps = oldGen ? [oldGen.privateIp] : [];
 
   rt.info(

--- a/infra/tasks/wait-for-images.ts
+++ b/infra/tasks/wait-for-images.ts
@@ -41,33 +41,52 @@ export function imageRef(registry: string, namespace: string, service: string, t
   return `${registry}/${namespace}/${service}:${tag}`;
 }
 
-/** Poll the registry until every image service's tag exists, or budgets run out. */
+/** Collapse concurrent callers onto one in-flight promise, so parallel pollers on the same tick share a single probe call. */
+function shareInflight<T>(fn: () => Promise<T>): () => Promise<T> {
+  let inflight: Promise<T> | undefined;
+  return () => {
+    inflight ??= fn().finally(() => {
+      inflight = undefined;
+    });
+    return inflight;
+  };
+}
+
+/** Poll the registry until every image service's tag exists, or budgets run out. Services poll concurrently: the slowest build gates the wait, not the sum of the builds. */
 export async function waitForImages(opts: WaitOptions): Promise<{ ok: boolean; missing: string[] }> {
   const attempts = opts.attempts ?? 80;
   const intervalMs = opts.intervalMs ?? 15000;
   const sleepFn = opts.sleep ?? sleep;
   const log = opts.log ?? ((msg: string) => console.info(msg));
+  const buildFailed = opts.buildFailed ? shareInflight(opts.buildFailed) : undefined;
 
-  const missing: string[] = [];
-  for (const service of opts.services ?? imageServiceNames) {
-    const ref = imageRef(opts.registry, opts.namespace, service, opts.tag);
-    log(`Waiting for ${service}:${opts.tag}`);
-    const ready = await pollUntil(
-      async (attempt) => {
-        if (opts.buildFailed && (await opts.buildFailed())) {
-          throw new Error(`build job for an image failed; not waiting out the registry budget (${ref})`);
-        }
-        if (!(await opts.inspect(ref))) return undefined;
-        log(`  ${service} ready after ${attempt} attempt(s)`);
-        return true;
-      },
-      { attempts, intervalMs, sleep: sleepFn },
-    );
-    if (!ready) {
+  const services = opts.services ?? imageServiceNames;
+  log(`Waiting for ${services.map((service) => `${service}:${opts.tag}`).join(', ')}`);
+  const outcomes = await Promise.allSettled(
+    services.map(async (service) => {
+      const ref = imageRef(opts.registry, opts.namespace, service, opts.tag);
+      const ready = await pollUntil(
+        async (attempt) => {
+          if (buildFailed && (await buildFailed())) {
+            throw new Error(`build job for an image failed; not waiting out the registry budget (${ref})`);
+          }
+          if (!(await opts.inspect(ref))) return undefined;
+          log(`  ${service} ready after ${attempt} attempt(s)`);
+          return true;
+        },
+        { attempts, intervalMs, sleep: sleepFn },
+      );
+      if (ready) return undefined;
       log(`::error::${ref} never appeared in registry`);
-      missing.push(ref);
-    }
-  }
+      return ref;
+    }),
+  );
+  // allSettled so a fail-fast abort in one poller never leaves a sibling's later rejection unhandled.
+  const aborted = outcomes.find((outcome) => outcome.status === 'rejected');
+  if (aborted?.status === 'rejected') throw aborted.reason;
+  const missing = outcomes.flatMap((outcome) =>
+    outcome.status === 'fulfilled' && outcome.value ? [outcome.value] : [],
+  );
 
   return { ok: missing.length === 0, missing };
 }


### PR DESCRIPTION
Tier 1 of the deploy-speed work discussed against the CONTAINER_GENERATIONS_OPTION analysis: keep the immutable-VM model, remove the waits that outlive what they wait for. Sized from the v0.9.4/v0.9.5 production deploy logs (2026-08-19, 6m15s–7m06s release→serving; waved rollout 197–219s of it).

## Correctness: singleVM cutover follows the effective strategy

Production runs `singleVM: true`, which folds the stop-first cdc worker into the backend VM — `effectiveStrategy(backend)` is stop-first and the wave-1 stack update destroys the old VM while creating the new one. The cutover plan was still built from the *declared* start-first strategy (`infra/tasks/rollout-plans.ts`), so it "expanded" the LB against a generation that no longer existed and then drained it for 10s (visible verbatim in the v0.9.5 log: `expand LB to [old, new] (1 server(s))` … `drain old generation for 10s`).

- `effectiveStrategy` moves to `infra/lib/services.ts`; the Pulumi program delegates to it, so plan and provisioning can no longer disagree.
- `planForService` marks the folded host `exclusive`: nothing to overlap with, nothing to drain (`drainSeconds: 0`).
- `sequenceCutover` logs `set LB to [new] (no old generation)` for an empty old set and skips the drain step entirely — which also removes the pointless 10s drain on first deploys.

Under stop-first the health-gate window is downtime, not overlap; this PR makes the deploy honest about that and stops adding dead time to it. (Whether prod *should* be stop-first is the separate DEV1-S sizing question from the Option A doc, not touched here.)

## Perf trims (measured basis per item)

| Change | Basis | Expected saving |
| --- | --- | --- |
| Healthcheck `interval` 30s → 5s (`infra/compose/infrastructure.ts`) | `compose up --wait` can only observe readiness once per interval; gate measured 60–65s (18–20 × 3s public polls) | ~20–30s off the boot health gate |
| Drain/expand of destroyed generation removed | 13s measured in v0.9.5 (expand write + 10s drain + contract) | ~13s |
| `wait-for-images` polls services concurrently, shared CI build-failed probe (one API call per tick) | Sequential walk at 15s per miss; was the co-limiter once (41s in v0.9.4) | 0–15s, removes a tail risk |
| Deploy job installs only `infra... shared... frontend...` | 21s (warm) / 46s (cold) measured; also the DEPLOY_RUNNER_PLAN Phase 0 hardening item (fewer lifecycle scripts in the credential-holding job) | ~10–25s |

`start_interval` (probe fast only during startup) was deliberately not used: it needs a compose/engine version floor the Scaleway marketplace VM image can't guarantee, and a compose file the VM's older compose can't parse would fail boot. A 5s steady-state localhost probe is free; nothing acts on transient unhealthy at runtime.

Healthcheck changes ride into the *next* release's generations (the healthcheck is deliberately outside the genId fingerprint; running VMs keep their baked compose).

## Explicitly out of scope (assessed, deferred)

- **Golden VM image / pre-pulled base layers** (~30–60s): needs boot-diag timings (`pnpm --filter infra diag`) to size, and Scaleway credentials to bake — the largest remaining item.
- **Pulumi pass consolidation** (base + wave-1): the base update is load-bearing — the IAM/secret preflights verify what it just converged *before* any VM boots; folding it into wave 1 would verify stale state or verify too late. Conditional-update design belongs to the Option A / P-pkg discussion.
- **`fetch-depth: 0`** in the deploy job stays: the docs-frontmatter plugin derives page `updatedAt` from git history.

## Verification

- 685 infra tests pass (3 new: exclusive plan resolution, straight-to-[new] LB write with follower repoint, no-old-generation cutover labels/drain skip).
- `pnpm ts` green repo-wide; `compose:check` clean; biome clean.
- The filtered install + in-process frontend build validated locally with the deploy's exact filter set and build env.
- Not live-verified on a real rollout — the first staging deploy after merge is the real test; the cutover behavior change is singleVM-only and its failure mode (health gate on the public URL) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
