### PR TITLE
refactor(sync): generic channel-path resolver, drop register-channel-paths seam

### DIFF
--- a/cella/cella.config.ts
+++ b/cella/cella.config.ts
@@ -47,7 +47,6 @@ export default defineConfig({
       'backend/src/modules/memberships/memberships-db.ts',
       'backend/src/modules/organization/setup-config-schema.ts',
       'frontend/src/query/extra-local-user-stores.ts',
-      'frontend/src/query/realtime/register-channel-paths.ts',
       'frontend/public/favicon.ico',
       'frontend/public/favicon.svg',
       'frontend/src/nav-config.tsx',

--- a/cella/migrations/20260902T0906-generic-channel-path-resolver/README.md
+++ b/cella/migrations/20260902T0906-generic-channel-path-resolver/README.md
@@ -1,0 +1,55 @@
+# Generic channel-path resolver replaces the register-channel-paths seam
+
+## What & why
+
+The sync engine's grant-boundary views and the fetch prioritizer's covering-channel computation
+need the root-first `path` of a cached channel row. That resolution was a fork seam: cella shipped
+an empty pinned `frontend/src/query/realtime/register-channel-paths.ts`, side-effect-imported from
+the pinned `frontend/src/list-queries-config.tsx`, and each app called
+`registerChannelPathResolver` with a loop over its own sub-organization channel types. Every app
+ended up with the same loop, differing only in the type list, and that list is already declared by
+the hierarchy. Nothing in it was app-specific: `path` is a generated column on every channel table
+via `channelColumns`, and it reaches the wire on every channel type.
+
+`resolveChannelPath` in `frontend/src/query/realtime/view-declaration.ts` now does the resolution
+itself: it iterates `hierarchy.channelTypes` minus the root and reads `path` off the cached row via
+`findInCache`. `registerChannelPathResolver` is removed, the seam file is deleted, and the pinned
+entry is gone from `cella/cella.config.ts`. An app adding a channel type no longer has to remember
+to extend a list; the hierarchy declaration is the only source.
+
+## Blast radius
+
+Sync-breaking for every app that owned a `register-channel-paths.ts`. Because that file and
+`list-queries-config.tsx` are pinned in the app, the sync keeps both, so nothing breaks at merge
+time. After the sync the app's `registerChannelPathResolver` import resolves to a missing export,
+so `pnpm check` fails until the manual steps below are done. Behavior is identical to the loop
+every known app registered: same cache lookup order, same null fallback to the organization view.
+No database or wire-shape change; `clientCacheVersion` untouched. An app with a single-channel
+hierarchy that never customized the file only needs steps 1 and 3.
+
+## Run
+
+No script — manual. Three deletions.
+
+## Manual steps
+
+1. Delete `frontend/src/query/realtime/register-channel-paths.ts` (`git rm`).
+2. Remove the `import '~/query/realtime/register-channel-paths';` line from
+   `frontend/src/list-queries-config.tsx`.
+3. Remove `'frontend/src/query/realtime/register-channel-paths.ts'` from the `pinned` list in
+   `cella/cella.config.ts`.
+4. Only if the app's resolver did something other than read `path` off cached channel rows: move
+   that logic into `resolveChannelPath` in `view-declaration.ts` and expect to carry the diff as a
+   local change. No known app does.
+
+## Verify
+
+```sh
+pnpm check
+pnpm test:core
+```
+
+`grep -rn "register-channel-paths\|registerChannelPathResolver" --include="*.ts" --include="*.tsx" .`
+(outside node_modules) must come back empty. In a running app with nested channels, open a
+sub-organization channel as a member of that channel only and confirm the catchup request body
+declares a view whose prefix is that channel's path, not just the organization id.

--- a/cella/migrations/manifest.json
+++ b/cella/migrations/manifest.json
@@ -627,6 +627,23 @@
     "pnpm check"
    ],
    "summary": "New push module: push_subscriptions table (unique-endpoint upsert, grants only, no CDC), /push subscribe/unsubscribe/VAPID routes, sender delivering {t:'notif', activityId, channelId, type} to offline subscribers of fresh notification rows (online users subtracted via their SSE user channel; 404/410 prunes, 429 backs off). Settings card gains a per-device toggle; SW gains push/notificationclick/pushsubscriptionchange and loses the periodicsync badge path. Double-gated: has.push config flag AND VAPID_* env keys. Apps run pnpm generate, set keys + flag to enable, and verify on desktop Chrome plus an installed iOS PWA."
+  },
+  {
+   "id": "20260902T0906-generic-channel-path-resolver",
+   "version": "next",
+   "title": "Generic channel-path resolver replaces the register-channel-paths seam",
+   "kind": "manual",
+   "syncBreaking": true,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "frontend/src",
+    "cella"
+   ],
+   "requires": [
+    "pnpm check"
+   ],
+   "summary": "resolveChannelPath in view-declaration.ts now reads the server-computed path off cached rows of every non-root hierarchy channel type itself; registerChannelPathResolver and the pinned frontend/src/query/realtime/register-channel-paths.ts seam are gone. Apps delete the file, drop its side-effect import from list-queries-config.tsx and remove the pinned entry from cella/cella.config.ts."
   }
  ]
 }

