### PR TITLE
feat(attachment): channel placement seam with an org-homed default

### DIFF
--- a/backend/src/modules/attachment/attachment-schema.ts
+++ b/backend/src/modules/attachment/attachment-schema.ts
@@ -3,6 +3,10 @@ import { schemaTags } from '#/core/openapi-helpers';
 import { evolutionContract } from '#/core/schema-evolution/evolution-contract';
 import { createInsertSchema, createSelectSchema, describeFields } from '#/db/utils/drizzle-schema';
 import { attachmentsTable } from '#/modules/attachment/attachment-db';
+import {
+  attachmentPlacementFieldsSchema,
+  validateAttachmentPlacement,
+} from '#/modules/attachment/helpers/attachment-placement';
 import { productViewCountSchema } from '#/modules/entities/entities-schema';
 import { batchResponseSchema, maxLength, paginationQuerySchema, stxBaseSchema, validUuidSchema } from '#/schemas';
 import { nullableUserMinimalBaseSchema } from '#/schemas/minimal-base';
@@ -66,6 +70,8 @@ const attachmentCreateBodySchema = attachmentInsertSchema
     // The column defaults to {}, making `keys` optional on the generated insert schema; a create
     // must carry at least the original key.
     keys: attachmentKeysSchema,
+    // Placement seam: apps exposing channel placement add their deepest-home-id fields here.
+    ...attachmentPlacementFieldsSchema,
   });
 
 export const attachmentContract = evolutionContract.product('attachment', {
@@ -75,7 +81,17 @@ export const attachmentContract = evolutionContract.product('attachment', {
   },
 });
 
-export const attachmentCreateManyStxBodySchema = attachmentContract.createItemSchema.array().min(1).max(50);
+export const attachmentCreateManyStxBodySchema = attachmentContract.createItemSchema
+  .array()
+  .min(1)
+  .max(50)
+  // Placement seam: per-item validation (e.g. ambiguous home ids); a no-op with no placement fields.
+  .superRefine((items, ctx) => {
+    items.forEach((item, index) => {
+      const issue = validateAttachmentPlacement(item);
+      if (issue) ctx.addIssue({ code: 'custom', path: [index, ...issue.path], message: issue.message });
+    });
+  });
 
 export const attachmentUpdateStxBodySchema = attachmentContract.updateBodySchema;
 

--- a/backend/src/modules/attachment/helpers/attachment-placement.ts
+++ b/backend/src/modules/attachment/helpers/attachment-placement.ts
@@ -1,0 +1,35 @@
+import type { AuthContext } from '#/core/context';
+
+/**
+ * Create-body placement fields, spread into the create-item schema. This file is the attachment
+ * placement seam: cella homes attachments at the organization only, so it exposes no fields and
+ * resolves every row org-homed. An app that re-homes attachments on its channel chain (nullable
+ * ancestor columns, deepest non-null = home) replaces this file; the cella-owned schema and
+ * create op call through the seam, so the swap stays local to it.
+ */
+export const attachmentPlacementFieldsSchema = {};
+
+/** A create-body item as the placement seam sees it; apps narrow to their placement fields. */
+export type AttachmentPlacementInput = Record<string, unknown>;
+
+/** Ancestor id columns to stamp on the inserted row; empty = org-homed. */
+export type ResolvedAttachmentPlacement = Record<string, string | null>;
+
+/**
+ * Per-item create-body validation, anchored at the returned path relative to the item. Apps
+ * reject ambiguous placement here (more than one home id per item); with no placement fields
+ * there is nothing to reject.
+ */
+export const validateAttachmentPlacement = (
+  _item: AttachmentPlacementInput,
+): { path: (string | number)[]; message: string } | null => null;
+
+/**
+ * Ancestor columns for one create-body item; the org-homed default stamps none. Apps resolve
+ * the most specific client-sent id to a real row (requiring read access on it) and derive the
+ * chain above it server-side, never from client input.
+ */
+export const resolveAttachmentPlacement = async (
+  _ctx: AuthContext,
+  _input: AttachmentPlacementInput,
+): Promise<ResolvedAttachmentPlacement> => ({});

--- a/backend/src/modules/attachment/operations/create-attachments.ts
+++ b/backend/src/modules/attachment/operations/create-attachments.ts
@@ -3,8 +3,10 @@ import type { AuthContext } from '#/core/context';
 import { AppError } from '#/core/error';
 import { buildStx } from '#/core/stx';
 import { tenantContext, tenantRead } from '#/db/tenant-context';
+import type { InsertAttachmentModel } from '#/modules/attachment/attachment-db';
 import { findAttachmentsByStxMutationId, insertAttachments } from '#/modules/attachment/attachment-queries';
 import { attachmentContract, type attachmentCreateManyStxBodySchema } from '#/modules/attachment/attachment-schema';
+import { resolveAttachmentPlacement } from '#/modules/attachment/helpers/attachment-placement';
 import { getOrganizationEntityCount } from '#/modules/entities/entities-queries';
 import { withAuditUsers } from '#/modules/user/helpers/audit-user';
 import { buildSubjectFromEntity } from '#/permissions/build-subject';
@@ -41,14 +43,20 @@ export async function createAttachmentsOp(ctx: AuthContext, rawInput: CreateAtta
     throw new AppError(429, 'restrict_by_org', 'warn', { entityType: 'attachment' });
   }
 
-  const attachmentsToInsert = input.map(({ stx, ...att }) => {
+  const now = getIsoDate();
+  const attachmentsToInsert: InsertAttachmentModel[] = [];
+  for (const { stx, ...att } of input) {
+    // Placement seam: ancestor columns derived server-side; the org-homed default stamps none.
+    const placement = await resolveAttachmentPlacement(ctx, att);
+
     const attachment = {
       ...att,
       convertedContentType: att.convertedContentType || null,
       groupId: att.groupId || null,
+      ...placement,
       tenantId: organization.tenantId,
       organizationId: organization.id,
-      createdAt: getIsoDate(),
+      createdAt: now,
       createdBy: ctx.var.user.id,
       stx: buildStx(stx),
     };
@@ -56,8 +64,8 @@ export async function createAttachmentsOp(ctx: AuthContext, rawInput: CreateAtta
     // The create-check channel scope comes from the row's hierarchy ancestors, so re-homing
     // attachments on a product entity needs no change here.
     canCreateEntity(ctx, buildSubjectFromEntity('attachment', attachment));
-    return attachment;
-  });
+    attachmentsToInsert.push(attachment);
+  }
 
   const createdAttachments = await tenantContext(ctx, (txCtx) =>
     insertAttachments(txCtx, { attachments: attachmentsToInsert }),

--- a/cella/cella.config.ts
+++ b/cella/cella.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
       'backend/src/tables.ts',
       'backend/src/routes.ts',
       'backend/src/mocks/app-product-mocks.ts',
+      'backend/src/modules/attachment/helpers/attachment-placement.ts',
       'backend/src/modules/memberships/memberships-db.ts',
       'backend/src/modules/organization/setup-config-schema.ts',
       'frontend/src/query/extra-local-user-stores.ts',

--- a/frontend/src/modules/attachment/helpers/persist-attachments.ts
+++ b/frontend/src/modules/attachment/helpers/persist-attachments.ts
@@ -6,9 +6,19 @@ import { queryClient } from '~/query/query-client';
 /** Persists BlockNote attachments and splices the confirmed rows into the home list: the own-create realtime echo only patches rows in place. */
 export async function persistAttachments(
   attachments: Attachment[],
-  { tenantId, organizationId }: { tenantId: string; organizationId: string },
+  {
+    tenantId,
+    organizationId,
+    placement,
+  }: {
+    tenantId: string;
+    organizationId: string;
+    /** Placement seam: the deepest home channel id only (ancestors are server-derived); omitted = org-homed. Apps expose their placement fields via the backend seam. */
+    placement?: Record<string, string>;
+  },
 ): Promise<void> {
   if (!attachments.length) return;
-  const result = await createAttachmentsMutationFn({ tenantId, organizationId, data: attachments });
+  const rows = placement ? attachments.map((attachment) => ({ ...attachment, ...placement })) : attachments;
+  const result = await createAttachmentsMutationFn({ tenantId, organizationId, data: rows });
   insertEntitiesIntoHome(queryClient, result.data);
 }


### PR DESCRIPTION
Item 3 of the projectcampus seam list. Authors the placement seam as a cella empty default rather than copying the fork's typed version: `helpers/attachment-placement.ts` (now **pinned** in cella.config.ts) exposes no create-body fields and resolves every row org-homed; the cella-owned schema and create op call through it (`attachmentPlacementFieldsSchema` spread, `validateAttachmentPlacement` superRefine, `resolveAttachmentPlacement` per item). The seam improves on pc's shape: validation returns a path-anchored issue so the cella-owned schema stays fork-agnostic (pc adapts `hasAmbiguousPlacement` on next sync). `persistAttachments` gains a generic optional `placement` record. Not sync-breaking — additive; forks without placement need no action.

Checks: `pnpm check` green; backend 660 + frontend 898 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)