### PR TITLE
fix: stop infinite paging on drifted totals + settle CDC slot before counter recalc

### DIFF
--- a/backend/scripts/seeds/50-counters.seed.ts
+++ b/backend/scripts/seeds/50-counters.seed.ts
@@ -1,10 +1,68 @@
+import { sql } from 'drizzle-orm';
 import type { SeedScript } from '../types';
 import { seedDb } from '#/db/db';
 import { recalculateCounters } from '#/modules/entities/helpers/recalculate-counters';
-import { startSpinner, succeedSpinner } from '#/utils/console';
+import { startSpinner, succeedSpinner, warnSpinner } from '#/utils/console';
 
 // Seed scripts use the admin connection for privileged operations.
 const db = seedDb;
+
+const CDC_SLOT_NAME = process.env.CDC_SLOT_NAME ?? 'cdc_slot';
+const CDC_CATCHUP_TIMEOUT_MS = 30_000;
+const CDC_CATCHUP_POLL_MS = 500;
+
+const readSlot = async (targetLsn: string) => {
+  const result = await db.execute(sql`
+    SELECT active, confirmed_flush_lsn >= ${targetLsn}::pg_lsn AS caught_up
+    FROM pg_replication_slots
+    WHERE slot_name = ${CDC_SLOT_NAME}
+  `);
+  return (result.rows[0] as { active: boolean; caught_up: boolean | null } | undefined) ?? null;
+};
+
+/**
+ * CDC counter deltas are pure increments, so recalculating while seed WAL is still pending in the
+ * replication slot double-counts: recalculation writes the true count, then the worker replays the
+ * seed inserts and increments on top. Settle the slot first so recalculation is the authority:
+ * - no slot: the worker creates one at current WAL on startup, so seed events never replay.
+ * - idle slot: advance it past the seed WAL; the pending events are skipped for good.
+ * - active slot: wait for the worker to flush past the seed WAL, then recalculate over its work.
+ * Never fails the seed: on timeout or missing privilege it warns and proceeds.
+ */
+const settleCdcSlot = async () => {
+  try {
+    const lsnResult = await db.execute(sql`SELECT pg_current_wal_lsn()::text AS lsn`);
+    const targetLsn = (lsnResult.rows[0] as { lsn: string }).lsn;
+
+    let slot = await readSlot(targetLsn);
+    if (!slot) return;
+
+    if (!slot.active && !slot.caught_up) {
+      try {
+        await db.execute(sql`SELECT pg_replication_slot_advance(${CDC_SLOT_NAME}, pg_current_wal_lsn())`);
+        return;
+      } catch {
+        // The worker attached between the checks; fall through to waiting for it.
+      }
+    }
+
+    const deadline = Date.now() + CDC_CATCHUP_TIMEOUT_MS;
+    while (slot && !slot.caught_up && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, CDC_CATCHUP_POLL_MS));
+      slot = await readSlot(targetLsn);
+    }
+
+    if (slot && !slot.caught_up) {
+      warnSpinner(
+        `CDC slot '${CDC_SLOT_NAME}' still behind after ${CDC_CATCHUP_TIMEOUT_MS / 1000}s; replayed events will drift the counters. Re-run "pnpm seed counters" once the worker has caught up.`,
+      );
+    }
+  } catch (error) {
+    warnSpinner(
+      `Could not settle CDC slot '${CDC_SLOT_NAME}' before recalculating: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+};
 
 /**
  * Recalculate channel_counters and product_counters from current DB state. Delegates to
@@ -14,6 +72,7 @@ const db = seedDb;
 export const countersSeed = async () => {
   startSpinner('Recalculating counters...');
 
+  await settleCdcSlot();
   const { channelRows, productRows } = await recalculateCounters(db);
 
   succeedSpinner(`Recalculated counters for ${channelRows} channel entities, ${productRows} product entities`);

--- a/frontend/src/query/basic/infinite-query-options.test.ts
+++ b/frontend/src/query/basic/infinite-query-options.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import type { PageParams, QueryData } from '~/query/types';
+import { baseInfiniteQueryOptions } from './infinite-query-options';
+
+const { getNextPageParam } = baseInfiniteQueryOptions;
+
+const page = (count: number, total: number): QueryData<unknown> => ({
+  items: Array.from({ length: count }, (_, i) => i),
+  total,
+});
+
+const next = (pages: QueryData<unknown>[]): PageParams | undefined | null =>
+  getNextPageParam(pages[pages.length - 1], pages, { page: 0, offset: 0 }, []);
+
+describe('baseInfiniteQueryOptions.getNextPageParam', () => {
+  it('advances offset by the fetched count while rows remain', () => {
+    expect(next([page(40, 100)])).toEqual({ page: 1, offset: 40 });
+    expect(next([page(40, 100), page(40, 100)])).toEqual({ page: 2, offset: 80 });
+  });
+
+  it('stops when every row is fetched', () => {
+    expect(next([page(40, 100), page(40, 100), page(20, 100)])).toBeUndefined();
+    expect(next([page(0, 0)])).toBeUndefined();
+  });
+
+  it('stops on an empty page even when a drifted total claims more rows', () => {
+    // Regression: a stale denormalized total (server counter > real rows) kept requesting the
+    // same offset in an unthrottled loop until the rate limiter blocked the user.
+    expect(next([page(5, 10), page(0, 10)])).toBeUndefined();
+    expect(next([page(0, 10)])).toBeUndefined();
+  });
+});

--- a/frontend/src/query/basic/infinite-query-options.ts
+++ b/frontend/src/query/basic/infinite-query-options.ts
@@ -8,6 +8,9 @@ export const baseInfiniteQueryOptions = {
     const total = lastPage.total;
     const fetchedCount = allPages.reduce((acc, page) => acc + page.items.length, 0);
 
+    // An empty page means the server has no more rows regardless of what `total` claims; without
+    // this guard a drifted denormalized total re-requests the same offset in an unthrottled loop.
+    if (lastPage.items.length === 0) return undefined;
     if (fetchedCount >= total) return undefined;
     return { page: allPages.length, offset: fetchedCount };
   }) as GetNextPageParamFunction<PageParams, QueryData<unknown>>,


### PR DESCRIPTION
## Incident

During dev, a browser tab hit the `syncRead` rate limit (5000 reads/hour) in ~9 minutes: the attachments table re-requested the same page (`offset=5`) at ~30 req/s until the limiter blocked the user for the rest of the hour window.

Root cause chain:
1. The org's `channel_counters` row said `e:c:attachment = 10` while only 5 rows existed — exactly 2×: the counters seed recalculated while the seed inserts' WAL was still pending in the CDC slot, and the worker later replayed them as pure `+1` increments on top of the correct recalculated count.
2. The counter-eligible path in `getAttachmentsOp` returns that counter as `total` for the default view.
3. `baseInfiniteQueryOptions.getNextPageParam` saw `fetchedCount (5) < total (10)`, returned the same offset, got an empty page, and the table's auto-fetch effect fired again immediately — an unthrottled loop with no forward progress.

## Fixes

**Frontend guard** — `getNextPageParam` returns `undefined` on an empty page: the server has no more rows regardless of what a stale `total` claims. Any future counter drift now costs one wasted request instead of a request loop. Regression test added.

**Seed determinism** — the counters seed settles the CDC replication slot before recalculating:
- no slot → nothing to do (the worker creates one at current WAL on startup, so seed events never replay)
- idle slot → `pg_replication_slot_advance` past the seed WAL, skipping the pending events for good
- active slot → poll until the worker's `confirmed_flush_lsn` passes the seed WAL (30s timeout), then recalculate over its increments

Either way the recalculation ends up authoritative. It never fails the seed: on timeout or missing replication privilege it warns and proceeds.

## Not addressed (known follow-up)

The CDC pipeline has no exactly-once guarantee for counter deltas in general: a crash between `applyBatchUnifiedDeltas` and the slot ack would also double-count on replay (the activity insert's `onConflictDoNothing` on the LSN-derived id dedupes the activity row but not the deltas). The empty-page guard makes that harmless client-side and periodic recalc remains the designed repair; the LSN-keyed activity insert is the natural dedup anchor if replay-safety is wanted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)