### PR TITLE
fix(attachments): description edits survive stale clocks, emptied documents and sheet dismissal; keywords derived on update

### DIFF
--- a/backend/src/core/schema-evolution/tests/lens-seam.test.ts
+++ b/backend/src/core/schema-evolution/tests/lens-seam.test.ts
@@ -38,7 +38,13 @@ import { applyArrayDelta, arrayDeltaSchema } from '#/core/stx/array-delta';
 import { _resetHLC, compareHLC } from '#/core/stx/hlc';
 import { resolveServerUpdateOps, resolveUpdateOps } from '#/core/stx/resolve-update';
 
-const stx = (fieldTimestamps: Record<string, string>) => ({ mutationId: 'm1', sourceId: 's1', fieldTimestamps });
+// Replayed writes keep their client timestamps, which is what the lens expectations below observe.
+const stx = (fieldTimestamps: Record<string, string>) => ({
+  mutationId: 'm1',
+  sourceId: 's1',
+  fieldTimestamps,
+  replayed: true,
+});
 const hlc = '100:0001:aaaaa';
 
 afterEach(() => _resetHLC());

--- a/backend/src/core/stx/resolve-update.ts
+++ b/backend/src/core/stx/resolve-update.ts
@@ -69,6 +69,10 @@ function resolvePreparedOps<T extends Record<string, unknown>>(
 /**
  * Lens normalization, no-op filtering, HLC conflicts and AWSet deltas. Keys and expand-window twins are
  * canonicalized before conflict logic; returns unchanged when no operation survives.
+ *
+ * An online write is ordered by server arrival: its client timestamps are replaced by one server HLC, so a
+ * device clock behind the stored value can never have its edit silently dropped. Only a replayed offline
+ * write (`stx.replayed`) keeps its client timestamps, the intent time that lets it lose to a later edit.
  */
 export function resolveUpdateOps<T extends Record<string, unknown>>(
   entityType: ProductEntityType,
@@ -76,17 +80,22 @@ export function resolveUpdateOps<T extends Record<string, unknown>>(
   rawOps: T,
   rawStx: StxBase,
 ): UpdateResult<T> {
+  if (!rawStx.replayed) return resolveServerUpdateOps(entityType, entity, rawOps, rawStx);
   const { ops, stx } = normalizeOps(entityType, rawOps, rawStx);
   return resolvePreparedOps<T>(entity, prepareOps(entity, ops), stx);
 }
 
-/** Resolve a trusted server update after assigning one causally-new HLC to all changed scalar fields. */
+/**
+ * Resolve an update after assigning one causally-new server HLC to all changed scalar fields. `baseStx`
+ * keeps a client's mutation and source ids for idempotency and echo recognition; server-origin writes omit it.
+ */
 export function resolveServerUpdateOps<T extends Record<string, unknown>>(
   entityType: ProductEntityType,
   entity: Record<string, unknown> & { stx: StxBase },
   rawOps: T,
+  baseStx: StxBase = createServerStx(),
 ): UpdateResult<T> {
-  const { ops, stx } = normalizeOps(entityType, rawOps, createServerStx());
+  const { ops, stx } = normalizeOps(entityType, rawOps, baseStx);
   const prepared = prepareOps(entity, ops);
   const scalarFieldNames = Object.keys(prepared.scalarOps);
 

--- a/backend/src/core/stx/tests/resolve-update.test.ts
+++ b/backend/src/core/stx/tests/resolve-update.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { compareHLC } from '#/core/stx/hlc';
+import { resolveUpdateOps } from '#/core/stx/resolve-update';
+
+const storedHLC = '1800000000000:0001:ccccc';
+const entity = {
+  id: 'a1',
+  name: 'stored',
+  stx: { mutationId: 'm0', sourceId: 's0', fieldTimestamps: { name: storedHLC } },
+};
+// Older than the stored value: a device whose wall clock runs behind.
+const staleClientHLC = '1700000000000:0001:aaaaa';
+
+describe('resolveUpdateOps write ordering', () => {
+  it('online: accepts a write whose client timestamp is behind the stored value, stamped with a newer server HLC', () => {
+    const resolved = resolveUpdateOps(
+      'attachment',
+      entity,
+      { name: 'live edit' },
+      { mutationId: 'm1', sourceId: 'tab-1', fieldTimestamps: { name: staleClientHLC } },
+    );
+    if (!resolved.changed) throw new Error('expected the live edit to be accepted');
+    expect(resolved.values).toEqual({ name: 'live edit' });
+    expect(compareHLC(resolved.stx.fieldTimestamps.name, storedHLC)).toBe(1);
+    // Idempotency and echo recognition keep the client's identity.
+    expect(resolved.stx.mutationId).toBe('m1');
+    expect(resolved.stx.sourceId).toBe('tab-1');
+  });
+
+  it('replayed: keeps client timestamps as intent time, so a stale replay loses', () => {
+    const resolved = resolveUpdateOps(
+      'attachment',
+      entity,
+      { name: 'queued while offline' },
+      { mutationId: 'm1', sourceId: 'tab-1', fieldTimestamps: { name: staleClientHLC }, replayed: true },
+    );
+    expect(resolved.changed).toBe(false);
+  });
+
+  it('replayed: a newer intent time still wins and is stored as sent', () => {
+    const newerHLC = '1900000000000:0001:aaaaa';
+    const resolved = resolveUpdateOps(
+      'attachment',
+      entity,
+      { name: 'queued after' },
+      { mutationId: 'm1', sourceId: 'tab-1', fieldTimestamps: { name: newerHLC }, replayed: true },
+    );
+    if (!resolved.changed) throw new Error('expected the newer replay to be accepted');
+    expect(resolved.stx.fieldTimestamps.name).toBe(newerHLC);
+  });
+});

--- a/backend/src/modules/attachment/operations/get-attachments.ts
+++ b/backend/src/modules/attachment/operations/get-attachments.ts
@@ -75,6 +75,7 @@ export async function getAttachmentsOp(ctx: AuthContext, input: GetAttachmentsIn
         ilike(attachmentsTable.name, queryToken),
         ilike(attachmentsTable.filename, queryToken),
         ilike(attachmentsTable.contentType, queryToken),
+        ilike(attachmentsTable.keywords, queryToken),
       ) as SQL,
     );
   }

--- a/backend/src/modules/attachment/operations/update-attachment.ts
+++ b/backend/src/modules/attachment/operations/update-attachment.ts
@@ -6,6 +6,7 @@ import { updateAttachment } from '#/modules/attachment/attachment-queries';
 import { attachmentContract, type attachmentUpdateStxBodySchema } from '#/modules/attachment/attachment-schema';
 import { withAuditUser, withAuditUserLite } from '#/modules/user/helpers/audit-user';
 import { getValidProduct } from '#/permissions/get-valid-product';
+import { keywordsFromDocument } from '#/utils/description-document';
 import { getIsoDate } from '#/utils/iso-date';
 import { log } from '#/utils/logger';
 import { assertBlockMediaUrls } from '#/utils/validate-block-urls';
@@ -36,6 +37,10 @@ export async function updateAttachmentOp(
 
     const values = {
       ...(resolved.changed ? resolved.values : {}),
+      // A changed document re-derives the search column, on client edits and Yjs materializations alike.
+      ...(resolved.changed && resolved.values.description !== undefined
+        ? { keywords: keywordsFromDocument(resolved.values.description as string | null) }
+        : {}),
       updatedAt: getIsoDate(),
       updatedBy: user.id,
       ...(resolved.changed ? { stx: resolved.stx } : {}),

--- a/backend/src/schemas/sync-transaction-schemas.ts
+++ b/backend/src/schemas/sync-transaction-schemas.ts
@@ -11,6 +11,10 @@ export const stxBaseSchema = z
     fieldTimestamps: z
       .record(z.string(), z.string().refine(isValidHLC, 'Invalid HLC timestamp'))
       .describe('Per-field HLC timestamps for scalar fields being changed'),
+    replayed: z
+      .boolean()
+      .optional()
+      .describe('Set on a paused offline mutation being replayed: its field timestamps then arbitrate as intent time'),
   })
   .openapi('StxBase', {
     description:

--- a/backend/tests/attachment-notifications.test.ts
+++ b/backend/tests/attachment-notifications.test.ts
@@ -37,6 +37,14 @@ const paragraphWithMentions = (ids: string[]) => ({
   children: [],
 });
 
+const paragraphWithText = (text: string) => ({
+  id: generateId(),
+  type: 'paragraph',
+  props: {},
+  content: [{ type: 'text', text, styles: {} }],
+  children: [],
+});
+
 const updateStx = () => ({
   ...mockStxBase(`stx:${generateId()}`),
   fieldTimestamps: { description: generateServerHLC('test-client') },
@@ -70,6 +78,14 @@ describe('Attachment mentions (template notification source)', async () => {
       .from(attachmentsTable)
       .where(eq(attachmentsTable.id, attachmentId));
     return row.mentions;
+  };
+
+  const storedKeywords = async () => {
+    const [row] = await db
+      .select({ keywords: attachmentsTable.keywords })
+      .from(attachmentsTable)
+      .where(eq(attachmentsTable.id, attachmentId));
+    return row.keywords;
   };
 
   const notificationsFor = (userId: string) =>
@@ -158,6 +174,26 @@ describe('Attachment mentions (template notification source)', async () => {
     const result = await putDescription(JSON.stringify([paragraphWithMentions([])]));
     expect(result.response.status).toBe(200);
     expect(await storedMentions()).toEqual([]);
+  });
+
+  it('re-derives the keywords search column from the description on both write paths', async () => {
+    const result = await putDescription(
+      JSON.stringify([paragraphWithText('quarterly budget'), paragraphWithMentions([member.id])]),
+    );
+    expect(result.response.status).toBe(200);
+    expect(await storedKeywords()).toContain('quarterly budget');
+
+    await materializeDescriptionOp({
+      entityType: 'attachment',
+      entityId: attachmentId,
+      tenantId: tenant.tenantId,
+      organizationId: tenant.organization.id,
+      description: JSON.stringify([paragraphWithText('signed contract')]),
+      editedBy: tenant.user.id,
+    });
+    const keywords = await storedKeywords();
+    expect(keywords).toContain('signed contract');
+    expect(keywords).not.toContain('quarterly budget');
   });
 
   it('derives from Yjs materialization too, the write path of the collaborative editor', async () => {

--- a/cella/SYNC_ENGINE.md
+++ b/cella/SYNC_ENGINE.md
@@ -162,6 +162,8 @@ HLC: 1710500000123:0001:abcde
 
 Comparison uses milliseconds, then counter, then source. Each tab advances its own clock. The server advances its clock from received timestamps before generating its own. This is deterministic last-writer-wins, not a causal clock.
 
+Only a replayed offline write (`stx.replayed`) is arbitrated by its client timestamps: they are its intent time, which lets it lose to an edit made elsewhere while it was queued. An online write is ordered by server arrival: the server replaces its field timestamps with one fresh server HLC, so a device clock behind the stored value cannot get its edit silently dropped.
+
 Value shape selects merge behavior:
 
 ```typescript
@@ -175,7 +177,7 @@ Value shape selects merge behavior:
 }
 ```
 
-`fieldTimestamps` must name exactly the scalar operation keys. The server omits scalar values that lose HLC comparison and returns the authoritative row, never a conflict response. Merge resolution takes no `FOR UPDATE` lock, so overlapping updates can race.
+`fieldTimestamps` must name exactly the scalar operation keys. For a replay, the server omits scalar values that lose HLC comparison and returns the authoritative row, never a conflict response. Merge resolution takes no `FOR UPDATE` lock, so overlapping updates can race.
 
 ### Paused writes
 

--- a/frontend/src/modules/attachment/query-mutations.ts
+++ b/frontend/src/modules/attachment/query-mutations.ts
@@ -1,7 +1,7 @@
 import type { Attachment, CreateAttachmentsData, StxBase, UpdateAttachmentData } from 'sdk';
 import { createAttachments, deleteAttachments, updateAttachment } from 'sdk';
 import { type AncestorChannelType, appConfig, type EntityIdColumnKey, hierarchy } from 'shared';
-import { createStxForCreate, createStxForDelete, createStxForUpdate } from '~/query/offline/stx-utils';
+import { createStxForCreate, createStxForDelete, createStxForUpdate, withReplayFlag } from '~/query/offline/stx-utils';
 import type { QueryOrgContext } from '~/query/types';
 
 type CreateAttachmentItem = CreateAttachmentsData['body'][number];
@@ -38,7 +38,7 @@ export async function createAttachmentsMutationFn({ tenantId, organizationId, da
 
 export async function updateAttachmentMutationFn({ tenantId, organizationId, id, ops, stx }: UpdateAttachmentFullVars) {
   const scalarFieldNames = ops ? Object.keys(ops) : [];
-  const effectiveStx = stx ?? createStxForUpdate(scalarFieldNames);
+  const effectiveStx = withReplayFlag(stx ?? createStxForUpdate(scalarFieldNames));
   return updateAttachment({ path: { tenantId, organizationId, id }, body: { ops, stx: effectiveStx } });
 }
 

--- a/frontend/src/modules/common/blocknote/blocknote-editor.tsx
+++ b/frontend/src/modules/common/blocknote/blocknote-editor.tsx
@@ -239,6 +239,16 @@ function BlockNote({
     commit: commitDocument,
   });
 
+  // A host dismissed by an outside press (a sheet) unmounts the editor while it still has focus, so
+  // no blur fires; the cleanup commits what blur would have. Standalone only: the relay owns
+  // collaborative writes. lastCommittedRef keeps a blur that did fire from committing twice.
+  const commitDocumentRef = useRef(commitDocument);
+  commitDocumentRef.current = commitDocument;
+  useEffect(() => {
+    if (!editable || commitOnEveryChange || collaborative) return;
+    return () => commitDocumentRef.current();
+  }, [editable, commitOnEveryChange, collaborative]);
+
   const handleOnBeforeLoad = () => onBeforeLoad?.(editor);
 
   const renderUppyFilePanel = useCallback(

--- a/frontend/src/modules/common/blocknote/blocknote-editor.tsx
+++ b/frontend/src/modules/common/blocknote/blocknote-editor.tsx
@@ -211,22 +211,33 @@ function BlockNote({
     collaboration ? { entityType: collaboration.entityType, entityId: collaboration.entityId } : null,
   );
 
+  const checkUntrustedMedia = useUntrustedMediaWarning();
+
+  // Escape and blur both commit, so the same document is offered twice; the second call is skipped.
+  const lastCommittedRef = useRef<string | null>(null);
+
+  const handleUpdateData = (editor: CustomBlockNoteEditor) => {
+    const strBlocks = JSON.stringify(editor.document);
+    if (strBlocks === defaultValue || strBlocks === lastCommittedRef.current || !updateData) return;
+
+    lastCommittedRef.current = strBlocks;
+    checkUntrustedMedia(editor.document);
+    updateData(strBlocks);
+  };
+
+  // Collaborative: an empty editor may mean Yjs has not synced yet, so it is never written.
+  // Standalone: an emptied document is a real edit; handleUpdateData skips unchanged content.
+  const commitDocument = () => {
+    if (collaborative && editor.isEmpty) return;
+    handleUpdateData(editor);
+  };
+
   const handleKeyDown = useEditorKeyboard({
     editor,
     onEscapeClick,
     onEnterClick,
-    commit: () => handleUpdateData(editor),
+    commit: commitDocument,
   });
-
-  const checkUntrustedMedia = useUntrustedMediaWarning();
-
-  const handleUpdateData = (editor: CustomBlockNoteEditor) => {
-    const strBlocks = JSON.stringify(editor.document);
-    if (strBlocks === defaultValue || !updateData) return;
-
-    checkUntrustedMedia(editor.document);
-    updateData(strBlocks);
-  };
 
   const handleOnBeforeLoad = () => onBeforeLoad?.(editor);
 
@@ -242,8 +253,7 @@ function BlockNote({
     editor,
     containerRef: blockNoteRef,
     onBlur: () => {
-      // The isEmpty guard avoids writing empty content before Yjs has synced.
-      if (!commitOnEveryChange && !editor.isEmpty) handleUpdateData(editor);
+      if (!commitOnEveryChange) commitDocument();
     },
   });
 

--- a/frontend/src/modules/common/blocknote/hooks/use-editor-keyboard.ts
+++ b/frontend/src/modules/common/blocknote/hooks/use-editor-keyboard.ts
@@ -16,7 +16,7 @@ interface UseEditorKeyboardArgs {
   /** Called on Escape and Cmd/Ctrl+Enter, after the data has been committed. */
   onEscapeClick?: () => void;
   onEnterClick?: () => void;
-  /** Commits the editor's current document (parent decides what "commit" means). */
+  /** Commits the editor's current document (parent decides what "commit" means, including whether an empty one counts). */
   commit: () => void;
 }
 
@@ -54,13 +54,13 @@ export function useEditorKeyboard({
     event.preventDefault();
 
     if (isEscape) {
-      if (!editor.isEmpty) commit();
+      commit();
       onEscapeClick?.();
       return;
     }
 
     event.stopPropagation();
     onEnterClick?.();
-    if (!editor.isEmpty) commit();
+    commit();
   };
 }

--- a/frontend/src/query/offline/mutation-queue.ts
+++ b/frontend/src/query/offline/mutation-queue.ts
@@ -18,6 +18,19 @@ export function isPending(mutation: MutationLike): boolean {
   return mutation.state.status === 'pending';
 }
 
+/** Mutation ids that paused offline at least once, in this session or restored from the persisted cache. */
+const pausedMutationIds = new Set<string>();
+
+/** Records a mutation as having paused; the mutation cache subscription in the query client calls it. */
+export function recordPausedMutation(mutationId: string): void {
+  pausedMutationIds.add(mutationId);
+}
+
+/** True for a mutation that reaches the server as a replay rather than a live edit. */
+export function hasPaused(mutationId: string): boolean {
+  return pausedMutationIds.has(mutationId);
+}
+
 /** Only offline-paused mutations may be coalesced or cancelled; online intent stays separate and scope-serialized for backend idempotency and LWW handling. */
 export function canCoalesce(): boolean {
   return !onlineManager.isOnline();

--- a/frontend/src/query/offline/mutation-queue.ts
+++ b/frontend/src/query/offline/mutation-queue.ts
@@ -26,7 +26,7 @@ export function recordPausedMutation(mutationId: string): void {
   pausedMutationIds.add(mutationId);
 }
 
-/** True for a mutation that reaches the server as a replay rather than a live edit. */
+/** True for a mutation that paused while offline; the server treats its write as a replay. */
 export function hasPaused(mutationId: string): boolean {
   return pausedMutationIds.has(mutationId);
 }

--- a/frontend/src/query/offline/stx-utils.ts
+++ b/frontend/src/query/offline/stx-utils.ts
@@ -1,6 +1,7 @@
 import type { StxBase } from 'sdk';
 import { uuidv7 } from 'uuidv7';
 import { createFieldTimestamps, sourceId } from './hlc';
+import { hasPaused } from './mutation-queue';
 
 export { sourceId };
 
@@ -20,6 +21,14 @@ export function createStxForUpdate(scalarFieldNames: string[] = []): StxBase {
     sourceId,
     fieldTimestamps: createFieldTimestamps(scalarFieldNames),
   };
+}
+
+/**
+ * Flags a replayed offline update so the server arbitrates it by its field timestamps (intent time).
+ * A live edit carries no flag and is ordered by server arrival, so a skewed device clock cannot lose it.
+ */
+export function withReplayFlag(stx: StxBase): StxBase {
+  return hasPaused(stx.mutationId) ? { ...stx, replayed: true } : stx;
 }
 
 /** Deletes carry no field timestamps. */

--- a/frontend/src/query/offline/tests/stx-utils.test.ts
+++ b/frontend/src/query/offline/tests/stx-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { createStxForCreate, createStxForDelete, createStxForUpdate, sourceId } from '../stx-utils';
+import { recordPausedMutation } from '../mutation-queue';
+import { createStxForCreate, createStxForDelete, createStxForUpdate, sourceId, withReplayFlag } from '../stx-utils';
 
 // Covers stx metadata shape for create, update, delete, and source identity.
 describe('sourceId', () => {
@@ -62,5 +63,20 @@ describe('createStxForDelete', () => {
     expect(stx.fieldTimestamps).toEqual({});
     expect(stx.sourceId).toBe(sourceId);
     expect(stx.mutationId).toBeTruthy();
+  });
+});
+
+describe('withReplayFlag', () => {
+  it('leaves a live edit unflagged, so the server orders it by arrival', () => {
+    const stx = createStxForUpdate(['name']);
+    expect(withReplayFlag(stx).replayed).toBeUndefined();
+  });
+
+  it('flags a mutation that paused offline, so the server arbitrates it by its intent-time timestamps', () => {
+    const stx = createStxForUpdate(['name']);
+    recordPausedMutation(stx.mutationId);
+    const flagged = withReplayFlag(stx);
+    expect(flagged.replayed).toBe(true);
+    expect(flagged.fieldTimestamps).toEqual(stx.fieldTimestamps);
   });
 });

--- a/frontend/src/query/query-client.ts
+++ b/frontend/src/query/query-client.ts
@@ -2,6 +2,7 @@ import { MutationCache, onlineManager, QueryCache, QueryClient } from '@tanstack
 import { appConfig, type ProductEntityType } from 'shared';
 import type { ApiError } from '~/lib/api';
 import { resetConnectivityCache } from '~/query/offline/connectivity';
+import { recordPausedMutation } from '~/query/offline/mutation-queue';
 import { mutationRetry } from '~/query/offline/network-retry';
 import type { QueryMeta } from '~/query/react-query';
 
@@ -96,6 +97,16 @@ if (!import.meta.hot?.data?.listenersAttached) {
   handleOnlineStatus();
 }
 
+/** Marks every mutation that pauses offline, whether it pauses live or is restored paused from the persisted cache, so its eventual request is sent as a replay. */
+function trackPausedMutations(client: QueryClient): void {
+  client.getMutationCache().subscribe((event) => {
+    if (event.type !== 'added' && event.type !== 'updated') return;
+    if (!event.mutation.state.isPaused) return;
+    const mutationId = mutationIdOf(event.mutation.state.variables);
+    if (mutationId) recordPausedMutation(mutationId);
+  });
+}
+
 /**
  * QueryClient instance preserved across HMR to keep the cache intact.
  *
@@ -125,6 +136,9 @@ export const queryClient: QueryClient =
       },
     },
   });
+
+// Subscribed once per page load; the HMR-preserved client keeps its subscription.
+if (!import.meta.hot?.data?.listenersAttached) trackPausedMutations(queryClient);
 
 let resolveCacheRestored: () => void;
 /** Resolves once PersistQueryClientProvider has restored the IDB cache. */

--- a/sdk/gen/docs.gen/details.gen/attachments.gen.json
+++ b/sdk/gen/docs.gen/details.gen/attachments.gen.json
@@ -53,6 +53,11 @@
                         "required": true,
                         "description": "Per-field HLC timestamps for scalar fields being changed",
                         "additionalProperties": { "type": "string", "required": false }
+                      },
+                      "replayed": {
+                        "type": "boolean",
+                        "required": false,
+                        "description": "Set on a paused offline mutation being replayed: its field timestamps then arbitrate as intent time"
                       }
                     },
                     "ref": "#/components/schemas/StxBase"
@@ -357,6 +362,11 @@
                         "required": true,
                         "description": "Per-field HLC timestamps for scalar fields being changed",
                         "additionalProperties": { "type": "string", "required": false }
+                      },
+                      "replayed": {
+                        "type": "boolean",
+                        "required": false,
+                        "description": "Set on a paused offline mutation being replayed: its field timestamps then arbitrate as intent time"
                       }
                     },
                     "ref": "#/components/schemas/StxBase"
@@ -598,6 +608,11 @@
                         "required": true,
                         "description": "Per-field HLC timestamps for scalar fields being changed",
                         "additionalProperties": { "type": "string", "required": false }
+                      },
+                      "replayed": {
+                        "type": "boolean",
+                        "required": false,
+                        "description": "Set on a paused offline mutation being replayed: its field timestamps then arbitrate as intent time"
                       }
                     },
                     "ref": "#/components/schemas/StxBase"
@@ -908,6 +923,11 @@
                   "required": true,
                   "description": "Per-field HLC timestamps for scalar fields being changed",
                   "additionalProperties": { "type": "string", "required": false }
+                },
+                "replayed": {
+                  "type": "boolean",
+                  "required": false,
+                  "description": "Set on a paused offline mutation being replayed: its field timestamps then arbitrate as intent time"
                 }
               },
               "ref": "#/components/schemas/StxBase"
@@ -1200,6 +1220,11 @@
                   "required": true,
                   "description": "Per-field HLC timestamps for scalar fields being changed",
                   "additionalProperties": { "type": "string", "required": false }
+                },
+                "replayed": {
+                  "type": "boolean",
+                  "required": false,
+                  "description": "Set on a paused offline mutation being replayed: its field timestamps then arbitrate as intent time"
                 }
               },
               "ref": "#/components/schemas/StxBase"
@@ -1428,6 +1453,11 @@
                   "required": true,
                   "description": "Per-field HLC timestamps for scalar fields being changed",
                   "additionalProperties": { "type": "string", "required": false }
+                },
+                "replayed": {
+                  "type": "boolean",
+                  "required": false,
+                  "description": "Set on a paused offline mutation being replayed: its field timestamps then arbitrate as intent time"
                 }
               },
               "ref": "#/components/schemas/StxBase"
