### PR TITLE
refactor(memberships): members-config seam, hierarchy-aware test seeds from fork drift

### DIFF
--- a/backend/src/mocks/product-mock-registry.ts
+++ b/backend/src/mocks/product-mock-registry.ts
@@ -1,5 +1,5 @@
 import { getTableColumns } from 'drizzle-orm';
-import type { ProductEntityType } from 'shared';
+import { appConfig, hierarchy, type ProductEntityType } from 'shared';
 import { appProductMocks } from '#/mocks/app-product-mocks';
 import { mockAttachment } from '#/modules/attachment/attachment-mocks';
 import { getEntityTable } from '#/tables';
@@ -29,10 +29,15 @@ export function buildInsertableProduct(
       .filter(([, column]) => column.generated)
       .map(([prop]) => prop),
   );
+  // Nullable ancestors insert as null (org-homed) unless overridden: the SELECT-shape mock invents
+  // ids that never satisfy the ancestor foreign keys channelRelationColumns declares.
+  const nullableAncestorKeys = new Set<string>(
+    hierarchy.getNullableAncestors(entityType).map((type) => appConfig.entityIdColumnKeys[type]),
+  );
   const row: Record<string, unknown> = {};
   for (const [prop, value] of Object.entries(mock)) {
     if (generatedProps.has(prop)) continue;
-    row[prop] = value;
+    row[prop] = nullableAncestorKeys.has(prop) ? null : value;
   }
   return { ...row, ...overrides };
 }

--- a/backend/tests/integration/cdc-event-bus.test.ts
+++ b/backend/tests/integration/cdc-event-bus.test.ts
@@ -21,12 +21,14 @@ const mockEventWithData = (key: string): ActivityEvent =>
   }) as ActivityEvent;
 
 import { eq, sql } from 'drizzle-orm';
+import { buildTestEntityHierarchyPlan, type TestEntityHierarchyPlan } from 'shared/testing/entity-hierarchy';
 import { buildInsertableProduct } from '#/mocks';
 import { attachmentsTable } from '#/modules/attachment/attachment-db';
 import { channelCountersTable } from '#/modules/entities/channel-counters-db';
 import { mockChannelMembership } from '#/modules/memberships/memberships-mocks';
 import { mockOrganization } from '#/modules/organization/organization-mocks';
 import { mockUser } from '#/modules/user/user-mocks';
+import { cleanupEntityHierarchy, seedEntityHierarchy } from '../hierarchy-helpers';
 import { clearDatabase, ensureCdcSetup, startInProcessCdcWorker, waitFor, waitForEvent } from './test-utils';
 
 // Covers local ActivityBus events and the full DB change to CDC worker to WebSocket path.
