### PR TITLE
feat(infra): derive VM IAM principals and policies from the service registry

### DIFF
--- a/cella/DEPLOYMENT.md
+++ b/cella/DEPLOYMENT.md
@@ -146,14 +146,15 @@ All tunable infra config lives in committed, type-checked files under [config/](
 
 ## Changing infrastructure
 
-Most config changes ship through a normal CI deploy. **Bootstrap-owned** resources (database, VPC) can only be mutated with a temporary bootstrap key: `pnpm infra` → **Apply infra change**, which:
+Most config changes ship through a normal CI deploy, including toggling `appConfig.services.<slug>.enabled`. **Bootstrap-owned** resources (database, VPC, the VM IAM principals and policies) can only be mutated with a temporary bootstrap key: `pnpm infra` → **Apply infra change**, which:
 
-1. Reads the Pulumi passphrase and a fresh bootstrap key from `PULUMI_CONFIG_PASSPHRASE` and `SCW_BOOTSTRAP_ACCESS_KEY` / `SCW_BOOTSTRAP_SECRET_KEY`, prompting for whatever is missing ([Generate a bootstrap API key](#2-generate-a-bootstrap-api-key)).
-2. Passes the key to the Scaleway provider via `SCW_*` env. It is never written to stack config.
-3. Runs `pulumi up` against the bootstrapped stack without setting `bootstrap:computeDeferred`, so the running VMs and LB stay in place.
-4. Reminds you to revoke the bootstrap key.
+1. Reads the Pulumi passphrase and a fresh bootstrap key from `PULUMI_CONFIG_PASSPHRASE` and `SCW_BOOTSTRAP_ACCESS_KEY` / `SCW_BOOTSTRAP_SECRET_KEY`, prompting for whatever is missing ([Generate a bootstrap API key](#2-generate-a-bootstrap-api-key)). The state bucket admits only the CI deploy and admin applications, so also set `SCW_STATE_ACCESS_KEY` / `SCW_STATE_SECRET_KEY` to a key of the `<slug>-<mode>-ci-deploy` application (mint one in the console for the run, delete it after).
+2. Passes the bootstrap key to the Scaleway provider via `SCW_*` env. It is never written to stack config.
+3. Creates any missing VM IAM application (`<slug>-<mode>-vm-<service>`, `<slug>-<mode>-boot`) for the service registry.
+4. Runs `pulumi up` against the bootstrapped stack without setting `bootstrap:computeDeferred`, so the running VMs and LB stay in place. This run also reconciles the VM policy rules, which a CI deploy leaves untouched.
+5. Reminds you to revoke the bootstrap key.
 
-The VM IAM policies are bootstrap-owned too: a CI deploy never rewrites their rules. Toggling a co-hosted or collocated service (for example `appConfig.services.yjs.enabled` under `singleVM`) changes the host VM's secret-path condition, so run **Apply infra change** before the next release deploy or its "Verify VM IAM grants" step fails on the stale condition.
+VM IAM principals and policies follow the **service registry** ([config/services.config.ts](../infra/config/services.config.ts)), not the enabled set: every registry service that owns VMs has an application and a path-conditioned policy, and under `singleVM` the host condition covers every registry worker. Toggling `enabled` in either mode therefore needs no Apply. Adding or removing a registry service, or flipping `singleVM`, does: until you run **Apply infra change**, the next deploy fails at `requirePrincipalId` (split-VM) or at "Verify VM IAM grants" (`singleVM`). A registry service that is not deployed keeps its principal with zero API keys; the deploy's "Verify VM IAM grants" step asserts that and the key mint purges any it finds.
 
 ## Fresh installation
 

--- a/cella/migrations/20260911T0759-registry-owned-iam-principals/README.md
+++ b/cella/migrations/20260911T0759-registry-owned-iam-principals/README.md
@@ -1,0 +1,28 @@
+# VM IAM principals and policies follow the service registry
+
+## What & why
+
+`infra/lib/services.ts` gains `placeServices`, `principalServices` and `principalSecretScopeSlugs`; `resources/vm-iam.ts`, the deploy's `vm_assert_json` rows and bootstrap principal creation derive from the full registry, so toggling `appConfig.services.<slug>.enabled` never touches bootstrap-owned IAM. "Apply infra change" creates missing `vm-<service>`/`boot` applications itself. Dormant principals (registry services outside the deployed set) must hold zero API keys: the deploy asserts it and `mint-generation-keys` purges them. Trigger: enabling yjs under `singleVM` stalled the 0.10.2 deploy on a stale host condition (cella #1156).
+
+## Blast radius
+
+Infra only, not sync-breaking, no `clientCacheVersion` bump, no database change. Every bootstrapped stack needs one privileged run. `singleVM` stacks: the host condition gains each non-deployed registry folder (cella: `/<slug>-<mode>/mcp/`). Split-VM stacks: a new application and policy per registry service that was not deployed (raak: `vm-yjs`, `vm-mcp`). Until that run, the next CI deploy fails at `requirePrincipalId` (split-VM) or "Verify VM IAM grants" (`singleVM`).
+
+## Run
+
+No script: manual.
+
+## Manual steps
+
+1. Sync, so `infra/` carries this change.
+2. Per stack: `pnpm infra` → Stack setup → **Apply infra change**, with a fresh bootstrap key and `SCW_STATE_ACCESS_KEY` / `SCW_STATE_SECRET_KEY` set to a key of the `<slug>-<mode>-ci-deploy` application. Expect the `pulumi up` diff to show `~rules` on the VM policies, plus new `vm-<service>` policies on split-VM stacks.
+3. Revoke the bootstrap key and the temporary CI key.
+4. Deploy as usual; "Verify VM IAM grants" reports each dormant principal with no key.
+
+## Verify
+
+```sh
+pnpm --filter infra exec tsx tasks/print-deploy-env.ts production
+pnpm --filter infra exec vitest run
+pnpm check
+```

--- a/cella/migrations/manifest.json
+++ b/cella/migrations/manifest.json
@@ -921,6 +921,23 @@
     "pnpm check"
    ],
    "summary": "The relay lost the first update of a burst (in-memory merge across awaits, no ordering). New yjs_updates table: every frame is appended before broadcast, each socket's frames run in order through a serial queue, compaction merges the log into yjs_documents.state under a per-document lock and deletes exactly the rows it read; last_edited_by dropped in favor of per-row user_id. Server sends its own Step1 so clients upload what the relay lacks; client watches pendingStructs and resyncs. Storage API renamed (loadBase/ensureDoc/appendUpdate/readLog/compactState/deleteDoc), materializeState folded into compactDocument, YJS_SAVE_DEBOUNCE_MS -> YJS_COMPACT_DEBOUNCE_MS, retry timers removed. Apps run pnpm generate and add yjs_updates to any RLS table list of their own."
+  },
+  {
+   "id": "20260911T0759-registry-owned-iam-principals",
+   "version": "next",
+   "title": "VM IAM principals and policies follow the service registry",
+   "kind": "manual",
+   "syncBreaking": false,
+   "clientCacheBump": false,
+   "script": null,
+   "roots": [
+    "infra"
+   ],
+   "requires": [
+    "pnpm --filter infra exec vitest run",
+    "pnpm check"
+   ],
+   "summary": "Bootstrap-owned IAM (vm-<service> applications, their path-conditioned policies, the singleVM host condition) derives from the service registry; compute, LB and key minting keep deriving from the enabled set. Toggling appConfig.services.<slug>.enabled needs no Apply infra change; adding a registry service or flipping singleVM does, and Apply creates the missing applications itself. Dormant principals must hold zero API keys: the deploy asserts it and the key mint purges them. One Apply infra change per bootstrapped stack after syncing (cella: host condition gains /mcp/; raak: new vm-yjs and vm-mcp principals)."
   }
  ]
 }

--- a/infra/cli/actions/apply.ts
+++ b/infra/cli/actions/apply.ts
@@ -4,11 +4,15 @@ import type { InfraContext } from '../shared';
 import { printRevokeReminder, runPrivilegedConverge } from './privileged-converge';
 
 /**
- * One-shot `pulumi up` with a freshly-supplied bootstrap key in SCW_* env, for changes to bootstrap-owned resources (DB / VPC / private network) the read-only CI key cannot make.
+ * One-shot `pulumi up` with a freshly-supplied bootstrap key in SCW_* env, for changes to bootstrap-owned resources (registry IAM principals and policies, DB, VPC, private network) the read-only CI key cannot make.
  * It runs against a bootstrapped stack with live compute, so it must NOT set the computeDeferred marker, which belongs to the fresh-provision flow in setup.ts.
  */
 export async function runApply(context: InfraContext): Promise<void> {
-  console.info(pc.dim('\nApply infra change: run pulumi up with a bootstrap key (supplied via env).\n'));
+  console.info(
+    pc.dim(
+      '\nApply infra change: ensure registry IAM principals, then pulumi up with a bootstrap key (supplied via env).\n',
+    ),
+  );
 
   if (
     !(await confirm({

--- a/infra/cli/actions/privileged-converge.ts
+++ b/infra/cli/actions/privileged-converge.ts
@@ -7,6 +7,7 @@ import { parseOrphanedDeletes, pruneOrphanedDeletes, runPulumiUpWithHint } from 
 import { pc, warningMark } from '../../lib/utils/cli-output';
 import { errorMessage } from '../../lib/utils/errors';
 import { infraDir } from '../../lib/utils/paths';
+import { ensureRegistryPrincipals } from '../../tasks/setup-service-apps';
 import { maskedSecret } from '../prompts/masked-secret';
 import {
   acquireStackLockOrExit,
@@ -99,6 +100,23 @@ export async function runPrivilegedConverge(
       env.SCW_DEFAULT_ORGANIZATION_ID = await resolveOrganizationId(bootSecret, projectId);
     } catch (error) {
       console.warn(`${warningMark} Could not resolve organization id (${errorMessage(error)}); continuing without it.`);
+    }
+
+    // Registry principals are bootstrap-owned like the policies they anchor: create any missing vm-<service>/boot application here, so a registry change converges in this one run. Idempotent; a failure only warns because a missing application still fails the `up` with guidance.
+    console.info(pc.dim('\n→ Ensuring registry IAM principals (vm-<service> + boot applications)…'));
+    try {
+      await ensureRegistryPrincipals({
+        callerSecretKey: bootSecret,
+        projectId,
+        slug: appConfig.slug,
+        mode: context.environment,
+        organizationId: env.SCW_DEFAULT_ORGANIZATION_ID,
+        singleVM: appConfig.singleVM ?? false,
+      });
+    } catch (error) {
+      console.warn(
+        `${warningMark} Could not ensure registry principals (${errorMessage(error)}); \`pulumi up\` fails at requirePrincipalId if one is missing.`,
+      );
     }
 
     // Reconcile gen/sha from live state before `up`: a stale committed Pulumi.<stack>.yaml would converge compute back to an old generation and destroy newer live VMs.

--- a/infra/cli/actions/setup.ts
+++ b/infra/cli/actions/setup.ts
@@ -28,7 +28,7 @@ import { provisionManagedKey } from '../../tasks/provision-managed-key';
 import { seedOperatorSecrets } from '../../tasks/seed-operator-secrets';
 import { setupAdminApp } from '../../tasks/setup-admin-app';
 import { setupCiKey } from '../../tasks/setup-ci-key';
-import { setupServiceApps } from '../../tasks/setup-service-apps';
+import { ensureRegistryPrincipals } from '../../tasks/setup-service-apps';
 import { maskedSecret } from '../prompts/masked-secret';
 import type { CliMode, InfraContext } from '../shared';
 import {
@@ -562,16 +562,14 @@ export async function runSetup(context: InfraContext, mode: Extract<CliMode, 're
   // Identities: per-service + boot apps, CI deploy key, admin app. Service apps come FIRST: their ids feed the CI policy's key-mint rule.
   let serviceAppIds: readonly string[] = [];
   if (needsCiKey) {
-    console.info('\n→ Service VM applications (per-service principals; keys minted per deploy)');
+    console.info('\n→ Service VM applications (registry principals; keys minted per deploy)');
     try {
-      const { deployedServices } = await import('../../lib/services');
-      const deployed = deployedServices(appConfig.services, appConfig.singleVM ?? false).map((svc) => svc.slug);
-      const apps = await setupServiceApps({
+      const apps = await ensureRegistryPrincipals({
         callerSecretKey: ctx.secretKey,
         projectId: ctx.projectId,
         slug: appConfig.slug,
         mode: context.environment,
-        services: deployed,
+        singleVM: appConfig.singleVM ?? false,
       });
       serviceAppIds = apps.allAppIds;
     } catch (error) {

--- a/infra/cli/shared.ts
+++ b/infra/cli/shared.ts
@@ -181,7 +181,7 @@ export function pulumiLoginAndSelect(
   const login = spawnSync('pulumi', ['login', pulumiLoginUrl(appConfig)], { cwd: infraDir, env, stdio: 'inherit' });
   if (login.status !== 0) {
     console.error(
-      `${crossMark} pulumi login failed (exit ${login.status}). Check the state-bucket credentials (AWS_* env).`,
+      `${crossMark} pulumi login failed (exit ${login.status}). The state bucket admits only the CI deploy and admin applications: a bootstrap key needs SCW_STATE_ACCESS_KEY / SCW_STATE_SECRET_KEY set to a key of one of those.`,
     );
     process.exit(login.status ?? 1);
   }

--- a/infra/lib/services.test.ts
+++ b/infra/lib/services.test.ts
@@ -5,7 +5,11 @@ import {
   collocatedServices,
   deployedServices,
   enabledServices,
+  placeServices,
+  principalSecretScopeSlugs,
+  principalServices,
   type ServiceDefinition,
+  secretScopeSlugs,
   services,
 } from './services';
 
@@ -81,6 +85,54 @@ describe('service registry: singleVM (deployedServices / coHostedServices)', () 
     const cfg = { yjs: { enabled: false }, mcp: { enabled: true } };
     expect(coHostedServices(cfg, true).map((s) => s.slug)).not.toContain('yjs');
     expect(deployedServices(cfg, true).map((s) => s.slug)).not.toContain('yjs');
+  });
+});
+
+describe('placeServices (placement is independent of enablement)', () => {
+  it('split-VM places every given service on its own VM and folds nothing', () => {
+    const placed = placeServices(services, false);
+    expect(placed.vm).toEqual(services);
+    expect(placed.coHosted).toEqual([]);
+    expect(placed.collocated).toEqual([]);
+  });
+
+  it('singleVM keeps the host, folds co-hosted workers, collocates placement-host containers', () => {
+    const placed = placeServices(services, true);
+    expect(placed.vm.map((s) => s.slug)).toEqual(['backend']);
+    expect(placed.coHosted.map((s) => s.slug)).toEqual(['cdc', 'yjs', 'mcp']);
+    expect(placed.collocated.map((s) => s.slug)).toEqual(['frontend']);
+  });
+
+  it('applies the same placement to a narrower list (the enabled set)', () => {
+    const placed = placeServices(enabledServices(allOff), true);
+    expect(placed.vm.map((s) => s.slug)).toEqual(['backend']);
+    expect(placed.coHosted.map((s) => s.slug)).toEqual(['cdc']);
+    expect(placed.collocated.map((s) => s.slug)).toEqual(['frontend']);
+  });
+});
+
+describe('registry view: bootstrap-owned IAM ignores enablement', () => {
+  it('split-VM: every registry service owns a principal, whatever appConfig enables', () => {
+    expect(principalServices(false).map((s) => s.slug)).toEqual(['backend', 'cdc', 'yjs', 'mcp', 'frontend']);
+  });
+
+  it('singleVM: only the host owns a principal', () => {
+    expect(principalServices(true).map((s) => s.slug)).toEqual(['backend']);
+  });
+
+  it('singleVM host scope unions every registry worker and collocated container, enabled or not', () => {
+    expect(principalSecretScopeSlugs(true, 'backend')).toEqual(['backend', 'cdc', 'yjs', 'mcp', 'frontend']);
+  });
+
+  it('a non-host principal reads only its own folder', () => {
+    expect(principalSecretScopeSlugs(true, 'cdc')).toEqual(['cdc']);
+    expect(principalSecretScopeSlugs(false, 'backend')).toEqual(['backend']);
+    expect(principalSecretScopeSlugs(false, 'yjs')).toEqual(['yjs']);
+  });
+
+  it('secretScopeSlugs over the enabled set still narrows to what is enabled', () => {
+    expect(secretScopeSlugs(enabledServices(allOff), true, 'backend')).toEqual(['backend', 'cdc', 'frontend']);
+    expect(secretScopeSlugs(services, true, 'backend')).toEqual(principalSecretScopeSlugs(true, 'backend'));
   });
 });
 

--- a/infra/lib/services.ts
+++ b/infra/lib/services.ts
@@ -24,32 +24,20 @@ export function enabledServices(serviceConfig: Record<string, EngineServiceEndpo
   return services.filter((s) => serviceConfig[s.slug]?.enabled !== false);
 }
 
-/** Services receiving dedicated VMs. Single-VM mode drops co-hosted workers and host-collocated containers from compute while keeping their routing through the host target. */
-export function deployedServices(
-  serviceConfig: Record<string, EngineServiceEndpoint>,
-  singleVM: boolean,
-): readonly ServiceDefinition[] {
-  const enabled = enabledServices(serviceConfig);
-  if (!singleVM) return enabled;
-  return enabled.filter((s) => !s.coHosted && s.placement !== 'host');
+/** A service list split by singleVM placement: `vm` owns VMs and IAM principals, `coHosted` folds into the host process, `collocated` runs as a container beside the host. Without singleVM everything is `vm`. */
+export interface PlacedServices {
+  vm: readonly ServiceDefinition[];
+  coHosted: readonly ServiceDefinition[];
+  collocated: readonly ServiceDefinition[];
 }
 
-/** Enabled workers folded into the host process under singleVM, empty when singleVM is off. Their runtime secrets union onto the host VM and a co-hosted `exclusive` worker forces an exclusive host cutover. */
-export function coHostedServices(
-  serviceConfig: Record<string, EngineServiceEndpoint>,
-  singleVM: boolean,
-): readonly ServiceDefinition[] {
-  if (!singleVM) return [];
-  return enabledServices(serviceConfig).filter((s) => s.coHosted);
-}
-
-/** Enabled `placement: 'host'` containers the boot runner starts beside the host container under singleVM. Their LB pools follow the host cutover, their secrets union onto the host VM, and their compose blocks join the host's genId fingerprint. */
-export function collocatedServices(
-  serviceConfig: Record<string, EngineServiceEndpoint>,
-  singleVM: boolean,
-): readonly ServiceDefinition[] {
-  if (!singleVM) return [];
-  const collocated = enabledServices(serviceConfig).filter((s) => s.placement === 'host');
+/**
+ * Apply singleVM placement to any service list: the enabled set for compute, LB and key minting; the full registry for bootstrap-owned IAM.
+ * Bootstrap-owned IAM (principals, policies, conditions) follows the registry, so an `enabled` toggle changes compute only and needs no privileged up.
+ */
+export function placeServices(definitions: readonly ServiceDefinition[], singleVM: boolean): PlacedServices {
+  if (!singleVM) return { vm: definitions, coHosted: [], collocated: [] };
+  const collocated = definitions.filter((s) => s.placement === 'host');
   for (const svc of collocated) {
     if (svc.primaryRollout)
       throw new Error(
@@ -60,7 +48,35 @@ export function collocatedServices(
         `services: '${svc.slug}' cannot set both coHosted and placement 'host': in-process fold and container collocation are mutually exclusive.`,
       );
   }
-  return collocated;
+  return {
+    vm: definitions.filter((s) => !s.coHosted && s.placement !== 'host'),
+    coHosted: definitions.filter((s) => s.coHosted),
+    collocated,
+  };
+}
+
+/** Enabled services receiving dedicated VMs. Single-VM mode drops co-hosted workers and host-collocated containers from compute while keeping their routing through the host target. */
+export function deployedServices(
+  serviceConfig: Record<string, EngineServiceEndpoint>,
+  singleVM: boolean,
+): readonly ServiceDefinition[] {
+  return placeServices(enabledServices(serviceConfig), singleVM).vm;
+}
+
+/** Enabled workers folded into the host process under singleVM, empty when singleVM is off. Their runtime secrets union onto the host VM and a co-hosted `exclusive` worker forces an exclusive host cutover. */
+export function coHostedServices(
+  serviceConfig: Record<string, EngineServiceEndpoint>,
+  singleVM: boolean,
+): readonly ServiceDefinition[] {
+  return placeServices(enabledServices(serviceConfig), singleVM).coHosted;
+}
+
+/** Enabled `placement: 'host'` containers the boot runner starts beside the host container under singleVM. Their LB pools follow the host cutover, their secrets union onto the host VM, and their compose blocks join the host's genId fingerprint. */
+export function collocatedServices(
+  serviceConfig: Record<string, EngineServiceEndpoint>,
+  singleVM: boolean,
+): readonly ServiceDefinition[] {
+  return placeServices(enabledServices(serviceConfig), singleVM).collocated;
 }
 
 /** Resolve the VM replacement strategy. A singleVM host folding a stop-first worker must cut over stop-first too, so two replication-slot consumers never run at once. */
@@ -82,19 +98,26 @@ export function effectiveStrategy(
   return svc.replacementStrategy;
 }
 
-/** Secret folders a service's VMs must read: itself plus, for the singleVM host, every folded co-hosted worker and collocated container. The host's secret-path grant must union identically or hydration 403s on the folded secrets. */
+/** Secret folders `service`'s VMs read, over `definitions`: itself plus, for the singleVM host, every folded co-hosted worker and collocated container. The host's secret-path grant must union identically or hydration 403s on the folded secrets. */
 export function secretScopeSlugs(
-  serviceConfig: Record<string, EngineServiceEndpoint>,
+  definitions: readonly ServiceDefinition[],
   singleVM: boolean,
   service: ServiceName,
 ): readonly ServiceName[] {
-  const host = deployedServices(serviceConfig, singleVM).find((s) => s.primaryRollout)?.slug;
+  const placed = placeServices(definitions, singleVM);
+  const host = placed.vm.find((s) => s.primaryRollout)?.slug;
   if (!singleVM || service !== host) return [service];
-  return [
-    service,
-    ...coHostedServices(serviceConfig, singleVM).map((s) => s.slug),
-    ...collocatedServices(serviceConfig, singleVM).map((s) => s.slug),
-  ];
+  return [service, ...placed.coHosted.map((s) => s.slug), ...placed.collocated.map((s) => s.slug)];
+}
+
+/** Services owning an IAM principal and policy: every registry service under split-VM, only the host under singleVM. Registry-derived on purpose, so `enabled` never touches bootstrap-owned IAM; a registry service outside the deployed set is a dormant principal that must hold no key. */
+export function principalServices(singleVM: boolean): readonly ServiceDefinition[] {
+  return placeServices(services, singleVM).vm;
+}
+
+/** Secret scope of a principal's policy condition, over the full registry. Feeds both the Pulumi program and the deploy's grant assertion, which compare the resulting condition as a string. */
+export function principalSecretScopeSlugs(singleVM: boolean, service: ServiceName): readonly ServiceName[] {
+  return secretScopeSlugs(services, singleVM, service);
 }
 
 /**

--- a/infra/resources/vm-iam.ts
+++ b/infra/resources/vm-iam.ts
@@ -11,7 +11,7 @@ import {
 } from '../lib/scaleway/permissions';
 import { principalNames } from '../lib/scaleway/principals';
 import { bootKeyCondition, serviceKeyCondition } from '../lib/scaleway/secret-paths';
-import { deployedServices, secretScopeSlugs } from '../lib/services';
+import { principalSecretScopeSlugs, principalServices } from '../lib/services';
 import { vmPolicyIgnoreChanges } from '../lib/stack/privileged-up';
 import { mode, naming, organizationId, projectId, tags } from '../pulumi-context';
 
@@ -37,7 +37,10 @@ function findApplicationId(name: string): pulumi.Output<string | undefined> {
 /** Require a principal: missing means the stack cannot function, so fail with guidance. */
 function requirePrincipalId(resolved: pulumi.Output<string | undefined>, label: string): pulumi.Output<string> {
   return resolved.apply((id) => {
-    if (!id) throw new Error(`IAM application for ${label} not found: run the infra CLI bootstrap first.`);
+    if (!id)
+      throw new Error(
+        `IAM application for ${label} not found: run the infra CLI bootstrap first, or "Apply infra change" after a registry change.`,
+      );
     return id;
   });
 }
@@ -58,9 +61,10 @@ export const adminApplicationId: pulumi.Output<string | undefined> = findApplica
   return undefined;
 });
 
-// VM-side principals: one application per deployed service plus the boot fetcher.
+// VM-side principals: one application per registry service that owns VMs, plus the boot fetcher. Registry-derived: an `enabled` toggle changes compute, never a principal.
 
-const vmServices = deployedServices(appConfig.services, appConfig.singleVM ?? false);
+const singleVM = appConfig.singleVM ?? false;
+const vmServices = principalServices(singleVM);
 
 /** Per-service application ids. Required. */
 export const serviceApplicationIds: Record<string, pulumi.Output<string>> = Object.fromEntries(
@@ -79,6 +83,7 @@ export const bootApplicationId: pulumi.Output<string> = requirePrincipalId(
 /**
  * Pulumi-managed IAM policies for the VM-side principals. Bootstrap-owned: IAM policy write is forbidden to the CI key, so a bootstrap-key up creates these before compute exists, and compute VMs depend on them so grants attach before the first runtime-secret hydration.
  * One policy per service app (secret read conditioned to its own and shared folders) and one for the boot app (registry pull, diag write, handoff-only secret read). Conditions only narrow, and `assert-vm-grants` verifies no other policy un-scopes them.
+ * Principals and conditions follow the service registry, not the enabled set: a service toggle changes compute only, while a registry change or a `singleVM` flip needs a privileged up.
  * CI ups ignore `rules` (they would 403 on the IAM write, and the provider shows a phantom ~rules from its condition empty-vs-unset asymmetry); a privileged up (CLI "Apply infra change") reconciles them, which is how a changed secret scope reaches the live policy.
  * @see resources/compute.ts
  * @see lib/stack/privileged-up.ts
@@ -100,11 +105,7 @@ for (const svc of vmServices) {
           {
             permissionSetNames: [...SERVICE_SECRET_PERMISSION_SETS],
             projectIds: [projectId],
-            condition: serviceKeyCondition(
-              naming.slug,
-              mode,
-              secretScopeSlugs(appConfig.services, appConfig.singleVM ?? false, svc.slug),
-            ),
+            condition: serviceKeyCondition(naming.slug, mode, principalSecretScopeSlugs(singleVM, svc.slug)),
           },
           ...(isBackend
             ? [

--- a/infra/tasks/assert-vm-grants.test.ts
+++ b/infra/tasks/assert-vm-grants.test.ts
@@ -223,6 +223,54 @@ describe('assertVmGrants', () => {
     expect(calls.some((u) => u.includes('organization_id=org-resolved'))).toBe(true);
   });
 
+  it('a dormant principal holding an API key fails the check', async () => {
+    const fetchImpl = makeFetch([
+      NO_GROUPS,
+      { match: '/iam/v1alpha1/policies?', body: { policies: [{ id: 'pol-1', name: 'p', application_id: 'vm-app' }] } },
+      { match: '/iam/v1alpha1/rules?policy_id=pol-1', body: { rules: [{ permission_set_names: [...REQUIRED] }] } },
+      { match: '/iam/v1alpha1/api-keys?', body: { api_keys: [{ access_key: 'ak-1' }, { access_key: 'ak-2' }] } },
+    ]);
+
+    const result = await assertVmGrants({ ...baseOpts, dormant: true, fetchImpl });
+
+    expect(result.ok).toBe(false);
+    expect(result.dormantKeys).toEqual(['ak-1', 'ak-2']);
+    expect(result.missing).toEqual([]);
+  });
+
+  it('a dormant principal with no keys passes', async () => {
+    const fetchImpl = makeFetch([
+      NO_GROUPS,
+      { match: '/iam/v1alpha1/policies?', body: { policies: [{ id: 'pol-1', name: 'p', application_id: 'vm-app' }] } },
+      { match: '/iam/v1alpha1/rules?policy_id=pol-1', body: { rules: [{ permission_set_names: [...REQUIRED] }] } },
+      { match: '/iam/v1alpha1/api-keys?', body: { api_keys: [] } },
+    ]);
+
+    const result = await assertVmGrants({ ...baseOpts, dormant: true, fetchImpl });
+
+    expect(result.ok).toBe(true);
+    expect(result.dormantKeys).toEqual([]);
+  });
+
+  it('a live principal is never asked for its keys', async () => {
+    const fetchImpl = makeFetch([
+      NO_GROUPS,
+      { match: '/iam/v1alpha1/policies?', body: { policies: [{ id: 'pol-1', name: 'p', application_id: 'vm-app' }] } },
+      { match: '/iam/v1alpha1/rules?policy_id=pol-1', body: { rules: [{ permission_set_names: [...REQUIRED] }] } },
+    ]);
+    const calls: string[] = [];
+    const tracking: FetchLike = async (url, init) => {
+      calls.push(url);
+      return fetchImpl(url, init);
+    };
+
+    const result = await assertVmGrants({ ...baseOpts, fetchImpl: tracking });
+
+    expect(result.ok).toBe(true);
+    expect(result.dormantKeys).toEqual([]);
+    expect(calls.some((u) => u.includes('/api-keys'))).toBe(false);
+  });
+
   it('throws a useful error on a Scaleway error response', async () => {
     const fetchImpl = makeFetch([
       NO_GROUPS,

--- a/infra/tasks/assert-vm-grants.ts
+++ b/infra/tasks/assert-vm-grants.ts
@@ -1,6 +1,7 @@
 import {
   fetchGrantedRules,
   type IamAuth,
+  listApiKeys,
   resolveApplicationIdByName,
   resolveOrganizationIdViaProject,
 } from '../lib/scaleway/iam-client';
@@ -37,6 +38,8 @@ export interface AssertVmGrantsOptions {
    * IAM conditions only narrow an allow, so one unconditioned secret rule on this app un-scopes the conditioned one. That is a FAILURE here, not a warning.
    */
   requiredSecretCondition?: string;
+  /** A registry principal with no deployed VM. It keeps its policy but must hold ZERO API keys: any key on it is an unmonitored credential, a FAILURE. */
+  dormant?: boolean;
   /** Injected for tests; defaults to global fetch. */
   fetchImpl?: FetchLike;
   /** Injected for tests; defaults to console.info. */
@@ -51,6 +54,8 @@ export interface AssertVmGrantsResult {
   extra: string[];
   /** Secret-grant rules whose condition deviates from the required one (union semantics: ONE unconditioned rule un-scopes everything). */
   unconditionedSecretRules: string[];
+  /** Access keys found on a dormant principal; empty unless `dormant` was requested. */
+  dormantKeys: string[];
 }
 
 /**
@@ -93,21 +98,35 @@ export async function assertVmGrants(opts: AssertVmGrantsOptions): Promise<Asser
     }
   }
 
-  // Fatal: missing sets break hydration, a non-read-only extra set is an escalation, an un-scoped secret rule leaks secrets. Extra read-only sets only warn (see isBenignExtraSet).
-  const ok = missing.length === 0 && extraFatal.length === 0 && unconditionedSecretRules.length === 0;
+  // Only a dormant principal is listed: a live one legitimately holds the current and previous generation's keys.
+  const dormantKeys = opts.dormant
+    ? (await listApiKeys(auth, organizationId, applicationId)).map((key) => key.access_key)
+    : [];
+
+  // Fatal: missing sets break hydration, a non-read-only extra set is an escalation, an un-scoped secret rule leaks secrets, a key on a dormant principal is an unmonitored credential. Extra read-only sets only warn (see isBenignExtraSet).
+  const ok =
+    missing.length === 0 &&
+    extraFatal.length === 0 &&
+    unconditionedSecretRules.length === 0 &&
+    dormantKeys.length === 0;
   if (missing.length > 0) log(`✗ VM grant INCOMPLETE, missing: ${missing.join(', ')}`);
   if (extraFatal.length > 0) log(`✗ VM grant TOO BROAD, extra write/broad grant(s): ${extraFatal.join(', ')}`);
   for (const entry of unconditionedSecretRules)
     log(`✗ VM secret rule NOT path-scoped (union semantics un-scope the conditioned rule): ${entry}`);
+  if (dormantKeys.length > 0)
+    log(
+      `✗ dormant principal holds ${dormantKeys.length} API key(s): a registry service outside the deployed set must have none: ${dormantKeys.join(', ')}`,
+    );
   if (extraBenign.length > 0)
     log(
       `⚠ VM application has extra read-only grant(s) (benign drift; reconcile via a bootstrap "Apply infra change"): ${extraBenign.join(', ')}`,
     );
   if (ok) {
     const conditionNote = opts.requiredSecretCondition ? ', secret rules path-conditioned' : '';
-    log(`✓ VM grant verified: required permission sets present, no escalation${conditionNote}`);
+    const dormantNote = opts.dormant ? ', dormant principal holds no key' : '';
+    log(`✓ VM grant verified: required permission sets present, no escalation${conditionNote}${dormantNote}`);
   }
-  return { ok, granted: [...granted].sort(), missing, extra, unconditionedSecretRules };
+  return { ok, granted: [...granted].sort(), missing, extra, unconditionedSecretRules, dormantKeys };
 }
 
 // Standalone entry point.
@@ -123,6 +142,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   }
 
   const requiredSecretCondition = getFlag(argv, '--secret-condition') ?? undefined;
+  const dormant = argv.includes('--dormant');
   const requiredSetsCsv = getFlag(argv, '--required-sets');
   const required = (requiredSetsCsv ?? '')
     .split(',')
@@ -137,6 +157,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     organizationId,
     requiredSecretCondition,
     required,
+    dormant,
   });
   if (!result.ok) {
     // Only fatal problems reach here: missing sets, a write or broad escalation, or an un-scoped secret rule. Benign read-only extras warn without setting ok=false.
@@ -148,10 +169,11 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       result.unconditionedSecretRules.length > 0
         ? `secret rules without the required path condition: ${result.unconditionedSecretRules.join('; ')}`
         : '',
+      result.dormantKeys.length > 0 ? `dormant principal holds API key(s): ${result.dormantKeys.join(', ')}` : '',
     ].filter(Boolean);
     throw new Error(
       `VM application ${applicationId ?? applicationName} ${problems.join('; ')}. ` +
-        'The Pulumi-managed policy (infra/resources/vm-iam.ts) defines the exact grant; check that `pulumi up` succeeded and remove any manually-attached policies.',
+        'The Pulumi-managed policy (infra/resources/vm-iam.ts) defines the exact grant. A CI deploy never rewrites policy rules: after a registry change run `pnpm infra` -> Apply infra change (a privileged up reconciles them), remove any manually-attached policy, and delete keys on dormant principals.',
     );
   }
 }

--- a/infra/tasks/deploy-run.test.ts
+++ b/infra/tasks/deploy-run.test.ts
@@ -26,6 +26,12 @@ async function fakeDeployEnv(opts: DeployOptions): Promise<Record<AllowedKey, st
         condition: 'resource.name.startsWith("/cella-production/backend/")',
       },
       {
+        app: 'cella-production-vm-yjs',
+        sets: ['SecretManagerReadOnly', 'SecretManagerSecretAccess'],
+        condition: 'resource.name.startsWith("/cella-production/yjs/")',
+        dormant: true,
+      },
+      {
         app: 'cella-production-boot',
         sets: ['ContainerRegistryReadOnly', 'ObjectStorageObjectsWrite'],
         condition: 'resource.name.startsWith("/cella-production/handoff/")',
@@ -52,6 +58,7 @@ async function fakeDeployEnv(opts: DeployOptions): Promise<Record<AllowedKey, st
 function makeFake(opts: { rolloutFails?: boolean; verifyFails?: boolean; updateFails?: boolean } = {}) {
   const ops: string[] = [];
   const rolloutArgs: string[][] = [];
+  const grantArgs: string[][] = [];
   const fx: DeployEffects = {
     initTelemetry: async () => {
       ops.push('telemetry:init');
@@ -61,6 +68,7 @@ function makeFake(opts: { rolloutFails?: boolean; verifyFails?: boolean; updateF
     },
     task: async (name, argv = []) => {
       ops.push(`task:${name}${argv[0] && !argv[0].startsWith('--') ? `:${argv[0]}` : ''}`);
+      if (name === 'assert-vm-grants') grantArgs.push([...argv]);
     },
     exec: async (cmd, args, execOpts) => {
       ops.push(`exec:${cmd}:${args[0]}${execOpts?.allowFailure ? ':allow-failure' : ''}`);
@@ -88,7 +96,7 @@ function makeFake(opts: { rolloutFails?: boolean; verifyFails?: boolean; updateF
     groupEnd: () => {},
     info: () => {},
   };
-  return { fx, ops, rolloutArgs };
+  return { fx, ops, rolloutArgs, grantArgs };
 }
 
 const baseOpts = { mode: 'production', sha: 'abc123', distDir: '/tmp/dist' };
@@ -211,6 +219,20 @@ describe('runDeploy sequencing', () => {
     const waitIndex = ops.indexOf('task:wait-for-images');
     expect(bakeIndex).toBeGreaterThan(-1);
     expect(waitIndex).toBeGreaterThan(bakeIndex);
+  });
+
+  it('asserts every principal, flagging only the dormant one', async () => {
+    const { fx, grantArgs } = makeFake();
+    await runDeploy(baseOpts, fx, fakeDeployEnv);
+    const byApp = new Map(grantArgs.map((argv) => [argv[argv.indexOf('--application-name') + 1], argv]));
+    expect([...byApp.keys()]).toEqual([
+      'cella-production-vm-backend',
+      'cella-production-vm-yjs',
+      'cella-production-boot',
+    ]);
+    expect(byApp.get('cella-production-vm-yjs')).toContain('--dormant');
+    expect(byApp.get('cella-production-vm-backend')).not.toContain('--dormant');
+    expect(byApp.get('cella-production-boot')).not.toContain('--dormant');
   });
 
   it('passes --skip-reap to the rollout only with deferReap', async () => {

--- a/infra/tasks/deploy-run.ts
+++ b/infra/tasks/deploy-run.ts
@@ -246,8 +246,13 @@ export async function runDeploy(
       await fx.update(stack);
     });
     await step('Verify VM IAM grants', async () => {
-      // One assertion per principal: exact sets AND exact path condition.
-      const rows = JSON.parse(env.vm_assert_json) as Array<{ app: string; sets: string[]; condition: string }>;
+      // One assertion per principal: exact sets AND exact path condition; a dormant principal must also hold no key.
+      const rows = JSON.parse(env.vm_assert_json) as Array<{
+        app: string;
+        sets: string[];
+        condition: string;
+        dormant?: boolean;
+      }>;
       for (const row of rows) {
         await fx.task('assert-vm-grants', [
           '--application-name',
@@ -260,6 +265,7 @@ export async function runDeploy(
           process.env.SCW_DEFAULT_PROJECT_ID ?? '',
           '--organization-id',
           process.env.SCW_DEFAULT_ORGANIZATION_ID ?? '',
+          ...(row.dormant ? ['--dormant'] : []),
         ]);
       }
     });

--- a/infra/tasks/mint-generation-keys.test.ts
+++ b/infra/tasks/mint-generation-keys.test.ts
@@ -16,15 +16,18 @@ vi.mock('../lib/scaleway/scaleway-secret-manager', () => ({ createSecretManagerC
 let ops: string[];
 let mintCount: number;
 let failStagingFor: string | undefined;
+let missingApps: Set<string>;
 
 function installMocks(): void {
   ops = [];
   mintCount = 0;
   failStagingFor = undefined;
+  missingApps = new Set();
 
   vi.mocked(scwFetch).mockImplementation(async (_auth, method, url: string) => {
     if (method === 'GET' && url.includes('/applications?name=')) {
       const name = decodeURIComponent(new URL(url).searchParams.get('name') ?? '');
+      if (missingApps.has(name)) return { applications: [] } as never;
       return { applications: [{ id: `id-${name}`, name }] } as never;
     }
     if (method === 'POST' && url.endsWith('/api-keys')) {
@@ -104,6 +107,32 @@ describe('mintGenerationKeys', () => {
     // 3 apps (boot + 2 services) × 2 stale keys each; the newest 2 survive.
     expect(keyDeletes).toHaveLength(6);
     expect(new Set(keyDeletes)).toEqual(new Set(['delete:ak-old-1', 'delete:ak-old-2']));
+  });
+
+  it('purges every key on a dormant principal, after all bundles are staged', async () => {
+    const result = await mintGenerationKeys({ ...options(join(outDir, 'dormant.json')), dormantServices: ['yjs'] });
+
+    const lastStage = ops.map((op) => op.startsWith('stage:')).lastIndexOf(true);
+    const keyDeletes = ops.filter((op) => op.startsWith('delete:ak-'));
+    // 6 stale-prune deletes on the live apps plus all 4 keys on the dormant app.
+    expect(keyDeletes).toHaveLength(10);
+    expect(keyDeletes.slice(-4)).toEqual(['delete:ak-old-1', 'delete:ak-old-2', 'delete:ak-live', 'delete:ak-fresh-x']);
+    expect(ops.findIndex((op) => op.startsWith('delete:ak-'))).toBeGreaterThan(lastStage);
+    expect(Object.keys(result.handoffSecretIds)).toEqual(['backend', 'frontend']);
+  });
+
+  it('a missing dormant application only logs; the live principals still mint', async () => {
+    missingApps.add('cella-production-vm-mcp');
+    const logs: string[] = [];
+    const result = await mintGenerationKeys({
+      ...options(join(outDir, 'dormant-missing.json')),
+      dormantServices: ['mcp'],
+      log: (msg) => logs.push(msg),
+    });
+
+    expect(result.bootAccessKey).toBe('ak-fresh-1');
+    expect(ops.filter((op) => op.startsWith('delete:ak-'))).toHaveLength(6);
+    expect(logs.some((line) => line.includes('dormant application cella-production-vm-mcp not found'))).toBe(true);
   });
 
   it('a staging failure aborts with ZERO api keys pruned (old generation keeps its credentials)', async () => {

--- a/infra/tasks/mint-generation-keys.ts
+++ b/infra/tasks/mint-generation-keys.ts
@@ -26,9 +26,11 @@ export interface MintGenerationKeysOptions {
   region: string;
   projectId: string;
   organizationId: string;
-  /** Deployed service slugs. */
+  /** Deployed service slugs: the principals that receive a fresh key. */
   services: readonly string[];
-  /** CI secret key: holds the conditioned IAMApplicationManager grant. */
+  /** Registry principals outside the deployed set. They must hold no key, so every key found on them is deleted after staging. */
+  dormantServices?: readonly string[];
+  /** CI secret key: holds the unconditioned org-wide IAMApplicationManager grant (the boundary is the absent IAMPolicyManager). */
   callerSecretKey: string;
   /** Where the JSON result lands (read by the Pulumi program via INFRA_GENERATION_KEYS_FILE). */
   outFile: string;
@@ -81,8 +83,23 @@ async function pruneStaleKeys(
   }
 }
 
+/** Delete every key on a dormant principal: a registry service outside the deployed set has no VM to hand a key to, so any key on it is an unmonitored credential. */
+async function purgeDormantKeys(
+  auth: IamAuth,
+  organizationId: string,
+  appId: string,
+  label: string,
+  log: (msg: string) => void,
+): Promise<void> {
+  for (const key of await listApiKeys(auth, organizationId, appId)) {
+    await deleteApiKey(auth, key.access_key);
+    log(`  ~ purged dormant ${label} key ${key.access_key}`);
+  }
+}
+
 /**
- * Per-deploy credential mint (D3/REQ-7/REQ-10), run as CI under the conditioned IAMApplicationManager grant: key CRUD on exactly the service and boot apps, no app or policy creation.
+ * Per-deploy credential mint (D3/REQ-7/REQ-10), run as CI under the unconditioned org-wide IAMApplicationManager grant: key CRUD on the registry's service and boot apps, no app or policy creation.
+ *  0. Dormant principals (registry services outside the deployed set) get every key deleted last; a missing dormant application only logs, since the deploy's grant assertion reports it with guidance.
  *  1. Mint a fresh boot-fetcher key (registry pull and handoff-read only, baked into cloud-init) and prune stale ones.
  *  2. Per service: mint a fresh service key, stage it as a SINGLE-ACCESS secret under /handoff/<service>/ so a VM whose read fails knows the bundle was
  *     intercepted and halts, then prune older handoff bundles and stale service keys.
@@ -146,6 +163,15 @@ export async function mintGenerationKeys(opts: MintGenerationKeysOptions): Promi
     const appId = serviceAppIds.get(service);
     if (appId) await pruneStaleKeys(auth, opts.organizationId, appId, names.vmService(service), log);
   }
+  for (const service of opts.dormantServices ?? []) {
+    const appName = names.vmService(service);
+    const appId = await resolveApplicationIdByName(auth, opts.organizationId, appName);
+    if (!appId) {
+      log(`  ~ dormant application ${appName} not found (run "Apply infra change")`);
+      continue;
+    }
+    await purgeDormantKeys(auth, opts.organizationId, appId, appName, log);
+  }
 
   const result: GenerationKeys = {
     bootAccessKey: bootKey.access_key,
@@ -170,9 +196,13 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   }
   const { loadEngineConfig } = await import('../config/engine-config');
   const appConfig = await loadEngineConfig();
-  // VM-bearing services only (singleVM folds co-hosted/collocated into the host).
-  const { deployedServices } = await import('../lib/services');
-  const services = deployedServices(appConfig.services, appConfig.singleVM ?? false).map((svc) => svc.slug);
+  // Keys go to VM-bearing enabled services (singleVM folds co-hosted/collocated into the host); the rest of the registry's principals are dormant.
+  const { deployedServices, principalServices } = await import('../lib/services');
+  const singleVM = appConfig.singleVM ?? false;
+  const services = deployedServices(appConfig.services, singleVM).map((svc) => svc.slug);
+  const dormantServices = principalServices(singleVM)
+    .map((svc) => svc.slug)
+    .filter((slug) => !services.includes(slug));
   await mintGenerationKeys({
     slug: appConfig.slug,
     mode: appConfig.mode,
@@ -181,6 +211,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     projectId,
     organizationId,
     services,
+    dormantServices,
     callerSecretKey: secretKey,
     outFile,
   });

--- a/infra/tasks/print-deploy-env.test.ts
+++ b/infra/tasks/print-deploy-env.test.ts
@@ -6,7 +6,7 @@ import {
   SERVICE_SECRET_PERMISSION_SETS,
 } from '../lib/scaleway/permissions';
 import { bootKeyCondition, serviceKeyCondition } from '../lib/scaleway/secret-paths';
-import { deployedServices } from '../lib/services';
+import { principalSecretScopeSlugs, principalServices } from '../lib/services';
 import { ALLOWED_KEYS, buildDeployEnv, isAllowedProductionRef } from './print-deploy-env';
 
 const fakeAppConfig = {
@@ -44,10 +44,11 @@ describe('buildDeployEnv', () => {
       frontend_bucket: 'cella-frontend',
       state_bucket: 'cella-pulumi-state',
       vm_assert_json: JSON.stringify([
-        ...deployedServices(fakeAppConfig.services, false).map((svc) => ({
+        ...principalServices(false).map((svc) => ({
           app: `cella-production-vm-${svc.slug}`,
           sets: [...SERVICE_SECRET_PERMISSION_SETS, ...(svc.s3Access ? BACKEND_S3_PERMISSION_SETS : [])],
           condition: serviceKeyCondition('cella', 'production', svc.slug),
+          dormant: !['backend', 'cdc', 'frontend'].includes(svc.slug),
         })),
         {
           app: 'cella-production-boot',
@@ -100,6 +101,44 @@ describe('buildDeployEnv', () => {
         { service: 'frontend', health_url: 'https://www.cella.example' },
       ]),
     });
+  });
+
+  it('singleVM: one host principal whose condition covers every registry worker, enabled or not', () => {
+    const rows = JSON.parse(buildDeployEnv({ ...fakeAppConfig, singleVM: true }).vm_assert_json) as Array<{
+      app: string;
+      condition: string;
+      dormant?: boolean;
+    }>;
+    const serviceRows = rows.filter((row) => row.app.includes('-vm-'));
+    expect(serviceRows.map((row) => row.app)).toEqual(['cella-production-vm-backend']);
+    expect(serviceRows[0]?.condition).toBe(
+      serviceKeyCondition('cella', 'production', principalSecretScopeSlugs(true, 'backend')),
+    );
+    expect(serviceRows[0]?.condition).toContain('/cella-production/yjs/');
+    expect(serviceRows[0]?.condition).toContain('/cella-production/mcp/');
+    expect(serviceRows[0]?.dormant).toBe(false);
+  });
+
+  it('toggling enabled never changes a principal row, only its dormant flag', () => {
+    type Row = { app: string; sets: string[]; condition: string; dormant?: boolean };
+    const allOn = {
+      ...fakeAppConfig.services,
+      yjs: { enabled: true, publicUrl: 'https://yjs.cella.example' },
+      mcp: { enabled: true, publicUrl: 'https://mcp.cella.example' },
+    };
+    for (const singleVM of [false, true]) {
+      const off = JSON.parse(buildDeployEnv({ ...fakeAppConfig, singleVM }).vm_assert_json) as Row[];
+      const on = JSON.parse(buildDeployEnv({ ...fakeAppConfig, singleVM, services: allOn }).vm_assert_json) as Row[];
+      const strip = (rows: Row[]) => rows.map(({ dormant: _dormant, ...rest }) => rest);
+      expect(strip(on)).toEqual(strip(off));
+      expect(on.filter((row) => row.dormant)).toEqual([]);
+      if (!singleVM) {
+        expect(off.filter((row) => row.dormant).map((row) => row.app)).toEqual([
+          'cella-production-vm-yjs',
+          'cella-production-vm-mcp',
+        ]);
+      }
+    }
   });
 
   it('strips hyphens from registry_ns', () => {

--- a/infra/tasks/print-deploy-env.ts
+++ b/infra/tasks/print-deploy-env.ts
@@ -12,7 +12,8 @@ import {
   appStorageNeeds,
   deployedServices,
   enabledServices,
-  secretScopeSlugs,
+  principalSecretScopeSlugs,
+  principalServices,
   serviceEndpoints,
 } from '../lib/services';
 import { isMain } from '../lib/utils/is-main';
@@ -106,16 +107,18 @@ export function buildDeployEnv(appConfig: Cfg, opts: { imageTag?: string } = {})
     // One assertion row per principal (exact sets + exact condition, built by
     // the same shared builders the Pulumi program uses so the deploy's
     // assert-vm-grants step compares strings, not semantics), consumed by the
-    // deploy's grant-verification step.
+    // deploy's grant-verification step. Principals follow the registry; a
+    // registry service outside the deployed set is dormant and must hold no key.
     vm_assert_json: JSON.stringify([
-      ...deployedServices(appConfig.services, appConfig.singleVM ?? false).map((svc) => ({
+      ...principalServices(appConfig.singleVM ?? false).map((svc) => ({
         app: principalNames(appConfig.slug, appConfig.mode).vmService(svc.slug),
         sets: [...SERVICE_SECRET_PERMISSION_SETS, ...(svc.s3Access ? BACKEND_S3_PERMISSION_SETS : [])],
         condition: serviceKeyCondition(
           appConfig.slug,
           appConfig.mode,
-          secretScopeSlugs(appConfig.services, appConfig.singleVM ?? false, svc.slug),
+          principalSecretScopeSlugs(appConfig.singleVM ?? false, svc.slug),
         ),
+        dormant: !deployedSlugs.has(svc.slug),
       })),
       {
         app: principalNames(appConfig.slug, appConfig.mode).boot,

--- a/infra/tasks/setup-service-apps.test.ts
+++ b/infra/tasks/setup-service-apps.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { provisionScopedKey } from '../lib/scaleway/scaleway-iam';
+import { ensureRegistryPrincipals } from './setup-service-apps';
+
+vi.mock('../lib/scaleway/scaleway-iam', () => ({ provisionScopedKey: vi.fn() }));
+
+const base = { callerSecretKey: 'boot-secret', projectId: 'proj', slug: 'cella', mode: 'production' };
+
+beforeEach(() => {
+  vi.mocked(provisionScopedKey).mockReset();
+  vi.mocked(provisionScopedKey).mockImplementation(
+    async (_opts, config) => ({ applicationId: `id-${config.suffix}`, accessKey: '', secretKey: '' }) as never,
+  );
+});
+
+describe('ensureRegistryPrincipals', () => {
+  it('split-VM: one application per registry service plus boot, whatever is enabled', async () => {
+    const result = await ensureRegistryPrincipals({ ...base, singleVM: false });
+    const suffixes = vi.mocked(provisionScopedKey).mock.calls.map(([, config]) => config.suffix);
+    expect(suffixes).toEqual(['vm-backend', 'vm-cdc', 'vm-yjs', 'vm-mcp', 'vm-frontend', 'boot']);
+    expect(result.allAppIds).toEqual([
+      'id-vm-backend',
+      'id-vm-cdc',
+      'id-vm-yjs',
+      'id-vm-mcp',
+      'id-vm-frontend',
+      'id-boot',
+    ]);
+  });
+
+  it('singleVM: only the host application plus boot', async () => {
+    const result = await ensureRegistryPrincipals({ ...base, singleVM: true });
+    const suffixes = vi.mocked(provisionScopedKey).mock.calls.map(([, config]) => config.suffix);
+    expect(suffixes).toEqual(['vm-backend', 'boot']);
+    expect(result.serviceAppIds).toEqual({ backend: 'id-vm-backend' });
+    expect(result.bootAppId).toBe('id-boot');
+  });
+
+  it('creates applications only: policies stay Pulumi-managed and keys are minted per deploy', async () => {
+    await ensureRegistryPrincipals({ ...base, singleVM: false });
+    for (const [, config] of vi.mocked(provisionScopedKey).mock.calls) {
+      expect(config.managePolicy).toBe(false);
+      expect(config.mintKey).toBe(false);
+    }
+  });
+});

--- a/infra/tasks/setup-service-apps.ts
+++ b/infra/tasks/setup-service-apps.ts
@@ -1,9 +1,10 @@
 import { type ProvisionScopedKeyOptions, provisionScopedKey } from '../lib/scaleway/scaleway-iam';
+import { principalServices } from '../lib/services';
 
 export interface SetupServiceAppsOptions extends ProvisionScopedKeyOptions {
   /** Deploy mode; service apps are always per-mode. */
   mode: string;
-  /** Deployed service slugs (from the services registry). */
+  /** Registry principal slugs (see `principalServices`). */
   services: readonly string[];
 }
 
@@ -12,7 +13,7 @@ export interface ServiceAppsResult {
   serviceAppIds: Record<string, string>;
   /** The boot fetcher application id. */
   bootAppId: string;
-  /** Every created/reused application id (services + boot), for the CI key-mint condition. */
+  /** Every created/reused application id (services + boot); their presence gates the CI key-mint rule. */
   allAppIds: string[];
 }
 
@@ -21,9 +22,10 @@ export interface ServiceAppsResult {
  * the boot fetcher application (`<slug>-<mode>-boot`), applications only:
  * their POLICIES are Pulumi-managed (resources/vm-iam.ts, bootstrap-owned) and
  * their KEYS are minted per deploy by CI (tasks/mint-generation-keys.ts) under
- * the conditioned IAMApplicationManager grant. Runs during bootstrap/migration
- * with an IAMManager-capable key; the returned ids feed the CI policy's
- * key-mint condition, so this MUST run before setup-ci-key.
+ * the unconditioned org-wide IAMApplicationManager grant (the boundary is the
+ * absent IAMPolicyManager). Runs with an IAMManager-capable key; the returned
+ * ids gate the presence of the CI key-mint rule, so bootstrap runs this before
+ * setup-ci-key. Idempotent: an existing application is reused by name.
  */
 export async function setupServiceApps(opts: SetupServiceAppsOptions): Promise<ServiceAppsResult> {
   const serviceAppIds: Record<string, string> = {};
@@ -50,4 +52,12 @@ export async function setupServiceApps(opts: SetupServiceAppsOptions): Promise<S
     bootAppId: boot.applicationId,
     allAppIds: [...Object.values(serviceAppIds), boot.applicationId],
   };
+}
+
+/** Ensure every registry principal exists: one `vm-<service>` application per `principalServices` entry plus the boot application. Bootstrap and "Apply infra change" share it, so a registry change converges in one privileged run. */
+export async function ensureRegistryPrincipals(
+  opts: Omit<SetupServiceAppsOptions, 'services'> & { singleVM: boolean },
+): Promise<ServiceAppsResult> {
+  const { singleVM, ...rest } = opts;
+  return setupServiceApps({ ...rest, services: principalServices(singleVM).map((svc) => svc.slug) });
 }


### PR DESCRIPTION
Follow-up to #1156. Enabling `yjs` under `singleVM` changed the backend host VM's expected secret-path condition, and nothing but a human-run Apply could converge it. This PR adopts one rule: **bootstrap-owned IAM follows the service registry; compute, LB and key minting follow the enabled set.** Toggling `appConfig.services.<slug>.enabled` in either mode no longer touches a principal, a policy or a condition, so it needs no Apply. Apply stays for registry changes, `singleVM` flips, DB and VPC.

### What changed

- `infra/lib/services.ts`: `placeServices()` separates the singleVM placement filter from the enabled filter and is applied to either input (no singleVM-specific branch). `deployedServices` / `coHostedServices` / `collocatedServices` keep their names and semantics. New registry view: `principalServices(singleVM)` and `principalSecretScopeSlugs(singleVM, service)`.
- `resources/vm-iam.ts` and `tasks/print-deploy-env.ts` (`vm_assert_json`) derive from the registry view together, so the Pulumi program and the deploy's grant assertion keep comparing byte-identical conditions.
- `tasks/setup-service-apps.ts`: `ensureRegistryPrincipals()`; `cli/actions/setup.ts` and `privileged-converge.ts` both use it, so **Apply infra change creates missing `vm-<service>`/`boot` applications itself** (idempotent: reuse by name). A fork migration is one Apply, not Rotate keys + Apply.
- Dormant-principal tripwire: a registry principal outside the deployed set must hold zero API keys. `assert-vm-grants --dormant` fails on any (read-only, after the update); `mint-generation-keys` purges them after staging. `deploy-run` passes the flag from the new `dormant` row field.
- Login hint in `cli/shared.ts` names `SCW_STATE_ACCESS_KEY` / `SCW_STATE_SECRET_KEY`; three comments claiming a conditioned key-mint grant corrected (it has been unconditioned since #1021).
- Docs: `cella/DEPLOYMENT.md` "Changing infrastructure" rewritten to the rule; fork note + manifest entry `20260911T0759-registry-owned-iam-principals`.

### Security

Verified before designing: every secret except `database-url-cdc` lives in `/shared/`, which every service condition already includes, so a dormant principal's policy grants the same effective reach as the existing backend principal; the CI key already holds an unconditioned org-wide `IAMApplicationManager` grant, so no actor gains a capability. The one new surface, unmonitored dormant principals, becomes a tripwire. CI still cannot attach permissions; `/engine/` and `/handoff/` stay outside every VM condition.

### Migration (per bootstrapped stack, after merge)

`pnpm infra` → Apply infra change with a bootstrap key and the split state identity. cella production: expect `~rules` on `cella-production-vm-backend-policy` (host condition gains `/mcp/`). raak (split-VM): new `vm-yjs` / `vm-mcp` applications and policies. Until run, the next deploy fails at `requirePrincipalId` (split-VM) or "Verify VM IAM grants" (singleVM), as documented.

### Verification

`pnpm exec vitest run --project=infra` (82 files), `pnpm --filter infra ts`, `pnpm style`, biome clean; `tasks/print-deploy-env.ts production` shows one backend row with backend, cdc, yjs, mcp, frontend, shared and `dormant: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
