### PR TITLE
fix(docs): let a newer commit overtake the frontmatter updatedAt stamp

### DIFF
--- a/frontend/vite/README.md
+++ b/frontend/vite/README.md
@@ -4,7 +4,7 @@ The frontend Vite config treats documentation as content, not application source
 
 `docs-frontmatter.ts` builds two virtual modules without importing page components: `virtual:docs-frontmatter` holds page metadata and headings for navigation; `virtual:docs-search-sections` holds bounded plaintext sections loaded only by search. Heading extraction must match the MDX `rehype-slug` config in `vite.config.ts`, including its `spy-` prefix and per-file GitHub slugger state.
 
-Wrapper pages combine their own metadata with imported repository documents. `updatedAt` is the newest commit date across the wrapper and imported bodies unless frontmatter pins a date; filesystem mtime is the fallback for untracked files and repos without usable Git history.
+Wrapper pages combine their own metadata with imported repository documents. `updatedAt` is the newest of the frontmatter `updatedAt` stamp and the commit dates of the wrapper and imported bodies, so a stamp written by the editor counts only until a later commit overtakes it; filesystem mtime is the fallback for untracked files and repos without usable Git history.
 
 Development builds add `docs-editor.ts`, which lets the pages table rewrite frontmatter and move files under `src/content/docs`. Moving a page changes its parent because the content directory is the hierarchy. The frontmatter watcher rebuilds the virtual indexes and reloads the page after each write. Production builds have no editing endpoint.
 

--- a/frontend/vite/docs-frontmatter.ts
+++ b/frontend/vite/docs-frontmatter.ts
@@ -140,11 +140,11 @@ function parseFrontmatter(source: string): unknown {
   return match ? parse(match[1]) : {};
 }
 
-/** Derive unpinned page `updatedAt` from the newest Git date across its imported documents. */
+/** Page `updatedAt`: newest of the frontmatter stamp and the Git dates of the page and its imported documents. */
 function withUpdatedAt(frontmatter: unknown, files: string[], resolver: UpdatedAtResolver): unknown {
   const record = frontmatter && typeof frontmatter === 'object' ? (frontmatter as Record<string, unknown>) : {};
-  const pinned = typeof record.updatedAt === 'string' ? record.updatedAt : undefined;
-  const updatedAt = resolver.resolve(files, pinned);
+  const stamped = typeof record.updatedAt === 'string' ? record.updatedAt : undefined;
+  const updatedAt = resolver.resolve(files, stamped);
   return updatedAt ? { ...record, updatedAt } : frontmatter;
 }
 

