### PR TITLE
refactor(attachments): hierarchy-derived placement seam, config subpath export

### DIFF
--- a/backend/src/modules/attachment/attachment-schema.ts
+++ b/backend/src/modules/attachment/attachment-schema.ts
@@ -64,6 +64,8 @@ const attachmentCreateBodySchema = attachmentInsertSchema
     publicBucket: true,
     groupId: true,
     convertedContentType: true,
+    // Row-local public read: client-sent, the template client stamps the home channel's value.
+    publicAt: true,
   })
   .extend({
     id: validUuidSchema,

--- a/backend/src/modules/attachment/helpers/attachment-placement.ts
+++ b/backend/src/modules/attachment/helpers/attachment-placement.ts
@@ -1,5 +1,14 @@
 import type { z } from '@hono/zod-openapi';
-import { appConfig, type ChannelEntityType, hierarchy } from 'shared';
+import {
+  type AncestorChannelType,
+  appConfig,
+  type ChannelEntityType,
+  type EntityIdColumns,
+  type EntityType,
+  hierarchy,
+  type NullableAncestorType,
+  type RootChannelType,
+} from 'shared';
 import type { AuthContext } from '#/core/context';
 import { AppError } from '#/core/error';
 import type { DB } from '#/db/db';
@@ -30,8 +39,17 @@ export const attachmentPlacementFieldsSchema = Object.fromEntries(
 /** A create-body item as the placement seam sees it; apps narrow to their placement fields. */
 export type AttachmentPlacementInput = Record<string, unknown>;
 
-/** Ancestor id columns to stamp on the inserted row (null above the home); empty = org-homed. */
-export type ResolvedAttachmentPlacement = Record<string, string | null>;
+type SubOrgAncestor = Exclude<AncestorChannelType<'attachment'>, RootChannelType>;
+
+/**
+ * Ancestor id columns to stamp on the inserted row, typed like the table columns: strict ancestors
+ * are `string`, nullable ones `string | null`; empty for org-homed rows.
+ */
+export type ResolvedAttachmentPlacement = EntityIdColumns<
+  Exclude<SubOrgAncestor, NullableAncestorType<'attachment'>> & EntityType,
+  string
+> &
+  EntityIdColumns<Extract<SubOrgAncestor, NullableAncestorType<'attachment'>> & EntityType, string | null>;
 
 const providedHome = (item: AttachmentPlacementInput) =>
   placementAncestors.filter((type) => typeof item[placementKey(type)] === 'string' && item[placementKey(type)]);
@@ -57,21 +75,21 @@ export const resolveAttachmentPlacement = async (
   ctx: AuthContext,
   input: AttachmentPlacementInput,
 ): Promise<ResolvedAttachmentPlacement> => {
-  const placement: ResolvedAttachmentPlacement = Object.fromEntries(
+  const columns: Record<string, string | null> = Object.fromEntries(
     placementAncestors.map((type) => [placementKey(type), null]),
   );
   const home = providedHome(input)[0];
-  if (!home) return placement;
+  if (!home) return columns as ResolvedAttachmentPlacement;
 
   const { entity } = await getValidChannel(ctx, input[placementKey(home)] as string, home, 'read');
   const row = entity as Record<string, unknown>;
-  placement[placementKey(home)] = entity.id;
+  columns[placementKey(home)] = entity.id;
   for (const ancestor of hierarchy.getOrderedAncestors(home)) {
     if (ancestor === rootChannelType) break;
     const id = row[placementKey(ancestor)];
-    placement[placementKey(ancestor)] = typeof id === 'string' ? id : null;
+    columns[placementKey(ancestor)] = typeof id === 'string' ? id : null;
   }
-  return placement;
+  return columns as ResolvedAttachmentPlacement;
 };
 
 /**
@@ -119,4 +137,8 @@ export const seedAttachmentPlacements = async (
   _db: DB,
   organizations: { id: string; tenantId: string }[],
 ): Promise<AttachmentSeedPlacement[]> =>
-  organizations.map((org) => ({ organizationId: org.id, tenantId: org.tenantId, placement: {} }));
+  organizations.map((org) => ({
+    organizationId: org.id,
+    tenantId: org.tenantId,
+    placement: {} as ResolvedAttachmentPlacement,
+  }));

--- a/backend/src/modules/attachment/helpers/attachment-placement.ts
+++ b/backend/src/modules/attachment/helpers/attachment-placement.ts
@@ -1,8 +1,9 @@
-import { hierarchy } from 'shared';
+import { appConfig, hierarchy } from 'shared';
 import type { AuthContext } from '#/core/context';
 import { AppError } from '#/core/error';
 import type { DB } from '#/db/db';
 import type { attachmentsTable } from '#/modules/attachment/attachment-db';
+import { getValidChannel } from '#/permissions/get-valid-channel';
 
 /**
  * Create-body placement fields, spread into the create-item schema: the deepest home id only.
@@ -42,22 +43,36 @@ export const resolveAttachmentPlacement = async (
 ): Promise<ResolvedAttachmentPlacement> => ({});
 
 /**
- * Column holding a row's home channel id: list reads compile the caller's grant scope against it.
- * Org-homed rows reuse the organization column; an app with one strict home names that column.
+ * The channel type attachments home at: the deepest strict ancestor, else the root. Apps with
+ * nullable placement (rows home at any depth) keep the root here and read org-wide.
  */
-export const attachmentHomeColumnKey = 'organizationId' satisfies keyof typeof attachmentsTable.$inferSelect;
+const homeChannelType =
+  hierarchy
+    .getOrderedAncestors('attachment')
+    .find((type) => !hierarchy.getNullableAncestors('attachment').includes(type)) ?? hierarchy.rootChannelType;
+
+/** Column holding a row's home channel id: list reads compile the caller's grant scope against it. */
+export const attachmentHomeColumnKey = appConfig.entityIdColumnKeys[
+  homeChannelType
+] as keyof typeof attachmentsTable.$inferSelect;
 
 /**
  * Home channel a list or delta read narrows to, from the `channelId` query param; undefined reads
- * org-wide. Apps validate the id as one of their home channels (requiring read access on it).
- * Org-homed default: the organization is the only home, so any other id is unknown.
+ * org-wide. The organization itself (or no id) is org-wide; any other id must be a readable channel
+ * of the home type. With the root as home there is no narrower channel, so other ids are unknown.
  */
 export const resolveAttachmentHomeScope = async (
   ctx: AuthContext,
   channelId: string | undefined,
 ): Promise<string | undefined> => {
   if (!channelId || channelId === ctx.var.organization.id) return undefined;
-  throw new AppError(404, 'not_found', 'warn', { entityType: hierarchy.rootChannelType });
+  // Widened so a single-channel hierarchy does not narrow `homeChannelType` to never below.
+  const rootChannelType: string = hierarchy.rootChannelType;
+  if (homeChannelType === rootChannelType) {
+    throw new AppError(404, 'not_found', 'warn', { entityType: hierarchy.rootChannelType });
+  }
+  const { entity } = await getValidChannel(ctx, channelId, homeChannelType, 'read');
+  return entity.id;
 };
 
 /** One seed batch: the organization it belongs to and the ancestor columns its rows carry. */

--- a/backend/src/modules/attachment/helpers/attachment-placement.ts
+++ b/backend/src/modules/attachment/helpers/attachment-placement.ts
@@ -1,55 +1,85 @@
-import { appConfig, hierarchy } from 'shared';
+import type { z } from '@hono/zod-openapi';
+import { appConfig, type ChannelEntityType, hierarchy } from 'shared';
 import type { AuthContext } from '#/core/context';
 import { AppError } from '#/core/error';
 import type { DB } from '#/db/db';
 import type { attachmentsTable } from '#/modules/attachment/attachment-db';
 import { getValidChannel } from '#/permissions/get-valid-channel';
+import { validUuidSchema } from '#/schemas';
+
+const rootChannelType: string = hierarchy.rootChannelType;
+const nullableAncestors = new Set<string>(hierarchy.getNullableAncestors('attachment'));
+/** Sub-organization ancestors an attachment can home at, deepest first; none in cella. */
+const placementAncestors = hierarchy.getOrderedAncestors('attachment').filter((type) => type !== rootChannelType);
+const placementKey = (type: string) => appConfig.entityIdColumnKeys[type as ChannelEntityType];
 
 /**
- * Create-body placement fields, spread into the create-item schema: the deepest home id only.
- * This file is the attachment placement seam (pinned; apps own their fill): cella homes attachments
- * at the organization, so the defaults below expose no fields, resolve every row org-homed, read
- * lists org-wide and seed one batch per organization. An app re-homing attachments on its channel
- * chain replaces the file; the cella-owned schema, list and create ops and the seed call through it.
+ * Create-body placement fields, spread into the create-item schema. This file is the attachment
+ * placement seam (pinned; apps own their fill), with defaults derived from the hierarchy: the
+ * client sends the deepest home id only (required when that home is a strict ancestor, optional
+ * when nullable), the chain above it is read off the resolved row, and every other sub-organization
+ * ancestor column is null. cella has no sub-organization ancestors, so its rows are org-homed.
  */
-export const attachmentPlacementFieldsSchema = {};
+export const attachmentPlacementFieldsSchema = Object.fromEntries(
+  placementAncestors.map((type) => [
+    placementKey(type),
+    nullableAncestors.has(type) ? validUuidSchema.optional() : validUuidSchema,
+  ]),
+) as Record<string, z.ZodType<string | undefined>>;
 
 /** A create-body item as the placement seam sees it; apps narrow to their placement fields. */
 export type AttachmentPlacementInput = Record<string, unknown>;
 
-/**
- * Ancestor id columns to stamp on the inserted row; empty = org-homed. May also carry `publicAt`
- * when the app inherits the home channel's public-read flag server-side.
- */
+/** Ancestor id columns to stamp on the inserted row (null above the home); empty = org-homed. */
 export type ResolvedAttachmentPlacement = Record<string, string | null>;
 
-/**
- * Per-item create-body validation, anchored at the returned path relative to the item. Apps
- * reject ambiguous placement here (more than one home id per item); with no placement fields
- * there is nothing to reject.
- */
+const providedHome = (item: AttachmentPlacementInput) =>
+  placementAncestors.filter((type) => typeof item[placementKey(type)] === 'string' && item[placementKey(type)]);
+
+/** Per-item create-body validation, anchored at the returned path relative to the item: one home id at most. */
 export const validateAttachmentPlacement = (
-  _item: AttachmentPlacementInput,
-): { path: (string | number)[]; message: string } | null => null;
+  item: AttachmentPlacementInput,
+): { path: (string | number)[]; message: string } | null => {
+  const provided = providedHome(item);
+  if (provided.length <= 1) return null;
+  return {
+    path: [placementKey(provided[0])],
+    message: 'Ambiguous placement: send only the deepest home id (its ancestors are derived server-side)',
+  };
+};
 
 /**
- * Ancestor columns for one create-body item; the org-homed default stamps none. Apps resolve
- * the most specific client-sent id to a real row (requiring read access on it) and derive the
- * chain above it server-side, never from client input.
+ * Ancestor columns for one create-body item: the deepest provided id, resolved to a readable
+ * channel row, plus that row's own ancestor ids; never client input above the home. No id means
+ * org-homed, which the fields schema only allows when no strict ancestor exists.
  */
 export const resolveAttachmentPlacement = async (
-  _ctx: AuthContext,
-  _input: AttachmentPlacementInput,
-): Promise<ResolvedAttachmentPlacement> => ({});
+  ctx: AuthContext,
+  input: AttachmentPlacementInput,
+): Promise<ResolvedAttachmentPlacement> => {
+  const placement: ResolvedAttachmentPlacement = Object.fromEntries(
+    placementAncestors.map((type) => [placementKey(type), null]),
+  );
+  const home = providedHome(input)[0];
+  if (!home) return placement;
+
+  const { entity } = await getValidChannel(ctx, input[placementKey(home)] as string, home, 'read');
+  const row = entity as Record<string, unknown>;
+  placement[placementKey(home)] = entity.id;
+  for (const ancestor of hierarchy.getOrderedAncestors(home)) {
+    if (ancestor === rootChannelType) break;
+    const id = row[placementKey(ancestor)];
+    placement[placementKey(ancestor)] = typeof id === 'string' ? id : null;
+  }
+  return placement;
+};
 
 /**
  * The channel type attachments home at: the deepest strict ancestor, else the root. Apps with
  * nullable placement (rows home at any depth) keep the root here and read org-wide.
  */
 const homeChannelType =
-  hierarchy
-    .getOrderedAncestors('attachment')
-    .find((type) => !hierarchy.getNullableAncestors('attachment').includes(type)) ?? hierarchy.rootChannelType;
+  hierarchy.getOrderedAncestors('attachment').find((type) => !nullableAncestors.has(type)) ?? hierarchy.rootChannelType;
 
 /** Column holding a row's home channel id: list reads compile the caller's grant scope against it. */
 export const attachmentHomeColumnKey = appConfig.entityIdColumnKeys[
@@ -66,8 +96,6 @@ export const resolveAttachmentHomeScope = async (
   channelId: string | undefined,
 ): Promise<string | undefined> => {
   if (!channelId || channelId === ctx.var.organization.id) return undefined;
-  // Widened so a single-channel hierarchy does not narrow `homeChannelType` to never below.
-  const rootChannelType: string = hierarchy.rootChannelType;
   if (homeChannelType === rootChannelType) {
     throw new AppError(404, 'not_found', 'warn', { entityType: hierarchy.rootChannelType });
   }

--- a/cella/cella.config.ts
+++ b/cella/cella.config.ts
@@ -57,7 +57,6 @@ export default defineConfig({
       'backend/src/modules/attachment/helpers/attachment-placement.ts',
       'backend/src/modules/memberships/memberships-db.ts',
       'backend/src/modules/organization/setup-config-schema.ts',
-      'shared/app-exports.ts',
       'frontend/src/query/extra-local-user-stores.ts',
       'frontend/src/nav-config.tsx',
       'frontend/src/placement-config.ts',

--- a/cella/migrations/20260902T0945-attachment-placement-seam-v2/README.md
+++ b/cella/migrations/20260902T0945-attachment-placement-seam-v2/README.md
@@ -18,8 +18,12 @@ New seam exports (cella ships the org-homed defaults; apps replace the file):
   as one of the app's home channels and returns it; the default accepts only the organization.
 - `seedAttachmentPlacements(db, organizations)`: where the attachment seed homes its rows; return
   `[]` to skip seeding.
-- `ResolvedAttachmentPlacement` may carry `publicAt` so an app inherits the home channel's
-  public-read flag server-side instead of accepting it from the client.
+- The default fill is hierarchy-derived: the fields schema requires the deepest home id when that
+  ancestor is strict and accepts it optionally when nullable, validation rejects a second id as
+  ambiguous, and resolution reads the chain above the home off the resolved row. Apps with no
+  extra behavior keep cella's file as is.
+- `publicAt` is accepted on attachment create, as PERMISSIONS.md prescribes for every product:
+  client-sent, row-local, the template upload path stamps the home channel's value as the default.
 
 Cella-owned changes that read the seam or the hierarchy:
 
@@ -61,10 +65,9 @@ No script — manual.
 2. Create the pinned `backend/src/db/channel-tables.ts` from cella's and add one lazy getter per
    channel type (`project: () => projectsTable`, ...); add it to `pinned` in `cella/cella.config.ts`.
    Product tables that declared ancestor foreign keys by hand drop them (same constraint names).
-3. Extend the pinned `attachment-placement.ts` with `attachmentHomeColumnKey`,
-   `resolveAttachmentHomeScope` and `seedAttachmentPlacements` (see cella's default for the
-   contract). Move any `publicAt` inheritance from the client body into
-   `resolveAttachmentPlacement`.
+3. Take cella's `attachment-placement.ts` and keep only what the derived defaults do not cover
+   (typically `seedAttachmentPlacements`). Apps that inherited `publicAt` server-side send it from
+   the client instead (the upload path stamps the home channel's value).
 4. Take upstream for `attachment-schema.ts`, `get-attachments.ts`, `attachment-db.ts`,
    `20-attachment.seed.ts`, `recalculate-sequence.test.ts`, `frontend/.../query.ts`,
    `query-mutations.ts`, `parse-uploaded.ts`, `persist-attachments.ts`,

--- a/cella/migrations/20260902T0949-generic-app-adoptions/README.md
+++ b/cella/migrations/20260902T0949-generic-app-adoptions/README.md
@@ -19,9 +19,9 @@ their copies converge to identical:
 - `frontend/.../derive-description-props.ts` uses `shared/utils/derive-description-core` (cella had
   shipped the core but its own frontend still inlined the walk). `DerivedDescriptionCounts` now also
   carries `attachments: string[]`, the referenced attachment ids.
-- `shared/app-exports.ts` (pinned, empty in cella) is re-exported from `shared/index.ts`: app-owned
-  constants under `shared/config/*` reach consumers through the `shared` import without editing the
-  synced barrel.
+- `shared/package.json` exports `./config/*`, so app-owned modules under `shared/config/` (label
+  vocabularies, setup-config constants) are imported as `shared/config/<file>` the way
+  `shared/transloadit-config` already is, instead of being re-exported from the synced barrel.
 - `appConfig.memberStatProductTypes` (`['attachment']`) drives the members table stats:
   `member-counts.ts` resolves tables through `entityTables`, counts only published rows where the
   table has `publishedAt`, and stamps activity by publish time there; `members-columns.tsx` reads the
@@ -32,8 +32,9 @@ their copies converge to identical:
 
 ## Blast radius
 
-Sync-breaking only through the new `shared/app-exports.ts` import in `shared/index.ts` and the
-new `memberStatProductTypes` config key: `pnpm check` fails until both exist in the app. Everything
+Sync-breaking only through the new `memberStatProductTypes` config key: `pnpm check` fails until
+it exists in the app. `package.json` files are never synced, so the `./config/*` export is a
+manual step. Everything
 else is additive; fork copies of these files merge clean or conflict trivially (take upstream and
 re-apply what is genuinely app-specific).
 
@@ -45,8 +46,9 @@ No script — manual.
 
 1. `shared/config/config.default.ts`: add `memberStatProductTypes` (the product types the members
    table shows stats for; `['attachment']` keeps today's behavior).
-2. Create `shared/app-exports.ts` and move app-owned re-exports out of `shared/index.ts` into it
-   (raak: the label vocabulary exports). Add it to `pinned` in `cella/cella.config.ts`.
+2. Add `"./config/*": "./config/*.ts"` to `exports` in `shared/package.json`, then import
+   app-owned config modules as `shared/config/<file>` and take upstream's `shared/index.ts`
+   verbatim (raak: the label vocabulary exports).
 3. Take upstream for `tenant-context.ts`, `lib/module.ts`, `channel-route.ts`,
    `recalculate-counters.ts`, `tabs-arrangement-card.tsx`, `derive-description-props.ts` (+ test),
    `member-counts.ts`, `members-columns.tsx`, `notification-link.ts`. Keep app-only icons in

--- a/cella/migrations/manifest.json
+++ b/cella/migrations/manifest.json
@@ -701,7 +701,7 @@
     "pnpm sdk",
     "pnpm check"
    ],
-   "summary": "tenantReadAs, wider resolveEmailLink input, getCreatedChannelRoute/getNearestAncestorRoute, text-compared host ids in recalculate-counters, derive-description-core in the frontend, the pinned shared/app-exports.ts barrel, appConfig.memberStatProductTypes driving member stats, and channelRouteConfig.notificationSearch. Apps add the config key and the barrel file, then take upstream for the listed files."
+   "summary": "tenantReadAs, wider resolveEmailLink input, getCreatedChannelRoute/getNearestAncestorRoute, text-compared host ids in recalculate-counters, derive-description-core in the frontend, a ./config/* subpath export on the shared package, appConfig.memberStatProductTypes driving member stats, and channelRouteConfig.notificationSearch. Apps add the config key and the package export, then take upstream for the listed files."
   },
   {
    "id": "20260902T0950-brand-and-app-locale-ignored",

--- a/frontend/src/modules/attachment/helpers/parse-uploaded.ts
+++ b/frontend/src/modules/attachment/helpers/parse-uploaded.ts
@@ -8,8 +8,8 @@ import { createOptimisticEntity } from '~/query/basic/create-optimistic';
 export const parseUploadedAttachments = (
   result: UploadedUppyFile<'attachment'>,
   organizationId: string,
-  /** Placement seam: the deepest home channel id column (`{ projectId }`); omitted = org-homed. */
-  placement?: Record<string, string>,
+  /** Placement seam: the deepest home channel id column (`{ projectId }`) plus the channel's `publicAt` default; omitted = org-homed, private. */
+  placement?: Record<string, string | null>,
 ): Attachment[] => {
   const originalFiles = result[':original'] ?? [];
 

--- a/frontend/src/modules/attachment/table/attachments-bar.tsx
+++ b/frontend/src/modules/attachment/table/attachments-bar.tsx
@@ -37,10 +37,12 @@ export function AttachmentsTableBar({
 }: AttachmentsTableBarProps) {
   const { t } = useTranslation();
   const createDialog = useDialoger((state) => state.create);
-  // Placement seam: a sub-organization channel homes its uploads on itself; the organization row is the org.
+  // Placement seam: a sub-organization channel homes its uploads on itself; the organization row is the
+  // org. Publication is row-local, so the channel's `publicAt` is only the default a new row starts with.
   const isRoot = channel.entityType === hierarchy.rootChannelType;
   const organizationId = !isRoot && 'organizationId' in channel ? String(channel.organizationId) : channel.id;
-  const placement = isRoot ? undefined : { [appConfig.entityIdColumnKeys[channel.entityType]]: channel.id };
+  const publicAt = 'publicAt' in channel && typeof channel.publicAt === 'string' ? channel.publicAt : null;
+  const placement = { ...(isRoot ? {} : { [appConfig.entityIdColumnKeys[channel.entityType]]: channel.id }), publicAt };
   const { open } = useAttachmentsUploadDialog(channel.tenantId, organizationId, placement);
   const resolveCan = useResolveCan();
 

--- a/frontend/src/modules/attachment/table/use-attachments-upload-dialog.tsx
+++ b/frontend/src/modules/attachment/table/use-attachments-upload-dialog.tsx
@@ -12,8 +12,8 @@ const maxTotalFileSize = maxNumberOfFiles * appConfig.uppy.defaultRestrictions.m
 export const useAttachmentsUploadDialog = (
   tenantId: string,
   organizationId: string,
-  /** Placement seam: home channel id column for uploads into a sub-organization channel. */
-  placement?: Record<string, string>,
+  /** Placement seam: home channel id column and `publicAt` default for uploads into a channel. */
+  placement?: Record<string, string | null>,
 ) => {
   const createAttachments = useAttachmentCreateMutation(tenantId, organizationId);
 

--- a/sdk/gen/docs.gen/details.gen/attachments.gen.json
+++ b/sdk/gen/docs.gen/details.gen/attachments.gen.json
@@ -876,6 +876,10 @@
               "description": "MIME type of the server-converted variant; null when none.",
               "maxLength": 255
             },
+            "publicAt": {
+              "type": ["string", "null"],
+              "required": false
+            },
             "stx": {
               "type": "object",
               "required": true,

--- a/sdk/gen/openapi.json
+++ b/sdk/gen/openapi.json
@@ -9469,6 +9469,9 @@
                       "maxLength": 255,
                       "description": "MIME type of the server-converted variant; null when none."
                     },
+                    "publicAt": {
+                      "type": ["string", "null"]
+                    },
                     "stx": {
                       "$ref": "#/components/schemas/StxBase"
                     }

--- a/sdk/gen/types.gen.ts
+++ b/sdk/gen/types.gen.ts
@@ -4486,6 +4486,7 @@ export type CreateAttachmentsData = {
      * MIME type of the server-converted variant; null when none.
      */
     convertedContentType?: string | null;
+    publicAt?: string | null;
     stx: StxBase;
   }>;
   path: {

--- a/sdk/gen/zod.gen.ts
+++ b/sdk/gen/zod.gen.ts
@@ -1646,6 +1646,7 @@ export const zCreateAttachmentsBody = z
       publicBucket: z.boolean().optional(),
       groupId: z.uuid().nullish(),
       convertedContentType: z.string().max(255).nullish(),
+      publicAt: z.string().nullish(),
       stx: zStxBase,
     }),
   )

--- a/shared/app-exports.ts
+++ b/shared/app-exports.ts
@@ -1,4 +1,0 @@
-// App barrel seam (pinned; apps own it): re-exported from `shared/index.ts`, so app-owned config
-// under `shared/config/*` (which has no subpath export) reaches consumers through the `shared`
-// import without editing the synced barrel. Cella exports nothing here.
-export {};

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -8,8 +8,6 @@ export type { ConfigMode } from './src/config-builder/types.ts';
 // `hierarchy` must override these from the same synthetic instance.
 export const { isChannel, isProduct } = hierarchy;
 
-// App-owned exports (label vocabularies, setup-config constants, ...); empty in cella.
-export * from './app-exports.ts';
 export type {
   ChannelView,
   EntityHierarchy,

--- a/shared/package.json
+++ b/shared/package.json
@@ -16,7 +16,8 @@
     "./testing/*": "./src/testing/*.ts",
     "./blocknote": "./src/utils/text-from-block.ts",
     "./health-app": "./src/health-app.ts",
-    "./transloadit-config": "./config/transloadit-config.ts"
+    "./transloadit-config": "./config/transloadit-config.ts",
+    "./config/*": "./config/*.ts"
   },
   "dependencies": {
     "@blocknote/core": "^0.54.0",


### PR DESCRIPTION
## Why

#1121 was squash-merged before its last three commits were pushed. This PR carries exactly those three, cherry-picked onto main; the resulting tree is identical to the reviewed branch tip.

## What

1. **Seam review.** The `shared/app-exports.ts` barrel is replaced by a `./config/*` subpath export in `shared/package.json` (the pattern `./transloadit-config` already uses), so app-owned config modules are imported by path. The placement seam's home column and home-scope defaults derive from the hierarchy.
2. **Hierarchy-derived placement resolution.** The seam's default fields schema (deepest home id, required for a strict home, optional for a nullable one), validation (a second id is ambiguous) and resolution (chain read off the resolved row) derive from the hierarchy; both apps had hand-written exactly this. `publicAt` is accepted on attachment create as PERMISSIONS.md prescribes for products (client-sent, row-local), with the upload path stamping the home channel's value.
3. **Typed placement.** `ResolvedAttachmentPlacement` is typed from the hierarchy (strict ancestors `string`, nullable `string | null`), so a strict-home app satisfies the insert type in cella-owned code.

Migration notes for the placement seam and the generic adoptions are updated accordingly. `package.json` is never synced, so the `./config/*` export is a documented manual step for apps.

## Verified

- TypeScript for all packages, biome, style gate.
- Backend attachment, sequence and security suites: 60 tests. Frontend attachment suite: 66 tests.
- Both app adoption branches already carry these files byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
