### PR TITLE
fix(test): exclude the storybook browser project from root vitest runs

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     __DEV_TOOLS__: 'true',
   },
   // Top-level alias so this config also works when invoked as a single project
-  // from the root vitest config (which flattens nested `projects`).
+  // from the root vitest config.
   resolve: {
     alias: {
       '~': path.resolve(import.meta.dirname, './src'),
@@ -18,12 +18,12 @@ export default defineConfig({
   },
   test: {
     passWithNoTests: true,
-    // Applies when this config is flattened into a single `frontend` project by
-    // the root vitest config (which ignores the nested `projects` below). Keeps
-    // console noise silenced in both the root and standalone test runs. Env stays
-    // node (most src tests stub their own window); DOM tests opt in per-file with
-    // `// @vitest-environment jsdom`.
+    // Keeps console noise silenced in both the root and standalone test runs. Env
+    // stays node (most src tests stub their own window); DOM tests opt in per-file
+    // with `// @vitest-environment jsdom`.
     setupFiles: ['./vitest.setup.ts'],
+    // The root vitest config runs the node and unit projects; the storybook browser
+    // project is excluded there and runs via `pnpm test:storybook`.
     projects: [
       // Node-side tests (vite plugins, helpers, etc.)
       {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,11 @@ const coverageReporters =
 export default defineConfig({
   test: {
     passWithNoTests: true,
+    // Vitest 5 recurses into nested projects, so the frontend's Storybook browser
+    // project would run here too and needs Playwright browsers plus a Storybook
+    // server. It only runs on its own via `pnpm test:storybook`. A CLI `--project`
+    // replaces this list.
+    project: ['!frontend (storybook)'],
     projects: [
       'backend',
       'bench',


### PR DESCRIPTION
Fixes the failing `test` job on the release PR #1151.

Vitest 5 recurses into nested projects, so the root `pnpm test:full` run now also picks up the frontend Storybook browser project. That project needs Playwright browsers plus a Storybook server, which the `test` job does not install, so it died on a missing chromium headless shell.

The root config now excludes `frontend (storybook)` via `test.project`; Storybook tests keep running on their own in the `storybook-test` job via `--project=storybook`. A CLI `--project` (as used by `test:core:runtime`) still replaces the list. Stale comments in the frontend config about flattened nested projects are refreshed.

Verified locally: root `vitest list` no longer includes the storybook project, `--project=backend-runtime` still resolves, and the frontend standalone `--project=storybook` still finds all 80 story files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
