### PR TITLE
fix(marketing): mobile drawer says About, not Home

### DIFF
--- a/frontend/src/modules/marketing/nav.tsx
+++ b/frontend/src/modules/marketing/nav.tsx
@@ -177,7 +177,7 @@ export const MarketingNav = () => {
                 />
               }
             >
-              {t('c:home')}
+              {t('c:about')}
             </Button>
             {renderNavItems()}
             {appConfig.company.githubUrl && (


### PR DESCRIPTION
The marketing mobile navigation drawer labelled the /about link "Home", which collides with the app home. Rename it to "About" using the existing `c:about` key (already used by the desktop nav item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)