### PR TITLE
perf(blocknote): static document pipeline with first-pass HTML cache

### DIFF
--- a/frontend/src/modules/common/blocknote/full-html.tsx
+++ b/frontend/src/modules/common/blocknote/full-html.tsx
@@ -20,6 +20,34 @@ import { useUIStore } from '~/modules/ui/ui-store';
 const ALLOWED_URI_REGEXP =
   /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|blob):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i;
 
+/**
+ * First-pass HTML (unresolved media refs) per document string. Layout-identical to the resolved pass
+ * (media boxes are reserved via aspect-ratio), so a cache hit lets the first commit paint the document
+ * at full height synchronously; lists that measure rows (virtualizers) see the real height at once.
+ */
+const firstPassHtmlCache = new Map<string, string>();
+const FIRST_PASS_CACHE_MAX = 300;
+
+const cacheFirstPass = (document: string, html: string) => {
+  if (firstPassHtmlCache.size >= FIRST_PASS_CACHE_MAX) {
+    const oldest = firstPassHtmlCache.keys().next().value;
+    if (oldest !== undefined) firstPassHtmlCache.delete(oldest);
+  }
+  firstPassHtmlCache.set(document, html);
+};
+
+/**
+ * Computes a document's first-pass HTML into the cache ahead of render, so the component's first
+ * commit is synchronous. Calls blocksToFullHTML (flushSync inside): never call during React render
+ * or commit; an effect's async continuation is safe.
+ */
+export function precomputeDocumentHtml(document: string): void {
+  if (firstPassHtmlCache.has(document)) return;
+  const blocks = getParsedContent(document);
+  if (!blocks) return;
+  cacheFirstPass(document, getHeadlessEditor().blocksToFullHTML(blocks));
+}
+
 interface BlockNoteFullHtmlProps {
   id: string;
   defaultValue: string;
@@ -81,10 +109,11 @@ function BlockNoteFullHtml({
   const mode = useUIStore((state) => state.mode);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const [renderState, setRenderState] = useState<{ html: string; mediaItems: CarouselItemData[] }>({
-    html: '',
+  const [renderState, setRenderState] = useState<{ html: string; mediaItems: CarouselItemData[] }>(() => ({
+    // A precomputed first pass paints the document at full height in the first commit (no pop-in).
+    html: firstPassHtmlCache.get(defaultValue) ?? '',
     mediaItems: [],
-  });
+  }));
 
   const onReadyRef = useRef(onReady);
   onReadyRef.current = onReady;
@@ -106,11 +135,18 @@ function BlockNoteFullHtml({
 
     let cancelled = false;
 
-    queueMicrotask(() => {
-      if (cancelled) return;
-      const html = getHeadlessEditor().blocksToFullHTML(blocks);
-      setRenderState({ html, mediaItems: [] });
-    });
+    const cached = firstPassHtmlCache.get(defaultValue);
+    if (cached !== undefined) {
+      // Covers defaultValue changes after mount; on first mount the initializer already painted it.
+      setRenderState((prev) => (prev.html === cached ? prev : { html: cached, mediaItems: [] }));
+    } else {
+      queueMicrotask(() => {
+        if (cancelled) return;
+        const html = getHeadlessEditor().blocksToFullHTML(blocks);
+        cacheFirstPass(defaultValue, html);
+        setRenderState({ html, mediaItems: [] });
+      });
+    }
 
     async function resolveUrls(blocks: CustomBlock[]) {
       const resolveUrl = (ref: string): Promise<string> =>

--- a/frontend/src/modules/common/blocknote/lazy-full-html.ts
+++ b/frontend/src/modules/common/blocknote/lazy-full-html.ts
@@ -1,4 +1,47 @@
+import { useEffect, useRef, useState } from 'react';
 import { lazyNamed } from '~/utils/lazy-named';
 
 /** One shared lazy instance so preloading resolves the same wrapper every consumer uses, avoiding a Suspense spinner flash. */
 export const BlockNoteFullHtml = lazyNamed(() => import('~/modules/common/blocknote/full-html'), 'BlockNoteFullHtml');
+
+// Once warm, later mounts skip the gate: per-card compute lands within a frame and already-seen
+// documents render synchronously from the first-pass cache, so gating again would only add a
+// skeleton flash.
+let rendererWarm = false;
+
+/**
+ * Warms the static document renderer and precomputes the given documents' first-pass HTML,
+ * reporting when they can all render at full height in their first commit. Pass `null` while the
+ * documents are not known yet. Holding a list's skeleton on this flag turns lazy-chunk load plus
+ * per-card async HTML passes (which pop in and re-measure virtualized rows) into one reveal.
+ * Flips true once per mount and stays true; later documents compute on demand.
+ */
+export function useStaticDocumentsReady(documents: string[] | null): boolean {
+  const [ready, setReady] = useState(rendererWarm);
+  const startedRef = useRef(false);
+  const mountedRef = useRef(true);
+  // Set inside the effect so StrictMode's simulated unmount/remount leaves the flag true.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+  useEffect(() => {
+    if (ready || startedRef.current || !documents) return;
+    startedRef.current = true;
+    (async () => {
+      // The async continuation runs outside React's render/commit, which blocksToFullHTML requires.
+      const [fullHtml, helpers] = await Promise.all([
+        import('~/modules/common/blocknote/full-html'),
+        import('~/modules/common/blocknote/helpers/blocknote-helpers'),
+      ]);
+      if (!mountedRef.current) return;
+      helpers.getHeadlessEditor();
+      for (const document of documents) fullHtml.precomputeDocumentHtml(document);
+      rendererWarm = true;
+      if (mountedRef.current) setReady(true);
+    })();
+  }, [ready, documents]);
+  return ready;
+}

--- a/frontend/src/modules/common/blocknote/static-body.tsx
+++ b/frontend/src/modules/common/blocknote/static-body.tsx
@@ -1,0 +1,43 @@
+import { Suspense } from 'react';
+import { splitTitleBlocks } from '~/modules/common/blocknote/helpers/forced-title';
+import { BlockNoteFullHtml } from '~/modules/common/blocknote/lazy-full-html';
+
+interface Props {
+  id: string;
+  /** A product's `description`: a stringified block document (composer output) or legacy HTML. */
+  document: string;
+  tenantId?: string;
+  organizationId?: string;
+  className?: string;
+}
+
+/**
+ * A product description outside its card (panels, sheets): block documents render through the static
+ * renderer with the title block dropped (the host prints the name itself); anything unparseable is
+ * legacy HTML from seeds/ETL and renders as-is. Renders nothing for a title-only document.
+ */
+export function StaticDocumentBody({ id, document, tenantId, organizationId, className }: Props) {
+  let body: string | null | undefined;
+  try {
+    const blocks = JSON.parse(document);
+    if (Array.isArray(blocks)) {
+      const rest = splitTitleBlocks(blocks).body;
+      body = rest.length > 0 ? JSON.stringify(rest) : null;
+    }
+  } catch {
+    body = undefined; // not JSON: legacy HTML
+  }
+
+  if (body === null) return null;
+  if (body === undefined) {
+    // biome-ignore lint/security/noDangerouslySetInnerHtml: legacy HTML descriptions (same trust as feed cards)
+    return <div className={className} dangerouslySetInnerHTML={{ __html: document }} />;
+  }
+  return (
+    <div className={className}>
+      <Suspense fallback={null}>
+        <BlockNoteFullHtml id={id} defaultValue={body} dense tenantId={tenantId} organizationId={organizationId} />
+      </Suspense>
+    </div>
+  );
+}

--- a/frontend/src/modules/common/preserve-description-height.tsx
+++ b/frontend/src/modules/common/preserve-description-height.tsx
@@ -1,0 +1,49 @@
+import { type ReactNode, useLayoutEffect, useRef } from 'react';
+
+/**
+ * Holds the slot's last non-empty height while its content is momentarily empty, so a content swap
+ * (editor -> static description on leaving edit) cannot collapse and reflow the card. Stores only a
+ * pixel height, never content, so it can never show stale text. The height is applied imperatively
+ * (no React state) so children never re-render. A hold is released shortly after the content stays
+ * empty, so a genuinely empty description settles to its natural size.
+ */
+export function PreserveDescriptionHeight({ children }: { children: ReactNode }) {
+  const outerRef = useRef<HTMLDivElement>(null);
+  const innerRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const inner = innerRef.current;
+    const outer = outerRef.current;
+    if (!inner || !outer) return;
+
+    let releaseTimer = 0;
+    const measure = () => {
+      const hasContent = (inner.textContent?.trim().length ?? 0) > 0 || inner.querySelector('img, svg') !== null;
+      clearTimeout(releaseTimer);
+      if (hasContent) {
+        outer.style.minHeight = `${inner.offsetHeight}px`;
+      } else {
+        releaseTimer = window.setTimeout(() => {
+          outer.style.minHeight = '';
+        }, 150);
+      }
+    };
+
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(inner);
+    const mo = new MutationObserver(measure);
+    mo.observe(inner, { childList: true, subtree: true, characterData: true });
+    return () => {
+      clearTimeout(releaseTimer);
+      ro.disconnect();
+      mo.disconnect();
+    };
+  }, []);
+
+  return (
+    <div ref={outerRef}>
+      <div ref={innerRef}>{children}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
Item 5 of the projectcampus seam list, adopted as-is (all generic; comments generalized from item to product vocabulary):

- `full-html.tsx`: first-pass HTML LRU cache (300 entries) + `precomputeDocumentHtml`; a cache hit makes the first commit paint at full height synchronously, so virtualizers measure real heights immediately
- `useStaticDocumentsReady` in `lazy-full-html.ts`: warms the lazy renderer + a document set, letting lists reveal once instead of popping in per card
- `StaticDocumentBody`: description rendering outside the card (drops the forced-title block via `splitTitleBlocks`, passes legacy HTML through)
- `PreserveDescriptionHeight`: imperative min-height hold across content swaps (edit → static)

Note: no cella call sites yet — shipped as template building blocks (pc consumes them; the fork sheds this diff on next sync).

Checks: `pnpm check` green; frontend 898 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)