### PR TITLE
refactor(memberships): generalize JoinedButton for reuse beyond the org header

### DIFF
--- a/frontend/src/modules/memberships/joined-button.tsx
+++ b/frontend/src/modules/memberships/joined-button.tsx
@@ -1,3 +1,4 @@
+import type { VariantProps } from 'class-variance-authority';
 import { CheckIcon, XIcon } from 'lucide-react';
 import type { MouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -6,11 +7,14 @@ import { useDropdowner } from '~/modules/common/dropdowner/use-dropdowner';
 import { PopConfirm } from '~/modules/common/popconfirm';
 import type { LeaveChannelButtonProps } from '~/modules/memberships/leave-channel-button';
 import { LeaveChannelForm } from '~/modules/memberships/leave-channel-form';
-import { Button } from '~/modules/ui/button';
+import { Button, type buttonVariants } from '~/modules/ui/button';
+import { cn } from '~/utils/cn';
 
 type JoinedButtonProps = Omit<LeaveChannelButtonProps, 'buttonProps'> & {
   /** Membership role shown on the trigger ("✓ Admin"). */
   role?: MembershipBase['role'] | null;
+  size?: VariantProps<typeof buttonVariants>['size'];
+  className?: string;
 };
 
 /**
@@ -18,7 +22,7 @@ type JoinedButtonProps = Omit<LeaveChannelButtonProps, 'buttonProps'> & {
  * to signal that clicking undoes the join. Clicking opens a leave popconfirm through the
  * dropdowner, so it renders as a drawer below the `sm` breakpoint.
  */
-function JoinedButton({ role, ...props }: JoinedButtonProps) {
+function JoinedButton({ role, size = 'sm', className, ...props }: JoinedButtonProps) {
   const { t } = useTranslation();
   const { channel } = props;
 
@@ -45,13 +49,17 @@ function JoinedButton({ role, ...props }: JoinedButtonProps) {
   };
 
   return (
-    <div className="flex items-center p-2">
-      <Button size="sm" variant="success" className="group" aria-label={t('c:leave')} onClick={openLeaveConfirm}>
-        <CheckIcon className="group-hover:hidden group-focus-visible:hidden group-data-dropdowner-active:hidden" />
-        <XIcon className="hidden group-hover:block group-focus-visible:block group-data-dropdowner-active:block" />
-        <span className="ml-1 max-xs:hidden">{role ? t(role) : t('c:joined')}</span>
-      </Button>
-    </div>
+    <Button
+      size={size}
+      variant="success"
+      className={cn('group', className)}
+      aria-label={t('c:leave')}
+      onClick={openLeaveConfirm}
+    >
+      <CheckIcon className="group-hover:hidden group-focus-visible:hidden group-data-dropdowner-active:hidden" />
+      <XIcon className="hidden group-hover:block group-focus-visible:block group-data-dropdowner-active:block" />
+      <span className="ml-1 max-xs:hidden">{role ? t(role) : t('c:joined')}</span>
+    </Button>
   );
 }
 

--- a/frontend/src/modules/memberships/leave-channel-button.tsx
+++ b/frontend/src/modules/memberships/leave-channel-button.tsx
@@ -16,7 +16,8 @@ import { cn } from '~/utils/cn';
 
 export type LeaveChannelButtonProps = {
   channel: ChannelBase;
-  redirectPath?: string;
+  /** Where to navigate after leaving; `null` stays put, for surfaces outside the channel itself. */
+  redirectPath?: string | null;
   buttonProps?: ButtonProps;
   callback?: (args: CallbackArgs) => void;
 };
@@ -37,7 +38,7 @@ export function LeaveChannelButton({
     },
     onSuccess: () => {
       toaster.success(t('c:success.you_left_entity', { entity: channel.entityType }));
-      navigate({ to: redirectPath, replace: true });
+      if (redirectPath !== null) navigate({ to: redirectPath, replace: true });
 
       // Directly remove entity from list cache so menu updates immediately
       const keys = getEntityQueryKeys(channel.entityType);

--- a/frontend/src/modules/organization/organization-page.tsx
+++ b/frontend/src/modules/organization/organization-page.tsx
@@ -60,7 +60,9 @@ function OrganizationPage({ organizationId, tenantId }: Props) {
         panel={
           organization.membership && (
             <Suspense>
-              <JoinedButton channel={organization} role={organization.membership?.role} />
+              <div className="flex items-center p-2">
+                <JoinedButton channel={organization} role={organization.membership?.role} />
+              </div>
             </Suspense>
           )
         }


### PR DESCRIPTION
Accept size/className on the trigger and drop the hardcoded p-2 wrapper (the org page call site wraps itself instead), so forks can mount the joined-state button on tiles and channel page headers. LeaveChannelButton gains `redirectPath: null` to stay put when leaving from a surface outside the channel itself (e.g. a grid tile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)