### PR TITLE
refactor(table): drop dead sticky wiring from table filter bars

### DIFF
--- a/cella/migrations/20260904T1349-table-bar-sticky-cleanup/README.md
+++ b/cella/migrations/20260904T1349-table-bar-sticky-cleanup/README.md
@@ -1,0 +1,34 @@
+# Table filter bars drop the dead sticky wiring
+
+## What & why
+
+`TableBarContainer` (`frontend/src/modules/common/data-table/table-bar-container.tsx`) no longer
+wraps the filter row in `StickyBox`. The sticky path was unreachable: `enableSticky` defaulted to
+false and no bar ever set it, so `offsetTop`, `enableSticky`, the `focusView` subscription and the
+`group/sticky` classes were inert. The container is now a plain flex row plus the search-vars
+scroll reset. `EntityGridBar` lost its `isSheet` prop, which only fed that `offsetTop`.
+
+## Blast radius
+
+Not sync-breaking for the shared bars (they arrive migrated). App-owned bars that pass `offsetTop`
+to `TableBarContainer`, or `isSheet` to `EntityGridBar`, fail `pnpm check` with an unknown-prop
+error until step 1 and 2. `StickyBox` itself is untouched; tab navs, the docs operations page and
+any app use of it keep working. No DB or wire change.
+
+## Run
+
+No script: manual.
+
+## Manual steps
+
+1. In every app-owned `*-bar.tsx` remove `offsetTop={...}` (and `enableSticky`) from `<TableBarContainer>`.
+2. In every app-owned `*-grid.tsx` remove `isSheet={...}` from `<EntityGridBar>`.
+3. Only if an app-owned bar relied on the table bar rendering `data-sticky` or the `group/sticky` name: it never did in practice, but move that styling onto a direct `StickyBox` if it must stay.
+
+## Verify
+
+```sh
+grep -rn "TableBarContainer" frontend/src | grep -n "offsetTop\|enableSticky"   # must be empty
+grep -rn -A12 "<EntityGridBar" frontend/src | grep "isSheet"                    # must be empty
+pnpm check
+```

--- a/cella/migrations/manifest.json
+++ b/cella/migrations/manifest.json
@@ -847,6 +847,22 @@
     "pnpm check"
    ],
    "summary": "RLS tables are ENABLE (never FORCE) so admin_role bypasses as owner; Scaleway cannot grant BYPASSRLS (found by the 0.10.0 smoke failure). create-db-roles and the test setup create admin_role without BYPASSRLS; verify asserts enabled-not-forced. CDC worker probes effective bypass per table (rlsBypass/rlsBlockedTables, health reason rls_bypass_missing replaces role_missing_bypassrls). Smoke results are ok/warn/fail (degraded warns via ::warning::, unhealthy fails); infra status gains live.components on the shared lib/health-components.ts."
+  },
+  {
+   "id": "20260904T1349-table-bar-sticky-cleanup",
+   "version": "next",
+   "title": "Table filter bars drop the dead sticky wiring",
+   "kind": "manual",
+   "syncBreaking": false,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "frontend/src"
+   ],
+   "requires": [
+    "pnpm check"
+   ],
+   "summary": "TableBarContainer no longer wraps filter rows in StickyBox: enableSticky defaulted to false and no bar ever set it, so offsetTop, enableSticky, the focusView subscription and the group/sticky classes were dead. The container is now a plain flex row plus the search-vars scroll reset, and EntityGridBar drops its isSheet prop (it only fed offsetTop). App-owned bars remove offsetTop from <TableBarContainer> and isSheet from <EntityGridBar>. StickyBox itself is untouched."
   }
  ]
 }

