### PR TITLE
perf(infra): async exec so the registry wait really overlaps the frontend build

### DIFF
--- a/infra/tasks/deploy-run.test.ts
+++ b/infra/tasks/deploy-run.test.ts
@@ -62,7 +62,7 @@ function makeFake(opts: { rolloutFails?: boolean; verifyFails?: boolean; updateF
     task: async (name, argv = []) => {
       ops.push(`task:${name}${argv[0] && !argv[0].startsWith('--') ? `:${argv[0]}` : ''}`);
     },
-    exec: (cmd, args, execOpts) => {
+    exec: async (cmd, args, execOpts) => {
       ops.push(`exec:${cmd}:${args[0]}${execOpts?.allowFailure ? ':allow-failure' : ''}`);
     },
     update: async (stack) => {
@@ -178,6 +178,22 @@ describe('runDeploy sequencing', () => {
     expect(ops).toContain('upload-assets');
     expect(ops).toContain('publish-entry');
     expect(ops).toContain('task:smoke');
+  });
+
+  it('the registry wait progresses while the frontend build runs (exec must not block it)', async () => {
+    const { fx, ops } = makeFake();
+    const fxConcurrent: DeployEffects = {
+      ...fx,
+      exec: async (cmd, args) => {
+        // The fake build finishes only after the concurrent images branch completed its registry wait; a build that blocks that branch deadlocks this test.
+        if (cmd === 'pnpm' && args[0] === '--filter') {
+          while (!ops.includes('task:wait-for-images')) await new Promise((tick) => setTimeout(tick, 1));
+        }
+        ops.push(`exec:${cmd}:${args[0]}`);
+      },
+    };
+    await runDeploy({ mode: 'production', sha: 'abc123' }, fxConcurrent, fakeDeployEnv);
+    expect(ops.indexOf('task:wait-for-images')).toBeLessThan(ops.indexOf('exec:pnpm:--filter'));
   });
 
   it('skips the frontend build (but still uploads) with a prebuilt dist dir', async () => {

--- a/infra/tasks/deploy-run.ts
+++ b/infra/tasks/deploy-run.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { basename, resolve } from 'node:path';
@@ -56,12 +56,12 @@ export interface DeployEffects {
   initTelemetry(init: { mode: string; sha: string }): Promise<void>;
   /** Run a task module's main(argv) in-process; throws on failure. */
   task(name: TaskName, argv?: string[]): Promise<void>;
-  /** Run an external binary in the infra dir; throws on non-zero exit unless allowFailure. */
+  /** Run an external binary in the infra dir; rejects on non-zero exit unless allowFailure. Async so concurrent steps (registry wait, asset upload) keep progressing while a build runs. */
   exec(
     cmd: string,
     args: string[],
     opts?: { allowFailure?: boolean; stdin?: string; env?: Record<string, string>; secretless?: boolean },
-  ): void;
+  ): Promise<void>;
   /** Upload the built frontend bundle (hashed assets skip when present; entry files excluded). */
   uploadAssets(opts: { distDir: string; bucket: string; region: string }): Promise<void>;
   /** One full stack update through the configured Pulumi driver. */
@@ -185,15 +185,15 @@ export async function runDeploy(
     const distDir = opts.distDir ?? resolve(infraDir, '..', 'frontend', 'dist');
     const imagesReady = (async () => {
       if (opts.build) {
-        await step('Build images (buildx bake)', () => {
+        await step('Build images (buildx bake)', async () => {
           const bake = bakeDefinition(parseBuildRows(env.build_images_matrix), {
             registry,
             namespace: env.registry_ns,
             tag: opts.sha,
             context: '..',
           });
-          fx.exec('pnpm', ['run', 'boot:build']);
-          fx.exec('docker', ['buildx', 'bake', '--file', '-', '--push'], { stdin: JSON.stringify(bake) });
+          await fx.exec('pnpm', ['run', 'boot:build']);
+          await fx.exec('docker', ['buildx', 'bake', '--file', '-', '--push'], { stdin: JSON.stringify(bake) });
         });
       }
       await step('Wait for image tags in registry', () =>
@@ -378,8 +378,11 @@ export async function runReap(
 
   let lockHeld = false;
   try {
-    fx.exec('pulumi', ['login', `s3://${env.state_bucket}?endpoint=s3.${env.region}.scw.cloud&region=${env.region}`]);
-    fx.exec('pulumi', ['stack', 'select', stack]);
+    await fx.exec('pulumi', [
+      'login',
+      `s3://${env.state_bucket}?endpoint=s3.${env.region}.scw.cloud&region=${env.region}`,
+    ]);
+    await fx.exec('pulumi', ['stack', 'select', stack]);
     await fx.task('stack-lock', ['acquire', '--stack', stack, '--operation', 'reap', '--ttl-min', '30']);
     lockHeld = true;
     await fx.task('install-pulumi-providers');
@@ -486,14 +489,24 @@ function createRealEffects(): DeployEffects {
       // opts.env on top, so an untrusted build (the frontend Vite plugin graph)
       // cannot read them. The default path is unchanged: full env inheritance.
       const baseEnv = opts.secretless ? scrubSecretEnv(process.env) : process.env;
-      const res = spawnSync(cmd, args, {
-        cwd: infraDir,
-        env: opts.env ? { ...baseEnv, ...opts.env } : baseEnv,
-        stdio: [opts.stdin === undefined ? 'inherit' : 'pipe', 'inherit', 'inherit'],
-        input: opts.stdin,
+      // spawn, not spawnSync: a synchronous child blocks the event loop, which
+      // serialized the "concurrent" registry wait behind the frontend build.
+      return new Promise((done, fail) => {
+        const child = spawn(cmd, args, {
+          cwd: infraDir,
+          env: opts.env ? { ...baseEnv, ...opts.env } : baseEnv,
+          stdio: [opts.stdin === undefined ? 'inherit' : 'pipe', 'inherit', 'inherit'],
+        });
+        if (opts.stdin !== undefined) child.stdin?.end(opts.stdin);
+        child.once('error', (err) => {
+          if (opts.allowFailure) done();
+          else fail(new Error(`${cmd} ${args[0] ?? ''} failed to start: ${errorMessage(err)}`));
+        });
+        child.once('close', (status) => {
+          if (status !== 0 && !opts.allowFailure) fail(new Error(`${cmd} ${args[0] ?? ''} failed with exit ${status}`));
+          else done();
+        });
       });
-      if (res.status !== 0 && !opts.allowFailure)
-        throw new Error(`${cmd} ${args[0] ?? ''} failed with exit ${res.status}`);
     },
     async uploadAssets(assetOpts) {
       const { uploadFrontendAssets } = await import('./frontend-assets');

--- a/infra/tasks/wait-for-images.ts
+++ b/infra/tasks/wait-for-images.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import type { ServiceName } from '../compose/compose';
 import { imageServiceNames } from '../lib/services';
 import { isMain } from '../lib/utils/is-main';
@@ -9,11 +9,13 @@ import { getFlag, getNumFlag, sleep } from './args';
 /** Inspect a single image ref; resolves true if it exists. Injectable for tests. */
 export type InspectFn = (imageRef: string) => Promise<boolean>;
 
-/** Default inspector: `docker buildx imagetools inspect <ref>` (no shell). */
-export const dockerInspect: InspectFn = async (imageRef) => {
-  const { status } = spawnSync('docker', ['buildx', 'imagetools', 'inspect', imageRef], { stdio: 'ignore' });
-  return status === 0;
-};
+/** Default inspector: `docker buildx imagetools inspect <ref>` (no shell). Async spawn so the per-service pollers genuinely overlap and never block the event loop. */
+export const dockerInspect: InspectFn = (imageRef) =>
+  new Promise((resolve) => {
+    const child = spawn('docker', ['buildx', 'imagetools', 'inspect', imageRef], { stdio: 'ignore' });
+    child.once('error', () => resolve(false));
+    child.once('close', (status) => resolve(status === 0));
+  });
 
 export interface WaitOptions {
   registry: string;


### PR DESCRIPTION
Follow-up to #1091, from the v0.9.6 deploy log: the deploy command's "images and frontend converge concurrently" block was not actually concurrent. `fx.exec` used `spawnSync`, which blocks the Node event loop, so `wait-for-images`' poll timers could not fire while the frontend build ran — the log shows `Waiting for backend, cdc, frontend` appearing only after `Build frontend: ok (34s)`.

It cost ~0s in v0.9.6 (the backend image tag was not in the registry until after the build finished anyway), but it serializes the block whenever the build outlives the image availability — slow build days, warm registries, and every `--build`-less staging deploy where images were pushed by an earlier run.

## Changes

- `fx.exec` becomes an async `spawn` with identical semantics (infra cwd, `env` layering, `secretless` scrub, `stdin` piping, `allowFailure`); a spawn failure now reports the underlying error instead of a bare non-zero status. The interface changes from `void` to `Promise<void>`, and the two call sites that relied on sync completion (`--build` bake sequence, reap's pulumi login/select) now await explicitly.
- `dockerInspect` in `wait-for-images` follows suit, so the per-service registry probes from #1091's parallel wait genuinely overlap instead of queueing behind one blocking child each.
- New test pins the property: a frontend build that finishes only after the registry wait completes must not deadlock or reorder the pipeline — a regression to a blocking exec fails it by timeout.

## Verification

- 686 infra tests pass (1 new); `pnpm ts` green; biome clean.
- No behavior change to step ordering, failure handling, or logging; only the scheduling of already-concurrent branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
