### PR TITLE
feat(seen): app badge counts unread notifications

### DIFF
--- a/frontend/src/modules/seen/seen-tracker.tsx
+++ b/frontend/src/modules/seen/seen-tracker.tsx
@@ -1,7 +1,8 @@
+import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { appConfig } from 'shared';
+import { notificationsQueryOptions } from '~/modules/notification/query';
 import { seenStore, setupSeenBeaconFlush } from '~/modules/seen/seen-store';
-import { useTotalUnseenCount } from './use-unseen-count';
 
 interface PeriodicSyncManager {
   register(tag: string, options?: { minInterval?: number }): Promise<void>;
@@ -43,9 +44,15 @@ export function SeenTracker() {
   return null;
 }
 
-/** Syncs the PWA app badge with the total unseen count. Badging API only (Chrome/Edge/Safari iOS 16.4+); no-ops elsewhere. */
+/**
+ * Syncs the PWA app badge with the unread NOTIFICATION count, not the unseen total: unseen counts
+ * effectively never reach zero in an active channel, and a permanently lit badge is one users
+ * learn to ignore, while unread notifications are addressed to you and clear by reading. Unseen
+ * counts stay on the in-app menu badges. Badging API only (Chrome/Edge/Safari iOS 16.4+).
+ */
 function useAppBadge() {
-  const total = useTotalUnseenCount();
+  const { data } = useQuery(notificationsQueryOptions());
+  const total = data?.unreadCount ?? 0;
 
   useEffect(() => {
     if (!('setAppBadge' in navigator)) return;


### PR DESCRIPTION
Phase 2 of `.todos/WEB_PUSH_BADGE_PLAN.md` (v2), now that #1113 gives the badge something to count: `useAppBadge()` reads the inbox `unreadCount` instead of `useTotalUnseenCount()`. Rationale per the plan: unseen counts never reach zero in an active channel (a permanently lit badge gets ignored), unread notifications self-clear — and a small, meaningful, self-clearing number is what makes push worth building in phases 3–4. Unseen counts keep their in-app menu badges; the `periodicsync` closed-app path stays until push retires it (phase 5).

Checks: `pnpm check` green; frontend 898 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)