### PR TITLE
fix(infra): reconcile VM IAM policy rules on a privileged up

### DIFF
--- a/cella/DEPLOYMENT.md
+++ b/cella/DEPLOYMENT.md
@@ -153,6 +153,8 @@ Most config changes ship through a normal CI deploy. **Bootstrap-owned** resourc
 3. Runs `pulumi up` against the bootstrapped stack without setting `bootstrap:computeDeferred`, so the running VMs and LB stay in place.
 4. Reminds you to revoke the bootstrap key.
 
+The VM IAM policies are bootstrap-owned too: a CI deploy never rewrites their rules. Toggling a co-hosted or collocated service (for example `appConfig.services.yjs.enabled` under `singleVM`) changes the host VM's secret-path condition, so run **Apply infra change** before the next release deploy or its "Verify VM IAM grants" step fails on the stale condition.
+
 ## Fresh installation
 
 `pnpm infra` launches the CLI ([cli/infra-cli.ts](../infra/cli/infra-cli.ts)). Without a local `Pulumi.<stack>.yaml` it runs the install wizard. A fresh install defaults to **staging**. Production is the same wizard via `pnpm infra --mode production`. `--defaults` takes every optional default and prompts only for required inputs (bootstrap key, admin email). `INFRA_NON_INTERACTIVE=1` also takes the defaults but fails on a required input with no environment value. `pnpm --filter infra status` shows the current state and next action.

--- a/infra/cli/actions/privileged-converge.ts
+++ b/infra/cli/actions/privileged-converge.ts
@@ -72,7 +72,7 @@ export async function runPrivilegedConverge(
     passphrase,
     ...stateOverride,
   });
-  // Marks the `pulumi up` child as bootstrap-keyed so bootstrap-owned resources (VM IAM policy rules) reconcile instead of being ignored as on CI ups.
+  // Marks the `pulumi up` child as bootstrap-keyed: bootstrap-owned resources (VM IAM policy rules) reconcile under this marker.
   env[PRIVILEGED_UP_ENV] = '1';
   pulumiLoginAndSelect(infraDir, env, appConfig, stack);
 

--- a/infra/cli/actions/privileged-converge.ts
+++ b/infra/cli/actions/privileged-converge.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { confirm } from '@inquirer/prompts';
 import { buildProviderEnv, stateKeyOverrideFromEnv } from '../../lib/scaleway/bootstrap-scw-env';
 import { resolveOrganizationId } from '../../lib/scaleway/scaleway-iam';
+import { PRIVILEGED_UP_ENV } from '../../lib/stack/privileged-up';
 import { parseOrphanedDeletes, pruneOrphanedDeletes, runPulumiUpWithHint } from '../../lib/stack/pulumi-up';
 import { pc, warningMark } from '../../lib/utils/cli-output';
 import { errorMessage } from '../../lib/utils/errors';
@@ -71,6 +72,8 @@ export async function runPrivilegedConverge(
     passphrase,
     ...stateOverride,
   });
+  // Marks the `pulumi up` child as bootstrap-keyed so bootstrap-owned resources (VM IAM policy rules) reconcile instead of being ignored as on CI ups.
+  env[PRIVILEGED_UP_ENV] = '1';
   pulumiLoginAndSelect(infraDir, env, appConfig, stack);
 
   // Lock the stack through the control bucket to exclude concurrent operators and CI.

--- a/infra/lib/stack/privileged-up.test.ts
+++ b/infra/lib/stack/privileged-up.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { isPrivilegedUp, PRIVILEGED_UP_ENV, vmPolicyIgnoreChanges } from './privileged-up';
+
+describe('privileged-up', () => {
+  it('is off unless the marker is exactly "1"', () => {
+    expect(isPrivilegedUp({})).toBe(false);
+    expect(isPrivilegedUp({ [PRIVILEGED_UP_ENV]: 'true' })).toBe(false);
+    expect(isPrivilegedUp({ [PRIVILEGED_UP_ENV]: '1' })).toBe(true);
+  });
+
+  it('CI ups ignore policy rules; privileged ups reconcile them', () => {
+    expect(vmPolicyIgnoreChanges({})).toEqual(['rules', 'description']);
+    expect(vmPolicyIgnoreChanges({ [PRIVILEGED_UP_ENV]: '1' })).toEqual(['description']);
+  });
+});

