### PR TITLE
feat(memberships): per-member insight counts and recent-activity default sort

### DIFF
--- a/backend/src/modules/memberships/helpers/member-counts.ts
+++ b/backend/src/modules/memberships/helpers/member-counts.ts
@@ -1,0 +1,96 @@
+import { z } from '@hono/zod-openapi';
+import { and, eq, getTableColumns, isNull, sql } from 'drizzle-orm';
+import { appConfig, type ChannelEntityType, hierarchy, isChannel, recordFromKeys } from 'shared';
+import { buildSubtreeCoverWhere } from '#/db/utils/subtree-cover';
+import { attachmentsTable } from '#/modules/attachment/attachment-db';
+import { membershipsTable } from '#/modules/memberships/memberships-db';
+import { usersTable } from '#/modules/user/user-db';
+
+/**
+ * Product types with per-member stats for the members table (`include=counts` on GET /members);
+ * must match `memberStatProductTypes` in members-columns.tsx. Counts are computed per request,
+ * scoped to the viewed channel, and the subqueries read RLS-guarded tables, so the members query
+ * must run under `tenantRead` when counts are requested. Apps swap this map and
+ * `liveAuthoredWhere` for their own content types.
+ */
+const memberStatProductTables = { attachment: attachmentsTable } as const;
+export type MemberStatProductType = keyof typeof memberStatProductTables;
+export const memberStatProductTypes = Object.keys(memberStatProductTables) as MemberStatProductType[];
+
+/** Channel types a member row can carry a membership count for (all non-root channels). */
+const memberStatChannelTypes = hierarchy
+  .getOrderedDescendants('organization')
+  .filter((type): type is ChannelEntityType => isChannel(type));
+
+/** Rows a member gets credited for: live rows they created within the viewed scope. */
+const liveAuthoredWhere = (
+  productType: MemberStatProductType,
+  entityType: ChannelEntityType,
+  entityId: string,
+  organizationId: string,
+) => {
+  const t = memberStatProductTables[productType];
+  return and(
+    eq(t.createdBy, usersTable.id),
+    // Org clamp is redundant for sub-channel scopes but lets a `(created_by, organization_id)` index drive every scope
+    eq(t.organizationId, organizationId),
+    ...(entityType === 'organization' ? [] : [buildSubtreeCoverWhere(t, productType, entityId)]),
+    isNull(t.deletedAt),
+  );
+};
+
+/**
+ * Select fragment for the members query: `counts: memberCountsSelect(...)`. Correlated scalar
+ * subqueries per row (the `memberSelect.lastSeenAt` precedent); cost scales with page size and
+ * per-user content, not channel volume.
+ */
+export const memberCountsSelect = (entityType: ChannelEntityType, entityId: string, organizationId: string) => {
+  // Membership counts per descendant channel type, scoped by the viewed channel's ancestor column
+  // on the membership rows themselves (populated by insertMemberships for every level).
+  const scopeColumn = getTableColumns(membershipsTable)[appConfig.entityIdColumnKeys[entityType]].name;
+  const descendantChannels = hierarchy.getOrderedDescendants(entityType).filter(isChannel);
+  const membershipPairs = descendantChannels.map(
+    (type) =>
+      sql`${sql.raw(`'${type}'`)}, (SELECT count(*)::int FROM ${membershipsTable} mc
+        WHERE mc.user_id = ${usersTable.id} AND mc.channel_type = ${sql.raw(`'${type}'`)}
+          AND mc.${sql.raw(scopeColumn)} = ${entityId})`,
+  );
+
+  const productPairs = memberStatProductTypes.map((type) => {
+    const table = memberStatProductTables[type];
+    const where = liveAuthoredWhere(type, entityType, entityId, organizationId);
+    return sql`${sql.raw(`'${type}'`)}, (SELECT count(*)::int FROM ${table} WHERE ${where})`;
+  });
+
+  // Epoch ms of the member's latest live row per product type; null when never.
+  const activityPairs = memberStatProductTypes.map((type) => {
+    const table = memberStatProductTables[type];
+    const where = liveAuthoredWhere(type, entityType, entityId, organizationId);
+    return sql`${sql.raw(`'${type}'`)}, (SELECT (extract(epoch from max(${table.createdAt})) * 1000)::bigint
+      FROM ${table} WHERE ${where})`;
+  });
+
+  return {
+    memberships: sql<
+      Partial<Record<ChannelEntityType, number>>
+    >`json_build_object(${sql.join(membershipPairs, sql`, `)})`,
+    products: sql<Record<MemberStatProductType, number>>`json_build_object(${sql.join(productPairs, sql`, `)})`,
+    activity: sql<Record<MemberStatProductType, number | null>>`json_build_object(${sql.join(activityPairs, sql`, `)})`,
+  };
+};
+
+/**
+ * ORDER BY expression for `sort=lastPostedAt`; the caller must run under tenantRead (the product
+ * table is RLS-guarded). Never-posted coalesces to -infinity so those members trail the recent
+ * posters under the default descending sort (plain DESC is NULLS FIRST in Postgres).
+ */
+export const lastPostedAtOrder = (entityType: ChannelEntityType, entityId: string, organizationId: string) =>
+  sql`coalesce((SELECT max(${attachmentsTable.createdAt}) FROM ${attachmentsTable}
+    WHERE ${liveAuthoredWhere('attachment', entityType, entityId, organizationId)}), '-infinity')`;
+
+/** Response shape for `member.counts`; membership keys are scoped to the viewed channel, so all optional. */
+export const memberCountsSchema = z.object({
+  memberships: z.object(recordFromKeys(memberStatChannelTypes, () => z.number().optional())),
+  products: z.object(recordFromKeys(memberStatProductTypes, () => z.number())),
+  activity: z.object(recordFromKeys(memberStatProductTypes, () => z.number().nullable())),
+});