--- a/frontend/src/modules/attachment/table/attachments-bar.tsx
+++ b/frontend/src/modules/attachment/table/attachments-bar.tsx
@@ -86,7 +86,7 @@ export function AttachmentsTableBar({
 
   return (
     <>
-      <TableBarContainer searchVars={searchVars} offsetTop={48}>
+      <TableBarContainer searchVars={searchVars}>
         <TableFilterBar onResetFilters={onResetFilters} isFiltered={isFiltered}>
           <FilterBarActions>
             {showUpload && <TableBarButton icon={UploadIcon} label="c:upload" onClick={() => open()} />}

--- a/frontend/src/modules/common/data-table/table-bar-container.tsx
+++ b/frontend/src/modules/common/data-table/table-bar-container.tsx
@@ -1,25 +1,15 @@
 import { type ReactNode, useEffect, useRef } from 'react';
 import { useScrollReset } from '~/modules/common/scroll-reset';
-import { useUIStore } from '~/modules/ui/ui-store';
 import { cn } from '~/utils/cn';
-import { StickyBox } from '../sticky-box';
 
 interface TableBarContainerProps {
   children: ReactNode;
   className?: string;
-  enableSticky?: boolean;
-  offsetTop?: number;
   searchVars?: Record<string, unknown>;
 }
 
-export function TableBarContainer({
-  children,
-  className,
-  enableSticky = false,
-  offsetTop,
-  searchVars,
-}: TableBarContainerProps) {
-  const focusView = useUIStore((state) => state.focusView);
+/** Row above a data table holding its filters and actions. Scrolls back to the top whenever the search vars change. */
+export function TableBarContainer({ children, className, searchVars }: TableBarContainerProps) {
   const scrollToReset = useScrollReset();
 
   const isInitialRender = useRef(true);
@@ -33,14 +23,5 @@ export function TableBarContainer({
     scrollToReset();
   }, [serialized]);
 
-  return (
-    <StickyBox
-      enabled={enableSticky}
-      className="group/sticky max-sm:static! z-10 bg-background/60 backdrop-blur-xs max-sm:top-auto!"
-      offsetTop={focusView ? 0 : offsetTop}
-      hideWhenOutOfView
-    >
-      <div className={cn('flex items-center py-2 max-sm:justify-between md:gap-2', className)}>{children}</div>
-    </StickyBox>
-  );
+  return <div className={cn('flex items-center py-2 max-sm:justify-between md:gap-2', className)}>{children}</div>;
 }

--- a/frontend/src/modules/docs/operations/operations-table/operations-bar.tsx
+++ b/frontend/src/modules/docs/operations/operations-table/operations-bar.tsx
@@ -77,7 +77,7 @@ export function OperationsTableBar({
   ];
 
   return (
-    <TableBarContainer searchVars={searchVars} offsetTop={0}>
+    <TableBarContainer searchVars={searchVars}>
       <TableFilterBar onResetFilters={onResetFilters} isFiltered={isFiltered}>
         <FilterBarActions>
           <ViewModeToggle />

--- a/frontend/src/modules/entities/entity-grid/entity-grid-bar.tsx
+++ b/frontend/src/modules/entities/entity-grid/entity-grid-bar.tsx
@@ -43,7 +43,6 @@ type Props = {
   entityType: ChannelEntityType;
   searchVars: EntityGridBarSearch;
   setSearch: (search: EntityGridBarSearch) => void;
-  isSheet?: boolean;
   focusView?: boolean;
   /** Sort options shown in the bar; defaults to alphabetical + created date. */
   sortOptions?: readonly EntityGridSortOption[];
@@ -66,7 +65,6 @@ export function EntityGridBar({
   entityType,
   searchVars,
   setSearch,
-  isSheet,
   focusView,
   sortOptions = entityGridSortOptions,
   actions,
@@ -93,7 +91,7 @@ export function EntityGridBar({
   const onResetFilters = () => setSearch({ q: '' });
 
   return (
-    <TableBarContainer searchVars={searchVars} offsetTop={isSheet ? 0 : 48}>
+    <TableBarContainer searchVars={searchVars}>
       <TableFilterBar onResetFilters={onResetFilters} isFiltered={isFiltered}>
         <FilterBarActions>
           {!isFiltered && actions}

--- a/frontend/src/modules/memberships/members-table/members-bar.tsx
+++ b/frontend/src/modules/memberships/members-table/members-bar.tsx
@@ -135,7 +135,7 @@ export function MembersTableBar({
 
   return (
     <>
-      <TableBarContainer searchVars={searchVars} offsetTop={isSheet ? 0 : 48}>
+      <TableBarContainer searchVars={searchVars}>
         <TableFilterBar onResetFilters={onResetFilters} isFiltered={isFiltered}>
           <FilterBarActions>
             {!isFiltered && canUpdate && (

--- a/frontend/src/modules/memberships/pending-table/pending-bar.tsx
+++ b/frontend/src/modules/memberships/pending-table/pending-bar.tsx
@@ -7,7 +7,7 @@ export function PendingMembershipsTableBar({ queryKey }: { queryKey: QueryKey })
   const total = useListQueryTotal(queryKey);
 
   return (
-    <TableBarContainer offsetTop={0}>
+    <TableBarContainer>
       <TableCount count={total} label="c:pending_invitation" />
     </TableBarContainer>
   );

--- a/frontend/src/modules/organization/organizations-grid.tsx
+++ b/frontend/src/modules/organization/organizations-grid.tsx
@@ -48,7 +48,6 @@ export function OrganizationsGrid({ fixedQuery, saveDataInSearch, focusView, lim
           roleFilter={false}
           alwaysShow
           setSearch={setSearch}
-          isSheet={!focusView}
           focusView={focusView}
         />
       )}

--- a/frontend/src/modules/organization/table/organizations-bar.tsx
+++ b/frontend/src/modules/organization/table/organizations-bar.tsx
@@ -89,7 +89,7 @@ export function OrganizationsTableBar({
   };
 
   return (
-    <TableBarContainer searchVars={searchVars} offsetTop={48}>
+    <TableBarContainer searchVars={searchVars}>
       <TableFilterBar onResetFilters={onResetFilters} isFiltered={isFiltered}>
         <FilterBarActions>
           {!isFiltered && (

--- a/frontend/src/modules/requests/table/requests-bar.tsx
+++ b/frontend/src/modules/requests/table/requests-bar.tsx
@@ -111,7 +111,7 @@ export function RequestsTableBar({
   };
 
   return (
-    <TableBarContainer searchVars={searchVars} offsetTop={48}>
+    <TableBarContainer searchVars={searchVars}>
       <TableFilterBar onResetFilters={onResetFilters} isFiltered={isFiltered}>
         <FilterBarActions>
           <TableCount count={total} label="c:request" isFiltered={isFiltered} onResetFilters={onResetFilters} />

--- a/frontend/src/modules/tenants/table/tenants-bar.tsx
+++ b/frontend/src/modules/tenants/table/tenants-bar.tsx
@@ -34,7 +34,7 @@ export function TenantsTableBar({ queryKey, searchVars, setSearch, columns, setC
   };
 
   return (
-    <TableBarContainer searchVars={searchVars} offsetTop={48}>
+    <TableBarContainer searchVars={searchVars}>
       <TableFilterBar onResetFilters={onResetFilters} isFiltered={isFiltered}>
         <FilterBarActions>
           <TableCount count={total} label="c:tenant" isFiltered={isFiltered} onResetFilters={onResetFilters} />

--- a/frontend/src/modules/user/table/users-bar.tsx
+++ b/frontend/src/modules/user/table/users-bar.tsx
@@ -104,7 +104,7 @@ export function UsersTableBar({
 
   return (
     <>
-      <TableBarContainer searchVars={searchVars} offsetTop={48}>
+      <TableBarContainer searchVars={searchVars}>
         <TableFilterBar onResetFilters={onResetFilters} isFiltered={isFiltered}>
           <FilterBarActions>
             {!isFiltered && (


### PR DESCRIPTION
## Summary

- `TableBarContainer` wrapped every table filter row in `StickyBox`, but `enableSticky` defaulted to false and no bar ever set it. `offsetTop`, `enableSticky`, the `focusView` store subscription and the `group/sticky` / `max-sm:static!` / `max-sm:top-auto!` classes were all unreachable.
- The container is now a plain flex row plus the existing search-vars scroll reset. All ten bars drop their `offsetTop` prop.
- `EntityGridBar` loses its `isSheet` prop, which only fed that `offsetTop`; `organizations-grid` stops passing it.
- `StickyBox` itself is untouched: tab-nav, local-tab-nav, the docs operations page (and the raak task-card header) keep using it directly.

## Forks

Both raak and projectcampus carry a byte-identical copy of the container and never enable sticky either. Their fork-only bars (pc: sections/courses/projects/submissions bars, plus the `isSheet={!focusView}` on their grid callers) will fail `pnpm check` after sync until they drop the props. Migration note `cella/migrations/20260904T1349-table-bar-sticky-cleanup` + manifest entry covers that.

## Test plan

- [x] `pnpm lint` (biome, style, sdk gen unchanged, `pnpm -r ts`, commitlint) green in the worktree
- [x] planner lists the new migration as pending
- [ ] visual check that filter bars render unchanged on a table page (no sticky behaviour existed, so only the wrapper div and its classes went away)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