@@ -1656,6 +1686,11 @@
                 "required": true,
                 "description": "Per-field HLC timestamps for scalar fields being changed",
                 "additionalProperties": { "type": "string", "required": false }
+              },
+              "replayed": {
+                "type": "boolean",
+                "required": false,
+                "description": "Set on a paused offline mutation being replayed: its field timestamps then arbitrate as intent time"
               }
             },
             "ref": "#/components/schemas/StxBase"

--- a/sdk/gen/docs.gen/schemas.gen.json
+++ b/sdk/gen/docs.gen/schemas.gen.json
@@ -41,6 +41,11 @@
               "required": true,
               "description": "Per-field HLC timestamps for scalar fields being changed",
               "additionalProperties": { "type": "string", "required": false }
+            },
+            "replayed": {
+              "type": "boolean",
+              "required": false,
+              "description": "Set on a paused offline mutation being replayed: its field timestamps then arbitrate as intent time"
             }
           },
           "ref": "#/components/schemas/StxBase"
@@ -2086,6 +2091,11 @@
           "required": true,
           "description": "Per-field HLC timestamps for scalar fields being changed",
           "additionalProperties": { "type": "string", "required": false }
+        },
+        "replayed": {
+          "type": "boolean",
+          "required": false,
+          "description": "Set on a paused offline mutation being replayed: its field timestamps then arbitrate as intent time"
         }
       }
     },

