### PR TITLE
feat: retire common fork drift via registry seam, counts seam and docs glob

### DIFF
--- a/backend/src/schemas/app-channel-counts.ts
+++ b/backend/src/schemas/app-channel-counts.ts
@@ -1,0 +1,9 @@
+import type { ChannelEntityType } from 'shared';
+
+/**
+ * Extra fields for a channel's `counts` object in the included schema. App-owned: cella ships
+ * none, apps add e.g. `milestones: z.object({...}).optional()` here — mark fields optional when
+ * only some ops populate them. Keep the return a plain object literal (no ZodRawShape annotation)
+ * so the counts schema keeps exact field inference for SDK generation.
+ */
+export const appChannelCountFields = (_entityType: ChannelEntityType) => ({});

--- a/backend/src/schemas/app-channel-counts.ts
+++ b/backend/src/schemas/app-channel-counts.ts
@@ -2,8 +2,8 @@ import type { ChannelEntityType } from 'shared';
 
 /**
  * Extra fields for a channel's `counts` object in the included schema. App-owned: cella ships
- * none, apps add e.g. `milestones: z.object({...}).optional()` here — mark fields optional when
- * only some ops populate them. Keep the return a plain object literal (no ZodRawShape annotation)
- * so the counts schema keeps exact field inference for SDK generation.
+ * none, apps add e.g. `milestones: z.object({...}).optional()` here, optional when only some ops
+ * populate them. Keep the return a plain object literal (no ZodRawShape annotation) so the counts
+ * schema keeps exact field inference for SDK generation.
  */
 export const appChannelCountFields = (_entityType: ChannelEntityType) => ({});

--- a/backend/src/schemas/channel-included.ts
+++ b/backend/src/schemas/channel-included.ts
@@ -1,6 +1,7 @@
 import { z } from '@hono/zod-openapi';
 import { type ChannelEntityType, hierarchy, isProduct, recordFromKeys } from 'shared';
 import { membershipBaseSchema } from '#/modules/memberships/memberships-schema';
+import { appChannelCountFields } from '#/schemas/app-channel-counts';
 import { membershipCountSchema } from '#/schemas/count-schemas';
 import { userMinimalBaseSchema } from '#/schemas/minimal-base';
 
