### PR TITLE
fix(account): drop bare id on notifications card that broke scroll spy

### DIFF
--- a/frontend/src/modules/notification/account-notifications-card.tsx
+++ b/frontend/src/modules/notification/account-notifications-card.tsx
@@ -19,7 +19,7 @@ export function AccountNotificationsCard() {
   const push = usePushSubscription();
 
   return (
-    <ToolCard label="c:notifications" description={t('c:notifications.text')} id="notifications" className={cardClass}>
+    <ToolCard label="c:notifications" description={t('c:notifications.text')} className={cardClass}>
       <div className="flex flex-col gap-4">
         <div className="flex items-center gap-4">
           <Switch


### PR DESCRIPTION
## Summary
- The notifications settings card set `id="notifications"` on its own card element, identical to the section hash.
- Scroll spy anchors are `spy-` prefixed on purpose so no DOM element matches the URL fragment and the browser never natively scrolls to it. The bare id let the browser jump to the card whenever the hash became `#notifications`, fighting the store's own scroll and section pick around that section.
- Removed the id. The section keeps its `spy-notifications` anchor from `AsideAnchor`, so `/account#notifications` and the aside link still work through the store. Nothing else referenced the bare id.

## Test plan
- [ ] Open `/account#notifications`: page lands on the notifications section without a jump
- [ ] Scroll through the account page: aside highlight tracks sessions → authentication → notifications → delete account smoothly
- [ ] Click the notifications aside link: smooth scroll, hash updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)