### PR TITLE
chore: bump biome to 2.5.10 and add channel-path resolver seam

### DIFF
--- a/cella/cella.config.ts
+++ b/cella/cella.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
       'backend/src/modules/memberships/memberships-db.ts',
       'backend/src/modules/organization/setup-config-schema.ts',
       'frontend/src/query/extra-local-user-stores.ts',
+      'frontend/src/query/realtime/register-channel-paths.ts',
       'frontend/public/favicon.ico',
       'frontend/public/favicon.svg',
       'frontend/src/nav-config.tsx',

--- a/frontend/src/list-queries-config.tsx
+++ b/frontend/src/list-queries-config.tsx
@@ -1,4 +1,5 @@
 import type { ChannelEntityType } from 'shared';
+import '~/query/realtime/register-channel-paths';
 import { attachmentsCanonicalOptions } from '~/modules/attachment/query';
 import { membersListQueryOptions } from '~/modules/memberships/query';
 import { organizationsListQueryOptions } from '~/modules/organization/query';

--- a/frontend/src/query/realtime/register-channel-paths.ts
+++ b/frontend/src/query/realtime/register-channel-paths.ts
@@ -1,0 +1,4 @@
+// App channel-path resolver seam (pinned; apps own their registration): apps with nested channels
+// call `registerChannelPathResolver` (view-declaration.ts) with a resolver reading the
+// server-computed `path` off cached channel rows; cella's single-channel hierarchy registers none.
+export {};


### PR DESCRIPTION
Straggler items 1+2 from the projectcampus seam list: biome 2.5.10 (dep + schema URL, kills a permanent contributions-diff line) and an empty pinned `register-channel-paths.ts` seam (side-effect-imported from the pinned `list-queries-config.tsx`; apps with nested channels register their resolver there, cella registers none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)