--- a/sdk/gen/openapi.json
+++ b/sdk/gen/openapi.json
@@ -706,6 +706,10 @@
               "type": "string"
             },
             "description": "Per-field HLC timestamps for scalar fields being changed"
+          },
+          "replayed": {
+            "type": "boolean",
+            "description": "Set on a paused offline mutation being replayed: its field timestamps then arbitrate as intent time"
           }
         },
         "required": ["mutationId", "sourceId", "fieldTimestamps"],

--- a/sdk/gen/types.gen.ts
+++ b/sdk/gen/types.gen.ts
@@ -106,6 +106,10 @@ export type StxBase = {
   fieldTimestamps: {
     [key: string]: string;
   };
+  /**
+   * Set on a paused offline mutation being replayed: its field timestamps then arbitrate as intent time
+   */
+  replayed?: boolean;
 };
 
 /**

--- a/sdk/gen/zod.gen.ts
+++ b/sdk/gen/zod.gen.ts
@@ -93,6 +93,7 @@ export const zStxBase = z.object({
   mutationId: z.string().max(36),
   sourceId: z.string().max(64),
   fieldTimestamps: z.record(z.string(), z.string()),
+  replayed: z.boolean().optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

Four fixes for attachment description edits that were silently lost or never written, found while enabling Yjs in cella (#1146 retests depend on this landing first).

- **Stale-clock drop**: a client whose wall clock ran behind the stored field timestamp had its edit dropped with a 200, hidden by the optimistic cache until reload. `resolveUpdateOps` now stamps a fresh server HLC on every live write; only a mutation replayed after an offline pause (`stx.replayed`) keeps its client timestamps as intent time.
- **Emptied document never saved**: the blur guard that avoids writing before Yjs syncs also refused a deliberate clear in standalone mode. The guard is collaborative-only now; Escape and blur commit the same document once.
- **Sheet dismissal**: an outside press removes the sheet at once, so the editor unmounts while focused and no blur fires. Standalone editors now commit in the effect cleanup.
- **Keywords**: the update op derives `keywords` from the description with `keywordsFromDocument`; attachment search matches keywords.

## Test plan

- [x] `src/core/stx` and `src/query/offline` suites (104 tests) after rebase onto main
- [x] `pnpm sdk` unchanged after rebase; biome + typecheck via pre-commit
- [ ] Manual: standalone sheet (relay stopped), type, click outside: one update request, text persists after reload
- [ ] Manual: clear a description, close: empty is stored
- [ ] Manual: search the attachments table by a word from a description

🤖 Generated with [Claude Code](https://claude.com/claude-code)