--- a/frontend/src/list-queries-config.tsx
+++ b/frontend/src/list-queries-config.tsx
@@ -1,5 +1,4 @@
 import type { ChannelEntityType } from 'shared';
-import '~/query/realtime/register-channel-paths';
 import { attachmentsCanonicalOptions } from '~/modules/attachment/query';
 import { membersListQueryOptions } from '~/modules/memberships/query';
 import { organizationsListQueryOptions } from '~/modules/organization/query';

--- a/frontend/src/query/realtime/register-channel-paths.ts
+++ b/frontend/src/query/realtime/register-channel-paths.ts
@@ -1,4 +1,0 @@
-// App channel-path resolver seam (pinned; apps own their registration): apps with nested channels
-// call `registerChannelPathResolver` (view-declaration.ts) with a resolver reading the
-// server-computed `path` off cached channel rows; cella's single-channel hierarchy registers none.
-export {};

--- a/frontend/src/query/realtime/view-declaration.ts
+++ b/frontend/src/query/realtime/view-declaration.ts
@@ -1,21 +1,27 @@
 import type { GetMyMembershipsResponse } from 'sdk';
+import { hierarchy } from 'shared';
 import { getRegisteredProductEntityTypes } from '~/query/basic/entity-query-registry';
+import { findInCache } from '~/query/basic/find-in-list-cache';
 import { queryClient } from '~/query/query-client';
 import { deriveGrantBoundaryViews } from '~/query/realtime/views';
 import { syncStore } from './sync-store';
 
-/** Apps register a resolver for cached sub-organization channel paths. An unknown path skips its precise grant view, and the organization baseline still covers it. */
-let channelPathResolver: (channelType: string | null, channelId: string) => string | null = () => null;
+/** Sub-organization channel types: every channel below the root carries a server-computed `path`. */
+const nestedChannelTypes = hierarchy.channelTypes.filter((type) => hierarchy.getParent(type) !== null);
 
-export function registerChannelPathResolver(
-  resolver: (channelType: string | null, channelId: string) => string | null,
-): void {
-  channelPathResolver = resolver;
-}
-
-/** `channelType` is null when the caller knows only the id, as in the fetch prioritizer's covering-prefix computation; resolvers then search their cached channel types. */
+/**
+ * Root-first id path of a cached channel row, or null when uncached; the engine then keeps the
+ * organization-wide view, so this is precision, never a correctness dependency. `channelType` is null
+ * when the caller knows only the id, as in the fetch prioritizer's covering-prefix computation; every
+ * nested channel type is searched then. Cella's single-channel hierarchy has no nested types.
+ */
 export function resolveChannelPath(channelType: string | null, channelId: string): string | null {
-  return channelPathResolver(channelType, channelId);
+  const types = channelType ? [channelType] : nestedChannelTypes;
+  for (const type of types) {
+    const row = findInCache<{ id: string; path?: string | null }>(type, channelId);
+    if (row?.path) return row.path;
+  }
+  return null;
 }
 
 /** Rebuilt from the membership cache before each catchup request: built-in org views absorb equivalent derived views, and a disappeared grant removes its own. */
@@ -27,7 +33,7 @@ export function declareViewsFromMemberships(): void {
   const derived = deriveGrantBoundaryViews({
     memberships,
     entityTypes,
-    resolvePath: (channelType, channelId) => channelPathResolver(channelType, channelId),
+    resolvePath: resolveChannelPath,
   });
 
   const store = syncStore.getState();


### PR DESCRIPTION
## Why

`frontend/src/query/realtime/register-channel-paths.ts` was a pinned fork seam: cella shipped an empty file and each app called `registerChannelPathResolver` with a loop over its sub-organization channel types reading `path` off cached rows. raak and projectcampus ended up with byte-identical loops that differ only in the type list, and that list is already declared by the hierarchy. `path` itself is a generated column from `channelColumns` on every channel table and reaches the wire on every channel type, so a fork cannot have a channel without it. Nothing in the seam was app-specific.

## What

- `resolveChannelPath` in `view-declaration.ts` now iterates `hierarchy.channelTypes` minus the root and reads `path` via `findInCache`. For cella that list is empty, so behavior is unchanged; for both forks the result is identical to what they registered.
- `registerChannelPathResolver` removed, seam file deleted, side-effect import dropped from `list-queries-config.tsx`, pinned entry removed from `cella/cella.config.ts`.
- Migration `20260902T0906-generic-channel-path-resolver` (manual, sync-breaking, no cache bump) with the three fork-side deletions and a manifest entry.

A new channel type in a fork is now covered automatically instead of depending on someone extending a list.

## Fork adoption

Both the seam file and `list-queries-config.tsx` are pinned in the forks, so sync keeps them and `pnpm check` fails on the missing `registerChannelPathResolver` export until the fork applies the migration: delete the file, drop the import line, drop the pinned entry.

## Verified

- `pnpm --filter frontend ts` clean
- `pnpm biome check .` clean
- frontend `src/query/realtime` vitest: 11 files, 92 tests pass
- `cella/migrations/run.ts --all` lists the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
