### PR TITLE
docs(migrations): formlabel help popover replaces FormDescription

### DIFF
--- a/cella/migrations/20260828T1711-formlabel-help-popover/README.md
+++ b/cella/migrations/20260828T1711-formlabel-help-popover/README.md
@@ -1,0 +1,48 @@
+# FormDescription removed: field help moves into a FormLabel popover
+
+## What & why
+
+`frontend/src/modules/ui/field.tsx` no longer exports `FormDescription` (cella #1105, adopted from
+projectcampus). Field help text now rides on the label: `FormLabel` accepts a `help` prop and
+renders it behind a question-mark popover next to the label text, so forms lose the inline
+always-reserved description row and its collapse toggle. `FieldDescription` stays exported but is
+now a plain paragraph (its own collapse behavior is gone). Every cella-side consumer
+(`form-fields/domains.tsx`, `form-fields/input.tsx`, `form-fields/slug.tsx`,
+`update-organization-form.tsx`, `invite-bulk-email-form.tsx`, `stories/form.stories.tsx`) already
+uses the `help` prop.
+
+## Blast radius
+
+Sync-breaking for any fork-local file that imports `FormDescription` from `~/modules/ui/field`:
+the import fails to resolve after sync, so `pnpm check` reports every affected file. No wire,
+database, or cache change (`clientCacheVersion` untouched, no lens). An app that never used
+`FormDescription` in fork-local files is unaffected. Visual side effects of the same PR that need
+no action: soft buttons use the new `soft-*-strong` steps, unseen badges are filled
+(`bg-primary`), and textareas gained `focus-effect` styling.
+
+## Run
+
+No script — manual. The pattern is a two-line mechanical edit per call site; find them with:
+
+```sh
+grep -rln "FormDescription" frontend/src
+```
+
+## Manual steps
+
+1. In each hit, move the description content into the sibling label:
+   `<FormLabel>X</FormLabel> … <FormDescription>Y</FormDescription>` becomes
+   `<FormLabel help={Y}>X</FormLabel>` (the `help` prop takes any `ReactNode`; conditional
+   wrappers like `{description && <FormDescription>…</FormDescription>}` collapse to
+   `help={description}` since a nullish `help` renders no popover).
+2. Drop `FormDescription` from the `~/modules/ui/field` import.
+3. A call site with no matching `FormLabel` (a bare description paragraph) switches to
+   `FieldDescription`, which renders the same plain text without a label.
+
+## Verify
+
+```sh
+pnpm check
+```
+
+`grep -rn "FormDescription" frontend/src` must come back empty afterwards.

--- a/cella/migrations/manifest.json
+++ b/cella/migrations/manifest.json
@@ -405,7 +405,7 @@
     "pnpm check",
     "pnpm test"
    ],
