### PR TITLE
feat(ui): spotlighter page-dim overlay primitive

### DIFF
--- a/frontend/src/modules/common/app/app-layout.tsx
+++ b/frontend/src/modules/common/app/app-layout.tsx
@@ -6,6 +6,7 @@ import { Dialoger } from '~/modules/common/dialoger/provider';
 import { Dropdowner } from '~/modules/common/dropdowner/provider';
 import { ErrorNotice, type ErrorNoticeError } from '~/modules/common/error-notice';
 import { Sheeter } from '~/modules/common/sheeter/provider';
+import { Spotlighter } from '~/modules/common/spotlighter/provider';
 import { AppNav } from '~/modules/navigation/app-nav';
 import { SeenTracker } from '~/modules/seen/seen-tracker';
 import { SidebarWrapper } from '~/modules/ui/sidebar';
@@ -46,6 +47,7 @@ function AppLayout() {
           <AttachmentDialogHandler />
         </Suspense>
         <Sheeter />
+        <Spotlighter />
         <DownAlert />
         <Dropdowner />
       </ErrorBoundary>

--- a/frontend/src/modules/common/spotlighter/provider.tsx
+++ b/frontend/src/modules/common/spotlighter/provider.tsx
@@ -1,0 +1,39 @@
+import { AnimatePresence, motion } from 'motion/react';
+import { useEffect } from 'react';
+import { useSpotlighter } from '~/modules/common/spotlighter/use-spotlighter';
+
+const closeTop = () => {
+  const { stack } = useSpotlighter.getState();
+  stack[stack.length - 1]?.onClose();
+};
+
+/** The one page-dim layer, mounted in AppLayout beside the other global layers (see use-spotlighter.ts). */
+export function Spotlighter() {
+  const hasActive = useSpotlighter((state) => state.stack.length > 0);
+
+  useEffect(() => {
+    if (!hasActive) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      // Leave Esc to whatever is layered on top (dropdowns, dialogs, the editor's own handling)
+      if (event.key === 'Escape' && !event.defaultPrevented) closeTop();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [hasActive]);
+
+  return (
+    <AnimatePresence>
+      {hasActive && (
+        <motion.div
+          className="fixed inset-0 z-110 bg-black/40"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          onClick={closeTop}
+          aria-hidden="true"
+        />
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/modules/common/spotlighter/use-spotlighter.ts
+++ b/frontend/src/modules/common/spotlighter/use-spotlighter.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react';
+import { create } from 'zustand';
+
+/**
+ * Spotlighter: one page-dim overlay for in-place spotlight states (an expanded composer, a card
+ * in edit mode, a focused panel that should mute the page around it). The overlay renders
+ * once at the app root (see provider.tsx) at `z-110`, above all page and navigation chrome; the
+ * spotlit elements raise themselves above it with `spotlightLift`.
+ *
+ * The fixed z ladder: sidebar 10, sticky tab nav 80, floating nav/FAB 105, spotlight overlay 110,
+ * spotlit content 111, dialogs/sheets/dropdowns 113+ (so pickers opened from spotlit content stay
+ * usable). A lift only escapes the overlay when no ancestor between it and the app root creates its
+ * own stacking context (transform, filter, opacity, contain, positioned z-index): lift the
+ * outermost element of a region, not a node deep inside one.
+ */
+interface SpotlightEntry {
+  id: string;
+  /** Invoked on backdrop click and Esc while this entry is topmost. */
+  onClose: () => void;
+}
+
+interface SpotlighterState {
+  /** Overlapping spotlights stack (e.g. editing the one visible post of a submission view): the overlay stays up until the last one closes, and close gestures pop the top. */
+  stack: SpotlightEntry[];
+  open: (entry: SpotlightEntry) => void;
+  close: (id: string) => void;
+}
+
+export const useSpotlighter = create<SpotlighterState>((set) => ({
+  stack: [],
+  open: (entry) => set((state) => ({ stack: [...state.stack.filter((e) => e.id !== entry.id), entry] })),
+  close: (id) => set((state) => ({ stack: state.stack.filter((e) => e.id !== id) })),
+}));
+
+/** Declarative registration: the overlay shows while `active`, and backdrop/Esc call `onClose`. */
+export function useSpotlight(id: string, active: boolean, onClose: () => void) {
+  // Ref'd so a re-rendered closure never re-registers (and close always sees fresh state).
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  useEffect(() => {
+    if (!active) return;
+    useSpotlighter.getState().open({ id, onClose: () => onCloseRef.current() });
+    return () => useSpotlighter.getState().close(id);
+  }, [id, active]);
+}
+
+/** Raises an element above the overlay. Apply to the outermost element of the spotlit region. */
+export const spotlightLift = 'relative z-111';
+
+/**
+ * Lift for a row inside a virtualized list: virtua's row wrappers have `contain: layout style`
+ * (their own stacking context), so the z-index must land on the wrapper itself. The wrapper is
+ * render-owned by virtua, so the row marks itself and a global rule (styling/tailwind.css) climbs
+ * one level with `:has(>)`.
+ */
+export const spotlightLiftRow = 'spotlight-lift-row';

--- a/frontend/src/styling/tailwind.css
+++ b/frontend/src/styling/tailwind.css
@@ -200,6 +200,14 @@
   }
 }
 
+/* Spotlight lift for virtualized rows (spotlighter/use-spotlighter.ts): virtua's row wrappers have
+   `contain: layout style`, so escaping the z-110 overlay needs the z-index on the wrapper itself;
+   the row marks itself and this rule climbs one level (pairs with `spotlightLift`, relative z-111). */
+:has(> .spotlight-lift-row) {
+  position: relative;
+  z-index: 111;
+}
+
 /* Keep mobile prose near 16px despite the 18px root. Unlayered rules outrank typography utilities. */
 .prose {
   @apply max-sm:text-md;


### PR DESCRIPTION
Straggler item 5 from the projectcampus seam list. A 95-line generic UI primitive in the Dialoger/Sheeter family: one page-dim overlay at the app root, stacked entries with backdrop/Esc close, `useSpotlight` declarative registration, and the `spotlightLift`/`spotlightLiftRow` pair (+ the `:has()` rule for virtua rows). Comments generalized from fork vocabulary (milestone/submission examples). The z ladder (overlay 110 < sheets 113 < dialogs 115) is byte-identical between cella and pc, so no reconciliation was needed. Consumer-less in cella and fully inert until something opens a spotlight.

Checks: `pnpm check` green; frontend 898 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)