### PR TITLE
feat(account): email digest label, spacing, radio group with help popover

### DIFF
--- a/frontend/src/modules/notification/account-notifications-card.tsx
+++ b/frontend/src/modules/notification/account-notifications-card.tsx
@@ -51,7 +51,7 @@ export function AccountNotificationsCard() {
           </div>
         )}
 
-        <div className="flex flex-col gap-1.5">
+        <div className="mt-3 flex flex-col gap-1.5">
           <Label htmlFor="digest">{t('c:notifications.digest')}</Label>
           <Select value={data.digest} onValueChange={(digest) => mutate({ digest: digest as DigestFrequency })}>
             <SelectTrigger id="digest" className="w-56">

--- a/frontend/src/modules/notification/account-notifications-card.tsx
+++ b/frontend/src/modules/notification/account-notifications-card.tsx
@@ -1,13 +1,21 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
+import { HelpText } from '~/modules/common/help-text';
 import { ToolCard } from '~/modules/common/tool-card';
 import { notificationPreferencesQueryOptions, useUpdateNotificationPreferences } from '~/modules/notification/query';
 import { usePushSubscription } from '~/modules/notification/use-push-subscription';
 import { Label } from '~/modules/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/modules/ui/select';
+import { RadioGroup, RadioGroupItem } from '~/modules/ui/radio-group';
 import { Switch } from '~/modules/ui/switch';
 
 type DigestFrequency = 'off' | 'daily' | 'weekly';
+
+/** Cadences are mutually exclusive: one enum column, and each notification is digested once. */
+const digestOptions = [
+  { value: 'off', label: 'c:notifications.digest_off' },
+  { value: 'daily', label: 'c:notifications.digest_daily' },
+  { value: 'weekly', label: 'c:notifications.digest_weekly' },
+] as const satisfies { value: DigestFrequency; label: string }[];
 
 const cardClass = 'mx-auto sm:w-full';
 
@@ -52,17 +60,21 @@ export function AccountNotificationsCard() {
         )}
 
         <div className="mt-3 flex flex-col gap-1.5">
-          <Label htmlFor="digest">{t('c:notifications.digest')}</Label>
-          <Select value={data.digest} onValueChange={(digest) => mutate({ digest: digest as DigestFrequency })}>
-            <SelectTrigger id="digest" className="w-56">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="off">{t('c:notifications.digest_off')}</SelectItem>
-              <SelectItem value="daily">{t('c:notifications.digest_daily')}</SelectItem>
-              <SelectItem value="weekly">{t('c:notifications.digest_weekly')}</SelectItem>
-            </SelectContent>
-          </Select>
+          <HelpText type="popover" content={t('c:notifications.digest.text')} className="mb-0">
+            <Label>{t('c:notifications.digest')}</Label>
+          </HelpText>
+          <RadioGroup
+            value={data.digest}
+            onValueChange={(digest) => mutate({ digest: digest as DigestFrequency })}
+            className="flex flex-wrap items-center gap-4"
+          >
+            {digestOptions.map(({ value, label }) => (
+              <Label key={value} className="cursor-pointer font-normal">
+                <RadioGroupItem value={value} />
+                {t(label)}
+              </Label>
+            ))}
+          </RadioGroup>
         </div>
       </div>
     </ToolCard>

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -336,7 +336,7 @@
   "notification_email.text": "Receive announcements and product updates through this email address.",
   "notifications": "Notifications",
   "notifications.comment_email": "Email me about comments on my posts",
-  "notifications.digest": "Email summary",
+  "notifications.digest": "Email digest",
   "notifications.digest_daily": "Daily",
   "notifications.digest_off": "Off",
   "notifications.digest_weekly": "Weekly",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -337,6 +337,7 @@
   "notifications": "Notifications",
   "notifications.comment_email": "Email me about comments on my posts",
   "notifications.digest": "Email digest",
+  "notifications.digest.text": "A periodic email listing notifications you have not read and were not already emailed about. Daily digests go out every morning, weekly ones on Friday morning. Nothing is sent when there is nothing new.",
   "notifications.digest_daily": "Daily",
   "notifications.digest_off": "Off",
   "notifications.digest_weekly": "Weekly",

--- a/locales/nl/common.json
+++ b/locales/nl/common.json
@@ -41,6 +41,7 @@
   "notification.reply": "{{actor}} antwoordde je op '{{subject}}' in {{channel}}",
   "notifications.comment_email": "E-mail bij reacties op mijn berichten",
   "notifications.digest": "E-mailoverzicht",
+  "notifications.digest.text": "Een periodieke e-mail met meldingen die je nog niet hebt gelezen en waarover je nog geen e-mail kreeg. Dagelijkse overzichten gaan elke ochtend uit, wekelijkse op vrijdagochtend. Zonder nieuws wordt er niets verstuurd.",
   "notifications.digest_daily": "Dagelijks",
   "notifications.digest_off": "Uit",
   "notifications.digest_weekly": "Wekelijks",

--- a/locales/nl/common.json
+++ b/locales/nl/common.json
@@ -40,7 +40,7 @@
   "notification.mention": "{{actor}} noemde je in '{{subject}}' in {{channel}}",
   "notification.reply": "{{actor}} antwoordde je op '{{subject}}' in {{channel}}",
   "notifications.comment_email": "E-mail bij reacties op mijn berichten",
-  "notifications.digest": "E-mailsamenvatting",
+  "notifications.digest": "E-mailoverzicht",
   "notifications.digest_daily": "Dagelijks",
   "notifications.digest_off": "Uit",
   "notifications.digest_weekly": "Wekelijks",


### PR DESCRIPTION
## Summary
- Rename the notification preference label from "Email summary" to "Email digest" (en + nl), and add spacing between the digest block and the email/push switches on `/account#notifications`.
- Replace the digest cadence select with an inline radio group (Off / Daily / Weekly). The cadences are mutually exclusive by design: one enum column, and each notification is stamped `digestedAt` once, so checkboxes would have suggested a "both" state that cannot exist.
- Add a `HelpText` popover next to the label explaining what the digest is (unread, not-yet-emailed notifications; daily every morning or weekly Friday morning; skipped when empty). Popover rather than tooltip so it also works on mobile, where tooltips are hidden.

New locale key: `notifications.digest.text` (en + nl). Option keys are a literal `as const` list, not a template string.

## Test plan
- [ ] `/account#notifications`: label reads "Email digest", radio group shows the stored cadence, switching updates the preference
- [ ] Question-mark icon opens the explanation popover on desktop and mobile
- [ ] Dutch locale shows "E-mailoverzicht" and the translated help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)