### PR TITLE
fix(frontend): compile an app's root-level CHANGELOG.md in MDX, build the frontend in PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: CI
 permissions: {}
 
 # CI runs on pull_request only (there is no merge queue). Two tiers of checks:
-#   • Every PR: cheap checks (lint, pr-title, schema-bust-gate) for fast feedback.
+#   • Every PR: cheap checks (lint, pr-title, schema-bust-gate, frontend-build) for fast feedback.
 #   • Release PR only: the heavy suites (test, storybook-test) run on the
 #     release-please PR. That PR is what you merge to cut the release + deploy,
 #     so gating its merge gates production. On feature PRs these jobs are
@@ -84,6 +84,34 @@ jobs:
       # (infra/resources/compute.ts), so a stale copy must fail the PR.
       - name: Check compose model artifact is committed
         run: pnpm --filter infra compose:check
+
+  # Production frontend build. Cheap (~1 min): runs on every PR. Some breakage only surfaces at
+  # build time (a repo-doc import the MDX include regex refuses, a broken relative import in a
+  # docs wrapper) and would otherwise fail the release deploy, which builds the frontend from the tag.
+  # Apps keep their release-please CHANGELOG.md at the repo root, a path cella itself never builds.
+  frontend-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend
+        run: pnpm --filter frontend build
 
   # Runs all tests (full mode with PostgreSQL). Heavy: runs on the release PR only.
   # `pnpm test:full` starts the `db_test` compose container (DB_TEST_PORT) and applies

--- a/cella/RELEASES.md
+++ b/cella/RELEASES.md
@@ -23,7 +23,7 @@ Production deploys fire only when the `cella` GitHub Release is published: [depl
 
 The heavy suites (full tests + Storybook component tests) run **only on the release-please PR**, as required status checks in [ci.yml](../.github/workflows/ci.yml):
 
-- Feature PRs run cheap checks only (`lint`, `pr-title`, `schema-bust-gate`). The heavy jobs report `skipped`, which a required check treats as a pass.
+- Feature PRs run cheap checks only (`lint`, `pr-title`, `schema-bust-gate`, `frontend-build`). The heavy jobs report `skipped`, which a required check treats as a pass.
 - Each merge to `main` refreshes the release PR, and the heavy jobs run for real against current `main`.
 - The release PR cannot merge until they pass, so a broken `main` blocks the release before any tag or deploy.
 

--- a/frontend/src/content/docs/wrapper-imports.test.ts
+++ b/frontend/src/content/docs/wrapper-imports.test.ts
@@ -13,8 +13,8 @@ function collectPages(dir: string): string[] {
   });
 }
 
-// Guards relative imports in docs wrappers because PR CI does not run the frontend build.
-// Broken repo-doc imports otherwise fail only at build time.
+// Guards relative imports in docs wrappers with a fast, local check. The `frontend-build` CI job
+// catches the same breakage, but only after a full production build.
 describe('docs content wrapper imports', () => {
   const pages = collectPages(contentRoot);
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -334,8 +334,9 @@ const viteConfig = {
     {
       enforce: 'pre' as const,
       ...mdx({
-        // Repo docs live under cella/ only; an app's root-level SHOUTCASE .md (README, CHANGELOG) are not doc pages.
-        include: /\/(src\/content\/docs\/.*\.(md|mdx)|cella\/[A-Z][A-Z_]*\.md|[a-z-]+\/README\.md)$/,
+        // Template docs live under cella/. An app keeps its release-please CHANGELOG.md at the repo root
+        // (cella/CHANGELOG.md is template-owned and overwritten on sync), so root-level SHOUTCASE .md compile too.
+        include: /\/(src\/content\/docs\/.*\.(md|mdx)|(cella\/)?[A-Z][A-Z_]*\.md|[a-z-]+\/README\.md)$/,
         format: 'detect',
         // Read component overrides (links, headings) from MDXProvider context. A
         // `components` prop does not cross into imported modules, and wrapper pages


### PR DESCRIPTION
## Summary
- The MDX `include` regex in `frontend/vite.config.ts` only accepted SHOUTCASE `.md` under `cella/`. An app's release-please `CHANGELOG.md` lives at the repo root by design (`cella/CHANGELOG.md` is template-owned and overwritten on sync; `frontend/src/content` is app-owned via the sync ignore list), so the only file an app's changelog page can import was refused and rolldown parsed it as JS. That failed raak's 0.1.11 release deploy: https://github.com/cellajs/raak/actions/runs/33680919827 (`[PARSE_ERROR] Invalid Character` at `../CHANGELOG.md:1:2`). Make `cella/` optional in the include.
- Add a `frontend-build` job to PR CI (every PR, ~1 min). The release deploy is the first place any app builds the frontend, and cella itself never builds a root-level changelog, so this class of bug could not surface upstream before.
- Update RELEASES.md's cheap-checks list and the wrapper-imports test comment (it said PR CI does not build the frontend).

Follow-up (repo settings, not in this PR): add `frontend-build` to the required checks in the `main` ruleset.

## Test plan
- [x] Reproduced in the worktree with a root `CHANGELOG.md` + a docs page importing it: old regex fails with the same `PARSE_ERROR`, new regex builds.
- [x] `pnpm --filter frontend build` passes (19s locally).
- [x] `pnpm biome check`, `pnpm prose:check`, wrapper-imports test pass.
- [ ] `frontend-build` job green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)