### PR TITLE
refactor: adopt projectcampus tunings sweep (UI, drafts, sync, seen)

### DIFF
--- a/backend/src/mocks/mock-channel-id-columns.ts
+++ b/backend/src/mocks/mock-channel-id-columns.ts
@@ -53,9 +53,13 @@ const rootChannelType = hierarchy.channelTypes.find((t) => hierarchy.getParent(t
 /** Non-root ancestor and related-channel IDs for create-body mocks; the route supplies the root ID. */
 export const generateMockEntityBodyChannelIdColumns = <E extends ProductEntityType>(
   entityType: E,
-): Omit<MockEntityChannelIdColumns<E>, EntityIdColumnKey<RootChannelType>> =>
-  mockIdColumns(
+): Omit<MockEntityChannelIdColumns<E>, EntityIdColumnKey<RootChannelType>> => {
+  // Nullable ancestors are optional placement resolved from real rows server-side, so a
+  // create-body mock carries only the required ones; an invented id would never resolve.
+  const nullableAncestors = new Set<string>(hierarchy.getNullableAncestors(entityType));
+  return mockIdColumns(
     [...hierarchy.getOrderedAncestors(entityType), ...hierarchy.getRelatedChannels(entityType)].filter(
-      (channelType) => channelType !== rootChannelType,
+      (channelType) => channelType !== rootChannelType && !nullableAncestors.has(channelType),
     ),
   ) as Omit<MockEntityChannelIdColumns<E>, EntityIdColumnKey<RootChannelType>>;
+};

--- a/backend/src/modules/memberships/memberships-queries.ts
+++ b/backend/src/modules/memberships/memberships-queries.ts
@@ -293,7 +293,8 @@ export const findMembersPaginated = async (ctx: DbContext, opts: FindMembersPagi
       name: usersTable.name,
       email: usersTable.email,
       createdAt: usersTable.createdAt,
-      lastSeenAt: sql`(SELECT ${userCountersTable.lastSeenAt} FROM ${userCountersTable} WHERE ${userCountersTable.userId} = ${usersTable.id})`,
+      // COALESCE so never-signed-in members sort as oldest: plain DESC is NULLS FIRST in Postgres
+      lastSeenAt: sql`COALESCE((SELECT ${userCountersTable.lastSeenAt} FROM ${userCountersTable} WHERE ${userCountersTable.userId} = ${usersTable.id}), '-infinity')`,
       role: membershipsTable.role,
     },
     tieBreaker: usersTable.id,

--- a/backend/src/modules/user/user-queries.ts
+++ b/backend/src/modules/user/user-queries.ts
@@ -35,7 +35,8 @@ export const findUsersPaginated = async (ctx: DbContext, opts: FindUsersPaginate
       name: usersTable.name,
       email: usersTable.email,
       createdAt: usersTable.createdAt,
-      lastSeenAt: sql`(SELECT ${userCountersTable.lastSeenAt} FROM ${userCountersTable} WHERE ${userCountersTable.userId} = ${usersTable.id})`,
+      // COALESCE so never-signed-in users sort as oldest: plain DESC is NULLS FIRST in Postgres
+      lastSeenAt: sql`COALESCE((SELECT ${userCountersTable.lastSeenAt} FROM ${userCountersTable} WHERE ${userCountersTable.userId} = ${usersTable.id}), '-infinity')`,
       role: systemRolesTable.role,
     },
     tieBreaker: usersTable.id,

--- a/cdc/src/utils/embedding-cleanup.ts
+++ b/cdc/src/utils/embedding-cleanup.ts
@@ -36,7 +36,13 @@ function resolveEmbeddings(): ReadonlyMap<ProductEntityType, ResolvedEmbedding[]
       throw new Error(`productEmbeddings: column "${hostColumnName}" not found on "${hostProduct}" table`);
     }
 
-    const parentType = hierarchy.getParent(embeddedProduct);
+    // Scope by the deepest STRICT ancestor, not the parent: a nullable placement column may
+    // be null on the deleted row (which would silently skip cleanup), while the strict ancestor
+    // (ultimately the org root) is present on the row and on every host table.
+    const nullableAncestors = new Set<string>(hierarchy.getNullableAncestors(embeddedProduct));
+    const parentType = hierarchy
+      .getOrderedAncestors(embeddedProduct)
+      .find((ancestor) => !nullableAncestors.has(ancestor));
     if (!parentType)
       throw new Error(
         `productEmbeddings: "${embeddedProduct}" has no parent context: cleanup requires a scoping column`,

--- a/frontend/src/modules/common/blocknote/styles.css
+++ b/frontend/src/modules/common/blocknote/styles.css
@@ -164,9 +164,11 @@ li:has(.is-focused) {
   font-weight: 600;
 }
 
+/* The handle must fit inside a 1.5rem left inset (the grip glyph's own transparent margin
+   supplies the visual gap), so hosts need no extra gutter beyond their ordinary padding. */
 .bn-shadcn .bn-side-menu {
   position: relative;
-  left: -0.6rem;
+  left: -0.125rem;
   top: -0.15rem;
   opacity: 0.5;
   transition: opacity 0.15s ease;

--- a/frontend/src/modules/common/data-table/export.tsx
+++ b/frontend/src/modules/common/data-table/export.tsx
@@ -61,11 +61,14 @@ export function Export<R extends Record<string, any>>({
       <DropdownMenuContent align="end" className="p-1">
         {isOnline && (
           <>
+            {/* Label the full-export pair so it reads apart from the selected-rows pair below */}
             <DropdownMenuItem onClick={() => exportDefault('csv')}>
               <span>CSV</span>
+              <span className="ml-2 text-xs opacity-75">{t('c:all_rows').toLowerCase()}</span>
             </DropdownMenuItem>
             <DropdownMenuItem onClick={() => exportDefault('pdf')}>
               <span>PDF</span>
+              <span className="ml-2 text-xs opacity-75">{t('c:all_rows').toLowerCase()}</span>
             </DropdownMenuItem>
           </>
         )}

--- a/frontend/src/modules/common/form-draft/use-draft-form.tsx
+++ b/frontend/src/modules/common/form-draft/use-draft-form.tsx
@@ -2,12 +2,13 @@ import { useEffect, useRef, useState } from 'react';
 import type { FieldPath, FieldValues, UseFormProps, UseFormReturn } from 'react-hook-form';
 import { useForm, useFormState } from 'react-hook-form';
 import { useDraftStore } from '~/modules/common/form-draft/draft-store';
+import { flushKvWrites } from '~/query/idb-kv-storage';
 import { defaultOnInvalid } from '~/utils/form-on-invalid';
 
 /**
  * Form state with draft-saving: restores saved drafts on mount, tracks unsaved changes. Drafts persist via a
- * debounced `form.watch` subscription (not per keystroke) and flush on unmount to prevent data loss.
- * `formContainerId` names the element whose `.unsaved-changes` class is toggled.
+ * debounced `form.watch` subscription, immediately when a form first turns dirty, and flush on unmount and
+ * tab-hide to prevent data loss. `formContainerId` names the element whose `.unsaved-changes` class is toggled.
  */
 // biome-ignore lint/suspicious/noExplicitAny: Can be any form context
 export function useFormWithDraft<TFieldValues extends FieldValues = FieldValues, TContext = any>(
@@ -41,10 +42,28 @@ export function useFormWithDraft<TFieldValues extends FieldValues = FieldValues,
   const formIdRef = useRef(formId);
   formIdRef.current = formId;
 
+  // The subscribed isDirty, readable from timers and cleanups: `form.formState.isDirty` is a proxy
+  // read that lags the subscription in both directions (still false right after the first edit,
+  // still true right after a reset), so callbacks must never branch on it directly.
+  const isDirtyRef = useRef(isDirty);
+  isDirtyRef.current = isDirty;
+
   const toggleUnsavedBadge = (show: boolean) => {
     const el = document.getElementById(formContainerId || formId);
     if (!el) return;
     el.classList.toggle('unsaved-changes', show);
+  };
+
+  /** Save the current values (or clear the draft when clean). Reads only refs and stable store actions. */
+  const saveDraft = () => {
+    const id = formIdRef.current;
+    if (isDirtyRef.current) {
+      const values = form.getValues();
+      const cleaned = Object.fromEntries(Object.entries(values).filter(([_, v]) => v !== undefined));
+      if (Object.keys(cleaned).length > 0) setDraftForm(id, cleaned);
+    } else {
+      resetDraftForm(id);
+    }
   };
 
   // Subscribe directly to form changes so debounced persistence does not rerender the form tree.
@@ -54,31 +73,53 @@ export function useFormWithDraft<TFieldValues extends FieldValues = FieldValues,
 
       clearTimeout(draftTimeoutRef.current);
       draftTimeoutRef.current = setTimeout(() => {
-        const id = formIdRef.current;
-        if (form.formState.isDirty) {
-          const values = form.getValues();
-          const cleaned = Object.fromEntries(Object.entries(values).filter(([_, v]) => v !== undefined));
-          if (Object.keys(cleaned).length > 0) setDraftForm(id, cleaned);
-        } else {
-          resetDraftForm(id);
-        }
-      }, 1000);
+        draftTimeoutRef.current = undefined;
+        saveDraft();
+      }, 300);
     });
+
+    // Flush an armed debounce, i.e. edits from the last few hundred ms. With no timer armed the
+    // store is already current: the debounce fired, or a reset deliberately cleared the draft
+    // (`formState.isDirty` reads stale-true inside cleanup, so it cannot gate this flush).
+    const flushPendingDraft = () => {
+      if (draftTimeoutRef.current === undefined) return;
+      clearTimeout(draftTimeoutRef.current);
+      draftTimeoutRef.current = undefined;
+      saveDraft();
+    };
+
+    // Best-effort flush when the tab is hidden: covers backgrounding (the put commits while the page
+    // lives on). It can NOT cover reload/close, since IndexedDB writes issued during unload never
+    // commit; the dirty-flag effect below therefore also writes the values the moment a form turns dirty.
+    // flushKvWrites, because the storage layer's own hide flush has already run by the time this
+    // later-registered listener appends its write.
+    const flushOnHide = () => {
+      if (draftTimeoutRef.current === undefined) return;
+      flushPendingDraft();
+      flushKvWrites();
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') flushOnHide();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    window.addEventListener('pagehide', flushOnHide);
 
     return () => {
       subscription.unsubscribe();
-      clearTimeout(draftTimeoutRef.current);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      window.removeEventListener('pagehide', flushOnHide);
       // Flush draft on cleanup (unmount or dep change) to prevent data loss
-      if (form.formState.isDirty) {
-        const values = form.getValues();
-        const cleaned = Object.fromEntries(Object.entries(values).filter(([_, v]) => v !== undefined));
-        if (Object.keys(cleaned).length > 0) setDraftForm(formIdRef.current, cleaned);
-      }
+      flushPendingDraft();
     };
   }, [form, setDraftForm, resetDraftForm]);
 
   useEffect(() => {
     toggleUnsavedBadge(isDirty);
+    // Values first, flag second, into the one persisted blob: the flag must never land in storage
+    // without content behind it. A reload cannot flush anything (unload-time IndexedDB writes are
+    // discarded), so this immediate save is what keeps a draft badge truthful after one. Only on
+    // dirty: the clean branch must not clear a stored draft before the mount restore below reads it.
+    if (isDirty) saveDraft();
     setFormDirty(formId, isDirty);
   }, [isDirty]);
 
@@ -104,10 +145,13 @@ export function useFormWithDraft<TFieldValues extends FieldValues = FieldValues,
     reset: (values, keepStateOptions) => {
       isResetting.current = true;
       clearTimeout(draftTimeoutRef.current);
+      draftTimeoutRef.current = undefined;
       resetDraftForm(formId);
       setFormDirty(formId, false);
       toggleUnsavedBadge(false);
       form.reset(values, keepStateOptions);
+      // reset() has notified its watchers synchronously; re-arm so later edits persist again.
+      isResetting.current = false;
     },
   };
 }

