### PR TITLE
fix(ci): exempt release changelog from app-vocabulary gate

### DIFF
--- a/shared/scripts/check-app-vocabulary.test.ts
+++ b/shared/scripts/check-app-vocabulary.test.ts
@@ -37,4 +37,8 @@ describe('findAppVocabularyFindings', () => {
   it('allows the Cella CLI configuration', () => {
     expect(findAppVocabularyFindings('cella/cella.config.ts', legacyTerm)).toEqual([]);
   });
+
+  it('allows the release-please changelog', () => {
+    expect(findAppVocabularyFindings('cella/CHANGELOG.md', legacyTerm)).toEqual([]);
+  });
 });

--- a/shared/scripts/check-app-vocabulary.ts
+++ b/shared/scripts/check-app-vocabulary.ts
@@ -8,6 +8,9 @@ const here = dirname(fileURLToPath(import.meta.url));
 const defaultRepoRoot = join(here, '..', '..');
 const disallowedTerm = /fork/gi;
 const allowedFiles = new Set([
+  // release-please copies merged commit titles into the changelog verbatim, so any
+  // title using the CLI's source-control term would otherwise fail the release PR.
+  'cella/CHANGELOG.md',
   'cella/cella.config.ts',
   // The cella-sync skill documents the CLI sync workflow and the app-side marker convention,
   // both of which use the CLI's source-control term. It must stay byte-identical with the


### PR DESCRIPTION
The 0.9.8 release-please PR (#1098) failed CI in the style gate: release-please copied the merged title of #1100 into `cella/CHANGELOG.md`, and the app-vocabulary check flagged the CLI's source-control term in it.

The changelog is auto-generated commit history, not app-facing prose, and the pr-title check doesn't screen vocabulary — so any future commit title using that term would retrip the gate on every release PR. This adds `cella/CHANGELOG.md` to the check's allowlist, with a test.

After merge, the release PR needs a re-run (or release-please will refresh it on the next push to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)