### PR TITLE
fix(query): make revalidateIfStale reach ensureQueryData, retire two stale TODOs

### DIFF
--- a/frontend/src/modules/organization/route-logic.ts
+++ b/frontend/src/modules/organization/route-logic.ts
@@ -13,7 +13,7 @@ type OrganizationLayoutBeforeLoadArgs = {
 
 /** Loads and authorizes the organization route context. */
 export const organizationLayoutBeforeLoad = async ({ params, cause }: OrganizationLayoutBeforeLoadArgs) => {
-  // TODO [#12] Revalidate on initial entry; child useSuspenseQuery handles search param changes.
+  // Revalidate a stale organization on fresh entry only; preloads and in-route param changes reuse the cache.
   const shouldRevalidate = cause === 'enter';
 
   const { tenantId, organizationSlug } = params;

--- a/frontend/src/modules/ui/scroll-area.tsx
+++ b/frontend/src/modules/ui/scroll-area.tsx
@@ -35,7 +35,6 @@ export function ScrollArea({
     });
   }, [autoScrollOnDrag, viewportRef]);
 
-  // TODO [#13]: Remove when Base UI observes content subtrees.
   // Base UI's content ResizeObserver cannot fire while the content div is height-pinned to 100%, so a subtree
   // mutation that changes the scrollable size re-dispatches a scroll event to trigger the primitive's recompute.
   React.useEffect(() => {

--- a/frontend/src/query/basic/resolve-channel-by-slug.ts
+++ b/frontend/src/query/basic/resolve-channel-by-slug.ts
@@ -64,15 +64,17 @@ export async function resolveChannelBySlug<
   if (id) {
     const options = detailQueryOptions(id);
 
-    // Seeding the detail cache lets ensureQueryData return without blocking on a fetch; a stale entry still revalidates in the background.
+    // Seeding the detail cache lets ensureQueryData return without blocking on a fetch.
     if (cached && !queryClient.getQueryData<T>(options.queryKey)) {
       queryClient.setQueryData<T>(options.queryKey, cached);
     }
 
+    // ensureQueryData returns cached data without blocking and, with revalidateIfStale, prefetches a stale entry in the background.
+    // Background revalidation is online-only so an offline entry never leaves the detail query in an error state.
     const shouldEnsure = ensureRequiresOnline ? isOnline : true;
-    entity =
-      queryClient.getQueryData<T>(options.queryKey) ??
-      (shouldEnsure ? await queryClient.ensureQueryData({ ...options, revalidateIfStale }) : undefined);
+    entity = shouldEnsure
+      ? await queryClient.ensureQueryData({ ...options, revalidateIfStale: revalidateIfStale && isOnline })
+      : queryClient.getQueryData<T>(options.queryKey);
   } else if (isOnline) {
     entity = await fetchSlugCacheId(fetchBySlug, slugFetchCacheKey);
   }


### PR DESCRIPTION
## Summary

- **resolve-channel-by-slug**: the resolver read the detail cache first and only fell through to `ensureQueryData` when empty, so `revalidateIfStale` never reached TanStack (and an empty cache fetches regardless). `ensureQueryData` now owns the cached path: returns cached data without blocking, prefetches a stale entry in the background. Background revalidation is gated on being online so an offline entry cannot leave the detail query in an error state.
- **organization route-logic**: TODO #12 was originally committed as "TODO not working"; the rewording in #848 dropped that. With the resolver fix the `cause === 'enter'` flag does what the comment says. Comment rewritten, TODO removed. The second half of the old comment was also wrong: `refetchOnMount: false` is the global default, so the child `useSuspenseQuery` never refetched stale data.
- **scroll-area**: TODO #13 waited on Base UI observing content subtrees. The workaround exists because our content div is height-pinned to 100%, so Base UI's own content ResizeObserver can never fire; there is no upstream event to wait for (Base UI 1.7.0, latest, still observes only the content box). Marker dropped, explanation kept.

## Fork impact

`resolve-channel-by-slug.ts` and `organization/route-logic.ts` are byte-identical in raak and projectcampus; raak's workspace/project route-logic do not pass `revalidateIfStale`. Flows through a normal sync.

## Verification

- `pnpm --filter frontend ts` clean, biome clean on the three touched files
- No runtime test exists for the resolver; behavior verified against query-core 5.102 `ensureQueryData` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)