--- a/backend/src/modules/memberships/memberships-queries.ts
+++ b/backend/src/modules/memberships/memberships-queries.ts
@@ -4,6 +4,7 @@ import type { ChannelEntityType, EntityRole } from 'shared';
 import type { AuthContext, DbContext } from '#/core/context';
 import { resolveListTotal } from '#/db/utils/list-total';
 import { tokensTable } from '#/modules/auth/tokens-db';
+import { lastPostedAtOrder, memberCountsSelect } from '#/modules/memberships/helpers/member-counts';
 import { membershipBaseSelect } from '#/modules/memberships/helpers/select';
 import { inactiveMembershipsTable } from '#/modules/memberships/inactive-memberships-db';
 import { membershipsTable } from '#/modules/memberships/memberships-db';
@@ -259,17 +260,19 @@ interface FindMembersPaginatedOpts {
   entityId: string;
   entityType: ChannelEntityType;
   q?: string;
-  sort?: 'id' | 'name' | 'email' | 'createdAt' | 'lastSeenAt' | 'role';
+  sort?: 'id' | 'name' | 'email' | 'createdAt' | 'lastSeenAt' | 'role' | 'lastPostedAt';
   order?: 'asc' | 'desc';
   offset: number;
   limit: number;
   role?: EntityRole;
   userIds?: string[];
+  // Opt-in per-member insight counts; caller must run under tenantRead (product subqueries are RLS-guarded)
+  includeCounts?: boolean;
 }
 
 export const findMembersPaginated = async (ctx: DbContext, opts: FindMembersPaginatedOpts) => {
   const { db } = ctx.var;
-  const { organizationId, entityId, entityType, q, sort, order, offset, limit, role, userIds } = opts;
+  const { organizationId, entityId, entityType, q, sort, order, offset, limit, role, userIds, includeCounts } = opts;
 
   const $or = q
     ? [ilike(usersTable.name, prepareStringForILikeFilter(q)), ilike(usersTable.email, prepareStringForILikeFilter(q))]
@@ -296,6 +299,8 @@ export const findMembersPaginated = async (ctx: DbContext, opts: FindMembersPagi
       // COALESCE so never-signed-in members sort as oldest: plain DESC is NULLS FIRST in Postgres
       lastSeenAt: sql`COALESCE((SELECT ${userCountersTable.lastSeenAt} FROM ${userCountersTable} WHERE ${userCountersTable.userId} = ${usersTable.id}), '-infinity')`,
       role: membershipsTable.role,
+      // Latest live product row by the member in the viewed channel; RLS-guarded like the counts
+      lastPostedAt: lastPostedAtOrder(entityType, entityId, organizationId),
     },
     tieBreaker: usersTable.id,
   });
