### PR TITLE
fix(test): pick a materializer-free product type in yjs-materializers test

### DIFF
--- a/backend/src/modules/yjs/yjs-materializers.test.ts
+++ b/backend/src/modules/yjs/yjs-materializers.test.ts
@@ -11,7 +11,7 @@ import { getYjsMaterializer, type YjsMaterializer } from '#/modules/yjs/yjs-mate
  * guards the registration round-trip: the relay is entity-agnostic, the registry is not.
  */
 describe('Yjs materializers', () => {
-  // Forks may ship a materializer on any product type, so probe for one that has none.
+  // Apps may ship a materializer on any product type, so probe for one that has none.
   const unregisteredType = appConfig.productEntityTypes.find((type) => getYjsMaterializer(type) === undefined);
 
   it.skipIf(!unregisteredType)('returns undefined for a product type without a registered materializer', () => {

--- a/backend/src/modules/yjs/yjs-materializers.test.ts
+++ b/backend/src/modules/yjs/yjs-materializers.test.ts
@@ -1,6 +1,6 @@
 import '#/modules';
 
-import { appConfig } from 'shared';
+import { appConfig, type ProductEntityType } from 'shared';
 import { describe, expect, it } from 'vitest';
 import { defineBackendModule } from '#/lib/module';
 import { getYjsMaterializer, type YjsMaterializer } from '#/modules/yjs/yjs-materializers';
@@ -11,13 +11,15 @@ import { getYjsMaterializer, type YjsMaterializer } from '#/modules/yjs/yjs-mate
  * guards the registration round-trip: the relay is entity-agnostic, the registry is not.
  */
 describe('Yjs materializers', () => {
-  const [productType] = appConfig.productEntityTypes;
+  // Forks may ship a materializer on any product type, so probe for one that has none.
+  const unregisteredType = appConfig.productEntityTypes.find((type) => getYjsMaterializer(type) === undefined);
 
-  it('returns undefined for a product type without a registered materializer', () => {
-    expect(getYjsMaterializer(productType)).toBeUndefined();
+  it.skipIf(!unregisteredType)('returns undefined for a product type without a registered materializer', () => {
+    expect(getYjsMaterializer(unregisteredType as ProductEntityType)).toBeUndefined();
   });
 
   it('resolves a materializer registered through defineBackendModule', () => {
+    const productType = unregisteredType ?? appConfig.productEntityTypes[0];
     const materializer: YjsMaterializer = async () => undefined;
     defineBackendModule({
       name: 'yjs-materializer-test',


### PR DESCRIPTION
## What

`yjs-materializers.test.ts` used `productEntityTypes[0]` for its negative case and asserted it has no registered materializer. That assumption only holds by accident of type ordering: any fork whose first product type ships a `yjsMaterializer` (e.g. projectcampus, whose first product type `item` has one) fails the test on every `cella sync` and has to carry a fork-marked drift.

## How

- Probe `productEntityTypes` for a type the registry has no materializer for, and use that for the negative assertion.
- `it.skipIf` the negative case when every product type has a materializer (nothing to assert then).
- The registration round-trip test uses the same materializer-free type, falling back to `productEntityTypes[0]` (overwriting its entry is harmless inside the test process).

Retires the drift marker forks otherwise need on this file.

## Verified

- `vitest run src/modules/yjs/yjs-materializers.test.ts`: 2 passed (both branches exercised in cella, where a materializer-free type exists).
- Pre-commit biome + full-workspace tsgo pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)