### PR TITLE
refactor(permissions)!: per-channel elevatedGrants and explicit rootRoles

### DIFF
--- a/backend/src/modules/memberships/helpers/membership-helpers.test.ts
+++ b/backend/src/modules/memberships/helpers/membership-helpers.test.ts
@@ -1,16 +1,24 @@
 import { describe, expect, it } from 'vitest';
-import { resolveParentMembershipRole } from './membership-helpers';
+import { resolveAssociatedMembershipRole, resolveRootMembershipRole } from './membership-helpers';
 
-describe('resolveParentMembershipRole', () => {
-  it("defaults to 'member' when the vocabulary has it (previous hardcoded behavior)", () => {
-    expect(resolveParentMembershipRole('organization', 'admin')).toBe('member');
+describe('resolveAssociatedMembershipRole', () => {
+  it("defaults to the vocabulary's least-privileged role", () => {
+    expect(resolveAssociatedMembershipRole('organization', 'admin')).toBe('member');
   });
 
   it('carries the invited role over when carryRole is set and valid', () => {
-    expect(resolveParentMembershipRole('organization', 'admin', true)).toBe('admin');
+    expect(resolveAssociatedMembershipRole('organization', 'admin', true)).toBe('admin');
   });
 
-  it('ignores carryRole for the default path when the invited role equals member', () => {
-    expect(resolveParentMembershipRole('organization', 'member', true)).toBe('member');
+  it('falls back to the least-privileged role for an invited role outside the vocabulary, even with carryRole', () => {
+    expect(resolveAssociatedMembershipRole('organization', 'staff' as any, true)).toBe('member');
+  });
+});
+
+describe('resolveRootMembershipRole', () => {
+  // The app hierarchy has a single root channel, which cannot declare rootRoles; mapping resolution
+  // against a declared map is covered by the config-builder tests (entity-hierarchy.test.ts).
+  it('throws for a channel without a rootRoles map: explicit escalation is required', () => {
+    expect(() => resolveRootMembershipRole('organization', 'admin')).toThrow(/rootRoles/);
   });
 });

--- a/backend/src/modules/memberships/helpers/membership-helpers.ts
+++ b/backend/src/modules/memberships/helpers/membership-helpers.ts
@@ -14,18 +14,36 @@ const rootChannelType = hierarchy.channelTypes.find((t) => hierarchy.getParent(t
 const rootIdColumnKey = appConfig.entityIdColumnKeys[rootChannelType];
 
 /**
- * Role for an auto-created parent or associated membership: `member` when the target vocabulary has it, else that
- * vocabulary's last role (roles are declared most to least privileged). With `carryRole`, the invited role carries over when valid.
+ * Role for an auto-created associated membership (menuStructure): the invited role carries over
+ * when `carryRole` is set and valid, else the target vocabulary's least-privileged (last) role.
  */
-export const resolveParentMembershipRole = (
+export const resolveAssociatedMembershipRole = (
   channelType: ChannelEntityType,
   invitedRole: MembershipModel['role'],
   carryRole = false,
 ): MembershipModel['role'] => {
   const channelRoles = hierarchy.getRoles(channelType) as readonly MembershipModel['role'][];
   if (carryRole && channelRoles.includes(invitedRole)) return invitedRole;
-  if (channelRoles.includes('member' as MembershipModel['role'])) return 'member' as MembershipModel['role'];
   return channelRoles[channelRoles.length - 1];
+};
+
+/**
+ * Role for the auto-created root context membership, from the source channel's `rootRoles` map.
+ * No implicit fallback: a channel that auto-creates root rows must declare the complete map
+ * (config-time validation makes a miss here a programming error, not a data-dependent one).
+ */
+export const resolveRootMembershipRole = (
+  sourceChannelType: ChannelEntityType,
+  invitedRole: MembershipModel['role'],
+): MembershipModel['role'] => {
+  const explicit = hierarchy.getRootRole(sourceChannelType, invitedRole) as MembershipModel['role'] | undefined;
+  if (explicit === undefined) {
+    throw new Error(
+      `insertMemberships: channel "${sourceChannelType}" declares no rootRoles mapping for role "${invitedRole}"; ` +
+        'explicit escalation is required to auto-create the root membership row.',
+    );
+  }
+  return explicit;
 };
 
 type BaseEntityModel = EntityModel<ChannelEntityType> & {
@@ -119,8 +137,8 @@ export const insertMemberships = async <T extends BaseEntityModel>(
       return {
         ...baseMembership,
         tenantId: entity.tenantId,
-        // Parent membership defaults to the least-privileged fitting role
-        role: resolveParentMembershipRole(rootChannelType, baseMembership.role),
+        // Explicit escalation via the source channel rootRoles map; a missing map throws
+        role: resolveRootMembershipRole(entity.entityType as ChannelEntityType, baseMembership.role),
         [rootIdColumnKey]: targetEntitiesIdColumnKeys[rootIdColumnKey],
         channelType: rootChannelType,
         channelId: targetEntitiesIdColumnKeys[rootIdColumnKey],
@@ -146,7 +164,7 @@ export const insertMemberships = async <T extends BaseEntityModel>(
         ...baseMembership,
         tenantId: entity.tenantId,
         // associated membership role: least-privileged fit, or carried over when carryRole is set
-        role: resolveParentMembershipRole(
+        role: resolveAssociatedMembershipRole(
           associatedType as ChannelEntityType,
           baseMembership.role,
           // Config literals only carry the property when an app sets it

--- a/backend/src/permissions/collection-scope.ts
+++ b/backend/src/permissions/collection-scope.ts
@@ -2,7 +2,6 @@ import {
   type Actor,
   hierarchy as appHierarchy,
   type ChannelEntityType,
-  elevatedRoles as configuredElevatedRoles,
   publicReadGrants as configuredPublicReadGrants,
   type EntityHierarchy,
   type EntityRole,
@@ -36,7 +35,7 @@ export interface ConditionalScope {
   channelIds: string[] | undefined;
   /** The grant's level; absent = the entity's home channel. */
   channelType?: ChannelEntityType;
-  /** Home-scoped grant (elevatedRoles): these levels' columns must be NULL as well. */
+  /** Home-scoped grant (non-elevated): these levels' columns must be NULL as well. */
   deeperChannels?: ChannelEntityType[];
 }
 
@@ -46,7 +45,7 @@ export interface IntermediateScope {
   channelIds: string[];
 }
 
-/** A HOME-scoped grant (roles outside `elevatedRoles`): that level's column matches AND deeper ancestor columns are NULL. */
+/** A HOME-scoped grant (outside `elevatedGrants`): that level's column matches AND deeper ancestor columns are NULL. */
 export interface HomeScope {
   channelType: ChannelEntityType;
   channelIds: string[];
@@ -60,7 +59,7 @@ interface ScopeAccumulator {
   unconditionalIds: Set<string>;
   /** Unconditional grants at intermediate ancestor levels (deep chains), keyed by channel type. */
   intermediateUnconditional: Map<ChannelEntityType, Set<string>>;
-  /** HOME-scoped unconditional grants (elevatedRoles), keyed by channel type. */
+  /** HOME-scoped unconditional grants (non-elevated), keyed by channel type. */
   homeScoped: Map<ChannelEntityType, Set<string>>;
   /** Keyed by `${condition name}:${level}:${homeOnly}`; the name uniquely identifies the rule. */
   conditional: Map<
@@ -81,17 +80,17 @@ const resolveScopes = (
   memberships: MembershipBaseModel[],
   entityType: ProductEntityType,
   organizationId: string,
-  elevatedRoles: readonly string[] | undefined,
+  elevatedGrants: ReadonlySet<string> | undefined,
   ancestors: readonly ChannelEntityType[], // most-specific → root, e.g. [project, course, organization]
   publicGrants: PublicReadGrants | undefined,
 ): ScopeAccumulator => {
   const rootChannel = ancestors.at(-1) ?? null;
   const homeChannelType = ancestors.find((channel) => channel !== rootChannel) ?? null;
 
-  // With elevatedRoles configured, a non-elevated role's grant speaks only for rows HOMED at its
+  // With elevatedGrants configured, a non-elevated grant speaks only for rows HOMED at its
   // level; deepest-level grants are home-exact already, so only higher levels carry the mark.
   const isHomeScopedGrant = (channelType: ChannelEntityType, role: EntityRole): boolean =>
-    elevatedRoles !== undefined && !elevatedRoles.includes(role) && channelType !== homeChannelType;
+    elevatedGrants !== undefined && !elevatedGrants.has(`${channelType}:${role}`) && channelType !== homeChannelType;
 
   const acc: ScopeAccumulator = {
     unconditionalOrgWide: false,
@@ -178,7 +177,7 @@ export interface CollectionReadFilter {
   conditionalScopes: ConditionalScope[];
   /** Unconditional grants at intermediate ancestor levels (aggregate reads only), each scoped by its own level's column. */
   intermediateScopes?: IntermediateScope[];
-  /** HOME-scoped grants (elevatedRoles; aggregate reads only): rows homed exactly at the grant's level. */
+  /** HOME-scoped grants (non-elevated; aggregate reads only): rows homed exactly at the grant's level. */
   homeScopes?: HomeScope[];
 }
 
@@ -268,8 +267,8 @@ export interface CollectionReadScopeInput {
   actor: Actor;
   /** Home-channel narrowing from the request; when neither field is given the read aggregates over the readable scope. */
   requested?: { homeChannelId?: string; homeChannelIds?: string[] };
-  /** Grant scoping role list. @see shared/config/permissions-config.ts */
-  elevatedRoles?: readonly string[];
+  /** Channel-qualified subtree-grant keys, compiled from the hierarchy. @see shared/config/hierarchy-config.ts */
+  elevatedGrants?: ReadonlySet<string>;
   /** Entity-type public read grants. @see shared/src/permissions/public-read.ts */
   publicGrants?: PublicReadGrants;
   /** Hierarchy override, as `getAllDecisions(…, { hierarchy })` takes; parity tests pass a synthetic deep chain. */
@@ -294,7 +293,7 @@ export const resolveCollectionReadFilter = (
     organizationId,
     actor,
     requested,
-    elevatedRoles: configuredElevatedRoles,
+    elevatedGrants: appHierarchy.elevatedGrants,
     publicGrants: configuredPublicReadGrants,
   });
 
@@ -306,7 +305,7 @@ export const resolveCollectionReadFilterForPolicies = ({
   organizationId,
   actor,
   requested,
-  elevatedRoles,
+  elevatedGrants,
   publicGrants,
   hierarchy,
 }: CollectionReadScopeInput): CollectionReadFilter => {
@@ -327,7 +326,7 @@ export const resolveCollectionReadFilterForPolicies = ({
     memberships,
     entityType,
     organizationId,
-    elevatedRoles,
+    elevatedGrants,
     orderedChannels,
     publicGrants,
   );

--- a/backend/src/permissions/row-predicates.test.ts
+++ b/backend/src/permissions/row-predicates.test.ts
@@ -18,9 +18,11 @@ import {
 import {
   type DeepChannelType,
   deepChannelRoles,
+  deepHierarchy,
   deepOverrides,
   deepReadPolicies as deepPolicies,
 } from 'shared/testing/deep-fixture';
+import { elevateAcross } from 'shared/testing/elevate';
 import { configurePolicyMatrix } from 'shared/testing/policies';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { seedDb } from '#/db/db';
@@ -42,7 +44,7 @@ const HOME_INSTANCES = HOME ? ['s1', 's2', 's3'] : []; // home-channel instance 
 const homeIdKey = HOME ? appConfig.entityIdColumnKeys[HOME] : null; // 'projectId' | null
 const homeColumnName = homeIdKey ? toColumnName(homeIdKey) : null; // 'project_id' | null
 
-// Root id column: `elevatedRoles` configs compile home-scoped grants against it, so the scratch table carries it.
+// Root id column: `elevatedGrants` configs compile home-scoped grants against it, so the scratch table carries it.
 const rootIdKey = appConfig.entityIdColumnKeys[ROOT];
 const rootColumnName = toColumnName(rootIdKey);
 
@@ -53,6 +55,14 @@ const baseColumns = {
   // Public readability, denormalized onto the row exactly as `productColumns` carries it.
   publicAt: varchar('public_at'),
   [rootIdKey]: varchar(rootColumnName).notNull(),
+  // Intermediate nullable ancestors (always null here, rows home at HOME or ROOT), so the
+  // compiled scope conditions of elevated intermediate-channel grants find their columns.
+  ...Object.fromEntries(
+    CHAIN.filter((channelType) => channelType !== ROOT && channelType !== HOME).map((channelType) => {
+      const idKey = appConfig.entityIdColumnKeys[channelType];
+      return [idKey, varchar(toColumnName(idKey))];
+    }),
+  ),
 };
 const parityTable = pgTable(
   'test_permission_parity_rows',
@@ -220,13 +230,17 @@ const sqlReadableIds = async (scenario: Scenario): Promise<Set<string>> => {
 
 beforeAll(async () => {
   await seedDb.execute(sql`drop table if exists test_permission_parity_rows`);
+  // Intermediate nullable ancestor columns follow the chain (see baseColumns above).
+  const intermediateColumnsDdl = CHAIN.filter((channelType) => channelType !== ROOT && channelType !== HOME)
+    .map((channelType) => `,\n      ${toColumnName(appConfig.entityIdColumnKeys[channelType])} varchar`)
+    .join('');
   await seedDb.execute(
     sql.raw(`
     create table test_permission_parity_rows (
       id varchar primary key,
       created_by varchar,
       public_at varchar,
-      ${rootColumnName} varchar not null${homeColumnName ? `,\n      ${homeColumnName} varchar not null` : ''}
+      ${rootColumnName} varchar not null${homeColumnName ? `,\n      ${homeColumnName} varchar not null` : ''}${intermediateColumnsDdl}
     )
   `),
   );
@@ -419,13 +433,13 @@ const deepRowSubject = (row: DeepParityRow): SubjectForPermission =>
     },
   }) as unknown as SubjectForPermission;
 
-const deepEngineReadableIds = (scenario: DeepScenario, elevatedRoles?: readonly string[]): Set<string> => {
+const deepEngineReadableIds = (scenario: DeepScenario, elevatedGrants?: ReadonlySet<string>): Set<string> => {
   const readable = new Set<string>();
   for (const row of DEEP_ROWS) {
     const { can } = getAllDecisions(scenario.policies, scenario.memberships, deepRowSubject(row), {
       userId: scenario.userId,
       ...deepOverrides,
-      ...(elevatedRoles && { elevatedRoles }),
+      ...(elevatedGrants && { elevatedGrants }),
     });
     if (can.read) readable.add(row.id);
   }
@@ -436,14 +450,17 @@ const deepEngineReadableIds = (scenario: DeepScenario, elevatedRoles?: readonly 
 const deepActor = (scenario: DeepScenario): Actor =>
   scenario.userId === undefined ? { anonymous: true } : { userId: scenario.userId, isSystemAdmin: false };
 
-const deepSqlReadableIds = async (scenario: DeepScenario, elevatedRoles?: readonly string[]): Promise<Set<string>> => {
+const deepSqlReadableIds = async (
+  scenario: DeepScenario,
+  elevatedGrants?: ReadonlySet<string>,
+): Promise<Set<string>> => {
   const filter = resolveCollectionReadFilterForPolicies({
     policies: scenario.policies,
     memberships: scenario.memberships,
     entityType: DEEP_ITEM,
     organizationId: ROOT_ID,
     actor: deepActor(scenario),
-    elevatedRoles,
+    elevatedGrants,
     ...deepOverrides,
   });
   const where = buildCollectionReadWhere(filter, deepParityTable, deepParityTable.projectId, deepActor(scenario));
@@ -519,11 +536,11 @@ describe('deep-chain parity: intermediate ancestor grants agree between engine a
   });
 });
 
-const SUBTREE_ROLES = ['admin', 'staff'] as const;
+const SUBTREE_ROLES = elevateAcross(deepHierarchy, ['admin', 'staff']);
 
 // Non-elevated product roles see rows homed at their grant level; elevated roles keep subtree scope.
-describe('elevatedRoles parity: home-scoped grants agree between engine and SQL', () => {
-  it('agrees on every row across random policies and memberships with elevatedRoles configured', async () => {
+describe('elevatedGrants parity: home-scoped grants agree between engine and SQL', () => {
+  it('agrees on every row across random policies and memberships with elevatedGrants configured', async () => {
     const random = mulberry32(0x50b7);
 
     for (let i = 0; i < 100; i++) {
@@ -619,8 +636,16 @@ const randomRealScenario = (
 };
 
 /** Channel id columns as they appear on an activity event (and its row). */
+// Intermediate nullable ancestors ride as null, exactly as a real row carries them;
+// buildSubject's validateAncestorScope requires every ancestor key present on chains deeper than 2.
 const rowChannelColumns = (row: ParityRow): Record<string, unknown> => ({
   [appConfig.entityIdColumnKeys[ROOT]]: ROOT_ID,
+  ...Object.fromEntries(
+    CHAIN.filter((channelType) => channelType !== ROOT && channelType !== HOME).map((channelType) => [
+      appConfig.entityIdColumnKeys[channelType],
+      null,
+    ]),
+  ),
   ...(homeIdKey ? { [homeIdKey]: row.homeChannelId } : {}),
 });
 

--- a/backend/src/permissions/row-predicates.ts
+++ b/backend/src/permissions/row-predicates.ts
@@ -70,7 +70,7 @@ export const buildCollectionReadWhere = (
     clauses.push(inArray(scopeColumn(channelType), channelIds));
   }
 
-  // HOME-scoped grants (elevatedRoles): the grant level's column matches AND every deeper ancestor column is NULL.
+  // HOME-scoped grants (non-elevated): the grant level's column matches AND every deeper ancestor column is NULL.
   for (const { channelType, channelIds, deeperChannels } of filter.homeScopes ?? []) {
     if (channelIds.length === 0) continue;
     const scoped = and(

--- a/backend/src/permissions/view-read-status.test.ts
+++ b/backend/src/permissions/view-read-status.test.ts
@@ -1,6 +1,15 @@
 import type { PolicyCellInput, ProductEntityType } from 'shared';
-import { type DeepChannelType, deepOverrides, deepReadPolicies as policies } from 'shared/testing/deep-fixture';
+import {
+  type DeepChannelType,
+  deepHierarchy,
+  deepOverrides,
+  deepReadPolicies as policies,
+} from 'shared/testing/deep-fixture';
+import { elevateAcross } from 'shared/testing/elevate';
 import { describe, expect, it } from 'vitest';
+
+const DEEP_ELEVATED = elevateAcross(deepHierarchy, ['admin', 'staff']);
+
 import type { MembershipBaseModel } from '#/modules/memberships/helpers/select';
 import { resolveViewReadStatusForPolicies } from './view-read-status';
 
@@ -28,7 +37,7 @@ const statusFor = (
     read?: (channelType: DeepChannelType, role: string) => PolicyCellInput;
     memberships?: MembershipBaseModel[];
     isSystemAdmin?: boolean;
-    elevatedRoles?: readonly string[];
+    elevatedGrants?: ReadonlySet<string>;
     depth?: 'self' | 'subtree';
     truePath?: string | null;
   } = {},
@@ -40,7 +49,7 @@ const statusFor = (
       entityType: ITEM,
       organizationId: ROOT_ID,
       actor: { userId: 'actor', isSystemAdmin: opts.isSystemAdmin ?? false },
-      elevatedRoles: opts.elevatedRoles,
+      elevatedGrants: opts.elevatedGrants,
       ...deepOverrides,
     },
     prefix,
@@ -94,14 +103,14 @@ describe('resolveViewReadStatus', () => {
     expect(statusFor(`${ROOT_ID}/c1`, opts)).toBe('opaque');
   });
 
-  it('SELF views: a home-scoped grant (non-elevated under elevatedRoles) answers its own node', () => {
-    // Course student read=1 with elevatedRoles configured: the home-scoped grant covers exactly the course wall (rows homed at c1).
+  it('SELF views: a home-scoped grant (non-elevated under elevatedGrants) answers its own node', () => {
+    // Course student read=1 with elevatedGrants configured: the home-scoped grant covers exactly the course wall (rows homed at c1).
     const courseStudentRead = (ct: DeepChannelType, role: string): PolicyCellInput =>
       ct === 'course' && role === 'student' ? 1 : 0;
     const opts = {
       read: courseStudentRead,
       memberships: [membership('course', 'c1', 'student')],
-      elevatedRoles: ['admin', 'staff'] as const,
+      elevatedGrants: DEEP_ELEVATED,
     };
 
     // Self view on the granted node: provable because homed rows are exactly the grant.
@@ -116,7 +125,7 @@ describe('resolveViewReadStatus', () => {
     const opts = {
       read: courseStaffRead,
       memberships: [membership('course', 'c1', 'staff')],
-      elevatedRoles: ['admin', 'staff'] as const,
+      elevatedGrants: DEEP_ELEVATED,
     };
     expect(statusFor(`${ROOT_ID}/c1`, { ...opts, depth: 'self' })).toBe('ok');
   });
@@ -149,7 +158,7 @@ describe('resolveViewReadStatus', () => {
     const opts = {
       read: courseStudentRead,
       memberships: [membership('course', 'c1', 'student')],
-      elevatedRoles: ['admin', 'staff'] as const,
+      elevatedGrants: DEEP_ELEVATED,
     };
     const deep = `${ROOT_ID}/c1/s1/p1`;
     // The student's course home-grant covers the course WALL, not project walls below.

--- a/cella/PERMISSIONS.md
+++ b/cella/PERMISSIONS.md
@@ -23,8 +23,9 @@ Creator-only rules compare the user with the row's `createdBy` value.
 │  │ createEntityHierarchy(roles)  │  │ configurePermissions(types, cb)     │  │
 │  │   .user()                     │  │   entity × channel × role → cell    │  │
 │  │   .channel(name, {parent,     │  │   cell = 0 | 1 | 'own'              │  │
-│  │             roles})           │  │   publicRead()                      │  │
-│  │   .product(name, {parent})    │  │   elevatedRoles                     │  │
+│  │     roles, elevated,          │  │   publicRead()                      │  │
+│  │     rootRoles})               │  │                                     │  │
+│  │   .product(name, {parent})    │  │                                     │  │
 │  │                               │  │                                     │  │
 │  │ kinds, ancestor chains, roles │  │ → policyMatrix, publicReadGrants    │  │
 │  └──────────────┬────────────────┘  └────────────────┬────────────────────┘  │
@@ -141,7 +142,7 @@ For channel entities, note the two row kinds: **elevation** rows sit on an _ance
 
 ## The permission returned
 
-Presenting an access to the engine yields per-action verdicts. `getAllDecisions(policies, memberships, subject, options)` is the core; the **`checkAccess*` family** is the bound surface every tier actually calls — three named projections of the same engine, all injecting the configured `publicReadGrants` and `elevatedRoles`. The name at the call site tells you the shape:
+Presenting an access to the engine yields per-action verdicts. `getAllDecisions(policies, memberships, subject, options)` is the core; the **`checkAccess*` family** is the bound surface every tier actually calls — three named projections of the same engine, all injecting the configured `publicReadGrants` and the hierarchy-compiled `elevatedGrants` (per-channel `elevated` declarations as `channelType:role` keys). The name at the call site tells you the shape:
 
 ```ts
 checkAccess(access, action, subject); // → PermissionResult — the request-path check

--- a/cella/migrations/20260828T2030-elevated-grants-root-roles/README.md
+++ b/cella/migrations/20260828T2030-elevated-grants-root-roles/README.md
@@ -1,0 +1,58 @@
+# Per-channel elevatedGrants and explicit rootRoles
+
+## What & why
+
+Two hierarchy seams replace implicit permission behavior with declared config. The global
+`elevatedRoles` list is gone from `shared/config/permissions-config.ts` (and from the `shared`
+exports): each hierarchy channel now declares `elevated` — the roles whose product grants cover
+that channel's whole subtree — and the builder compiles them into `hierarchy.elevatedGrants`
+(`${channelType}:${role}` keys) consumed by the engine check, the collection-scope SQL compiler
+and the frontend view derivation. Separately, auto-created root context memberships take their
+role from the source channel's explicit `rootRoles` map instead of an implicit `member`
+preference: `resolveParentMembershipRole` split into `resolveAssociatedMembershipRole` (associated
+memberships, least-privileged fallback, `carryRole` unchanged) and `resolveRootMembershipRole`,
+which throws when the channel declares no map.
+
+## Blast radius
+
+Sync-breaking for every fork. `pnpm check` fails after sync on any import of `elevatedRoles`, on
+calls to `resolveParentMembershipRole`, and on `elevatedRoles` options passed to the engine or
+view derivation. Behavior also shifts silently where config is not updated: with no `elevated`
+declarations the compiled set is empty and **every product grant at a non-home ancestor level
+becomes home-scoped** — previously `elevatedRoles: undefined` meant every grant was
+subtree-scoped. A fork with a multi-level hierarchy that skips step 1 below loses subtree reads
+for every role. Membership escalation tightens the same way: a channel whose invites auto-create
+root membership rows now throws at insert time without a complete `rootRoles` map. No database or
+wire-shape change; `clientCacheVersion` untouched.
+
+## Run
+
+No script — manual. Config declarations are app decisions a codemod cannot make.
+
+## Manual steps
+
+1. In `shared/config/hierarchy-config.ts`, add `elevated: [...]` to each channel for the roles
+   whose grants must cover the channel's subtree. To reproduce the old `elevatedRoles: ['x']`
+   semantics exactly, declare role `x` elevated on every channel that has it (the
+   `elevateAcross` helper in `shared/src/testing/elevate.ts` shows the equivalence); cella's
+   default declares `elevated: roles.all` on `organization`.
+2. Remove the `elevatedRoles` export from `shared/config/permissions-config.ts`.
+3. On every non-root channel whose invites auto-create root membership rows (menuStructure
+   submenus and associated types), declare a complete `rootRoles` map — every role of the channel
+   mapped to a root-channel role. Build-time validation rejects partial maps.
+4. Rename fork-local calls of `resolveParentMembershipRole` to `resolveAssociatedMembershipRole`;
+   root-row call sites use `resolveRootMembershipRole`.
+5. In fork-local tests that passed `elevatedRoles: [...]` to `getAllDecisions`,
+   `resolveCollectionReadFilter` or `deriveGrantBoundaryViews`, pass
+   `elevatedGrants: elevateAcross(hierarchy, [...])` (or an explicit key set) instead.
+
+## Verify
+
+```sh
+pnpm check
+pnpm test:core
+```
+
+`grep -rn "elevatedRoles\|resolveParentMembershipRole" --include="*.ts" .` (outside node_modules)
+must come back empty. Exercise one org member's catchup/sync after deploy: an org view answering
+`opaque` instead of `ok` means a missing `elevated` declaration.

--- a/cella/migrations/manifest.json
+++ b/cella/migrations/manifest.json
@@ -568,6 +568,25 @@
     "pnpm check"
    ],
    "summary": "field.tsx no longer exports FormDescription; FormLabel gains a help prop rendering a question-mark popover. Fork call sites move description content into help={...} on the sibling FormLabel and drop the import; bare description paragraphs switch to FieldDescription (now a plain <p>, collapse behavior gone)."
+  },
+  {
+   "id": "20260828T2030-elevated-grants-root-roles",
+   "version": "next",
+   "title": "Per-channel elevatedGrants and explicit rootRoles",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "shared",
+    "backend/src",
+    "frontend/src"
+   ],
+   "requires": [
+    "pnpm check",
+    "pnpm test:core"
+   ],
+   "summary": "Global elevatedRoles export removed: channels declare elevated (compiled to hierarchy.elevatedGrants ${channelType}:${role} keys); an empty set makes non-home grants home-scoped, so forks must declare elevation to keep subtree reads. resolveParentMembershipRole splits into resolveAssociatedMembershipRole and a throwing resolveRootMembershipRole; channels auto-creating root membership rows declare a complete rootRoles map. Tests inject elevation via elevateAcross."
   }
  ]
 }

--- a/frontend/src/query/realtime/views.test.ts
+++ b/frontend/src/query/realtime/views.test.ts
@@ -4,6 +4,7 @@ import {
   deepHierarchy,
   deepReadPolicies as policies,
 } from 'shared/testing/deep-fixture';
+import { elevateAcross } from 'shared/testing/elevate';
 import { describe, expect, it } from 'vitest';
 import { deriveGrantBoundaryViews, type ViewMembership } from './views';
 
@@ -29,7 +30,7 @@ const paths: Record<string, string> = {
 const derive = (
   memberships: ViewMembership[],
   read: (channelType: ChannelType, role: string) => PolicyCellInput,
-  elevatedRoles?: readonly string[],
+  elevatedGrants?: ReadonlySet<string>,
 ) =>
   deriveGrantBoundaryViews({
     memberships,
@@ -37,10 +38,10 @@ const derive = (
     resolvePath: (_type, id) => paths[id] ?? null,
     policies: policies(read),
     hierarchy: deepHierarchy,
-    elevatedRoles,
+    elevatedGrants,
   });
 
-const ELEVATED = ['admin', 'staff'] as const;
+const ELEVATED = elevateAcross(deepHierarchy, ['admin', 'staff']);
 
 describe('deriveGrantBoundaryViews', () => {
   it('org-wide subtree for elevated org roles; org SELF for home-scoped org roles', () => {
@@ -99,16 +100,14 @@ describe('deriveGrantBoundaryViews', () => {
     ]);
   });
 
-  it('a role listed in elevatedRoles keeps its unconditional grant subtree (engine parity)', () => {
-    // Config-independent form: passing `undefined` here would NOT exercise the
-    // "no elevatedRoles configured" branch, because JS default parameters substitute
-    // the app-config default on any undefined, so that branch is reachable
-    // only when the running app's config has no elevatedRoles. Asserting via
-    // an explicit list containing the granted role tests the same subtree
-    // semantics against the function's contract, independent of ambient config.
+  it('an elevated grant keeps its unconditional read subtree (engine parity)', () => {
+    // Config-independent form: an explicit set containing the granted (channel, role) key tests
+    // the subtree semantics against the function's contract, independent of ambient config.
     const studentRead = (ct: ChannelType, role: string): PolicyCellInput =>
       ct === 'course' && role === 'student' ? 1 : 0;
-    expect(derive([membership('course', 'c1', 'student')], studentRead, ['student'])).toEqual([
+    expect(
+      derive([membership('course', 'c1', 'student')], studentRead, elevateAcross(deepHierarchy, ['student'])),
+    ).toEqual([
       {
         key: `${ORG}:item:subtree`,
         organizationId: ORG,

--- a/frontend/src/query/realtime/views.ts
+++ b/frontend/src/query/realtime/views.ts
@@ -1,6 +1,5 @@
 import {
   hierarchy as appHierarchy,
-  elevatedRoles as configuredElevatedRoles,
   type EntityHierarchy,
   getEntityPolicies,
   getPolicyPermissions,
@@ -33,7 +32,8 @@ export interface DeriveViewsInput {
   /** Injectable for synthetic-hierarchy tests; default to the app's real config. */
   policies?: PolicyMatrix;
   hierarchy?: EntityHierarchy;
-  elevatedRoles?: readonly string[];
+  /** Channel-qualified subtree-grant keys; defaults to the hierarchy's compiled set. */
+  elevatedGrants?: ReadonlySet<string>;
 }
 
 /** Derives provable subtree or self views at unconditional grant boundaries; conditional grants and unknown paths keep only the organization fallback. */
@@ -43,7 +43,7 @@ export function deriveGrantBoundaryViews({
   resolvePath,
   policies = policyMatrix,
   hierarchy = appHierarchy,
-  elevatedRoles = configuredElevatedRoles,
+  elevatedGrants = hierarchy.elevatedGrants,
 }: DeriveViewsInput): DerivedSyncView[] {
   const views = new Map<string, DerivedSyncView>();
 
@@ -53,9 +53,9 @@ export function deriveGrantBoundaryViews({
     const ancestors = hierarchy.getOrderedAncestors(entityType);
     const root = ancestors[ancestors.length - 1];
     const homeLevel = ancestors.find((a) => a !== root) ?? root;
-    // Mirrors the engine's isHomeScopedGrant: without elevatedRoles every grant is subtree.
+    // Mirrors the engine's isHomeScopedGrant; the hierarchy-compiled set is always present.
     const isSubtreeGrant = (channelType: string, role: string) =>
-      channelType === homeLevel || elevatedRoles === undefined || elevatedRoles.includes(role);
+      channelType === homeLevel || elevatedGrants.has(`${channelType}:${role}`);
 
     for (const m of memberships) {
       if (!ancestors.includes(m.channelType)) continue;

--- a/shared/config/hierarchy-config.ts
+++ b/shared/config/hierarchy-config.ts
@@ -7,12 +7,16 @@ export const roles = createRoleRegistry(['admin', 'member'] as const);
 /**
  * Entity relationships, single-parent inheritance. Parents before children; order sets the ancestor
  * chain. Products may add `relatedChannels` (non-ancestor context refs, nullable id columns). Public
- * readability is a permission concern, not declared here.
+ * readability is a permission concern, not declared here. Channels may add `elevated` (roles whose
+ * product grants cover the whole subtree, compiled into `hierarchy.elevatedGrants`); non-root
+ * channels may add `rootRoles` (the complete escalation map for auto-created root membership rows).
  *
  * @see cella/PERMISSIONS.md
  */
 export const hierarchy = createEntityHierarchy(roles)
   .user()
-  .channel('organization', { parent: null, roles: roles.all })
+  // Both org roles are elevated: their product grants cover the whole org subtree, which keeps
+  // catchup/view proving org-wide. Apps adding sub-channels narrow this per channel and role.
+  .channel('organization', { parent: null, roles: roles.all, elevated: roles.all })
   .product('attachment', { parent: 'organization' })
   .build();

--- a/shared/config/permissions-config.ts
+++ b/shared/config/permissions-config.ts
@@ -4,16 +4,6 @@ import { configurePermissions } from '../src/permissions/policy-matrix.ts';
 // Access policies per entity type: `1` = allowed, `0`/omitted = denied. Elevation vs. self rows,
 // product home rows, publicRead and row conditions are all explained in cella/PERMISSIONS.md.
 
-/**
- * Roles whose grants cover every row physically below their channel, not only rows homed at that
- * channel level. Static per role, never per-row. `undefined` keeps every grant subtree-scoped. Read
- * by the engine check, the collection-scope SQL compiler and SSE dispatch, which must stay
- * mirror-consistent.
- *
- * @see cella/PERMISSIONS.md
- */
-export const elevatedRoles: readonly string[] | undefined = undefined;
-
 export const { policyMatrix, publicReadGrants } = configurePermissions(
   appConfig.entityTypes,
   ({ entityType, channels }) => {

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -84,7 +84,6 @@ export {
   computeCan,
   configurePermissions,
   createActionRecord,
-  elevatedRoles,
   formatBatchPermissionSummary,
   formatPermissionDecision,
   getAllDecisions,

--- a/shared/src/config-builder/entity-hierarchy.ts
+++ b/shared/src/config-builder/entity-hierarchy.ts
@@ -38,6 +38,17 @@ interface ChannelEntry<R extends string = string> {
   roles: readonly R[];
   /** Non-ancestor channel entities referenced as optional denormalized columns. */
   relatedChannels?: readonly string[];
+  /**
+   * Explicit root-membership escalation: the root-channel role each of this channel's roles
+   * materializes as when a membership here auto-creates the root context row. When declared, the
+   * map must cover every role of the channel; there is no implicit fallback.
+   */
+  rootRoles?: Readonly<Record<string, string>>;
+  /**
+   * Roles of THIS channel whose product grants cover the whole subtree below it, not only rows
+   * homed at this level. Undeclared roles are home-scoped. Compiled into `elevatedGrants`.
+   */
+  elevated?: readonly string[];
 }
 interface ProductEntry {
   kind: 'product';
@@ -53,6 +64,8 @@ export interface ChannelView<R extends string = string> {
   readonly parent: string | null;
   readonly roles: readonly R[];
   readonly relatedChannels?: readonly string[];
+  readonly rootRoles?: Readonly<Record<string, string>>;
+  readonly elevated?: readonly string[];
 }
 
 export interface ProductView {
@@ -101,9 +114,32 @@ class EntityHierarchyBuilder<
     );
   }
 
-  channel<N extends string, P extends TChannels | null, const RC extends readonly TChannels[] = []>(
+  channel<
+    N extends string,
+    P extends TChannels | null,
+    const RO extends readonly RoleFromRegistry<TRoles>[],
+    const RC extends readonly TChannels[] = [],
+  >(
     name: N,
-    options: { parent: P; roles: readonly RoleFromRegistry<TRoles>[]; relatedChannels?: RC },
+    options: {
+      parent: P;
+      roles: RO;
+      relatedChannels?: RC;
+      /**
+       * Root-channel role each of this channel's roles escalates to when a membership here
+       * auto-creates the root context row. Complete when declared (every role must be mapped,
+       * no implicit fallback), and only valid on non-root channels. A channel without the map
+       * cannot auto-create root memberships (insertMemberships throws).
+       */
+      rootRoles?: Record<RO[number], RoleFromRegistry<TRoles>>;
+      /**
+       * Roles of this channel whose product grants cover its whole subtree; undeclared roles
+       * grant only rows homed at this level. Read by the engine, the collection-scope SQL
+       * compiler, SSE dispatch and the frontend view derivation, which stay mirror-consistent
+       * through the compiled `elevatedGrants` set.
+       */
+      elevated?: readonly RO[number][];
+    },
   ): EntityHierarchyBuilder<
     TRoles,
     TChannels | N,
@@ -116,6 +152,8 @@ class EntityHierarchyBuilder<
     this.validateParent(name, options.parent, 'channel');
     this.validateRoles(name, options.roles);
     this.validateRelatedChannels(name, options.parent, options.relatedChannels);
+    this.validateRootRoles(name, options.parent, options.roles, options.rootRoles);
+    this.validateElevated(name, options.roles, options.elevated);
     return new EntityHierarchyBuilder<
       TRoles,
       TChannels | N,
@@ -130,8 +168,67 @@ class EntityHierarchyBuilder<
         parent: options.parent,
         roles: options.roles,
         relatedChannels: options.relatedChannels,
+        rootRoles: options.rootRoles as Readonly<Record<string, string>> | undefined,
+        elevated: options.elevated,
       }),
     );
+  }
+
+  /** Each elevated role must be one of the channel's own roles. */
+  private validateElevated(name: string, roles: readonly string[], elevated?: readonly string[]): void {
+    if (!elevated) return;
+    for (const role of elevated) {
+      if (!roles.includes(role)) {
+        throw new Error(
+          `EntityHierarchy: channel "${name}" elevates unknown role "${role}". Own roles: ${roles.join(', ')}`,
+        );
+      }
+    }
+  }
+
+  /** Keys must be this channel's own roles; values must be roles of the chain's root channel. */
+  private validateRootRoles(
+    name: string,
+    parent: string | null,
+    roles: readonly string[],
+    rootRoles?: Partial<Record<string, string>>,
+  ): void {
+    if (!rootRoles) return;
+    if (parent === null) {
+      throw new Error(`EntityHierarchy: root channel "${name}" cannot declare rootRoles (it has no root above it)`);
+    }
+
+    // Walk to the chain's root; parents are declared before children, so it already exists.
+    let rootName = parent;
+    let entry = this.entities.get(rootName);
+    while (entry && entry.kind === 'channel' && entry.parent !== null) {
+      rootName = entry.parent;
+      entry = this.entities.get(rootName);
+    }
+    const rootRolesVocabulary = entry?.kind === 'channel' ? entry.roles : [];
+
+    for (const [role, rootRole] of Object.entries(rootRoles)) {
+      if (!roles.includes(role)) {
+        throw new Error(
+          `EntityHierarchy: channel "${name}" maps unknown role "${role}" in rootRoles. Own roles: ${roles.join(', ')}`,
+        );
+      }
+      if (rootRole !== undefined && !rootRolesVocabulary.includes(rootRole)) {
+        throw new Error(
+          `EntityHierarchy: channel "${name}" maps role "${role}" to "${rootRole}", which is not a role of ` +
+            `root channel "${rootName}". Root roles: ${rootRolesVocabulary.join(', ')}`,
+        );
+      }
+    }
+
+    // Complete when declared: a partial map is a config error, caught here at build time.
+    const unmapped = roles.filter((role) => rootRoles[role] === undefined);
+    if (unmapped.length > 0) {
+      throw new Error(
+        `EntityHierarchy: channel "${name}" declares rootRoles but leaves ${unmapped.join(', ')} unmapped. ` +
+          'The map must cover every role — there is no implicit fallback.',
+      );
+    }
   }
 
   /**
@@ -342,6 +439,12 @@ export class EntityHierarchy<
   readonly relatableChannelTypes: readonly TChannels[];
   /** Id-column key per entity type; `appConfig.entityIdColumnKeys` is derived from this. */
   readonly idColumnKeys: { readonly [K in 'user' | TChannels | TProducts]: `${K}Id` };
+  /**
+   * Compiled `${channelType}:${role}` keys of every declared elevated role: the value the
+   * permission engine, SQL scope compiler, SSE dispatch and frontend view derivation consume.
+   * Empty when no channel declares elevation: every product grant is then home-scoped.
+   */
+  readonly elevatedGrants: ReadonlySet<string>;
 
   constructor(roles: TRoles, entities: Map<string, EntityEntry>) {
     this.roleRegistry = roles;
@@ -351,17 +454,20 @@ export class EntityHierarchy<
     const products: TProducts[] = [];
     const all: ('user' | TChannels | TProducts)[] = [];
     const relatableChannels = new Set<TChannels>();
+    const elevatedGrants = new Set<string>();
 
     for (const [name, entry] of entities) {
       all.push(name as 'user' | TChannels | TProducts);
 
       if (entry.kind === 'channel') {
         channels.push(name as TChannels);
+        for (const role of entry.elevated ?? []) elevatedGrants.add(`${name}:${role}`);
       } else if (entry.kind === 'product') {
         products.push(name as TProducts);
         relatableChannels.add(entry.parent as TChannels);
       }
     }
+    this.elevatedGrants = Object.freeze(elevatedGrants);
 
     this.channelTypes = Object.freeze(channels);
     this.productTypes = Object.freeze(products);
@@ -390,6 +496,17 @@ export class EntityHierarchy<
   readonly getRoles = (channelType: string): readonly RoleFromRegistry<TRoles>[] => {
     const entry = this.entities.get(channelType);
     return entry?.kind === 'channel' ? (entry.roles as readonly RoleFromRegistry<TRoles>[]) : [];
+  };
+
+  /**
+   * Explicit root-channel role a membership role escalates to when it auto-creates the root
+   * context row; undefined when the channel declares no mapping for it (insertMemberships treats
+   * that as a programming error and throws).
+   */
+  readonly getRootRole = (channelType: string, role: string): RoleFromRegistry<TRoles> | undefined => {
+    const entry = this.entities.get(channelType);
+    if (entry?.kind !== 'channel') return undefined;
+    return entry.rootRoles?.[role] as RoleFromRegistry<TRoles> | undefined;
   };
 
   /** Always a channel; null for root entities and for user. */

--- a/shared/src/config-builder/tests/entity-hierarchy.test.ts
+++ b/shared/src/config-builder/tests/entity-hierarchy.test.ts
@@ -222,4 +222,80 @@ describe('EntityHierarchyBuilder', () => {
       );
     });
   });
+
+  describe('rootRoles', () => {
+    const base = () => createEntityHierarchy(roles).user().channel('organization', { parent: null, roles: roles.all });
+
+    it('exposes the declared escalation map via getRootRole', () => {
+      const h = base()
+        .channel('workspace', {
+          parent: 'organization',
+          roles: ['member', 'guest'],
+          rootRoles: { member: 'member', guest: 'guest' },
+        })
+        .build();
+      expect(h.getRootRole('workspace', 'member')).toBe('member');
+      expect(h.getRootRole('workspace', 'guest')).toBe('guest');
+    });
+
+    it('returns undefined for a channel without a map and for roles outside it', () => {
+      const h = base()
+        .channel('workspace', { parent: 'organization', roles: ['member'] })
+        .build();
+      expect(h.getRootRole('workspace', 'member')).toBeUndefined();
+      expect(h.getRootRole('organization', 'admin')).toBeUndefined();
+    });
+
+    it('throws when the root channel declares a map (it has no root above it)', () => {
+      expect(() =>
+        createEntityHierarchy(roles)
+          .user()
+          .channel('organization', { parent: null, roles: roles.all, rootRoles: { admin: 'admin' } as never }),
+      ).toThrow('cannot declare rootRoles');
+    });
+
+    it('throws when a declared map leaves one of the channel roles unmapped', () => {
+      expect(() =>
+        base().channel('workspace', {
+          parent: 'organization',
+          roles: ['member', 'guest'],
+          rootRoles: { member: 'member' } as any,
+        }),
+      ).toThrow('leaves guest unmapped');
+    });
+
+    it('throws when a mapped value is not a role of the chain root', () => {
+      expect(() =>
+        base().channel('workspace', {
+          parent: 'organization',
+          roles: ['guest'],
+          rootRoles: { guest: 'owner' } as any,
+        }),
+      ).toThrow('not a role of');
+    });
+  });
+
+  describe('elevatedGrants', () => {
+    it('compiles channel-qualified keys from each channel elevated list', () => {
+      const h = createEntityHierarchy(roles)
+        .user()
+        .channel('organization', { parent: null, roles: roles.all, elevated: ['admin'] })
+        .channel('workspace', { parent: 'organization', roles: ['member', 'guest'], elevated: ['member'] })
+        .build();
+      expect(h.elevatedGrants).toEqual(new Set(['organization:admin', 'workspace:member']));
+    });
+
+    it('compiles an empty set when no channel declares elevation', () => {
+      const h = createEntityHierarchy(roles).user().channel('organization', { parent: null, roles: roles.all }).build();
+      expect(h.elevatedGrants.size).toBe(0);
+    });
+
+    it('throws when an elevated role is not one of the channel roles', () => {
+      expect(() =>
+        createEntityHierarchy(roles)
+          .user()
+          .channel('organization', { parent: null, roles: ['admin'], elevated: ['owner'] as any }),
+      ).toThrow('elevates unknown role');
+    });
+  });
 });

--- a/shared/src/permissions/check-access.ts
+++ b/shared/src/permissions/check-access.ts
@@ -1,4 +1,5 @@
-import { elevatedRoles, policyMatrix, publicReadGrants } from '../../config/permissions-config.ts';
+import { hierarchy } from '../../config/hierarchy-config.ts';
+import { policyMatrix, publicReadGrants } from '../../config/permissions-config.ts';
 import type { EntityActionType } from '../../types.ts';
 import { getAllDecisions } from './engine/check.ts';
 import { type EngineAccess, getDecisionsForAccesses } from './engine/resolve-access.ts';
@@ -52,7 +53,7 @@ export interface CheckAccessFanoutOptions {
 
 // Every entry point injects the same public and elevated grants. SQL collection predicates are
 // the tested database-side projection of the same decisions.
-const boundOptions = { publicGrants: publicReadGrants, elevatedRoles };
+const boundOptions = { publicGrants: publicReadGrants, elevatedGrants: hierarchy.elevatedGrants };
 
 const accessOptions = <T extends AccessMembership>(engineAccess: EngineAccess<T>): PermissionCheckOptions => ({
   ...boundOptions,

--- a/shared/src/permissions/engine/check.ts
+++ b/shared/src/permissions/engine/check.ts
@@ -103,7 +103,7 @@ export const checkWithIndices = <T extends AccessMembership>(
   isSystemAdmin: boolean,
   userId?: string,
   publicGrants?: PublicReadGrants,
-  elevatedRoles?: readonly string[],
+  elevatedGrants?: ReadonlySet<string>,
   debug?: boolean,
 ): PermissionDecision<T> => {
   const primaryChannel = orderedChannels[0];
@@ -141,11 +141,11 @@ export const checkWithIndices = <T extends AccessMembership>(
   const conditionRow: RowForCondition = { ...subject.row, createdBy: subject.createdBy };
   const conditionActor: ConditionActor = { userId };
 
-  // Non-elevated roles grant product access only at the row's home channel; channel subjects
-  // keep ancestor elevation.
+  // Non-elevated grants apply only at the row's home channel; channel subjects keep ancestor
+  // elevation. Elevation is per (channelType, role): `${channelType}:${role}` ∈ elevatedGrants.
   const isProductSubject = (subject.entityType as string) !== primaryChannel;
   const homeChannel =
-    elevatedRoles && isProductSubject ? orderedChannels.find((ct) => getSubjectChannelId(subject, ct)) : undefined;
+    elevatedGrants && isProductSubject ? orderedChannels.find((ct) => getSubjectChannelId(subject, ct)) : undefined;
 
   for (const channelType of orderedChannels) {
     const channelRoles = getRoles(channelType);
@@ -172,7 +172,12 @@ export const checkWithIndices = <T extends AccessMembership>(
       // Missing policy rows deny by default, like omitted actions.
       if (!permissions) continue;
 
-      if (elevatedRoles && isProductSubject && !elevatedRoles.includes(m.role) && channelType !== homeChannel) {
+      if (
+        elevatedGrants &&
+        isProductSubject &&
+        !elevatedGrants.has(`${channelType}:${m.role}`) &&
+        channelType !== homeChannel
+      ) {
         continue;
       }
 
@@ -239,7 +244,7 @@ export function getAllDecisions<T extends AccessMembership>(
   const isSystemAdmin = options?.isSystemAdmin === true;
   const userId = options?.userId;
   const publicGrants = options?.publicGrants;
-  const elevatedRoles = options?.elevatedRoles;
+  const elevatedGrants = options?.elevatedGrants;
   const debug = options?.debug === true;
   const { hierarchy: resolvedHierarchy, entityActions, getRoles } = resolveHierarchy(options);
 
@@ -288,7 +293,7 @@ export function getAllDecisions<T extends AccessMembership>(
       isSystemAdmin,
       userId,
       publicGrants,
-      elevatedRoles,
+      elevatedGrants,
       debug,
     );
 

--- a/shared/src/permissions/engine/resolve-access.test.ts
+++ b/shared/src/permissions/engine/resolve-access.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import { elevateAcross } from '../../testing/elevate.ts';
 import {
   configureWidePermissions,
   type WideChannelType,
   type WideProductType,
   type WideRole,
+  wideHierarchy,
   wideMembership,
   wideOverrides,
   wideSubject,
@@ -25,7 +27,7 @@ const USERS = ['user1', 'user2', 'user3', 'user4'];
 interface PolicyScenario {
   name: string;
   result: ReturnType<typeof configureWidePermissions>;
-  elevatedRoles?: readonly string[];
+  elevatedGrants?: ReadonlySet<string>;
 }
 
 const scenarios: PolicyScenario[] = [
@@ -93,7 +95,7 @@ const scenarios: PolicyScenario[] = [
           break;
       }
     }),
-    elevatedRoles: ['admin'],
+    elevatedGrants: elevateAcross(wideHierarchy, ['admin']),
   },
 ];
 
@@ -170,7 +172,7 @@ describe('getDecisionsForAccesses ≍ mapped getAllDecisions', () => {
       const baseOptions = {
         ...wideOverrides,
         publicGrants: publicReadGrants,
-        elevatedRoles: scenario.elevatedRoles,
+        elevatedGrants: scenario.elevatedGrants,
       };
 
       for (let iteration = 0; iteration < 150; iteration++) {

--- a/shared/src/permissions/engine/resolve-access.ts
+++ b/shared/src/permissions/engine/resolve-access.ts
@@ -118,7 +118,7 @@ export function getDecisionsForAccesses<T extends AccessMembership>(
         access.isSystemAdmin === true,
         access.userId,
         options?.publicGrants,
-        options?.elevatedRoles,
+        options?.elevatedGrants,
         options?.debug,
       );
       memo.set(key, decision);

--- a/shared/src/permissions/engine/types.ts
+++ b/shared/src/permissions/engine/types.ts
@@ -65,8 +65,13 @@ export interface PermissionCheckOptions {
   userId?: string;
   /** The `checkAccess*` wrappers inject the configured grants. @see public-read.ts */
   publicGrants?: PublicReadGrants;
-  /** `undefined` treats every role as subtree-wide. @see shared/config/README.md */
-  elevatedRoles?: readonly string[];
+  /**
+   * `${channelType}:${role}` keys of subtree-wide grants, compiled from the hierarchy's
+   * per-channel `elevated` declarations (`hierarchy.elevatedGrants`). An empty set makes every
+   * product grant home-scoped; `undefined` disables the elevation concept entirely (every grant
+   * subtree-wide) for callers driving the engine with synthetic policies.
+   */
+  elevatedGrants?: ReadonlySet<string>;
   /** Synthetic hierarchy override; defaults to the app singleton. */
   hierarchy?: EntityHierarchy;
   /** Action set override; defaults to `appConfig.entityActions`. */

--- a/shared/src/permissions/index.ts
+++ b/shared/src/permissions/index.ts
@@ -1,4 +1,4 @@
-export { elevatedRoles, policyMatrix, publicReadGrants } from '../../config/permissions-config.ts';
+export { policyMatrix, publicReadGrants } from '../../config/permissions-config.ts';
 export {
   allActionsAllowed,
   allActionsDenied,

--- a/shared/src/testing/elevate.ts
+++ b/shared/src/testing/elevate.ts
@@ -1,0 +1,9 @@
+import type { EntityHierarchy } from '../config-builder/entity-hierarchy.ts';
+
+/**
+ * Channel-qualified elevation keys for tests: the given role names at every channel of the
+ * hierarchy ("role X is subtree-wide wherever it appears"). App code never uses this; it reads
+ * the hierarchy's compiled `elevatedGrants`.
+ */
+export const elevateAcross = (hierarchy: EntityHierarchy, roles: readonly string[]): ReadonlySet<string> =>
+  new Set(hierarchy.channelTypes.flatMap((channelType) => roles.map((role) => `${channelType}:${role}`)));


### PR DESCRIPTION
Adopts the two hierarchy seams from projectcampus (items 1+2 of the seam list).

**elevatedGrants** — the global `elevatedRoles` list is replaced by per-channel `elevated` declarations, compiled by the hierarchy builder into a `${channelType}:${role}` key set consumed by the engine check, the collection-scope SQL compiler and frontend view derivation. Cella's org declares `elevated: roles.all`, preserving current behavior (the catchup tests caught that an empty set flips org grants to home-scoped — view answers went `opaque`). Tests inject elevation via the new `elevateAcross` helper.

**rootRoles** — auto-created root context memberships take their role from the source channel's explicit, build-time-validated `rootRoles` map; `resolveParentMembershipRole` splits into `resolveAssociatedMembershipRole` + throwing `resolveRootMembershipRole`. Unreachable in cella's single-channel hierarchy; new config-builder tests cover mapping, validators and `elevatedGrants` compilation (pc shipped none).

Includes migration `20260828T2030-elevated-grants-root-roles` (manual, syncBreaking) with the exact fork steps, including the silent-behavior-shift warning. PERMISSIONS.md updated. pc's vocab-drift-only test diffs (member→guest) were excluded.

Checks: `pnpm check` green; shared 258, backend 661, frontend 898 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)