--- a/infra/lib/stack/privileged-up.ts
+++ b/infra/lib/stack/privileged-up.ts
@@ -1,0 +1,15 @@
+/** Env marker the infra CLI's privileged converge sets on its `pulumi up` child. Absent on CI ups, which run with the read-only CI key. */
+export const PRIVILEGED_UP_ENV = 'INFRA_PRIVILEGED_UP';
+
+/** Whether the running Pulumi program holds a bootstrap key that may write IAM. */
+export function isPrivilegedUp(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[PRIVILEGED_UP_ENV] === '1';
+}
+
+/**
+ * `ignoreChanges` for the VM IAM policies. A CI up must never diff `rules`: the write would 403 under the CI key, and the provider's condition empty-vs-unset asymmetry shows a phantom `~rules` anyway.
+ * A privileged up reconciles `rules`, so a changed secret scope (a co-hosted or collocated service toggled on or off) reaches the live policy before the deploy's assert-vm-grants step compares conditions.
+ */
+export function vmPolicyIgnoreChanges(env: NodeJS.ProcessEnv = process.env): string[] {
+  return isPrivilegedUp(env) ? ['description'] : ['rules', 'description'];
+}

--- a/infra/resources/vm-iam.ts
+++ b/infra/resources/vm-iam.ts
@@ -12,6 +12,7 @@ import {
 import { principalNames } from '../lib/scaleway/principals';
 import { bootKeyCondition, serviceKeyCondition } from '../lib/scaleway/secret-paths';
 import { deployedServices, secretScopeSlugs } from '../lib/services';
+import { vmPolicyIgnoreChanges } from '../lib/stack/privileged-up';
 import { mode, naming, organizationId, projectId, tags } from '../pulumi-context';
 
 const names = principalNames(appConfig.slug, mode);
@@ -78,10 +79,12 @@ export const bootApplicationId: pulumi.Output<string> = requirePrincipalId(
 /**
  * Pulumi-managed IAM policies for the VM-side principals. Bootstrap-owned: IAM policy write is forbidden to the CI key, so a bootstrap-key up creates these before compute exists, and compute VMs depend on them so grants attach before the first runtime-secret hydration.
  * One policy per service app (secret read conditioned to its own and shared folders) and one for the boot app (registry pull, diag write, handoff-only secret read). Conditions only narrow, and `assert-vm-grants` verifies no other policy un-scopes them.
- * `ignoreChanges: ['rules', 'description']` keeps CI ups from attempting IAM writes they would 403 on, and sidesteps the provider's condition empty-vs-unset diff asymmetry that shows a phantom ~rules.
+ * CI ups ignore `rules` (they would 403 on the IAM write, and the provider shows a phantom ~rules from its condition empty-vs-unset asymmetry); a privileged up (CLI "Apply infra change") reconciles them, which is how a changed secret scope reaches the live policy.
  * @see resources/compute.ts
+ * @see lib/stack/privileged-up.ts
  */
 export const vmIamPolicies: scaleway.iam.Policy[] = [];
+const policyOptions = { ignoreChanges: vmPolicyIgnoreChanges() };
 
 for (const svc of vmServices) {
   const isBackend = svc.s3Access === true;
@@ -114,7 +117,7 @@ for (const svc of vmServices) {
         ],
         tags,
       },
-      { ignoreChanges: ['rules', 'description'] },
+      policyOptions,
     ),
   );
 }
@@ -140,7 +143,7 @@ vmIamPolicies.push(
       ],
       tags,
     },
-    { ignoreChanges: ['rules', 'description'] },
+    policyOptions,
   ),
 );
 


### PR DESCRIPTION
The v0.10.2 release deploy (run 34379459483) failed at "Verify VM IAM grants": the live `cella-vm-backend-policy` secret rule still carries the four-folder condition (backend, cdc, frontend, shared) while this release enables `yjs`, which is `coHosted` under `singleVM` and therefore adds `/cella-production/yjs/` to the backend host's expected condition.

Nothing could have converged the rule: `vm-iam.ts` sets `ignoreChanges: ['rules']` unconditionally, so even the bootstrap-keyed **Apply infra change** left it untouched.

Changes:

- `infra/lib/stack/privileged-up.ts`: `INFRA_PRIVILEGED_UP` marker + `vmPolicyIgnoreChanges()` (CI: ignore rules; privileged: reconcile them), with a unit test.
- `privileged-converge.ts` sets the marker on its `pulumi up` env, so "Apply infra change" now rewrites stale policy rules.
- `vm-iam.ts` uses the helper; doc comment updated.
- `DEPLOYMENT.md`: toggling a co-hosted/collocated service requires an Apply infra change before the next release deploy.

Operator steps after merge (needs a bootstrap key, so not something CI can do): `pnpm infra` → Apply infra change on production, then re-run the failed deploy job. The Pulumi warning about a pending `vm-backend-policy` create is pre-existing (also on the 0.10.1 deploy) and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