-   "summary": "Settings-slot resolution moves into useChannelSettingsSections (grants, context-role pairs, overrides, stored toolsConfig); ChannelSettingsPage is a presentation-only map and a ChannelSettingsSheet reference consumer ships upstream. channelSettingsTools factory removed: spread generalToolBase/detailsToolBase/tabsToolBase/dangerToolBase(channelType, resource) and render full cards (DeleteToolCard exported; general now requires 'update'). getTools applies the section default order 50 (getSlotDescriptors stays raw for tabs); getChannelSettingsTools + ChannelSettingsToolFor removed. Surface trims: SlotToolsConfig.settings key dropped (no reader; stored config = order + hidden), PlacementOverride narrowed to hidden/order, heldContextRoles loses its unused entity-less overload; prefer requires over visibleTo (grants inherit down the ancestor chain). Backend mergeJsonbShallow util replaces inlined jsonb || merge fragments. Supersedes the channelSettingsTools guidance in 20260730T0858 step 5. No DB change, no cache bump. Arrangement UI pivots to tabs: ToolsArrangementCard deleted, TabsArrangementCard (flat data grid, row drag + visibility switches, writes toolsConfig['<channelType>.tabs']) demoed on organization settings via getNavTabCandidates (new ungated export from tab-nav); organization settings navTab now locked. toolsConfig is UI visibility only, never authorization — enforcement belongs to permissions/quotas."
+   "summary": "Settings-slot resolution moves into useChannelSettingsSections (grants, context-role pairs, overrides, stored toolsConfig); ChannelSettingsPage is a presentation-only map and a ChannelSettingsSheet reference consumer ships upstream. channelSettingsTools factory removed: spread generalToolBase/detailsToolBase/tabsToolBase/dangerToolBase(channelType, resource) and render full cards (DeleteToolCard exported; general now requires 'update'). getTools applies the section default order 50 (getSlotDescriptors stays raw for tabs); getChannelSettingsTools + ChannelSettingsToolFor removed. Surface trims: SlotToolsConfig.settings key dropped (no reader; stored config = order + hidden), PlacementOverride narrowed to hidden/order, heldContextRoles loses its unused entity-less overload; prefer requires over visibleTo (grants inherit down the ancestor chain). Backend mergeJsonbShallow util replaces inlined jsonb || merge fragments. Supersedes the channelSettingsTools guidance in 20260730T0858 step 5. No DB change, no cache bump. Arrangement UI pivots to tabs: ToolsArrangementCard deleted, TabsArrangementCard (flat data grid, row drag + visibility switches, writes toolsConfig['<channelType>.tabs']) demoed on organization settings via getNavTabCandidates (new ungated export from tab-nav); organization settings navTab now locked. toolsConfig is UI visibility only, never authorization \u2014 enforcement belongs to permissions/quotas."
   },
   {
    "id": "20260811T0905-ts-import-extensions",
@@ -495,7 +495,7 @@
     "pnpm sdk",
     "pnpm check"
    ],
-   "summary": "The toolsConfig jsonb column (sparse, NOT NULL DEFAULT '{}') moves from organizations into the shared channelColumns() factory; mockChannelColumns mirrors it. Additive DB change: every fork channel table gains tools_config on the next pnpm generate (dormant where unused; no backfill). CRITICAL: apps that hand-copied the column per 20260730T0858 step 5 must DELETE their local declaration — a leftover explicit key after the spread silently wins with no TS error. Supersedes the hand-copy instruction in 20260730T0858."
+   "summary": "The toolsConfig jsonb column (sparse, NOT NULL DEFAULT '{}') moves from organizations into the shared channelColumns() factory; mockChannelColumns mirrors it. Additive DB change: every fork channel table gains tools_config on the next pnpm generate (dormant where unused; no backfill). CRITICAL: apps that hand-copied the column per 20260730T0858 step 5 must DELETE their local declaration \u2014 a leftover explicit key after the spread silently wins with no TS error. Supersedes the hand-copy instruction in 20260730T0858."
   },
   {
    "id": "20260817T1447-remove-filter-tab-ids",
@@ -552,6 +552,22 @@
     "pnpm check"
    ],
    "summary": "backend/src/tables.ts (pinned) gains appPartitionConfigs, appFullCrudTables and appReadOnlyTables; the partman and RLS migrations, the verify block and partman-parity.test.ts merge them after cella's entries. defineBackendModule gains a jobs slot ({ name, start }) that main.api.ts starts under the migration-owner guard and stops on shutdown; scheduleDbMaintenance is the first registrant. Apps move their partition/grant entries into tables.ts and their cron jobs onto the module, then drop the edits to the four cella-owned files."
+  },
+  {
+   "id": "20260828T1711-formlabel-help-popover",
+   "version": "next",
+   "title": "FormDescription removed: field help moves into a FormLabel popover",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "frontend/src"
+   ],
+   "requires": [
+    "pnpm check"
+   ],
+   "summary": "field.tsx no longer exports FormDescription; FormLabel gains a help prop rendering a question-mark popover. Fork call sites move description content into help={...} on the sibling FormLabel and drop the import; bare description paragraphs switch to FieldDescription (now a plain <p>, collapse behavior gone)."
   }
  ]
 }


### PR DESCRIPTION
Fork-facing manual migration for the sync-breaking part of #1105: `field.tsx` no longer exports `FormDescription`; fork call sites move description content into the sibling `FormLabel`'s `help` prop and bare paragraphs switch to `FieldDescription`. Manifest entry `20260828T1711-formlabel-help-popover` (manual, syncBreaking, no cache bump). The rest of #1105 and #1104 is additive or rides cella-owned files on sync, so no further migrations are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)