### PR TITLE
feat(nav): notifications sheet tuning, drop home nav button, shared nav sheet frame

### DIFF
--- a/frontend/src/modules/navigation/account-nav-icon.tsx
+++ b/frontend/src/modules/navigation/account-nav-icon.tsx
@@ -1,11 +1,11 @@
-import { UserIcon } from 'lucide-react';
 import { EntityAvatar } from '~/modules/common/entity-avatar';
+import type { IconComponent } from '~/modules/common/icons/types';
 import { useUserStore } from '~/modules/user/user-store';
 
-export function AccountNavIcon({ className }: { className?: string }) {
+export function AccountNavIcon({ className, icon: Icon }: { className?: string; icon: IconComponent }) {
   const { user } = useUserStore();
 
-  if (!user) return <UserIcon className={className} strokeWidth={1.8} />;
+  if (!user) return <Icon className={className} strokeWidth={1.8} />;
 
   return (
     <EntityAvatar

--- a/frontend/src/modules/navigation/account-sheet.tsx
+++ b/frontend/src/modules/navigation/account-sheet.tsx
@@ -10,8 +10,7 @@ import { EntityAvatar } from '~/modules/common/entity-avatar';
 import type { IconComponent } from '~/modules/common/icons/types';
 import { useSheeter } from '~/modules/common/sheeter/use-sheeter';
 import { toaster } from '~/modules/common/toaster/toaster';
-import { FocusBridge, FocusTarget } from '~/modules/navigation/focus-bridge';
-import { MenuSheetPanels } from '~/modules/navigation/menu-sheet/sheet-panel';
+import { NavSheetFrame } from '~/modules/navigation/nav-sheet-frame';
 import { useNavigationStore } from '~/modules/navigation/navigation-store';
 import { Button } from '~/modules/ui/button';
 import { useCurrentUser, useUserStore } from '~/modules/user/user-store';
@@ -75,8 +74,7 @@ export function AccountSheet() {
   }, []);
 
   return (
-    <div ref={buttonWrapper} className="group/menu flex min-h-dvh w-full flex-col bg-card">
-      <FocusTarget target="sheet" />
+    <NavSheetFrame ref={buttonWrapper} panels>
       <div className="flex items-center justify-between px-3 pt-3">
         <h2 className="p-2 font-semibold text-base">{t('c:account')}</h2>
       </div>
@@ -148,14 +146,6 @@ export function AccountSheet() {
           action="/auth/sign-out"
         />
       </div>
-
-      <span className="mt-10" />
-      <MenuSheetPanels />
-
-      <div className="flex flex-col focus-within:p-3">
-        <FocusBridge direction="to-content" className="focus:relative" />
-        <FocusBridge direction="to-sidebar" className="focus:relative" />
-      </div>
-    </div>
+    </NavSheetFrame>
   );
 }

--- a/frontend/src/modules/navigation/app-nav-loader.tsx
+++ b/frontend/src/modules/navigation/app-nav-loader.tsx
@@ -1,14 +1,15 @@
 import { useIsFetching } from '@tanstack/react-query';
-import { HouseIcon } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useEffect, useState } from 'react';
 import { useDebounce } from '~/hooks/use-debounce';
+import type { IconComponent } from '~/modules/common/icons/types';
 import { Logo } from '~/modules/common/logo';
 import { Spinner } from '~/modules/common/spinner';
 import { useNavigationStore } from '~/modules/navigation/navigation-store';
 import { cn } from '~/utils/cn';
 
-export function AppNavLoader({ className }: { className?: string }) {
+/** Brand intro on first load, then the item's icon, swapped for a spinner while queries or navigation are in flight. */
+export function AppNavLoader({ className, icon: Icon }: { className?: string; icon: IconComponent }) {
   const [hasLoaded, setHasLoaded] = useState(false);
   const navSheetOpen = useNavigationStore((state) => state.navSheetOpen);
 
@@ -68,7 +69,7 @@ export function AppNavLoader({ className }: { className?: string }) {
       <AnimatePresence>
         {!showLogo && (
           <motion.div
-            key={isLoading ? 'spinner' : 'home'}
+            key={isLoading ? 'spinner' : 'icon'}
             initial={skipInitialAnimation ? false : { opacity: 0, scale: 0 }}
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0 }}
@@ -82,7 +83,7 @@ export function AppNavLoader({ className }: { className?: string }) {
               <Spinner className={cn('size-5', className)} noDelay />
             ) : (
               <div className="transition-transform group-hover:scale-110">
-                <HouseIcon strokeWidth={1.8} className={cn('size-5 min-h-5 min-w-5', className)} />
+                <Icon strokeWidth={1.8} className={cn('size-5 min-h-5 min-w-5', className)} />
               </div>
             )}
           </motion.div>

--- a/frontend/src/modules/navigation/app-nav.tsx
+++ b/frontend/src/modules/navigation/app-nav.tsx
@@ -68,7 +68,6 @@ export function AppNav() {
   useHotkeys([
     ['Shift + A', () => triggerNavItem('account')],
     ['Shift + F', () => triggerNavItem('search')],
-    ['Shift + H', () => triggerNavItem('home')],
     ['Shift + M', () => triggerNavItem('menu')],
   ]);
 

--- a/frontend/src/modules/navigation/bottom-bar-nav.tsx
+++ b/frontend/src/modules/navigation/bottom-bar-nav.tsx
@@ -1,10 +1,8 @@
-import { Fragment } from 'react/jsx-runtime';
 import { useMountedState } from '~/hooks/use-mounted-state';
 import { BottomBarNavButton } from '~/modules/navigation/nav-buttons';
 import { useNavigationStore } from '~/modules/navigation/navigation-store';
 import type { NavItem, TriggerNavItemFn } from '~/modules/navigation/types';
 import { navItems } from '~/nav-config';
-import { cn } from '~/utils/cn';
 
 let baseNavItems: NavItem[] | null = null;
 function getBaseNavItems() {
@@ -30,25 +28,11 @@ export function BottomBarNav({ triggerNavItem }: BottomBarNavProps) {
       className="fixed bottom-0 z-100 flex w-full flex-row justify-between bg-sidebar pb-[env(safe-area-inset-bottom,0px)] shadow-xs transition-transform ease-out group-[.focus-view]/body:hidden group-[.selection-active]/body:translate-y-full data-[started=false]:translate-y-full"
     >
       <ul className="flex w-full flex-row justify-between p-1 px-2">
-        {getBaseNavItems().map((navItem: NavItem, index: number) => {
-          const isSecondItem = index === 1;
-          const isActive = navSheetOpen === navItem.id;
-
-          return (
-            <Fragment key={navItem.id}>
-              <li
-                key={navItem.id}
-                className={cn(
-                  'flex transform justify-start',
-                  isSecondItem && 'xs:absolute xs:left-1/2 xs:-translate-x-1/2',
-                )}
-              >
-                <BottomBarNavButton navItem={navItem} isActive={isActive} onClick={triggerNavItem} />
-              </li>
-              {isSecondItem && <div className={'xs:flex hidden xs:grow'} />}
-            </Fragment>
-          );
-        })}
+        {getBaseNavItems().map((navItem: NavItem) => (
+          <li key={navItem.id} className="flex transform justify-start">
+            <BottomBarNavButton navItem={navItem} isActive={navSheetOpen === navItem.id} onClick={triggerNavItem} />
+          </li>
+        ))}
       </ul>
     </nav>
   );

--- a/frontend/src/modules/navigation/menu-sheet/menu-sheet.tsx
+++ b/frontend/src/modules/navigation/menu-sheet/menu-sheet.tsx
@@ -6,11 +6,10 @@ import { appConfig } from 'shared';
 import { menuSectionsSchema } from '~/menu-config';
 import { Spinner } from '~/modules/common/spinner';
 import { useMemberUpdateMutation } from '~/modules/memberships/query-mutations';
-import { FocusBridge, FocusTarget } from '~/modules/navigation/focus-bridge';
 import { MenuSheetHeader } from '~/modules/navigation/menu-sheet/header';
 import { getRelativeItemOrder, isPageData } from '~/modules/navigation/menu-sheet/helpers';
 import { MenuSheetSection } from '~/modules/navigation/menu-sheet/section';
-import { MenuSheetPanels } from '~/modules/navigation/menu-sheet/sheet-panel';
+import { NavSheetFrame } from '~/modules/navigation/nav-sheet-frame';
 import { useUserStore } from '~/modules/user/user-store';
 import { useMenu } from './helpers/use-menu';
 
@@ -77,17 +76,9 @@ export function MenuSheet() {
     .filter((el) => el !== null);
 
   return (
-    <div className="group/menu flex min-h-dvh w-full flex-col bg-card">
-      <FocusTarget target="sheet" />
-
+    <NavSheetFrame panels>
       <MenuSheetHeader />
       {renderedSections}
-      <span className="mt-10" />
-      <MenuSheetPanels />
-      <div className="flex flex-col focus-within:p-3">
-        <FocusBridge direction="to-content" className="focus:relative" />
-        <FocusBridge direction="to-sidebar" className="focus:relative" />
-      </div>
-    </div>
+    </NavSheetFrame>
   );
 }

--- a/frontend/src/modules/navigation/nav-buttons.tsx
+++ b/frontend/src/modules/navigation/nav-buttons.tsx
@@ -19,7 +19,7 @@ function AppNavIcon({ navItem, className }: { navItem: NavItem; className?: stri
 
   if (navItem.iconSlot) {
     const IconSlot = navItem.iconSlot;
-    return <IconSlot className={iconClass} />;
+    return <IconSlot className={iconClass} icon={navItem.icon} />;
   }
 
   const NavItemIcon = navItem.icon;

--- a/frontend/src/modules/navigation/nav-sheet-frame.tsx
+++ b/frontend/src/modules/navigation/nav-sheet-frame.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode, Ref } from 'react';
+import { FocusBridge, FocusTarget } from '~/modules/navigation/focus-bridge';
+import { MenuSheetPanels } from '~/modules/navigation/menu-sheet/sheet-panel';
+import { cn } from '~/utils/cn';
+
+interface NavSheetFrameProps {
+  children: ReactNode;
+  /** Sticky bottom panels (preferences etc.); sheets without them push the bridges to the bottom instead. */
+  panels?: boolean;
+  ref?: Ref<HTMLDivElement>;
+  className?: string;
+}
+
+/** Shell of every nav sheet: card column, the sheet focus target first, optional panels, and the bottom focus bridges. */
+export function NavSheetFrame({ children, panels = false, ref, className }: NavSheetFrameProps) {
+  return (
+    <div ref={ref} className={cn('group/menu flex min-h-dvh w-full flex-col bg-card', className)}>
+      <FocusTarget target="sheet" />
+      {children}
+      {panels && (
+        <>
+          <span className="mt-10" />
+          <MenuSheetPanels />
+        </>
+      )}
+      <div className={cn('flex flex-col focus-within:p-3', !panels && 'mt-auto')}>
+        <FocusBridge direction="to-content" className="focus:relative" />
+        <FocusBridge direction="to-sidebar" className="focus:relative" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/modules/navigation/nav-sheet-frame.tsx
+++ b/frontend/src/modules/navigation/nav-sheet-frame.tsx
@@ -5,7 +5,7 @@ import { cn } from '~/utils/cn';
 
 interface NavSheetFrameProps {
   children: ReactNode;
-  /** Sticky bottom panels (preferences etc.); sheets without them push the bridges to the bottom instead. */
+  /** Sticky bottom panels (preferences etc.); without them the bridges take `mt-auto` to stay at the bottom. */
   panels?: boolean;
   ref?: Ref<HTMLDivElement>;
   className?: string;

--- a/frontend/src/modules/navigation/types.ts
+++ b/frontend/src/modules/navigation/types.ts
@@ -27,8 +27,8 @@ export type NavItem = {
   action?: (ref: RefObject<HTMLButtonElement | null>) => void;
   href?: string;
   mirrorOnMobile?: boolean;
-  /** Replaces the default `icon` rendering (e.g. avatar, loader); receives the base icon classes. */
-  iconSlot?: React.ComponentType<{ className?: string }>;
+  /** Replaces the default `icon` rendering (e.g. avatar, loader); receives the base icon classes and the item's `icon`. */
+  iconSlot?: React.ComponentType<{ className?: string; icon: IconComponent }>;
   /** Renders over the button (e.g. an unseen counter); receives position classes per bar. */
   badgeSlot?: React.ComponentType<{ isActive: boolean; className?: string }>;
 };

--- a/frontend/src/modules/notification/notifications-sheet.tsx
+++ b/frontend/src/modules/notification/notifications-sheet.tsx
@@ -8,12 +8,14 @@ import { ContentPlaceholder } from '~/modules/common/content-placeholder';
 import { EntityAvatar } from '~/modules/common/entity-avatar';
 import { useSheeter } from '~/modules/common/sheeter/use-sheeter';
 import { Spinner } from '~/modules/common/spinner';
+import { NavSheetFrame } from '~/modules/navigation/nav-sheet-frame';
 import { useNavigationStore } from '~/modules/navigation/navigation-store';
 import { Button } from '~/modules/ui/button';
 import { pageTopHashNav } from '~/utils/channel-route';
 import { cn } from '~/utils/cn';
 import { getNotificationRoute } from './notification-link';
 import { notificationsQueryOptions, useMarkNotificationsRead } from './query';
+import { UnreadCountBadge } from './unread-nav-badge';
 
 type Notification = GetNotificationsResponse['items'][number];
 
@@ -27,9 +29,13 @@ export function NotificationsSheet() {
   const hasUnread = (data?.unreadCount ?? 0) > 0;
 
   return (
-    <div className="flex flex-col gap-2 p-3">
-      <div className="flex items-center justify-between gap-2 px-1">
-        <h2 className="font-medium text-lg">{t('c:notifications')}</h2>
+    <NavSheetFrame>
+      {/* Sticky like the menu sheet's section buttons: opaque card layer inside the sheet's scroll container. */}
+      <div className="sticky top-0 z-10 flex items-center justify-between gap-2 bg-card px-4 py-3">
+        <h2 className="flex items-center gap-2 font-medium text-lg">
+          {t('c:notifications')}
+          <UnreadCountBadge />
+        </h2>
         {hasUnread && (
           <Button variant="ghost" size="sm" onClick={() => markRead({})}>
             {t('c:mark_all_read')}
@@ -37,16 +43,18 @@ export function NotificationsSheet() {
         )}
       </div>
 
-      {isLoading && <Spinner className="mt-8" />}
+      <div className="flex flex-col gap-2 px-3 py-2">
+        {isLoading && <Spinner className="mt-8" />}
 
-      {!isLoading && items.length === 0 && <ContentPlaceholder icon={BellIcon} title="c:no_notifications" />}
+        {!isLoading && items.length === 0 && <ContentPlaceholder icon={BellIcon} title="c:no_notifications" />}
 
-      <ul className="flex flex-col gap-1">
-        {items.map((notification) => (
-          <NotificationRow key={notification.id} notification={notification} onOpen={markRead} />
-        ))}
-      </ul>
-    </div>
+        <ul className="flex flex-col gap-1 pb-60">
+          {items.map((notification) => (
+            <NotificationRow key={notification.id} notification={notification} onOpen={markRead} />
+          ))}
+        </ul>
+      </div>
+    </NavSheetFrame>
   );
 }
 
@@ -62,9 +70,11 @@ function NotificationRow({
   const route = getNotificationRoute(notification);
 
   const onActivate = () => {
-    // The nav owns the sheet and always mounts it under this id, so closing uses the nav's own pair.
-    useSheeter.getState().remove('nav-sheet');
-    useNavigationStore.getState().setNavSheetOpen(null);
+    // Like the account sheet: a pinned nav sheet stays open beside the content. The nav owns the sheet under this id.
+    if (!useNavigationStore.getState().keepNavOpen) {
+      useSheeter.getState().remove('nav-sheet');
+      useNavigationStore.getState().setNavSheetOpen(null);
+    }
     if (!notification.readAt) onOpen({ ids: [notification.id] });
   };
 
@@ -73,29 +83,29 @@ function NotificationRow({
     <>
       <EntityAvatar
         type="user"
-        className="h-8 w-8 shrink-0"
+        className={cn('h-8 w-8 shrink-0', notification.readAt && 'opacity-70')}
         id={actor?.id ?? 'unknown'}
         name={actor?.name ?? ''}
         url={actor?.thumbnailUrl ?? null}
       />
       <span className="flex min-w-0 flex-col gap-0.5">
         {/* One `c:notification.<type>` sentence per vocabulary type, interpolating actor, subject and channel; apps add theirs to app.json */}
-        <span className={cn('text-sm', !notification.readAt && 'font-medium')}>
+        <span className={cn('text-sm', notification.readAt && 'opacity-70')}>
           {t(`c:notification.${notification.type}`, {
             actor: actor?.name || t('c:someone'),
             subject: subjectTitle || t('c:unknown'),
             channel: channelName || t('c:unknown'),
           })}
         </span>
-        <span className="text-muted-foreground text-xs">{relativeDate}</span>
+        <span className="text-xs opacity-50">{relativeDate}</span>
       </span>
-      {!notification.readAt && <span className="mt-1.5 ml-auto h-2 w-2 shrink-0 rounded-full bg-primary" />}
     </>
   );
 
+  // Unread rows carry the full accent (accent/30 is ~3 sRGB steps off the card in light mode); only read rows tint on hover.
   const className = cn(
-    'flex w-full items-start gap-3 rounded-md px-2 py-2 text-left hover:bg-accent/50',
-    !notification.readAt && 'bg-accent/30',
+    'flex w-full items-start gap-3 rounded-md px-2 py-2 text-left',
+    notification.readAt ? 'hover:bg-accent/50' : 'bg-accent',
   );
 
   // An unknown channel type still marks read; it just cannot navigate anywhere sensible.

--- a/frontend/src/modules/notification/unread-nav-badge.tsx
+++ b/frontend/src/modules/notification/unread-nav-badge.tsx
@@ -21,7 +21,7 @@ export function UnreadCountBadge({ className }: { className?: string }) {
   );
 }
 
-/** Unread counter over the bell, mirroring `UnseenNavBadge`; the open sheet shows the count in its header instead. */
+/** Unread counter over the bell, mirroring `UnseenNavBadge`; hidden while the sheet is open, which shows the count in its header. */
 export function UnreadNavBadge({ isActive, className }: { isActive: boolean; className?: string }) {
   if (isActive) return null;
   return <UnreadCountBadge className={cn('absolute', className)} />;

--- a/frontend/src/modules/notification/unread-nav-badge.tsx
+++ b/frontend/src/modules/notification/unread-nav-badge.tsx
@@ -2,21 +2,27 @@ import { useQuery } from '@tanstack/react-query';
 import { cn } from '~/utils/cn';
 import { notificationsQueryOptions } from './query';
 
-/** Unread counter over the bell, mirroring `UnseenNavBadge`. */
-export function UnreadNavBadge({ isActive, className }: { isActive: boolean; className?: string }) {
+/** Red unread pill; renders nothing at zero. Positioned by the caller (`absolute` over the bell, inline in the sheet header). */
+export function UnreadCountBadge({ className }: { className?: string }) {
   const { data } = useQuery(notificationsQueryOptions());
   const unreadCount = data?.unreadCount ?? 0;
 
-  if (isActive || unreadCount === 0) return null;
+  if (unreadCount === 0) return null;
 
   return (
     <span
       className={cn(
-        'absolute flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 font-bold text-[0.6rem] text-destructive-foreground leading-none',
+        'flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 font-bold text-[0.6rem] text-destructive-foreground leading-none',
         className,
       )}
     >
       {unreadCount > 99 ? '99+' : unreadCount}
     </span>
   );
+}
+
+/** Unread counter over the bell, mirroring `UnseenNavBadge`; the open sheet shows the count in its header instead. */
+export function UnreadNavBadge({ isActive, className }: { isActive: boolean; className?: string }) {
+  if (isActive) return null;
+  return <UnreadCountBadge className={cn('absolute', className)} />;
 }

--- a/frontend/src/nav-config.tsx
+++ b/frontend/src/nav-config.tsx
@@ -1,4 +1,4 @@
-import { BellIcon, HouseIcon, MenuIcon, SearchIcon, UserIcon } from 'lucide-react';
+import { BellIcon, MenuIcon, SearchIcon, UserIcon } from 'lucide-react';
 import type { FooterLinkProps } from '~/modules/common/app/app-footer';
 import { AccountNavIcon } from '~/modules/navigation/account-nav-icon';
 import { AccountSheet } from '~/modules/navigation/account-sheet';
@@ -15,8 +15,15 @@ import { UnseenNavBadge } from '~/modules/seen/unseen-nav-badge';
  * the button; both are plain components, so apps can swap or drop them here.
  */
 export const navItems = [
-  { id: 'menu', type: 'base', icon: MenuIcon, sheet: () => <MenuSheet />, badgeSlot: UnseenNavBadge },
-  { id: 'home', type: 'base', icon: HouseIcon, href: '/home', iconSlot: AppNavLoader },
+  // Home lives in the menu sheet header, so the menu button also carries the brand intro and the loading spinner.
+  {
+    id: 'menu',
+    type: 'base',
+    icon: MenuIcon,
+    sheet: () => <MenuSheet />,
+    iconSlot: AppNavLoader,
+    badgeSlot: UnseenNavBadge,
+  },
   { id: 'search', type: 'base', icon: SearchIcon, action: startSearchAction },
   // Mentions and addressed activity; ambient posts stay on the menu badge above.
   { id: 'notifications', type: 'base', icon: BellIcon, sheet: () => <NotificationsSheet />, badgeSlot: UnreadNavBadge },

--- a/frontend/src/styling/tailwind.css
+++ b/frontend/src/styling/tailwind.css
@@ -307,7 +307,7 @@
     --sidebar-accent: oklch(0.97 0 0);
     --sidebar-accent-foreground: oklch(0.205 0 0);
     --sidebar-border: oklch(0.922 0 0);
-    --sidebar-ring: oklch(0.708 0 0);
+    --sidebar-ring: var(--ring);
   }
 
   .dark,
@@ -345,7 +345,7 @@
     --sidebar-accent: oklch(0.269 0 0);
     --sidebar-accent-foreground: oklch(0.985 0 0);
     --sidebar-border: oklch(0.269 0 0);
-    --sidebar-ring: oklch(0.439 0 0);
+    --sidebar-ring: var(--ring);
   }
 }
 


### PR DESCRIPTION
## Notifications sheet
- Read rows fade instead of unread rows shouting: text and avatar `opacity-70`, timeago `opacity-50`; the bold weight and primary dot on unread are gone.
- Unread rows carry the full accent. On the card background `accent/30` was ~3 sRGB steps off the surface in light mode (251 vs 248), full accent is 11 steps (light) / 20 (dark). Hover tint applies to read rows only, so an unread row never gets lighter on hover.
- The sheet uses the same `min-h-dvh bg-card` shell as the account and menu sheets.
- The unread count renders inline after the "Notifications" heading (the nav badge already hides while the sheet is active). The pill is extracted as `UnreadCountBadge`; `UnreadNavBadge` wraps it with `absolute`.
- Header (title, count, mark-all-read) is `sticky top-0` with an opaque card layer, the same pattern as the menu sheet section buttons.
- Clicking a notification no longer closes a pinned nav sheet: it uses the account sheet's `keepNavOpen` guard.

## Navigation
- The home button is removed from the sidebar and bottom bar; home stays reachable via the menu sheet header logo. The brand intro + loading spinner (`AppNavLoader`) move to the menu button.
- `iconSlot` now receives the item's `icon`, so the loader and `AccountNavIcon` render the declared icon instead of hardcoding one.
- Bottom bar drops the second-item centering (absolute + spacer) on `xs+`. `Shift + H` is removed with the `home` id.

## Focus
- New `NavSheetFrame` owns the shell every nav sheet copied by hand: card column, `FocusTarget target="sheet"` first, optional `MenuSheetPanels`, and the bottom `to-content`/`to-sidebar` bridges (`mt-auto` when there are no panels). Menu, account and notifications sheets use it.
- This fixes "go to panel" doing nothing while notifications is open: the sheet never rendered the focus target, so `focusById` returned early.
- `--sidebar-ring` now follows `--ring` in both themes. The sidebar token was still shadcn's default gray (L 0.71 light / 0.44 dark) while the main ring is near-black / near-white, which is why sidebar focus rings looked faded.

## Notes
- `nav-config.tsx` is no longer a pinned fork file, so this syncs to forks; a fork still referencing `triggerNavItem('home')` gets a type error.
- Not runtime-verified: sticky header scroll, keyboard bridge path, avatar/opacity look. `pnpm frontend:style` failures are the pre-existing `marketing/**` ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