@@ -74,6 +76,8 @@ describe.skipIf(process.env.TEST_MODE !== 'full')('Full CDC Flow', () => {
   let cdcHarness: Awaited<ReturnType<typeof startInProcessCdcWorker>>;
   let testOrg: { id: string; slug: string; tenantId: string };
   let testUser: { id: string; email: string };
+  // Ancestor chain derived from the app hierarchy; an org-only app seeds nothing.
+  let plan: TestEntityHierarchyPlan;
 
   beforeAll(async () => {
     cdcHarness = await startInProcessCdcWorker();
@@ -91,10 +95,19 @@ describe.skipIf(process.env.TEST_MODE !== 'full')('Full CDC Flow', () => {
     const userData = mockUser();
     [testUser] = await db.insert(usersTable).values(userData).returning({ id: usersTable.id, email: usersTable.email });
     await db.insert(emailsTable).values({ email: testUser.email, userId: testUser.id, verified: true });
+
+    // Strict sub-organization ancestor columns carry foreign keys, so their rows must exist.
+    plan = buildTestEntityHierarchyPlan({
+      entityType: 'attachment',
+      rootChannelId: testOrg.id,
+      makeChannelId: () => crypto.randomUUID(),
+    });
+    await seedEntityHierarchy(db, plan, { tenantId: testOrg.tenantId, createdBy: testUser.id, slugPrefix: 'cdc-seq' });
   });
 
   afterAll(async () => {
     await cdcHarness?.stop();
+    await cleanupEntityHierarchy(db, plan);
     await clearDatabase();
   });
 
@@ -123,7 +136,7 @@ describe.skipIf(process.env.TEST_MODE !== 'full')('Full CDC Flow', () => {
       {
         id: attachmentId,
         tenantId: testOrg.tenantId,
-        organizationId: testOrg.id,
+        ...plan.channelIdColumns,
         createdBy: testUser.id,
         updatedBy: testUser.id,
         seq: 0,

--- a/cella/cella.config.ts
+++ b/cella/cella.config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
       'frontend/src/query/extra-local-user-stores.ts',
       'frontend/src/nav-config.tsx',
       'frontend/src/placement-config.ts',
+      'frontend/src/members-config.ts',
       'frontend/src/routes-config.tsx',
       'frontend/src/menu-config.tsx',
       'frontend/src/alert-config.tsx',

--- a/cella/migrations/20260902T1355-members-config-and-hierarchy-test-seeds/README.md
+++ b/cella/migrations/20260902T1355-members-config-and-hierarchy-test-seeds/README.md
@@ -1,0 +1,61 @@
+# Members table config seam and hierarchy-aware test seeds
+
+## What & why
+
+Two things landed together, both distilled from fork drift after the 2026-09-02 syncs.
+
+**Members table config seam.** `frontend/src/modules/memberships/members-table/members-columns.tsx`
+hardcoded the icon per product stat (`memberStatIcons`) and offered no way to hide a count column
+by default. Apps with their own product types (projectcampus: item and comment) had to edit the
+template file. Both knobs now live in the new pinned, app-owned `frontend/src/members-config.ts`:
+`memberStatIcons` (icon per `appConfig.memberStatProductTypes` entry, `BoxIcon` fallback) and
+`hiddenMemberCountColumns` (product and sub-channel `${type}Count` columns hidden until the user
+toggles them on). Cella ships the attachment paperclip and hides nothing.
+
+**Hierarchy-aware test seeds.** Since the ancestor foreign keys of `channelRelationColumns`
+(20260902T0906), invented ancestor ids no longer insert. Three template files now derive them:
+
+- `backend/src/mocks/product-mock-registry.ts`: `buildInsertableProduct` inserts nullable
+  ancestors as null unless overridden (`hierarchy.getNullableAncestors`).
+- `backend/tests/integration/cdc-event-bus.test.ts` (full mode): seeds the attachment's ancestor
+  chain through `buildTestEntityHierarchyPlan` and `seedEntityHierarchy`, then spreads
+  `plan.channelIdColumns` into the insert.
+- `yjs/src/tests/integration/permissions.test.ts`: seeds every `ancestorColumns` entry of nested
+  channel rows, not only the parent.
+
+All three are no-ops on cella's org-only hierarchy; they exist for apps with nested channels.
+
+## Blast radius
+
+Not sync-breaking, no `clientCacheVersion` bump, no database change. An app that never touched
+`members-columns.tsx` and never patched these tests is unaffected beyond taking upstream and
+adding the pin. raak and projectcampus carry fork-marked versions of the three test and mock files
+that are byte-for-byte the upstream logic with a different comment; the sync merge reports them as
+diverged on that comment hunk only.
+
+## Run
+
+No script — manual.
+
+## Manual steps
+
+1. Add `'frontend/src/members-config.ts'` to `pinned` in `cella/cella.config.ts` (next to
+   `placement-config.ts`).
+2. If your `members-columns.tsx` drifted for icons or default-hidden columns, move those values
+   into `frontend/src/members-config.ts` (`memberStatIcons`, `hiddenMemberCountColumns`) and take
+   upstream for `members-columns.tsx`.
+3. Take upstream for `backend/src/mocks/product-mock-registry.ts`,
+   `backend/tests/integration/cdc-event-bus.test.ts` and
+   `yjs/src/tests/integration/permissions.test.ts` if your copies carry the fork-marked version of
+   the same change (only the comment differs).
+
+## Verify
+
+```sh
+pnpm cella analyze
+pnpm check
+pnpm test
+```
+
+`cella analyze` should list none of the four files as drifted or diverged; `members-config.ts`
+shows as protected.

--- a/cella/migrations/manifest.json
+++ b/cella/migrations/manifest.json
@@ -719,6 +719,26 @@
     "pnpm check"
    ],
    "summary": "favicons, thumbnail.png, logo.tsx, legal-config.ts and locales/*/app.json move from pinned to ignored in the template cella.config.ts; cella's onboarding copy moves from app.json to common.json. Apps take upstream's lists, drop stale ignores and re-adopt comment-only pins."
+  },
+  {
+   "id": "20260902T1355-members-config-and-hierarchy-test-seeds",
+   "version": "next",
+   "title": "Members table config seam and hierarchy-aware test seeds",
+   "kind": "manual",
+   "syncBreaking": false,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "frontend/src",
+    "backend/src/mocks",
+    "backend/tests",
+    "yjs/src/tests"
+   ],
+   "requires": [
+    "pnpm check",
+    "pnpm test"
+   ],
+   "summary": "memberStatIcons and hiddenMemberCountColumns move out of members-columns.tsx into the new pinned frontend/src/members-config.ts; buildInsertableProduct, the CDC event-bus test and the yjs permissions test derive ancestor ids from the hierarchy instead of inventing them. Apps add the pin, move their icon and hidden-column values into members-config.ts, and take upstream for the four files."
   }
  ]
 }

--- a/frontend/src/members-config.ts
+++ b/frontend/src/members-config.ts
@@ -1,0 +1,18 @@
+import { type LucideIcon, PaperclipIcon } from 'lucide-react';
+import type { ChannelEntityType, ProductEntityType } from 'shared';
+
+/**
+ * App configuration for the per-member insight columns in the members table. Which product stats
+ * exist comes from `appConfig.memberStatProductTypes`; this file decides how they look. Cella ships
+ * the attachment paperclip and hides nothing; apps map their own product types here without
+ * editing the template's members-columns.
+ */
+export const memberStatIcons: Partial<Record<ProductEntityType, LucideIcon>> = {
+  attachment: PaperclipIcon,
+};
+
+/**
+ * Count columns (`${type}Count`, product and sub-channel types alike) hidden by default. Users can
+ * still toggle them on via the columns view.
+ */
+export const hiddenMemberCountColumns: readonly (ProductEntityType | ChannelEntityType)[] = [];

--- a/frontend/src/modules/memberships/members-table/members-columns.tsx
+++ b/frontend/src/modules/memberships/members-table/members-columns.tsx
@@ -1,7 +1,8 @@
-import { BoxIcon, type LucideIcon, PaperclipIcon } from 'lucide-react';
+import { BoxIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { appConfig, type ChannelEntityType, hierarchy, isChannel } from 'shared';
+import { hiddenMemberCountColumns, memberStatIcons } from '~/members-config';
 import { enumSelectEditorOptions, RenderEnumSelect } from '~/modules/common/data-grid/cell-renderers';
 import { CheckboxColumn } from '~/modules/common/data-table/checkbox-column';
 import type { ColumnOrColumnGroup } from '~/modules/common/data-table/types';
@@ -11,10 +12,8 @@ import { UserCell } from '~/modules/user/user-cell';
 import { dateShort } from '~/utils/date-short';
 
 // Product types with per-member stat columns, from config (the response only carries these keys).
+// Their icons and the count columns hidden by default are app-owned in members-config.
 const memberStatProductTypes = appConfig.memberStatProductTypes;
-const memberStatIcons: Partial<Record<string, LucideIcon>> = {
-  attachment: PaperclipIcon,
-};
 
 export const useColumns = (isAdmin: boolean, isSheet: boolean, entityType: ChannelEntityType) => {
   const { t } = useTranslation();
@@ -123,6 +122,7 @@ export const useColumns = (isAdmin: boolean, isSheet: boolean, entityType: Chann
         return {
           key: `${type}Count`,
           name: t(`c:${type}`, { count: 2 }),
+          hidden: hiddenMemberCountColumns.includes(type),
           minBreakpoint: 'md',
           minWidth: 60,
           maxWidth: 120,
@@ -143,6 +143,7 @@ export const useColumns = (isAdmin: boolean, isSheet: boolean, entityType: Chann
           (type): ColumnOrColumnGroup<Member> => ({
             key: `${type}Count`,
             name: t(`c:${type}`, { count: 2, defaultValue: type }),
+            hidden: hiddenMemberCountColumns.includes(type),
             minBreakpoint: 'md',
             minWidth: 60,
             maxWidth: 120,

--- a/yjs/src/tests/integration/permissions.test.ts
+++ b/yjs/src/tests/integration/permissions.test.ts
@@ -55,7 +55,16 @@ async function seedEntityHierarchy(
   slugPrefix: string,
 ) {
   for (const row of plan.seedChannelRows) {
-    const columns = ['id', 'tenant_id', 'entity_type', 'name', 'slug', 'created_by', row.parentColumnName];
+    // Every ancestor id column is NOT NULL on nested channel tables, so seed all of them, not only the parent.
+    const columns = [
+      'id',
+      'tenant_id',
+      'entity_type',
+      'name',
+      'slug',
+      'created_by',
+      ...row.ancestorColumns.map((column) => column.columnName),
+    ];
     const values = [
       row.id,
       tenantId,
@@ -63,7 +72,7 @@ async function seedEntityHierarchy(
       `Authz ${row.channelType}`,
       `${slugPrefix}-${row.channelType}-${row.id.slice(0, 8)}`,
       createdBy,
-      row.parentId,
+      ...row.ancestorColumns.map((column) => column.id),
     ];
     const placeholders = values.map((_, i) => `$${i + 1}`).join(', ');
 


### PR DESCRIPTION
## Summary

Distills the four files raak and projectcampus reported as drifted after today's syncs (raak #132, projectcampus #65) into template changes, so the next fork sync clears them.

**Members table config seam.** `members-columns.tsx` hardcoded the icon per product stat and had no way to hide a count column by default; projectcampus edited the file for its item/comment icons and to hide the course count. Both knobs now live in the new pinned, app-owned `frontend/src/members-config.ts` (`memberStatIcons`, `hiddenMemberCountColumns`). Cella ships the attachment paperclip and hides nothing, so behavior is unchanged here.

**Hierarchy-aware test seeds.** Since the ancestor foreign keys of `channelRelationColumns` (#1122), invented ancestor ids no longer insert. Three files now derive them, all no-ops on cella's org-only hierarchy:

- `backend/src/mocks/product-mock-registry.ts`: `buildInsertableProduct` inserts nullable ancestors as null unless overridden (from projectcampus).
- `backend/tests/integration/cdc-event-bus.test.ts`: seeds the attachment's ancestor chain via `buildTestEntityHierarchyPlan` + `seedEntityHierarchy`, spreads `plan.channelIdColumns` into the insert (from raak).
- `yjs/src/tests/integration/permissions.test.ts`: seeds every `ancestorColumns` entry of nested channel rows, not only the parent (from projectcampus).

**Migration** `20260902T1355-members-config-and-hierarchy-test-seeds` (manual, not sync-breaking): add the pin, move icon and hidden-column values into `members-config.ts`, take upstream for the four files. Forks currently carry fork-marked copies of the three test/mock files that differ only in the comment, so the sync merge will report a diverged comment hunk there.

## Verification

- `pnpm check` clean, no generated-file churn
- `pnpm frontend:style` no violations in touched files
- `TEST_MODE=full vitest run` on the three suites: 3 files, 12 tests passed (CDC flow ran against `cella_db_test`)
- `cella/migrations/run.ts` lists the new entry as pending #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)