--- a/frontend/src/modules/common/form-fields/domains.tsx
+++ b/frontend/src/modules/common/form-fields/domains.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { type FieldValues, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import type { BaseFormFieldProps } from '~/modules/common/form-fields/type';
-import { FormDescription, FormField, FormItem, FormLabel, FormMessage } from '~/modules/ui/field';
+import { FormField, FormItem, FormLabel, FormMessage } from '~/modules/ui/field';
 import { TagInput } from '~/modules/ui/tag-input';
 
 type DomainsFieldProps<TFieldValues extends FieldValues> = BaseFormFieldProps<TFieldValues> & {
@@ -40,11 +40,10 @@ export function DomainsFormField<TFieldValues extends FieldValues>({
       render={({ field: { onChange } }) => {
         return (
           <FormItem>
-            <FormLabel>
+            <FormLabel help={description}>
               {label}
               {required && <span className="ml-1 opacity-50">*</span>}
             </FormLabel>
-            {description && <FormDescription>{description}</FormDescription>}
             <TagInput
               inputProps={{ value: currentValue, 'aria-invalid': !isValidInput(currentValue) }}
               onInputChange={(newValue) => setCurrentValue(newValue)}

--- a/frontend/src/modules/common/form-fields/input.tsx
+++ b/frontend/src/modules/common/form-fields/input.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { type FieldValues, useFormContext } from 'react-hook-form';
 import type { BaseFormFieldProps } from '~/modules/common/form-fields/type';
-import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '~/modules/ui/field';
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '~/modules/ui/field';
 import { Input } from '~/modules/ui/input';
 import { Textarea } from '~/modules/ui/textarea';
 import { cn } from '~/utils/cn';
@@ -56,11 +56,10 @@ export function InputFormField<TFieldValues extends FieldValues>({
       name={name}
       render={({ field: { value: formFieldValue, onBlur: fieldOnBlur, ...rest } }) => (
         <FormItem name={name.toString()}>
-          <FormLabel>
+          <FormLabel help={description}>
             {label}
             {required && <span className="ml-1 opacity-50">*</span>}
           </FormLabel>
-          {description && <FormDescription>{description}</FormDescription>}
           <div className="relative flex w-full items-center">
             {icon && (
               <button

--- a/frontend/src/modules/common/form-fields/select-combobox/parent.tsx
+++ b/frontend/src/modules/common/form-fields/select-combobox/parent.tsx
@@ -11,12 +11,28 @@ import { flattenInfiniteData } from '~/query/basic/flatten';
 
 type SelectParentProps<TFieldValues extends FieldValues> = BaseFormFieldProps<TFieldValues> & {
   parentType: ChannelEntityType;
+  /** Restrict the offered parents to one organization (e.g. sub-channels of the picked org). */
+  organizationId?: string;
   options?: ComboboxSelectProps['options'];
   onSelect?: (item: ChannelBase) => void;
 };
 
+/** Channels the user can pick as a parent; shares its cache with the picker's own list query. */
+export function useParentChannels(parentType: ChannelEntityType, organizationId?: string, enabled = true) {
+  const user = useCurrentUser();
+
+  const queryFactory = channelListQueriesByType[parentType];
+  // biome-ignore lint/suspicious/noExplicitAny: queryFactory returns heterogeneous query options based on parentType
+  const query = useInfiniteQuery({ ...(queryFactory as any)({ userId: user.id, organizationId }), enabled });
+  // biome-ignore lint/suspicious/noExplicitAny: queryFactory is heterogeneous, data shape is unknown
+  const items = flattenInfiniteData<ChannelBase>(query.data as any);
+
+  return { items, isLoaded: query.isSuccess };
+}
+
 export function SelectParentFormField<TFieldValues extends FieldValues>({
   parentType,
+  organizationId,
   control,
   name,
   label,
@@ -25,13 +41,7 @@ export function SelectParentFormField<TFieldValues extends FieldValues>({
   required,
   disabled,
 }: SelectParentProps<TFieldValues>) {
-  const user = useCurrentUser();
-
-  const queryFactory = channelListQueriesByType[parentType];
-  // biome-ignore lint/suspicious/noExplicitAny: queryFactory returns heterogeneous query options based on parentType
-  const query = useInfiniteQuery((queryFactory as any)({ userId: user.id }));
-  // biome-ignore lint/suspicious/noExplicitAny: queryFactory is heterogeneous, data shape is unknown
-  const items = flattenInfiniteData<ChannelBase>(query.data as any);
+  const { items } = useParentChannels(parentType, organizationId, !disabled);
 
   const options =
     opts ??

--- a/frontend/src/modules/common/form-fields/slug.tsx
+++ b/frontend/src/modules/common/form-fields/slug.tsx
@@ -12,7 +12,7 @@ import { useOnlineManager } from '~/hooks/use-online-manager';
 import type { ApiError } from '~/lib/api';
 import type { BaseFormFieldProps } from '~/modules/common/form-fields/type';
 import { Button } from '~/modules/ui/button';
-import { FormDescription, FormField, FormItem, FormLabel, FormMessage } from '~/modules/ui/field';
+import { FormField, FormItem, FormLabel, FormMessage } from '~/modules/ui/field';
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from '~/modules/ui/input-group';
 import { cn } from '~/utils/cn';
 
@@ -109,11 +109,10 @@ export function SlugFormField<TFieldValues extends FieldValues>({
       name={name as Path<TFieldValues>}
       render={({ field: { value: formFieldValue, ...rest } }) => (
         <FormItem name={name}>
-          <FormLabel>
+          <FormLabel help={description}>
             {label}
             <span className="ml-1 opacity-50">*</span>
           </FormLabel>
-          {description && <FormDescription>{description}</FormDescription>}
           <InputGroup className={cn('', inputClassName)}>
             <SlugInput type={entityType} onFocus={() => setDeviating(true)} value={formFieldValue || ''} {...rest} />
             {prefix && (

--- a/frontend/src/modules/memberships/members-table/members-bar.tsx
+++ b/frontend/src/modules/memberships/members-table/members-bar.tsx
@@ -168,7 +168,8 @@ export function MembersTableBar({
 
         <ColumnsView className="max-lg:hidden" columns={columns} setColumns={setColumns} />
 
-        {!isSheet && (
+        {/* Export is gated like the other admin actions in this bar; row selection needs the same grant */}
+        {!isSheet && canUpdate && (
           <Export
             className="max-lg:hidden"
             filename={`${entityType} members`}

--- a/frontend/src/modules/navigation/account-nav-icon.tsx
+++ b/frontend/src/modules/navigation/account-nav-icon.tsx
@@ -10,7 +10,7 @@ export function AccountNavIcon({ className }: { className?: string }) {
   return (
     <EntityAvatar
       type="user"
-      className="-m-0.5 size-7 shrink-0 rounded-full border-[0.1rem] border-primary text-base transition-transform group-hover:scale-110"
+      className="-m-0.5 size-7 shrink-0 rounded-full border-[0.1rem] border-current text-base transition-transform group-hover:scale-110"
       id={user.id}
       name={user.name}
       url={user.thumbnailUrl}

--- a/frontend/src/modules/navigation/menu-sheet/header.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/header.tsx
@@ -50,7 +50,7 @@ export function MenuSheetHeader() {
               className="in-[.floating-nav]:inline-flex hidden size-10"
             >
               <EntityAvatar
-                className="size-7 rounded-full border-[0.1rem] border-primary"
+                className="size-7 rounded-full border-[0.1rem] border-current"
                 type="user"
                 id={user.id}
                 name={user.name}

--- a/frontend/src/modules/navigation/menu-sheet/helpers/collect-channel-ids.ts
+++ b/frontend/src/modules/navigation/menu-sheet/helpers/collect-channel-ids.ts
@@ -1,16 +1,13 @@
 import type { UserMenuItem } from '~/modules/me/types';
 
-/** Expands sub-menus and filters out muted items. */
+/** Non-muted item ids plus their non-muted, non-archived sub-item ids; items can host content directly and in sub-channels. */
 export function collectChannelIds(items: UserMenuItem[], opts?: { archived?: boolean }): string[] {
   const ids: string[] = [];
   for (const item of items) {
     if (opts?.archived !== undefined && !!item.membership.archived !== opts.archived) continue;
-    if (item.submenu?.length) {
-      for (const sub of item.submenu) {
-        if (!sub.membership.muted && !sub.membership.archived) ids.push(sub.id);
-      }
-    } else if (!item.membership.muted) {
-      ids.push(item.id);
+    if (!item.membership.muted) ids.push(item.id);
+    for (const sub of item.submenu ?? []) {
+      if (!sub.membership.muted && !sub.membership.archived) ids.push(sub.id);
     }
   }
   return ids;

--- a/frontend/src/modules/navigation/menu-sheet/item-edit.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/item-edit.tsx
@@ -99,7 +99,7 @@ function MenuItemEditButton({ icon: Icon, title, onClick, subitem = false }: Men
     <Button
       variant="link"
       size="sm"
-      className="h-4 px-0 py-0 text-xs leading-3 underline-offset-1 opacity-60 hover:underline hover:opacity-100 focus-visible:bg-accent/50 focus-visible:ring-0 focus-visible:ring-offset-0"
+      className="h-4 px-0 py-0 text-xs leading-3 underline-offset-1 opacity-80 hover:underline hover:opacity-100 focus-visible:bg-accent/50 focus-visible:ring-0 focus-visible:ring-offset-0"
       aria-label={`Click ${title}`}
       onClick={onClick}
     >

--- a/frontend/src/modules/navigation/menu-sheet/item.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/item.tsx
@@ -29,10 +29,13 @@ export function MenuSheetItem({ item, icon: Icon, className }: MenuSheetItemProp
   const canAccess = offlineAccess ? (isOnline ? true : !item.membership.archived) : true;
   const isSubitem = !item.submenu;
 
-  // Parent-level aggregation is skipped when detailedMenu is on: sub-items then show their own badges.
-  let channelIds: string | string[] | undefined;
-  if (seenGroupingChannelTypes.has(item.entityType)) channelIds = item.id;
-  else if (!detailedMenu && item.submenu?.length) channelIds = item.submenu.map((sub) => sub.id);
+  // Own count for grouping channels, plus submenu aggregation when sub-rows don't render their own badges
+  // (detailedMenu off, or an archived item whose submenu is never rendered).
+  const aggregateSubmenu = !!item.submenu?.length && (!detailedMenu || !!item.membership.archived);
+  const channelIds = [
+    ...(seenGroupingChannelTypes.has(item.entityType) ? [item.id] : []),
+    ...(aggregateSubmenu && item.submenu ? item.submenu.map((sub) => sub.id) : []),
+  ];
   const unseenCount = useUnseenCount(channelIds);
   const showBadge = unseenCount > 0 && !item.membership.muted;
 
@@ -97,7 +100,7 @@ export function MenuSheetItem({ item, icon: Icon, className }: MenuSheetItemProp
         </div>
       </div>
       {showBadge && (
-        <span className="mr-3 flex h-4 min-w-4 shrink-0 items-center justify-center self-center rounded-full bg-background px-1 font-bold text-[0.6rem] text-primary leading-none">
+        <span className="mr-3 flex h-4 min-w-4 shrink-0 items-center justify-center self-center rounded-full bg-primary px-1 font-bold text-[0.6rem] text-primary-foreground leading-none">
           {unseenCount > 99 ? '99+' : unseenCount}
         </span>
       )}

--- a/frontend/src/modules/navigation/menu-sheet/section-archive-button.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/section-archive-button.tsx
@@ -35,7 +35,7 @@ export function SectionArchiveButton({
           <span className="text-sm group-data-[submenu=true]/archived:text-xs">{t('c:archived')}</span>
           <span className="inline-block px-2 py-1 text-muted-foreground text-xs group-data-[archived-visible=true]/archived:hidden">
             {archivedUnseenCount > 0 ? (
-              <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-background px-1 font-bold text-[0.6rem] text-primary leading-none">
+              <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 font-bold text-[0.6rem] text-primary-foreground leading-none">
                 {archivedUnseenCount > 99 ? '99+' : archivedUnseenCount}
               </span>
             ) : (

--- a/frontend/src/modules/navigation/menu-sheet/section-button.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/section-button.tsx
@@ -57,7 +57,7 @@ export function MenuSectionButton({
                 className="inline-block px-2 py-1 text-muted-foreground text-xs group-data-[visible=true]/menuSection:hidden"
               >
                 {sectionUnseenCount > 0 ? (
-                  <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-background px-1 font-bold text-[0.6rem] text-primary leading-none">
+                  <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 font-bold text-[0.6rem] text-primary-foreground leading-none">
                     {sectionUnseenCount > 99 ? '99+' : sectionUnseenCount}
                   </span>
                 ) : (

--- a/frontend/src/modules/organization/organizations-grid.tsx
+++ b/frontend/src/modules/organization/organizations-grid.tsx
@@ -44,6 +44,9 @@ export function OrganizationsGrid({ fixedQuery, saveDataInSearch, focusView, lim
           searchVars={baseSearch}
           label={'c:organization'}
           entityType="organization"
+          // Discovery grid: a role filter collapses the scope to membership-only; bar stays for short lists
+          roleFilter={false}
+          alwaysShow
           setSearch={setSearch}
           isSheet={!focusView}
           focusView={focusView}

--- a/frontend/src/modules/organization/update-organization-form.tsx
+++ b/frontend/src/modules/organization/update-organization-form.tsx
@@ -22,7 +22,7 @@ import { Spinner } from '~/modules/common/spinner';
 import { toaster } from '~/modules/common/toaster/toaster';
 import { useOrganizationUpdateMutation } from '~/modules/organization/query';
 import { Button, SubmitButton } from '~/modules/ui/button';
-import { Form, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '~/modules/ui/field';
+import { Form, FormField, FormItem, FormLabel, FormMessage } from '~/modules/ui/field';
 
 // welcomeText belongs to the details form; empty optional strings are stored as null.
 const formSchema = zUpdateOrganizationBody.omit({ welcomeText: true }).extend({
@@ -193,11 +193,10 @@ function DefaultLanguageField({ form }: { form: ReturnType<typeof useFormWithDra
 
         return (
           <FormItem name="defaultLanguage">
-            <FormLabel>
+            <FormLabel help={t('c:default_language.text')}>
               {t('c:default_language')}
               <span className="ml-1 opacity-50">*</span>
             </FormLabel>
-            <FormDescription>{t('c:default_language.text')}</FormDescription>
             <SelectLanguage options={languages} value={correctValue} onChange={(val) => field.onChange(val)} />
             <FormMessage />
           </FormItem>

--- a/frontend/src/modules/seen/helpers.ts
+++ b/frontend/src/modules/seen/helpers.ts
@@ -7,8 +7,9 @@ export const seenKeys = {
 export const isSeenTracked = (entityType: string): boolean =>
   (appConfig.seenTrackedProductTypes as readonly string[]).includes(entityType);
 
+/** Every channel type a seen-tracked product can be homed in; mirrors the server's grouping set in mark-seen.ts. */
 export const seenGroupingChannelTypes = new Set(
-  appConfig.seenTrackedProductTypes.map((t) => hierarchy.getParent(t)).filter(Boolean),
+  appConfig.seenTrackedProductTypes.flatMap((t) => hierarchy.possibleHomeChannels(t)),
 );
 
 /** Grouping channel for a row: its deepest non-null ancestor, matching mark-seen, unseen counts and unseen-sync. */

--- a/frontend/src/modules/seen/unseen-nav-badge.tsx
+++ b/frontend/src/modules/seen/unseen-nav-badge.tsx
@@ -9,7 +9,7 @@ export function UnseenNavBadge({ isActive, className }: { isActive: boolean; cla
   return (
     <span
       className={cn(
-        'absolute flex h-4 min-w-4 items-center justify-center rounded-full bg-background px-1 font-bold text-[0.6rem] text-primary leading-none',
+        'absolute flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 font-bold text-[0.6rem] text-primary-foreground leading-none',
         className,
       )}
     >

--- a/frontend/src/modules/seen/use-unseen-count.ts
+++ b/frontend/src/modules/seen/use-unseen-count.ts
@@ -1,10 +1,27 @@
 import { useQuery } from '@tanstack/react-query';
 import type { MembershipBase } from 'sdk';
+import { appConfig, hierarchy } from 'shared';
 import { myMembershipsQueryOptions } from '~/modules/me/query';
 import { seenGroupingChannelTypes } from '~/modules/seen/helpers';
 import { unseenCountsQueryOptions } from '~/modules/seen/query';
 
 const getMembershipChannelId = (m: MembershipBase) => m.channelId;
+
+/**
+ * True when a non-root ancestor channel of this membership (e.g. the channel above a sub-channel) is in
+ * `archivedChannelIds`. The root (org) membership row is an auto-created shell whose archived flag
+ * only tucks the org row into its own section's archived toggle; it must not hide subtree badges,
+ * or the total would diverge from the sum of the section toggles.
+ */
+const hasArchivedAncestor = (m: MembershipBase, archivedChannelIds: Set<string>) => {
+  for (const ancestor of hierarchy.getOrderedAncestors(m.channelType)) {
+    if (hierarchy.getParent(ancestor) === null) continue;
+    const idKey = appConfig.entityIdColumnKeys[ancestor as keyof typeof appConfig.entityIdColumnKeys];
+    const ancestorId = (m as unknown as Record<string, string | null | undefined>)[idKey];
+    if (ancestorId && archivedChannelIds.has(ancestorId)) return true;
+  }
+  return false;
+};
 
 const sumCounts = (counts: Record<string, number> | undefined) => {
   if (!counts) return 0;
@@ -37,9 +54,17 @@ export function useTotalUnseenCount() {
 
   if (!unseenData || !membershipsData) return 0;
 
+  // Archived anywhere in the chain excludes a channel: a sub-channel under an archived channel
+  // belongs to the archived toggle, not the total (its own membership row stays unarchived).
+  const archivedChannelIds = new Set<string>();
+  for (const m of membershipsData.items) {
+    if (m.archived) archivedChannelIds.add(m.channelId);
+  }
+
   const activeIds = new Set<string>();
   for (const m of membershipsData.items) {
     if (!seenGroupingChannelTypes.has(m.channelType) || m.muted || m.archived) continue;
+    if (hasArchivedAncestor(m, archivedChannelIds)) continue;
     const id = getMembershipChannelId(m);
     if (id) activeIds.add(id);
   }

--- a/frontend/src/modules/ui/button.tsx
+++ b/frontend/src/modules/ui/button.tsx
@@ -55,7 +55,10 @@ export const buttonVariants = cva(
       {
         variant: ['default', 'brand', 'destructive', 'success', 'warning'],
         soft: true,
-        className: 'soft-bg soft-border hover:soft-bg-hover soft-text border shadow-none',
+        // The strong steps (not plain soft-bg) so the button stays legible on a soft-tinted surface;
+        // hover deepens all three: fill, text and frame.
+        className:
+          'soft-bg-strong soft-border-medium hover:soft-bg-stronger hover:soft-border-strong soft-text-strong hover:soft-text-stronger border shadow-none',
       },
       { variant: 'default', soft: false, className: 'bg-primary text-primary-foreground hover:bg-primary/80' },
       { variant: 'brand', soft: false, className: 'bg-brand text-brand-foreground hover:bg-brand/80' },

--- a/frontend/src/modules/ui/field.tsx
+++ b/frontend/src/modules/ui/field.tsx
@@ -131,34 +131,7 @@ export function FieldTitle({ className, ...props }: React.ComponentProps<'div'>)
 }
 
 export function FieldDescription({ className, ...props }: React.ComponentProps<'p'>) {
-  const [collapsed, setCollapsed] = React.useState(true);
-
-  const toggleCollapsed = (e: { preventDefault: () => void }) => {
-    setCollapsed(!collapsed);
-    e.preventDefault();
-  };
-
-  return (
-    <div
-      data-slot="field-description"
-      className={cn('relative -mt-2! text-muted-foreground text-sm', className)}
-      {...props}
-    >
-      <div className="flex justify-between">
-        <Button
-          type="button"
-          variant="link"
-          size="sm"
-          onClick={toggleCollapsed}
-          className="absolute -top-6 right-1 h-auto p-2 text-regular opacity-50 ring-inset hover:opacity-100"
-        >
-          {collapsed && <CircleQuestionMarkIcon />}
-          {!collapsed && <ChevronUpIcon />}
-        </Button>
-        {!collapsed && <span className="py-1">{props.children}</span>}
-      </div>
-    </div>
-  );
+  return <p data-slot="field-description" className={cn('text-muted-foreground text-sm', className)} {...props} />;
 }
 
 export function FieldSeparator({
@@ -326,52 +299,76 @@ export function FormItem({ className, name, ...props }: Omit<React.ComponentProp
 export function FormLabel({
   className,
   nativeLabel = true,
+  help,
+  children,
   ...props
-}: React.ComponentProps<'label'> & { nativeLabel?: boolean }) {
-  return (
+}: React.ComponentProps<'label'> & { nativeLabel?: boolean; help?: React.ReactNode }) {
+  const [helpOpen, setHelpOpen] = React.useState(false);
+
+  const label = (
     <Field.Label
       data-slot="form-label"
       nativeLabel={nativeLabel}
       className={cn('w-fit select-none font-medium text-sm/4.5 data-invalid:text-destructive', className)}
       {...props}
-    />
+    >
+      {children}
+    </Field.Label>
+  );
+
+  if (help === undefined || help === null) return label;
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center gap-2">
+        {label}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-expanded={helpOpen}
+          onClick={() => setHelpOpen(!helpOpen)}
+          className="-my-1 size-6 opacity-50 hover:opacity-100 active:translate-y-0!"
+        >
+          <span className="relative size-4">
+            <CircleQuestionMarkIcon
+              className={cn(
+                'absolute inset-0 transition-all duration-200 motion-reduce:transition-none',
+                helpOpen ? 'rotate-90 opacity-0' : 'rotate-0 opacity-100',
+              )}
+            />
+            <ChevronUpIcon
+              className={cn(
+                'absolute inset-0 transition-all duration-200 motion-reduce:transition-none',
+                helpOpen ? 'rotate-0 opacity-100' : '-rotate-90 opacity-0',
+              )}
+            />
+          </span>
+        </Button>
+      </div>
+      <div
+        className={cn(
+          'grid transition-[grid-template-rows] duration-200 motion-reduce:transition-none',
+          helpOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+        )}
+      >
+        <Field.Description
+          render={<div />}
+          className={cn(
+            'overflow-hidden text-muted-foreground text-sm transition-opacity duration-200 motion-reduce:transition-none',
+            helpOpen ? 'opacity-100' : 'opacity-0',
+          )}
+        >
+          {help}
+        </Field.Description>
+      </div>
+    </div>
   );
 }
 
 /** Injects native field and accessibility props into one child; value-callback selectors must bind directly inside `FormItem`. */
 export function FormControl({ children }: { children: React.ReactElement }) {
   return <Field.Control render={children} />;
-}
-
-export function FormDescription({ className, children, ...props }: React.ComponentProps<'p'>) {
-  const [collapsed, setCollapsed] = React.useState(true);
-
-  const toggleCollapsed = (e: { preventDefault: () => void }) => {
-    setCollapsed(!collapsed);
-    e.preventDefault();
-  };
-
-  return (
-    <Field.Description
-      render={<div />}
-      className={cn('relative -mt-2! text-muted-foreground text-sm', className)}
-      {...props}
-    >
-      <div className="flex justify-between">
-        <Button
-          type="button"
-          variant="link"
-          size="sm"
-          onClick={toggleCollapsed}
-          className="absolute -top-6 right-1 h-auto p-2 text-regular opacity-50 ring-inset hover:opacity-100"
-        >
-          {collapsed && <CircleQuestionMarkIcon />}
-          {!collapsed && <ChevronUpIcon />}
-        </Button>
-        {!collapsed && <span className="py-1">{children}</span>}
-      </div>
-    </Field.Description>
-  );
 }
 
 export function FormMessage({ className, children, ...props }: React.ComponentProps<'p'>) {

--- a/frontend/src/modules/ui/stories/form.stories.tsx
+++ b/frontend/src/modules/ui/stories/form.stories.tsx
@@ -5,7 +5,7 @@ import { action } from 'storybook/actions';
 import { expect, userEvent } from 'storybook/test';
 import * as z from 'zod';
 import { Button } from '~/modules/ui/button';
-import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '~/modules/ui/field';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '~/modules/ui/field';
 
 /**
  * Building forms with React Hook Form and Zod.
@@ -46,7 +46,7 @@ function ProfileForm(args: Story['args']) {
           name="username"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Username</FormLabel>
+              <FormLabel help="This is your public display name.">Username</FormLabel>
               <FormControl>
                 <input
                   className="w-full rounded-md border border-input bg-background px-3 py-2"
@@ -54,7 +54,6 @@ function ProfileForm(args: Story['args']) {
                   {...field}
                 />
               </FormControl>
-              <FormDescription>This is your public display name.</FormDescription>
               <FormMessage />
             </FormItem>
           )}

--- a/frontend/src/modules/ui/textarea.tsx
+++ b/frontend/src/modules/ui/textarea.tsx
@@ -17,7 +17,7 @@ export function Textarea({
     <textarea
       data-slot="textarea"
       className={cn(
-        'field-sizing-content flex min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
+        'field-sizing-content focus-effect flex min-h-16 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow] placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
         className,
         autoResize && 'resize-none overflow-hidden',
       )}

--- a/frontend/src/modules/user/invite-bulk-email-form.tsx
+++ b/frontend/src/modules/user/invite-bulk-email-form.tsx
@@ -11,7 +11,7 @@ import type { EnrichedChannel } from '~/modules/entities/types';
 import { useInviteMemberMutation } from '~/modules/memberships/query-mutations';
 import { Badge } from '~/modules/ui/badge';
 import { Button, SubmitButton } from '~/modules/ui/button';
-import { Form, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '~/modules/ui/field';
+import { Form, FormField, FormItem, FormLabel, FormMessage } from '~/modules/ui/field';
 import { Textarea } from '~/modules/ui/textarea';
 import { type InviteFormValues, useInviteFormDraft } from '~/modules/user/invite-users';
 
@@ -76,8 +76,7 @@ export function InviteBulkEmailForm({ channel, dialog: isDialog, children }: Pro
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
         <FormItem name="bulk-emails">
-          <FormLabel>{t('c:paste_emails')}</FormLabel>
-          <FormDescription>{t('c:paste_emails.text')}</FormDescription>
+          <FormLabel help={t('c:paste_emails.text')}>{t('c:paste_emails')}</FormLabel>
           <Textarea
             value={rawText}
             onChange={(event) => onTextChange(event.target.value)}

--- a/frontend/src/query/idb-kv-storage.ts
+++ b/frontend/src/query/idb-kv-storage.ts
@@ -6,10 +6,21 @@ const WRITE_DEBOUNCE_MS = 250;
 
 /** Flush callbacks for every live store, invoked on tab hide for best-effort durability. */
 const flushers = new Set<() => void>();
+
+/**
+ * Issue every store's pending write immediately. For last-chance writes during unload (a reload
+ * fires only pagehide, where this module's own listener has already run before later-registered
+ * ones): write to the store, then call this so the put is issued in the same task.
+ */
+export const flushKvWrites = () => {
+  for (const flush of flushers) flush();
+};
+
 if (typeof document !== 'undefined') {
   document.addEventListener('visibilitychange', () => {
-    if (document.visibilityState === 'hidden') for (const flush of flushers) flush();
+    if (document.visibilityState === 'hidden') flushKvWrites();
   });
+  window.addEventListener('pagehide', flushKvWrites);
 }
 
 /** Per-user Zustand storage over the live app database: writes are trailing-debounced per store, signed-out operations no-op, and every operation re-resolves the bound database. */

--- a/frontend/src/query/realtime/sync-store.ts
+++ b/frontend/src/query/realtime/sync-store.ts
@@ -42,6 +42,8 @@ interface SyncStoreState {
   setLastSyncAt: (timestamp: string | null) => void;
   setOrgTenantId: (orgId: string, tenantId: string) => void;
   getOrgTenantId: (orgId: string) => string | null;
+  /** Drop a stale org (and its views) from the persisted store; orgs are otherwise never pruned and each one costs entity-type views in every catchup body. */
+  removeOrg: (orgId: string) => void;
   setOrgSeq: (orgId: string, entityType: string, seq: number) => void;
   getOrgSeq: (orgId: string, entityType: string) => number;
   setChannelSeq: (orgId: string, channelId: string, entityType: string, seq: number) => void;
@@ -108,6 +110,14 @@ export const syncStore = createStore<SyncStoreState>()(
           }),
         getOrgTenantId: (orgId) => get().orgs[orgId]?.tenantId || null,
 
+        removeOrg: (orgId) =>
+          set((s) => {
+            delete s.orgs[orgId];
+            for (const [key, view] of Object.entries(s.views)) {
+              if (view.organizationId === orgId) delete s.views[key];
+            }
+          }),
+
         setOrgSeq: (orgId, entityType, seq) =>
           set((s) => {
             ensureOrg(s.orgs, orgId).seqs[entityType] = seq;
@@ -171,6 +181,13 @@ export const syncStore = createStore<SyncStoreState>()(
           // Registered grant-boundary views ride the same request, adding precision over the org-view baseline.
           for (const [key, view] of Object.entries(get().views)) {
             views.push({ key, ...view });
+          }
+          // Server cap (streamCatchupBodySchema): an oversized body fails SDK validation client-side,
+          // killing the whole catchup. Truncation degrades to partial sync (dropped views simply do
+          // not advance this cycle), which beats no sync at all; org pruning keeps this unreachable.
+          if (views.length > 256) {
+            console.warn(`[SyncStore] Catchup views truncated ${views.length} → 256; sync coverage is partial`);
+            return views.slice(0, 256);
           }
           return views;
         },

--- a/frontend/src/query/realtime/view-declaration.ts
+++ b/frontend/src/query/realtime/view-declaration.ts
@@ -47,4 +47,15 @@ export function declareViewsFromMemberships(): void {
   for (const key of Object.keys(syncStore.getState().views)) {
     if (!keep.has(key)) store.removeSyncView(key);
   }
+
+  // Stored orgs the caller is no longer (or never was) a member of: prune them, or they accumulate
+  // forever in the persisted store; every dead org costs one view per entity type in each catchup
+  // body until the request overflows the server's views cap and catchup fails outright. Only prune
+  // against a loaded membership cache; `data` undefined just means memberships have not arrived yet.
+  if (data) {
+    const memberOrgIds = new Set(memberships.map((m) => m.organizationId));
+    for (const orgId of Object.keys(syncStore.getState().orgs)) {
+      if (!memberOrgIds.has(orgId)) store.removeOrg(orgId);
+    }
+  }
 }

--- a/frontend/src/styling/tailwind.css
+++ b/frontend/src/styling/tailwind.css
@@ -95,10 +95,24 @@
   background-color: color-mix(in srgb, var(--intent-color) 10%, var(--background));
 }
 
-/* Intent-colored text for soft variants. In dark mode the intent tokens are too dark to
-   read on the tinted fill, so lift them toward white to restore contrast. */
+/* Subtle depth ramp over soft-bg: brightest at top-right, deepest at bottom-left. One utility
+   covers every status because the stops derive from the same --intent-color map. */
+@utility soft-gradient {
+  background-image: linear-gradient(
+    to bottom left,
+    color-mix(in srgb, var(--intent-color) 6%, var(--background)),
+    color-mix(in srgb, var(--intent-color) 17%, var(--background))
+  );
+}
+
+/* Intent-colored text for soft variants. The `:root &` bump outranks sibling one-class text
+   utilities like Card's `text-card-foreground` in light mode. In dark mode the intent tokens
+   are too dark on the tinted fill, so lift them toward white to restore contrast. */
 @utility soft-text {
   color: var(--intent-color);
+  :root & {
+    color: var(--intent-color);
+  }
   .dark & {
     color: color-mix(in oklch, var(--intent-color), white 35%);
   }
@@ -108,8 +122,53 @@
   background-color: color-mix(in srgb, var(--intent-color) 15%, var(--background));
 }
 
+/* Stronger steps for interactive elements sitting ON a soft surface, where flat soft-bg blends
+   into the surface's own tint. Text darkens with the fill in light mode; dark mode lifts toward
+   white, harder on hover, to keep contrast. */
+@utility soft-bg-strong {
+  background-color: color-mix(in srgb, var(--intent-color) 18%, var(--background));
+}
+@utility soft-bg-stronger {
+  background-color: color-mix(in srgb, var(--intent-color) 26%, var(--background));
+}
+@utility soft-text-strong {
+  color: color-mix(in oklch, var(--intent-color), black 10%);
+  :root & {
+    color: color-mix(in oklch, var(--intent-color), black 10%);
+  }
+  .dark & {
+    color: color-mix(in oklch, var(--intent-color), white 45%);
+  }
+}
+@utility soft-text-stronger {
+  color: color-mix(in oklch, var(--intent-color), black 20%);
+  :root & {
+    color: color-mix(in oklch, var(--intent-color), black 20%);
+  }
+  .dark & {
+    color: color-mix(in oklch, var(--intent-color), white 55%);
+  }
+}
+
 @utility soft-border {
   border-color: color-mix(in srgb, var(--intent-color) 20%, var(--background));
+}
+
+/* Full-contrast frame: the border takes the exact color soft-text gives the copy, so the outline
+   reads as strongly as the words inside it. */
+@utility soft-border-strong {
+  border-color: var(--intent-color);
+  .dark & {
+    border-color: color-mix(in oklch, var(--intent-color), white 35%);
+  }
+}
+
+/* Button-weight frame: 40% of the full-contrast one at rest; hover steps up to soft-border-strong. */
+@utility soft-border-medium {
+  border-color: color-mix(in srgb, var(--intent-color) 40%, var(--background));
+  .dark & {
+    border-color: color-mix(in srgb, color-mix(in oklch, var(--intent-color), white 35%) 40%, var(--background));
+  }
 }
 
 /* Semantic icon sizes. Icons use classes because the base rule below overrides Lucide's

--- a/frontend/vite/sdk-watch.ts
+++ b/frontend/vite/sdk-watch.ts
@@ -90,6 +90,13 @@ export const sdkWatch = (): Plugin => {
 
           if (sdkGenExists()) {
             console.info(`[sdk-watch] ${checkMark} SDK output changed, reloading...`);
+            // server.watch.ignored covers **/sdk/**, so chokidar never invalidates these modules;
+            // without explicit invalidation the full-reload re-serves the stale transforms.
+            if (viteServer) {
+              for (const [id, mod] of viteServer.moduleGraph.idToModuleMap) {
+                if (id.includes(sdkGenDir)) viteServer.moduleGraph.invalidateModule(mod);
+              }
+            }
             viteServer?.ws.send({ type: 'full-reload' });
           }
         }, 200);

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -15,6 +15,7 @@
   "admin_other": "Admins",
   "admins": "Admins",
   "all": "All",
+  "all_rows": "All rows",
   "all_systems_healthy": "All systems healthy",
   "almost_there": "Almost there!",
   "alphabetical": "Alphabetical",

--- a/locales/nl/common.json
+++ b/locales/nl/common.json
@@ -1,4 +1,5 @@
 {
+  "all_rows": "Alle rijen",
   "audio": "Audio",
   "disable_resource": "{{resource}} uitschakelen",
   "email_bulk": "E-mail (bulk)",


### PR DESCRIPTION
Trivial-tier adoptions from the projectcampus fork, selected from the `pnpm cella contributions` report (133 divergent files; fork-territory and seam-dependent items were left out and are listed for discussion separately).

## What's adopted

**Forms & drafts**
- `FormLabel` gains a `help` popover replacing inline `FormDescription` blocks; all cella-side consumers (domains/input/slug fields, org update form, bulk invite, stories) migrated.
- Draft forms save immediately when a form first turns dirty, flush on tab-hide via new `flushKvWrites()` (idb-kv-storage also flushes on `pagehide`), debounce tightened to 300ms. Persisted dirty flags can no longer exist without values behind them.

**Sync engine robustness**
- `syncStore.removeOrg()` + pruning of non-member orgs in `declareViewsFromMemberships`, so dead orgs stop accumulating views in every catchup body.
- Catchup views truncated client-side at the server's 256 cap: partial sync instead of a failed catchup.

**Seen / navigation menu**
- Unseen badges restyled `bg-primary text-primary-foreground` (menu item, section, archive, nav badge).
- Menu item badge aggregates submenu counts when sub-rows render no badges (detailedMenu off, or archived parent); archived-ancestor channels excluded from the total unseen count.
- `seenGroupingChannelTypes` derives from `possibleHomeChannels` (nullable-ancestor aware); `collectChannelIds` counts items that host content directly and in sub-channels.

**Members**
- Export button gated by `canUpdate` like the other admin actions in the bar.
- `lastSeenAt` sort COALESCEs to `-infinity` so never-signed-in members sort as oldest (members + users queries; plain DESC is NULLS FIRST in Postgres).

**UI polish**
- Soft styling ramp: `soft-gradient` and strong bg/text/border steps in tailwind.css; soft buttons use them to stay legible on tinted surfaces.
- Data-table export entries labeled "all rows" (new `c:all_rows` key, en + nl); textarea uses `focus-effect` + `bg-background`; avatar borders `border-current`; menu edit buttons `opacity-80`; blocknote side-menu handle fits a 1.5rem left inset.
- `SelectParentFormField`: extracted `useParentChannels` hook with optional `organizationId` restriction and disabled-aware query.

**Backend/CDC correctness**
- Create-body mocks skip nullable ancestor id columns (an invented id would never resolve).
- CDC embedding cleanup scopes by the deepest strict (non-nullable) ancestor, so nullable placement columns cannot silently skip cleanup.
- sdk-watch invalidates stale SDK modules before full-reload (chokidar ignores `**/sdk/**`).

Fork `fork:` markers stripped; fork-vocabulary comment examples generalized. `pnpm check` green; backend core (660) and frontend (898) tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