--- a/frontend/vite/git-updated-at.test.ts
+++ b/frontend/vite/git-updated-at.test.ts
@@ -10,17 +10,26 @@ describe('createUpdatedAtResolver', () => {
 
   const asMs = (iso: string | undefined) => (iso ? Date.parse(iso) : Number.NaN);
 
-  it('returns an author-pinned date verbatim, ignoring the files', () => {
-    const pin = '2020-01-02T03:04:05.000Z';
-    expect(resolver.resolve([existing, alsoExisting], pin)).toBe(pin);
-    // A pin wins even when no file exists at all.
-    expect(resolver.resolve([missing], pin)).toBe(pin);
+  it('lets a newer commit overtake an older frontmatter stamp', () => {
+    const stale = '2020-01-02T03:04:05.000Z';
+    const result = resolver.resolve([existing, alsoExisting], stale);
+    expect(result).not.toBe(stale);
+    expect(asMs(result)).toBe(asMs(resolver.resolve([existing, alsoExisting])));
   });
 
-  it('ignores a blank pin and derives from the file instead', () => {
-    const result = resolver.resolve([existing], '   ');
-    expect(result).not.toBe('   ');
-    expect(Number.isNaN(asMs(result))).toBe(false);
+  it('keeps a stamp that is newer than every file date', () => {
+    const future = '2999-01-02T03:04:05.000Z';
+    expect(resolver.resolve([existing, alsoExisting], future)).toBe(future);
+    // With no existing file the stamp is the only candidate.
+    expect(resolver.resolve([missing], future)).toBe(future);
+  });
+
+  it('ignores a blank or unparsable stamp and derives from the file instead', () => {
+    for (const bad of ['   ', 'not-a-date']) {
+      const result = resolver.resolve([existing], bad);
+      expect(result).not.toBe(bad);
+      expect(Number.isNaN(asMs(result))).toBe(false);
+    }
   });
 
   it('derives a valid ISO date for an existing file (git date, else mtime)', () => {
@@ -29,7 +38,7 @@ describe('createUpdatedAtResolver', () => {
     expect(Number.isNaN(asMs(result))).toBe(false);
   });
 
-  it('returns undefined when nothing resolves (no pin, no existing files)', () => {
+  it('returns undefined when nothing resolves (no stamp, no existing files)', () => {
     expect(resolver.resolve([missing])).toBeUndefined();
     expect(resolver.resolve([])).toBeUndefined();
   });

--- a/frontend/vite/git-updated-at.ts
+++ b/frontend/vite/git-updated-at.ts
@@ -12,11 +12,12 @@ function laterIso(a: string | undefined, b: string | undefined): string | undefi
 
 export type UpdatedAtResolver = {
   /**
-   * Newest "updated" ISO date across `files` (a page plus its imported docs),
-   * or `pinned` when the page frontmatter sets one explicitly. `undefined` only
-   * when nothing resolves (no pin, no existing files).
+   * Newest "updated" ISO date across `files` (a page plus its imported docs) and
+   * the frontmatter `stamped` date, if any. A stamp is what the dev editor writes on
+   * an edit; a later commit touching the page or an imported doc overtakes it.
+   * `undefined` only when nothing resolves (no stamp, no existing files).
    */
-  resolve(files: string[], pinned?: string): string | undefined;
+  resolve(files: string[], stamped?: string): string | undefined;
   /** Absolute git work-tree root, or null when not inside a repo (probed once). */
   readonly repoRoot: string | null;
 };
@@ -61,10 +62,8 @@ export function createUpdatedAtResolver(fromDir: string): UpdatedAtResolver {
 
   return {
     repoRoot,
-    resolve(files, pinned) {
-      if (typeof pinned === 'string' && pinned.trim()) return pinned;
-
-      let newest: string | undefined;
+    resolve(files, stamped) {
+      let newest = stamped && Number.isFinite(Date.parse(stamped)) ? stamped : undefined;
       for (const file of files) {
         const mtime = mtimeMs(file);
         if (mtime === undefined) continue;


### PR DESCRIPTION
## Problem

The dev docs editor (`/docs/pages`) stamps `updatedAt` into a page's frontmatter on every edit. The frontmatter resolver treated any `updatedAt` as a permanent pin and never consulted git for that page again. Three pages carry stamps from the July sequence-sync editor session, so `/docs/page/architecture/sync-engine` showed July 18 after `cella/SYNC_ENGINE.md` was edited in #1132 on September 4.

## Change

`updatedAt` is a single field with one rule: newest wins across the frontmatter stamp, the wrapper's last commit, and the last commit of each imported repo doc.

- A stamp newer than every commit still shows, so the editor's stamp keeps meaning "edited just now" until it is committed.
- A later commit overtakes a stale stamp, so imported-body edits are visible again.
- Blank or unparsable stamps are ignored.

The three stale stamps are left in place: they are now harmless and the editor will keep writing them.

## Verified

- `vitest` on `git-updated-at.test.ts` and `docs-editor.test.ts`: 15 passed.
- Resolver probe on the real sync-engine wrapper with its July stamp resolves to `2026-09-04T08:46:00+02:00`.
- Frontend `tsgo --noEmit` and `biome check frontend/vite` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
