### PR TITLE
fix(attachment): dialog image fits between the chrome, one zoom clamp for wheel, pinch and buttons

### DIFF
--- a/frontend/src/modules/attachment/attachments-carousel.tsx
+++ b/frontend/src/modules/attachment/attachments-carousel.tsx
@@ -8,7 +8,11 @@ import { textFromDocument } from 'shared/blocknote';
 import { isCDNUrl } from 'shared/utils/is-cdn-url';
 import { useLatestCallback, useLatestRef } from '~/hooks/use-latest-ref';
 import { openAttachmentDialog } from '~/modules/attachment/dialog/open-attachment-dialog';
-import { ATTACHMENT_DIALOG_PARAM, clearAttachmentDialogSearchParams } from '~/modules/attachment/dialog/params';
+import {
+  ATTACHMENT_DIALOG_PARAM,
+  attachmentDialogStageClassName,
+  clearAttachmentDialogSearchParams,
+} from '~/modules/attachment/dialog/params';
 import { FilePlaceholder } from '~/modules/attachment/file-placeholder';
 import { AttachmentRender } from '~/modules/attachment/render/attachment-render';
 import { CloseButton } from '~/modules/common/close-button';
@@ -131,8 +135,9 @@ export function AttachmentsCarousel({
       className="group h-full w-full"
       setApi={handleSetApi}
     >
+      {/* z-20 matches the zoom controls: at z-10 the viewer, a flex item with the same index, paints over the title. */}
       {currentItem && isDialog && (
-        <div className="fixed top-0 left-0 z-10 flex w-full flex-col bg-background/60 p-3 backdrop-blur-xs">
+        <div className="fixed top-0 left-0 z-20 flex w-full flex-col bg-background/60 p-3 backdrop-blur-xs">
           <div className="flex w-full gap-2 text-center sm:text-left">
             {/* The visible name is the dialog's accessible name; with no name, a screen-reader-only title labels it. */}
             {currentItem.name ? (
@@ -237,6 +242,7 @@ export function AttachmentsCarousel({
               <AttachmentRender
                 containerClassName={cn(
                   'relative flex h-full items-center justify-center overflow-hidden',
+                  isDialog && attachmentDialogStageClassName,
                   classNameContainer,
                 )}
                 itemClassName={isDialog ? 'object-contain' : ''}

--- a/frontend/src/modules/attachment/dialog/attachment-dialog-handler.tsx
+++ b/frontend/src/modules/attachment/dialog/attachment-dialog-handler.tsx
@@ -38,7 +38,6 @@ function AttachmentDialogHandlerBase() {
           },
           // Open state lives in the URL: remove on ESC/outside-press so the search param clears before a re-open can flash.
           instantClose: true,
-          headerClassName: 'hidden',
         }),
       );
     });

--- a/frontend/src/modules/attachment/dialog/attachment-dialog.tsx
+++ b/frontend/src/modules/attachment/dialog/attachment-dialog.tsx
@@ -4,6 +4,7 @@ import { t } from 'i18next';
 import { FlameKindlingIcon } from 'lucide-react';
 import { useRef } from 'react';
 import { AttachmentsCarousel, type CarouselItemData } from '~/modules/attachment/attachments-carousel';
+import { attachmentDialogContentClassName } from '~/modules/attachment/dialog/params';
 import { useResolvedAttachments } from '~/modules/attachment/hooks/use-resolved-attachments';
 import { attachmentQueryOptions, useGroupAttachments } from '~/modules/attachment/query';
 import { CloseButton } from '~/modules/common/close-button';
@@ -66,7 +67,7 @@ export function AttachmentDialog() {
   if (!resolvedItems.length || (hasErrors && errorIds.includes(initialAttachmentId))) {
     return (
       <>
-        <div className="fixed top-0 left-0 z-10 flex w-full gap-2 bg-background/60 p-3 backdrop-blur-xs">
+        <div className="fixed top-0 left-0 z-20 flex w-full gap-2 bg-background/60 p-3 backdrop-blur-xs">
           <div className="grow" />
           <CloseButton onClick={() => removeDialog()} size="lg" className="-my-1" />
         </div>
@@ -81,7 +82,7 @@ export function AttachmentDialog() {
 
   hasRenderedRef.current = true;
   return (
-    <div className="relative -z-1 flex h-dvh grow flex-wrap justify-center p-2">
+    <div className={attachmentDialogContentClassName}>
       <AttachmentsCarousel items={resolvedItems} isDialog itemIndex={itemIndex} saveInSearchParams />
     </div>
   );

--- a/frontend/src/modules/attachment/dialog/open-attachment-dialog.tsx
+++ b/frontend/src/modules/attachment/dialog/open-attachment-dialog.tsx
@@ -19,7 +19,6 @@ export const openAttachmentDialog = ({ attachmentIndex, attachments, triggerRef 
       triggerRef: triggerRef || {
         current: document.activeElement instanceof HTMLButtonElement ? document.activeElement : null,
       },
-      headerClassName: 'absolute p-4 w-full backdrop-blur-xs bg-background/50',
     }),
   );
 };

--- a/frontend/src/modules/attachment/dialog/params.ts
+++ b/frontend/src/modules/attachment/dialog/params.ts
@@ -13,6 +13,13 @@ export const attachmentDialogClassName = 'min-w-full h-dvh max-h-dvh border-0 p-
 /** Wrapper the carousel is mounted in, identical for both dialog entry points. */
 export const attachmentDialogContentClassName = 'relative -z-1 flex h-dvh grow flex-wrap justify-center p-2';
 
+/**
+ * Per-slide stage insets: a fitted image stays clear of the fixed header (3rem) and, from `sm` up where the pan/zoom
+ * viewer renders them, the zoom controls (3.25rem from the bottom). Zoomed-in content still slides under the
+ * translucent chrome because overflow clips at the padding edge.
+ */
+export const attachmentDialogStageClassName = 'pt-12 sm:pb-14';
+
 export function openAttachmentDialogSearch(attachmentId: string, groupId?: string | null) {
   return (prev: Record<string, unknown>) => ({
     ...prev,
@@ -37,7 +44,7 @@ export const clearAttachmentDialogSearchParams = () => {
   });
 };
 
-/** Dialoger options shared by both entry points; `headerClassName` differs per caller. */
+/** Dialoger options shared by both entry points. */
 export function attachmentDialogOptions(overrides: DialogData): DialogData {
   return {
     drawerOnMobile: false,

--- a/frontend/src/modules/attachment/render/attachment-render.tsx
+++ b/frontend/src/modules/attachment/render/attachment-render.tsx
@@ -79,10 +79,8 @@ export function AttachmentRender({
             />
           ))}
         {type.includes('audio') && <RenderAudio src={url} className="mx-auto -mt-48 h-20 w-[80vw]" />}
-        {type.includes('video') && <RenderVideo src={url} className="mx-auto max-h-[90vh] max-w-7xl" />}
-        {type.includes('pdf') && (
-          <RenderPDF file={url} className="m-auto mt-12 h-[calc(97vh-3rem)] w-[95vw] max-w-280 overflow-auto" />
-        )}
+        {type.includes('video') && <RenderVideo src={url} className="mx-auto max-h-full max-w-7xl" />}
+        {type.includes('pdf') && <RenderPDF file={url} className="m-auto h-full w-[95vw] max-w-280 overflow-auto" />}
         {!['image', 'audio', 'video', 'pdf'].some((k) => type.includes(k)) && (
           <ContentPlaceholder icon={getFileIcon(type)} title="c:download_to_view">
             {/* The URL is always fetchable: a CDN or presigned URL online, a local blob URL offline. */}

--- a/frontend/src/modules/attachment/render/image-viewer.tsx
+++ b/frontend/src/modules/attachment/render/image-viewer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { WHEEL_ZOOM_SENSITIVITY } from '~/modules/attachment/render/image-zoom';
 
 interface ImageDragData {
   x: number;
@@ -211,10 +212,11 @@ export class ImageViewer extends React.PureComponent<ImageViewerProps, ImageView
     this.updateMousePosition(e.pageX, e.pageY);
   };
 
+  // A trackpad pinch arrives as a ctrlKey wheel with small deltas: the exponential step keeps pinch and mouse wheel
+  // continuous, and the parent's clamp sets the floor and ceiling.
   private onWheel = (e: React.WheelEvent<EventTarget>) => {
-    Math.sign(e.deltaY) < 0
-      ? this.props.setZoom((this.props.zoom || 0) + 0.1)
-      : (this.props.zoom || 0) > 1 && this.props.setZoom((this.props.zoom || 0) - 0.1);
+    const deltaY = e.deltaMode === WheelEvent.DOM_DELTA_LINE ? e.deltaY * 16 : e.deltaY;
+    this.props.setZoom((this.props.zoom || 1) * Math.exp(-deltaY * WHEEL_ZOOM_SENSITIVITY));
   };
 
   private onMouseEnter = () => {

--- a/frontend/src/modules/attachment/render/image-zoom.ts
+++ b/frontend/src/modules/attachment/render/image-zoom.ts
@@ -1,0 +1,8 @@
+/** Zoom 1 is the CSS fit inside the dialog stage; the floor keeps a zoomed-out image visible, the ceiling keeps it navigable. */
+export const MIN_ZOOM = 0.25;
+export const MAX_ZOOM = 8;
+export const ZOOM_STEP = 0.2;
+/** Per wheel pixel: a 100px mouse notch is roughly 20%, a pinch delta of a few pixels stays smooth. */
+export const WHEEL_ZOOM_SENSITIVITY = 0.002;
+
+export const clampZoom = (zoom: number) => Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom));

--- a/frontend/src/modules/attachment/render/image.tsx
+++ b/frontend/src/modules/attachment/render/image.tsx
@@ -3,6 +3,7 @@ import type React from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ImageViewer } from '~/modules/attachment/render/image-viewer';
+import { clampZoom, ZOOM_STEP } from '~/modules/attachment/render/image-zoom';
 import { TooltipButton } from '~/modules/common/tooltip-button';
 import { Button } from '~/modules/ui/button';
 import { cn } from '~/utils/cn';
@@ -51,7 +52,9 @@ export function ReactPanZoom({
   const [dx, setDx] = useState(0);
   const [dy, setDy] = useState(0);
 
-  const [zoom, setZoom] = useState(1);
+  const [zoom, setZoomState] = useState(1);
+  // Every input (buttons, wheel, trackpad pinch) goes through the same clamp.
+  const setZoom = (next: number) => setZoomState(clampZoom(next));
   const [rotation, setRotation] = useState(0);
   // On by default when no onPanStateToggle is passed.
   const [panState, setPanState] = useState(!onPanStateToggle);
@@ -64,8 +67,8 @@ export function ReactPanZoom({
     setRotation(0);
   };
 
-  const zoomIn = () => setZoom((prevZoom) => prevZoom + 0.2);
-  const zoomOut = () => setZoom((prevZoom) => (prevZoom >= 0.4 ? prevZoom - 0.2 : prevZoom));
+  const zoomIn = () => setZoom(zoom + ZOOM_STEP);
+  const zoomOut = () => setZoom(zoom - ZOOM_STEP);
   const rotateRight = () => setRotation((prevRotation) => (prevRotation === 3 ? 0 : prevRotation + 1));
 
   const onPan = (dx: number, dy: number) => {
@@ -76,7 +79,7 @@ export function ReactPanZoom({
   return (
     <>
       {showButtons && (
-        <div className="absolute bottom-3 left-[calc(50vw-6.5rem)] z-20 flex items-center justify-center gap-0 rounded-md bg-transparent text-sm shadow-xs ring-offset-background">
+        <div className="absolute bottom-3 left-1/2 z-20 flex -translate-x-1/2 items-center justify-center gap-0 rounded-md bg-transparent text-sm shadow-xs ring-offset-background">
           <ControlButton
             tooltipContent={t('c:zoom_in')}
             onClick={zoomIn}
@@ -118,7 +121,7 @@ export function ReactPanZoom({
       )}
 
       <ImageViewer
-        className={cn('z-10 flex h-full w-full items-center justify-center', backdropDismiss && 'pointer-events-none')}
+        className={cn('flex h-full w-full items-center justify-center', backdropDismiss && 'pointer-events-none')}
         zoom={zoom}
         setZoom={setZoom}
         enablePan={panState}

--- a/frontend/src/modules/attachment/tests/image-zoom.test.ts
+++ b/frontend/src/modules/attachment/tests/image-zoom.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { clampZoom, MAX_ZOOM, MIN_ZOOM, ZOOM_STEP } from '~/modules/attachment/render/image-zoom';
+
+describe('clampZoom', () => {
+  it('passes values inside the range through', () => {
+    expect(clampZoom(1)).toBe(1);
+    expect(clampZoom(1 + ZOOM_STEP)).toBeCloseTo(1.2);
+  });
+
+  it('stops at the floor so repeated zoom-out never hides the image', () => {
+    let zoom = 1;
+    for (let i = 0; i < 20; i++) zoom = clampZoom(zoom - ZOOM_STEP);
+    expect(zoom).toBe(MIN_ZOOM);
+    expect(clampZoom(0)).toBe(MIN_ZOOM);
+    expect(clampZoom(-3)).toBe(MIN_ZOOM);
+  });
+
+  it('stops at the ceiling for wheel bursts', () => {
+    expect(clampZoom(Math.exp(100))).toBe(MAX_ZOOM);
+  });
+});


### PR DESCRIPTION
## Problem

In the attachment dialog a tall image at the default zoom spans the full viewport, so the fixed header and the zoom controls overlap it. Trackpad pinch (and mouse wheel) could not zoom out below 1, which is exactly the fit that collides with the chrome. The header and the viewer also shared `z-10`, so the image painted over the title bar.

## Changes

- **Stage insets.** `attachmentDialogStageClassName` (`pt-12 sm:pb-14`, hardcoded on purpose) pads the per-slide container in dialog mode so zoom 1 fits between the header and the controls. Overflow still clips at the padding edge, so a zoomed-in image can slide under the translucent chrome as before. The bottom inset only applies from `sm` up, where the pan/zoom controls render.
- **One zoom clamp.** New `render/image-zoom.ts` holds the floor (0.25), ceiling (8), button step and wheel sensitivity. Buttons, mouse wheel and trackpad pinch all pass through it; wheel zoom is exponential on `deltaY`, so pinch is continuous and a mouse notch is roughly 20%.
- **Stacking.** Header moves to `z-20`, the viewer loses its `z-10`.
- **Cleanups.** Both entry points drop a `headerClassName` that never rendered (no title, so no `DialogHeader`), the dialog uses the shared wrapper class instead of an inline copy, the controls center with a translate instead of a `50vw` calculation, PDF and video drop their ad hoc viewport offsets in favor of the padded stage.

## Verification

- Frontend typecheck, biome, style gate and SDK regeneration pass; a new vitest covers the clamp.
- Not runtime-verified in a browser. Please check: portrait image at default zoom, trackpad pinch out, zoom buttons to the floor, rotate, caption toggle (it still overlays the image when open, as agreed), a PDF and a video in the dialog, and a mobile width.

## Fork impact

Unpinned template files only; forks pick this up on the next sync without a migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