@@ -304,6 +309,8 @@ export const findMembersPaginated = async (ctx: DbContext, opts: FindMembersPagi
     .select({
       ...memberSelect,
       membership: membershipBaseSelect,
+      // Per-member insight counts on the page rows only; the total below stays free of the subqueries
+      ...(includeCounts && { counts: memberCountsSelect(entityType, entityId, organizationId) }),
     })
     .from(usersTable)
     .innerJoin(membershipsTable, eq(membershipsTable.userId, usersTable.id))
@@ -314,10 +321,17 @@ export const findMembersPaginated = async (ctx: DbContext, opts: FindMembersPagi
     .limit(limit)
     .offset(offset);
 
+  // Totals count over a slim id-only query, so include=counts never evaluates its subqueries channel-wide
+  const totalQuery = db
+    .select({ id: usersTable.id })
+    .from(usersTable)
+    .innerJoin(membershipsTable, eq(membershipsTable.userId, usersTable.id))
+    .where(and(...membersFilters, or(...$or)));
+
   return resolveListTotal(itemsQuery, {
     kind: 'exact',
     getTotal: async () => {
-      const [{ total }] = await db.select({ total: count() }).from(membersQuery.as('members'));
+      const [{ total }] = await db.select({ total: count() }).from(totalQuery.as('members'));
       return total;
     },
   });

--- a/backend/src/modules/memberships/memberships-schema.ts
+++ b/backend/src/modules/memberships/memberships-schema.ts
@@ -6,6 +6,7 @@ import { inactiveMembershipsTable } from '#/modules/memberships/inactive-members
 import { membershipsTable } from '#/modules/memberships/memberships-db';
 import {
   channelEntityTypeSchema,
+  includeQuerySchema,
   paginationQuerySchema,
   validEmailSchema,
   validIdSchema,
@@ -71,8 +72,11 @@ export const membershipUpdateBodySchema = z.object({
 export const memberListQuerySchema = paginationQuerySchema.extend({
   entityId: validIdSchema,
   entityType: channelEntityTypeSchema,
-  sort: z.enum(['id', 'name', 'email', 'role', 'createdAt', 'lastSeenAt']).default('createdAt'),
+  // lastPostedAt sorts by the member's latest product row in the viewed channel; default is recent activity
+  sort: z.enum(['id', 'name', 'email', 'role', 'createdAt', 'lastSeenAt', 'lastPostedAt']).default('lastSeenAt'),
   role: z.enum(roles.all).optional(),
+  // Opt-in per-member insight counts (member-counts.ts), mirroring the channel lists' include=counts
+  include: includeQuerySchema,
   userIds: z
     .string()
     .transform((value) => value.split(',').map((id) => id.trim()))

--- a/backend/src/modules/memberships/operations/get-members.ts
+++ b/backend/src/modules/memberships/operations/get-members.ts
@@ -1,5 +1,6 @@
 import type { ChannelEntityType, EntityRole } from 'shared';
 import type { AuthContext } from '#/core/context';
+import { tenantRead } from '#/db/tenant-context';
 import { findMembersPaginated } from '#/modules/memberships/memberships-queries';
 import { getValidChannel } from '#/permissions/get-valid-channel';
 
@@ -7,22 +8,26 @@ interface GetMembersInput {
   entityId: string;
   entityType: ChannelEntityType;
   q?: string;
-  sort?: 'id' | 'name' | 'email' | 'createdAt' | 'lastSeenAt' | 'role';
+  sort?: 'id' | 'name' | 'email' | 'createdAt' | 'lastSeenAt' | 'role' | 'lastPostedAt';
   order?: 'asc' | 'desc';
   offset: number;
   limit: number;
   role?: EntityRole;
   userIds?: string[];
+  // Opt-in per-member insight counts
+  include?: string[];
 }
 
 export async function getMembersOp(ctx: AuthContext, input: GetMembersInput) {
   const organization = ctx.var.organization;
 
-  const { entityId, entityType, q, sort, order, offset, limit, role, userIds } = input;
+  const { entityId, entityType, q, sort, order, offset, limit, role, userIds, include } = input;
 
   const { entity } = await getValidChannel(ctx, entityId, entityType, 'read');
 
-  const { items, total } = await findMembersPaginated(ctx, {
+  const includeCounts = include?.includes('counts') ?? false;
+
+  const listOpts = {
     organizationId: organization.id,
     entityId: entity.id,
     entityType,
@@ -33,7 +38,15 @@ export async function getMembersOp(ctx: AuthContext, input: GetMembersInput) {
     limit,
     role,
     userIds,
-  });
+    includeCounts,
+  };
+
+  // Member counts and the lastPostedAt sort read RLS-guarded product tables,
+  // which read empty on this route's bare baseDb; tenantGuard pinned the tenant, so read as it.
+  const { items, total } =
+    includeCounts || sort === 'lastPostedAt'
+      ? await tenantRead(ctx, (readCtx) => findMembersPaginated(readCtx, listOpts))
+      : await findMembersPaginated(ctx, listOpts);
 
   return { items, total };
 }

--- a/backend/src/modules/user/user-schema.ts
+++ b/backend/src/modules/user/user-schema.ts
@@ -2,6 +2,7 @@ import { z } from '@hono/zod-openapi';
 import { appConfig, type EnabledOAuthProvider, type UserFlags } from 'shared';
 import { schemaTags } from '#/core/openapi-helpers';
 import { createInsertSchema, createSelectSchema } from '#/db/utils/drizzle-schema';
+import { memberCountsSchema } from '#/modules/memberships/helpers/member-counts';
 import { membershipBaseSchema } from '#/modules/memberships/memberships-schema';
 import { usersTable } from '#/modules/user/user-db';
 import {
@@ -54,6 +55,8 @@ export const memberUserSchema = userBaseSchema.extend({
 
 export const memberSchema = memberUserSchema.extend({
   membership: membershipBaseSchema,
+  // Per-member insight counts, present when the members list is fetched with include=counts
+  counts: memberCountsSchema.optional(),
 });
 
 export const userUpdateBodySchema = createInsertSchema(usersTable, {

--- a/frontend/src/modules/memberships/members-table/members-columns.tsx
+++ b/frontend/src/modules/memberships/members-table/members-columns.tsx
@@ -1,6 +1,7 @@
+import { BoxIcon, type LucideIcon, PaperclipIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { type ChannelEntityType, hierarchy } from 'shared';
+import { type ChannelEntityType, hierarchy, isChannel } from 'shared';
 import { enumSelectEditorOptions, RenderEnumSelect } from '~/modules/common/data-grid/cell-renderers';
 import { CheckboxColumn } from '~/modules/common/data-table/checkbox-column';
 import type { ColumnOrColumnGroup } from '~/modules/common/data-table/types';
@@ -8,6 +9,13 @@ import type { Member } from '~/modules/memberships/types';
 import { Badge } from '~/modules/ui/badge';
 import { UserCell } from '~/modules/user/user-cell';
 import { dateShort } from '~/utils/date-short';
+
+// Product types with per-member stat columns; must match `memberStatProductTypes` in the
+// backend's member-counts.ts (the response only carries these keys).
+const memberStatProductTypes = ['attachment'] as const;
+const memberStatIcons: Partial<Record<string, LucideIcon>> = {
+  attachment: PaperclipIcon,
+};
 
 export const useColumns = (isAdmin: boolean, isSheet: boolean, entityType: ChannelEntityType) => {
   const { t } = useTranslation();
@@ -96,6 +104,57 @@ export const useColumns = (isAdmin: boolean, isSheet: boolean, entityType: Chann
             </Badge>
           ),
       },
+      // Per-member insight columns from include=counts: when the member last posted in this
+      // channel, their authored counts within it, and their sub-channel membership counts.
+      {
+        key: 'lastPostedAt',
+        name: t('c:last_post'),
+        sortable: true,
+        sortDescendingFirst: true,
+        minBreakpoint: 'md',
+        minWidth: 120,
+        placeholderValue: '-',
+        renderCell: ({ row }) => {
+          const lastPostedAt = row.counts?.activity.attachment;
+          return lastPostedAt ? dateShort(new Date(lastPostedAt)) : null;
+        },
+      },
+      ...memberStatProductTypes.map((type): ColumnOrColumnGroup<Member> => {
+        const Icon = memberStatIcons[type] ?? BoxIcon;
+        return {
+          key: `${type}Count`,
+          name: t(`c:${type}`, { count: 2 }),
+          minBreakpoint: 'md',
+          minWidth: 60,
+          maxWidth: 120,
+          renderCell: ({ row }) => (
+            <>
+              <Icon className="mr-2 opacity-50" />
+              {row.counts?.products[type] ?? '-'}
+            </>
+          ),
+        };
+      }),
+      ...hierarchy
+        .getOrderedDescendants(entityType)
+        .filter(
+          (type): type is Exclude<ChannelEntityType, 'organization'> => isChannel(type) && type !== 'organization',
+        )
+        .map(
+          (type): ColumnOrColumnGroup<Member> => ({
+            key: `${type}Count`,
+            name: t(`c:${type}`, { count: 2, defaultValue: type }),
+            minBreakpoint: 'md',
+            minWidth: 60,
+            maxWidth: 120,
+            renderCell: ({ row }) => (
+              <>
+                <BoxIcon className="mr-2 opacity-50" />
+                {row.counts?.memberships[type] ?? '-'}
+              </>
+            ),
+          }),
+        ),
     ];
 
     return cols;

--- a/frontend/src/modules/memberships/members-table/members-table.tsx
+++ b/frontend/src/modules/memberships/members-table/members-table.tsx
@@ -52,7 +52,16 @@ function MembersTable({ channel, isSheet = false, children }: MembersTableWrappe
   const [columns, setColumns] = useColumns(canUpdate, isSheet, entityType);
   const { sortColumns, setSortColumns: onSortColumnsChange } = useSortColumns(sort, order, setSearch);
 
-  const queryOptions = membersListQueryOptions({ entityId, entityType, tenantId, organizationId, ...search, limit });
+  // include=counts feeds the per-member insight columns (last post, authored counts, sub-channel memberships)
+  const queryOptions = membersListQueryOptions({
+    entityId,
+    entityType,
+    tenantId,
+    organizationId,
+    ...search,
+    limit,
+    include: 'counts',
+  });
 
   const {
     data: rows,

--- a/frontend/src/modules/memberships/query.ts
+++ b/frontend/src/modules/memberships/query.ts
@@ -38,12 +38,14 @@ export const membersListQueryOptions = (params: MembersListParams) => {
     order = defaults.order,
     role,
     userIds,
+    include,
     limit = appConfig.requestLimits.members,
   } = params;
+  // `include` stays out of the cache key so queries with/without counts share the same cache
   const filters = { q, sort, order, role, userIds };
   const keyFilters = { entityId, entityType, tenantId, organizationId, ...filters };
   const path = { tenantId, organizationId };
-  const requestQuery = { ...filters, limit: String(limit), entityId, entityType };
+  const requestQuery = { ...filters, include, limit: String(limit), entityId, entityType };
 
   return infiniteQueryOptions({
     queryKey: keys.list.members(keyFilters),

--- a/frontend/src/modules/memberships/search-params-schemas.ts
+++ b/frontend/src/modules/memberships/search-params-schemas.ts
@@ -2,7 +2,8 @@ import { zGetMembersQuery } from 'sdk/zod.gen';
 import z from 'zod';
 
 /** Single source for URL stripping (route search middleware) and query fallbacks; mirrors `zGetMembersQuery`. */
-export const membersSearchDefaults = { q: '', sort: 'createdAt', order: 'desc' } as const;
+// Default members sort is recent activity (lastSeenAt desc)
+export const membersSearchDefaults = { q: '', sort: 'lastSeenAt', order: 'desc' } as const;
 
 export const membersRouteSearchParamsSchema = zGetMembersQuery
   .pick({ q: true, sort: true, order: true, role: true })

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -242,6 +242,7 @@
   "languages": "Languages",
   "last_edited": "Last edited",
   "last_name": "Last name",
+  "last_post": "Last post",
   "last_seen_at": "Last seen",
   "leave": "Leave",
   "leave_focus_view": "Leave focus",

--- a/locales/nl/common.json
+++ b/locales/nl/common.json
@@ -11,6 +11,7 @@
   "google": "Google",
   "id": "ID",
   "invite_bulk_link": "Klik hier om leden in bulk uit te nodigen via kopiëren en plakken.",
+  "last_post": "Laatste bericht",
   "loading": "Laden...",
   "magic": "Magische link",
   "microsoft": "Microsoft",

--- a/sdk/gen/docs.gen/details.gen/memberships.gen.json
+++ b/sdk/gen/docs.gen/details.gen/memberships.gen.json
@@ -588,6 +588,34 @@
                       "organizationId": { "type": "string", "required": true, "format": "uuid" }
                     },
                     "ref": "#/components/schemas/MembershipBase"
+                  },
+                  "counts": {
+                    "type": "object",
+                    "required": false,
+                    "properties": {
+                      "memberships": {
+                        "type": "object",
+                        "required": true,
+                        "properties": {}
+                      },
+                      "products": {
+                        "type": "object",
+                        "required": true,
+                        "properties": {
+                          "attachment": { "type": "number", "required": true }
+                        }
+                      },
+                      "activity": {
+                        "type": "object",
+                        "required": true,
+                        "properties": {
+                          "attachment": {
+                            "type": ["number", "null"],
+                            "required": true
+                          }
+                        }
+                      }
+                    }
                   }
                 },
                 "extendsRef": "#/components/schemas/UserBase"
@@ -709,7 +737,7 @@
           "sort": {
             "type": "string",
             "required": false,
-            "enum": ["id", "name", "email", "role", "createdAt", "lastSeenAt"]
+            "enum": ["id", "name", "email", "role", "createdAt", "lastSeenAt", "lastPostedAt"]
           },
           "order": {
             "type": "string",
@@ -730,6 +758,7 @@
             "required": false,
             "enum": ["admin", "member"]
           },
+          "include": { "type": "string", "required": false },
           "userIds": { "type": "string", "required": false }
         }
       }

--- a/sdk/gen/openapi.json
+++ b/sdk/gen/openapi.json
@@ -10162,8 +10162,8 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["id", "name", "email", "role", "createdAt", "lastSeenAt"],
-              "default": "createdAt"
+              "enum": ["id", "name", "email", "role", "createdAt", "lastSeenAt", "lastPostedAt"],
+              "default": "lastSeenAt"
             },
             "required": false,
             "name": "sort",
@@ -10231,6 +10231,14 @@
             },
             "required": false,
             "name": "role",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "include",
             "in": "query"
           },
           {
@@ -10320,6 +10328,34 @@
                               },
                               "membership": {
                                 "$ref": "#/components/schemas/MembershipBase"
+                              },
+                              "counts": {
+                                "type": "object",
+                                "properties": {
+                                  "memberships": {
+                                    "type": "object",
+                                    "properties": {}
+                                  },
+                                  "products": {
+                                    "type": "object",
+                                    "properties": {
+                                      "attachment": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "required": ["attachment"]
+                                  },
+                                  "activity": {
+                                    "type": "object",
+                                    "properties": {
+                                      "attachment": {
+                                        "type": ["number", "null"]
+                                      }
+                                    },
+                                    "required": ["attachment"]
+                                  }
+                                },
+                                "required": ["memberships", "products", "activity"]
                               }
                             },
                             "required": ["lastSeenAt", "membership"]

--- a/sdk/gen/sdk.gen.ts
+++ b/sdk/gen/sdk.gen.ts
@@ -3199,6 +3199,7 @@ export const handleMembershipInvitation = <ThrowOnError extends boolean = true>(
  * @param {string} options.query.entityid - `string`
  * @param {enum} options.query.entitytype - `enum`
  * @param {enum=} options.query.role - `enum` (optional)
+ * @param {string=} options.query.include - `string` (optional)
  * @param {string=} options.query.userids - `string` (optional)
  * @returns Possible status codes: 200, 400, 401, 403, 404, 409, 429
  */

--- a/sdk/gen/types.gen.ts
+++ b/sdk/gen/types.gen.ts
@@ -4561,7 +4561,7 @@ export type GetMembersData = {
   };
   query: {
     q?: string;
-    sort?: 'id' | 'name' | 'email' | 'role' | 'createdAt' | 'lastSeenAt';
+    sort?: 'id' | 'name' | 'email' | 'role' | 'createdAt' | 'lastSeenAt' | 'lastPostedAt';
     order?: 'asc' | 'desc';
     offset?: string;
     limit?: string;
@@ -4569,6 +4569,7 @@ export type GetMembersData = {
     entityId: string;
     entityType: 'organization';
     role?: 'admin' | 'member';
+    include?: string;
     userIds?: string;
   };
   url: '/{tenantId}/{organizationId}/memberships/members';
@@ -4615,6 +4616,17 @@ export type GetMembersResponses = {
       UserBase & {
         lastSeenAt: string | null;
         membership: MembershipBase;
+        counts?: {
+          memberships: {
+            [key: string]: unknown;
+          };
+          products: {
+            attachment: number;
+          };
+          activity: {
+            attachment: number | null;
+          };
+        };
       }
     >;
     total: number;

--- a/sdk/gen/zod.gen.ts
+++ b/sdk/gen/zod.gen.ts
@@ -1711,7 +1711,10 @@ export const zGetMembersPath = z.object({
 
 export const zGetMembersQuery = z.object({
   q: z.string().max(255).optional(),
-  sort: z.enum(['id', 'name', 'email', 'role', 'createdAt', 'lastSeenAt']).optional().default('createdAt'),
+  sort: z
+    .enum(['id', 'name', 'email', 'role', 'createdAt', 'lastSeenAt', 'lastPostedAt'])
+    .optional()
+    .default('lastSeenAt'),
   order: z.enum(['asc', 'desc']).optional().default('desc'),
   offset: z.string().regex(/^\d+$/).optional(),
   limit: z.string().regex(/^\d+$/).optional(),
@@ -1722,6 +1725,7 @@ export const zGetMembersQuery = z.object({
   entityId: z.string().max(50),
   entityType: z.enum(['organization']),
   role: z.enum(['admin', 'member']).optional(),
+  include: z.string().optional(),
   userIds: z.string().optional(),
 });
 
@@ -1734,6 +1738,17 @@ export const zGetMembersResponse = z.object({
       z.object({
         lastSeenAt: z.string().nullable(),
         membership: zMembershipBase,
+        counts: z
+          .object({
+            memberships: z.record(z.string(), z.unknown()),
+            products: z.object({
+              attachment: z.number(),
+            }),
+            activity: z.object({
+              attachment: z.number().nullable(),
+            }),
+          })
+          .optional(),
       }),
     ),
   ),


### PR DESCRIPTION
Item 4 of the projectcampus seam list, generalized to cella's product set (pc counts item/comment with a publishedAt workflow cella doesn't have; cella counts attachment live rows by createdAt — forks swap the `memberStatProductTables` map and `liveAuthoredWhere`).

- `include=counts` on GET /members: per-member sub-channel membership counts, authored product counts, last-activity stamps (correlated scalar subqueries, page rows only; slim id-only total query)
- `lastPostedAt` sort; counts and that sort run under `tenantRead` (RLS-guarded product tables)
- default members sort createdAt → lastSeenAt (pairs with the COALESCE fix from #1105)
- members table requests counts and renders last-post + product-count columns; sub-channel membership columns derive from the hierarchy (none in cella's single-channel template, columns appear in forks)
- `tenantReadAs`/`resolveOrgTenantId` from pc were **not** adopted — only pc's fork-local channel routes use them
- SDK regenerated; new `c:last_post` key (en+nl)

Not sync-breaking: forks that already diverged here (pc) reconcile on sync; others gain the feature.

Checks: `pnpm check` green; backend 661 + frontend 898 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)