@@ -23,6 +24,7 @@ export const channelIncludedSchema = (entityType: ChannelEntityType) => {
     // Home-only twin of `entities` (`e:c:h:` keys): rows homed directly at the channel.
     entitiesSelf: entityCountSchema,
     activity: activitySchema,
+    ...appChannelCountFields(entityType),
   });
 
   return z.object({

--- a/frontend/src/lib/module.ts
+++ b/frontend/src/lib/module.ts
@@ -1,9 +1,16 @@
+import type { ProductEntityType } from 'shared';
 import { type ModuleConfig, registerModule } from 'shared/module-registry';
 import type { Tool } from '~/lib/placements';
 
 /** A frontend module's registration: shared metadata plus frontend-only capabilities. */
 export interface FrontendModule extends ModuleConfig {
   tools?: Tool[];
+  /**
+   * Product entity the module edits through CollaborativeBlockNote. Declare it on the module whose
+   * backend counterpart registers a `yjsMaterializer`; the organization layout prefetches a Yjs
+   * token per declared type.
+   */
+  collaborativeProduct?: ProductEntityType;
 }
 
 const frontendModules: FrontendModule[] = [];
@@ -11,7 +18,7 @@ const listeners: ((module: FrontendModule) => void)[] = [];
 
 /** Registers a module: metadata to the shared registry, capabilities to {@link onFrontendModuleRegister} listeners. */
 export function defineFrontendModule(module: FrontendModule): void {
-  const { tools: _tools, ...metadata } = module;
+  const { tools: _tools, collaborativeProduct: _collaborativeProduct, ...metadata } = module;
   registerModule(metadata);
   frontendModules.push(module);
   for (const listener of listeners) listener(module);

--- a/frontend/src/modules/organization/organization-layout.tsx
+++ b/frontend/src/modules/organization/organization-layout.tsx
@@ -1,13 +1,17 @@
 import { Outlet } from '@tanstack/react-router';
 import { appConfig, type ProductEntityType } from 'shared';
 import { useOrganizationLayoutContext } from '~/hooks/use-route-context';
+import { onFrontendModuleRegister } from '~/lib/module';
 import { YjsTokenFetcher } from '~/modules/common/blocknote/yjs-token-fetcher';
 
 /**
- * Product types edited through CollaborativeBlockNote. Empty in the template; apps list the types
- * whose backend module registers a `yjsMaterializer`. Only read when the Yjs service is enabled.
+ * Product types edited through CollaborativeBlockNote, collected from module registrations
+ * (`collaborativeProduct`). Only read when the Yjs service is enabled.
  */
-const collaborativeProductTypes: readonly ProductEntityType[] = [];
+const collaborativeProductTypes: ProductEntityType[] = [];
+onFrontendModuleRegister((module) => {
+  if (module.collaborativeProduct) collaborativeProductTypes.push(module.collaborativeProduct);
+});
 
 /**
  * Organization layout body. Yjs tokens are fetched here, not beside an editor: a token is scoped

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -334,7 +334,8 @@ const viteConfig = {
     {
       enforce: 'pre' as const,
       ...mdx({
-        include: /\/(src\/content\/docs\/.*\.(md|mdx)|(cella\/)?[A-Z][A-Z_]*\.md|[a-z-]+\/README\.md)$/,
+        // Repo docs live under cella/ only; fork root-level SHOUTCASE .md (README, CHANGELOG) are not doc pages.
+        include: /\/(src\/content\/docs\/.*\.(md|mdx)|cella\/[A-Z][A-Z_]*\.md|[a-z-]+\/README\.md)$/,
         format: 'detect',
         // Read component overrides (links, headings) from MDXProvider context. A
         // `components` prop does not cross into imported modules, and wrapper pages

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -100,7 +100,7 @@ const repoDocRoutes = {
 } as const;
 
 // Tunnel mode: frontendUrl is the public ngrok origin (no port); Vite still listens locally.
-const devPort = Number(frontendUrl.port) || 3000;
+const devPort = Number(frontendUrl.port) || appConfig.devPorts.frontend;
 const isTunneled = frontendUrl.hostname !== 'localhost';
 
 // Release identifier for error/replay tagging (Maple serviceVersion). Git SHA

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -334,7 +334,7 @@ const viteConfig = {
     {
       enforce: 'pre' as const,
       ...mdx({
-        // Repo docs live under cella/ only; fork root-level SHOUTCASE .md (README, CHANGELOG) are not doc pages.
+        // Repo docs live under cella/ only; an app's root-level SHOUTCASE .md (README, CHANGELOG) are not doc pages.
         include: /\/(src\/content\/docs\/.*\.(md|mdx)|cella\/[A-Z][A-Z_]*\.md|[a-z-]+\/README\.md)$/,
         format: 'detect',
         // Read component overrides (links, headings) from MDXProvider context. A

--- a/shared/config/config.default.ts
+++ b/shared/config/config.default.ts
@@ -117,9 +117,11 @@ export const config = {
    * Local dev listen ports, also the Vite proxy targets. Ports are machine-global, so an app must
    * offset this whole block together with the port in the `frontendUrl` family (e.g. +20). With
    * two stacks up, whichever backend binds :4000 first answers every app's `/api` proxy.
-   * `PORT`-style env vars still override at runtime.
+   * `PORT`-style env vars still override at runtime. `frontend` is the Vite fallback for when
+   * `frontendUrl` carries no port (tunnel mode); otherwise the URL port wins.
    */
   devPorts: {
+    frontend: 3000,
     api: 4000,
     cdcHealth: 4001,
     yjs: 4002,

--- a/shared/config/config.template.ts
+++ b/shared/config/config.template.ts
@@ -95,8 +95,9 @@ export const config = {
   /**
    * Local dev service listen ports and Vite proxy targets. Offset the whole block together
    * with the dev `frontendUrl` port (unique per app) so parallel local stacks never collide.
+   * `frontend` is the Vite fallback for when `frontendUrl` carries no port (tunnel mode).
    */
-  devPorts: { api: 4000, cdcHealth: 4001, yjs: 4002, mcp: 4003 },
+  devPorts: { frontend: 3000, api: 4000, cdcHealth: 4001, yjs: 4002, mcp: 4003 },
   /**
    * Per-service toggles and public URLs. `enabled` controls whether the service
    * is wired up; `publicUrl` is the externally reachable endpoint.

--- a/shared/src/config-builder/types.ts
+++ b/shared/src/config-builder/types.ts
@@ -178,7 +178,7 @@ export interface RequiredConfig<T extends ConfigStringArrays = ConfigStringArray
   yjsUrl: string;
 
   mcpUrl: string;
-  devPorts: { api: number; cdcHealth: number; yjs: number; mcp: number };
+  devPorts: { frontend: number; api: number; cdcHealth: number; yjs: number; mcp: number };
   services: Record<string, AppServiceEndpointConfig>;
   singleVM: boolean;
   aboutUrl: string;


### PR DESCRIPTION
Follow-up to #1099: four alignment changes that retire fork-marked edits forks currently carry on cella-owned files (driven by scanning projectcampus's `// fork:` drift markers).

## 1. `collaborativeProduct` module capability (frontend)

`organization-layout.tsx` hardcoded `collaborativeProductTypes = []` and told apps to edit the array in place — registry-shaped data expressed as file drift. `FrontendModule` now carries `collaborativeProduct?: ProductEntityType` and the layout collects declared types via `onFrontendModuleRegister` (replay makes it order-safe; modules register in the `main.tsx` composition root before first render). Mirrors the backend `yjsMaterializer` seam: a fork declares the type on its product module and stops editing the layout.

## 2. `appChannelCountFields` seam (backend)

Apps adding a field to the channel-included `counts` object (e.g. projectcampus's `milestones`) had to edit the cella-owned schema factory. New `backend/src/schemas/app-channel-counts.ts` exports an empty-default factory spread into `countsSchema` — the same app-owned pattern as `membershipChannelColumns()`. The return stays an inferred object literal (no `ZodRawShape` annotation) so exact field inference for SDK gen is preserved; `pnpm sdk` reports generated output unchanged.

## 3. Docs glob drops the optional `cella/` prefix (frontend)

The mdx include matched `(cella\/)?[A-Z][A-Z_]*\.md`. Repo docs live under `cella/` only, and no MDX page imports a root-level SHOUTCASE file (doc pages import `cella/*.md` and package `*/README.md`, which have their own alternatives) — verified by grepping `frontend/src/content`. In forks the root-level alternative only risked compiling their fork-owned root `README`/`CHANGELOG`/`SECURITY` into doc pages; projectcampus fork-marked exactly this narrowing.

## 4. `devPorts.frontend` as the Vite dev-port fallback (shared + frontend)

In tunnel mode `frontendUrl` is the public origin with no port, so Vite's listen port fell back to a hardcoded 3000 — forks that offset their dev-port block (projectcampus is +20) had to fork-mark an edited fallback in `vite.config.ts`. `devPorts` gains a `frontend` entry (default 3000, added to `config.template.ts` and the builder type) and `vite.config.ts` reads it. Additive config key: create-cella's `generateEnvConfigs` only emits URL keys, so no companion change needed there.

## Fork adoption

On next sync projectcampus (and any fork) can retire four drift markers: declare `collaborativeProduct: 'item'` on its item module, move `milestones` into the counts seam file (and pin it), set `devPorts.frontend: 3020`, and take upstream's `vite.config.ts` lines for the docs glob and dev-port fallback.

## Verified

- frontend `placements.test.ts` (module registry round-trip): 11 passed
- pre-commit gate per commit: openapi gen, SDK gen (output unchanged), biome, full-workspace tsgo, commitlint — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
